### PR TITLE
Add padlock icon to annotation view to indicate private datasets

### DIFF
--- a/metaspace/webapp/src/api/annotation.ts
+++ b/metaspace/webapp/src/api/annotation.ts
@@ -22,6 +22,7 @@ export const annotationListQuery =
           name
           polarity
           metadataJson
+          isPublic
         }
         isotopeImages {
           mz

--- a/metaspace/webapp/src/components/AnnotationView.vue
+++ b/metaspace/webapp/src/components/AnnotationView.vue
@@ -126,6 +126,8 @@
     text-align: center !important;
     cursor: default !important;
     font: 24px 'Roboto', sans-serif;
+    line-height: 40px;
+    vertical-align: center;
 
     >*+* {
       margin-left: 8px;

--- a/metaspace/webapp/src/components/AnnotationView.vue
+++ b/metaspace/webapp/src/components/AnnotationView.vue
@@ -5,16 +5,19 @@
                    @change="onSectionsChange">
 
         <div class="el-collapse-item grey-bg">
-          <div class="el-collapse-item__header av-centered grey-bg">
+          <div class="el-collapse-item__header av-header grey-bg">
             <span class="sf-big" v-html="formattedMolFormula"> </span>
             <span class="mz-big">{{ annotation.mz.toFixed(4) }}</span>
-            <span>
-              <router-link target="_blank"
-                           style="font-size: 20px"
-                           title="Link to this annotation (opens in a new tab)"
-                           :to="permalinkHref"><img src="../assets/share-icon.png" width="18px">
-              </router-link>
-            </span>
+            <router-link target="_blank"
+                         style="font-size: 20px"
+                         title="Link to this annotation (opens in a new tab)"
+                         :to="permalinkHref">
+              <img src="../assets/share-icon.png" class="av-icon">
+            </router-link>
+            <img v-if="!annotation.dataset.isPublic"
+                 src="../assets/padlock-icon.svg"
+                 class="av-icon"
+                 title="This dataset's annotation results are not publicly visible">
           </div>
         </div>
 
@@ -115,16 +118,32 @@
  export default AnnotationView;
 </script>
 
-<style>
- .sf-big {
-   text-shadow : 0 0 0px #000;
-   font: 24px 'Roboto', sans-serif;
- }
+<style lang="scss">
+  .av-header {
+    text-align: center !important;
+    cursor: default !important;
+    font: 24px 'Roboto', sans-serif;
 
- .mz-big {
-   font: 24px 'Roboto';
-   padding: 0px 20px;
- }
+    >*+* {
+      margin-left: 8px;
+      margin-right: 8px;
+    }
+
+    .av-icon {
+      width: 20px;
+      height: 20px;
+    }
+
+    .sf-big {
+      font: 24px 'Roboto', sans-serif;
+      text-shadow : 0 0 0 #000;
+    }
+
+    .mz-big {
+      font: 24px 'Roboto';
+      padding: 0 4px;
+    }
+  }
 
  #annot-content {
    width: 100%;
@@ -153,11 +172,6 @@
 
  .compound-image {
    height: 700px;
- }
-
- .av-centered {
-   text-align: center !important;
-   cursor: default !important;
  }
 
  .el-collapse-item__header {

--- a/metaspace/webapp/src/components/AnnotationView.vue
+++ b/metaspace/webapp/src/components/AnnotationView.vue
@@ -8,16 +8,19 @@
           <div class="el-collapse-item__header av-header grey-bg">
             <span class="sf-big" v-html="formattedMolFormula"> </span>
             <span class="mz-big">{{ annotation.mz.toFixed(4) }}</span>
-            <router-link target="_blank"
-                         style="font-size: 20px"
-                         title="Link to this annotation (opens in a new tab)"
-                         :to="permalinkHref">
-              <img src="../assets/share-icon.png" class="av-icon">
-            </router-link>
-            <img v-if="!annotation.dataset.isPublic"
-                 src="../assets/padlock-icon.svg"
-                 class="av-icon"
-                 title="This dataset's annotation results are not publicly visible">
+            <el-popover trigger="hover" placement="bottom">
+              <router-link slot="reference"
+                           target="_blank"
+                           :to="permalinkHref">
+                <img src="../assets/share-icon.png" class="av-icon">
+              </router-link>
+              <div>Link to this annotation (opens in a new tab)</div>
+            </el-popover>
+
+            <el-popover v-if="!annotation.dataset.isPublic" trigger="hover" placement="bottom">
+              <img slot="reference" src="../assets/padlock-icon.svg" class="av-icon">
+              <div>This dataset's annotation results are not publicly visible</div>
+            </el-popover>
           </div>
         </div>
 


### PR DESCRIPTION
I ran out of inspiration on this one. I'm not completely happy with it, but I'm not sure what else to do. Comments & suggestions welcome.

Normal:
<img width="595" alt="image" src="https://user-images.githubusercontent.com/26366936/42265750-c0cf8250-7f74-11e8-947c-bdcc66233058.png">

Private:
<img width="601" alt="image" src="https://user-images.githubusercontent.com/26366936/42265770-cb4aed32-7f74-11e8-9a16-1afd154bfedd.png">

Hover text:
<img width="602" alt="image" src="https://user-images.githubusercontent.com/26366936/42265800-dd60062e-7f74-11e8-81b8-b8986f4c90a3.png">

Share link hover text (this was changed from a native browser tooltip to an Element UI popover to be consistent with the padlock):
<img width="600" alt="image" src="https://user-images.githubusercontent.com/26366936/42265839-fdb29d42-7f74-11e8-99ca-80e727505552.png">
