### PR TITLE
Fixes to scrolling on annotations page

### DIFF
--- a/metaspace/webapp/src/components/ImageAligner.vue
+++ b/metaspace/webapp/src/components/ImageAligner.vue
@@ -45,7 +45,7 @@
         @dblclick.native="onDoubleClick"
         @mousedown.native="onImageMouseDown"
         @contextmenu.native="onImageRightMouseDown"
-        style="z-index: 5;"
+        style="z-index: 5; overflow: visible"
         :max-height=100500
         @wheel.native="onWheel"
         :annot-image-opacity="annotImageOpacity"

--- a/metaspace/webapp/src/components/ImageLoader.vue
+++ b/metaspace/webapp/src/components/ImageLoader.vue
@@ -465,20 +465,24 @@
  }
 
  .image-loader {
+   display: flex;
+   flex-direction: column;
+   align-content: center;
+   justify-content: space-evenly;
+   overflow: hidden;
    cursor: -webkit-grab;
    cursor: grab;
    width: 100%;
-   height: 100%;
    line-height: 0px;
-   display: flex;
-   flex-direction: column;
-   align-self: center;
  }
 
  .image-loader__overlay-text {
    font: 24px 'Roboto', sans-serif;
-   display: inline-block;
-   line-height: 500px;
+   display: block;
+   position: relative;
+   text-align: center;
+   top: 50%;
+   transform: translateY(-50%);
    z-index: 4;
    color: #fff;
    padding: auto;

--- a/metaspace/webapp/src/components/annotation-widgets/default/MainImage.vue
+++ b/metaspace/webapp/src/components/annotation-widgets/default/MainImage.vue
@@ -105,7 +105,7 @@ export default class MainImage extends Vue {
         })
     }
 
-    showBrowserWarning(): any {
+    showBrowserWarning() {
       this.$alert('Due to technical limitations we are only able to support downloading layered and/or zoomed images' +
       ' on Chrome and Firefox. As a workaround, it is possible to get a copy of the raw ion image by right-clicking ' +
       'it and clicking "Save picture as", however this will not take into account your current zoom ' +

--- a/metaspace/webapp/src/components/annotation-widgets/default/MainImage.vue
+++ b/metaspace/webapp/src/components/annotation-widgets/default/MainImage.vue
@@ -44,7 +44,7 @@
                      width="32px"
                      style="opacity: 0.3"
                      title="Your browser is not supported"
-                     @click="browserWarning"
+                     @click="showBrowserWarning"
                      v-else/>
             </div>
         </div>
@@ -105,8 +105,11 @@ export default class MainImage extends Vue {
         })
     }
 
-    browserWarning(): string {
-      return alert('Your browser is not supported, please change to Chrome/Firefox instead')
+    showBrowserWarning(): any {
+      this.$alert('Due to technical limitations we are only able to support downloading layered and/or zoomed images' +
+      ' on Chrome and Firefox. As a workaround, it is possible to get a copy of the raw ion image by right-clicking ' +
+      'it and clicking "Save picture as", however this will not take into account your current zoom ' +
+      'settings or show the optical image.');
     }
 
   get browserSupportsDomToImage(): boolean {

--- a/metaspace/webapp/src/components/annotation-widgets/default/MainImage.vue
+++ b/metaspace/webapp/src/components/annotation-widgets/default/MainImage.vue
@@ -3,10 +3,9 @@
     <div class="main-ion-image-container-row1">
         <image-loader :src="annotation.isotopeImages[0].url"
                       :colormap="colormap"
-                      :max-height=500
                       ref="imageLoader"
                       scrollBlock
-                      style="overflow: hidden"
+                      class="image-loader"
                       v-bind="imageLoaderSettings"
                       @zoom="onImageZoom"
                       @move="onImageMove">
@@ -34,12 +33,19 @@
             </colorbar>
             {{ annotation.isotopeImages[0].minIntensity.toExponential(2) }}
 
-            <div class="annot-view__image-download" v-if="browserSupportsDomToImage">
+            <div class="annot-view__image-download">
                 <!-- see https://github.com/tsayen/dom-to-image/issues/155 -->
                 <img src="../../../assets/download-icon.png"
                      width="32px"
                      title="Save visible region in PNG format"
-                     @click="saveImage"/>
+                     @click="saveImage"
+                     v-if="browserSupportsDomToImage"/>
+                <img src="../../../assets/download-icon.png"
+                     width="32px"
+                     style="opacity: 0.3"
+                     title="Your browser is not supported"
+                     @click="browserWarning"
+                     v-else/>
             </div>
         </div>
     </div>
@@ -99,8 +105,13 @@ export default class MainImage extends Vue {
         })
     }
 
+    browserWarning(): string {
+      return alert('Your browser is not supported, please change to Chrome/Firefox instead')
+    }
+
   get browserSupportsDomToImage(): boolean {
-      return window.navigator.userAgent.includes('Chrome');
+      return window.navigator.userAgent.includes('Chrome') ||
+          window.navigator.userAgent.includes('Firefox');
     }
 
     onOpacityInput(val: number): void {


### PR DESCRIPTION
- fixed text alignment problem (Use ctrl to zoom in..)
- filling of the empty space on Y axis (before only free space on X axis was used when zooming)
- domtoimage browser dependency warning(works on Firefox/Chrome, warns on other browsers)