### PR TITLE
Group profile page and menu changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
         environment:
           POSTGRES_USER: sm
           POSTGRES_PASSWORD: password
-      
+
       - image: node:8
 
     working_directory: ~/metaspace/metaspace/graphql
@@ -63,6 +63,7 @@ jobs:
       - run:
           name: Run tests
           command: |
+            yarn run deref-schema
             yarn run test
 
   test-webapp-e2e:

--- a/metaspace/graphql/esConnector.js
+++ b/metaspace/graphql/esConnector.js
@@ -137,7 +137,7 @@ function constructAnnotationQuery(args, docType, user) {
 
   for (var key in datasetFilters) {
     const val = datasetFilter[key];
-    if (val) {
+    if (val != null && val !== '') {
       const f = datasetFilters[key].esFilter(val);
       if (Array.isArray(f))
         for (let x of f)
@@ -146,7 +146,6 @@ function constructAnnotationQuery(args, docType, user) {
         addFilter(f);
     }
   }
-
   return body;
 }
 

--- a/metaspace/graphql/resolvers.js
+++ b/metaspace/graphql/resolvers.js
@@ -236,6 +236,18 @@ const Resolvers = {
 
     reprocessingNeeded(_, args, {user}) {
       return DSQuery.reprocessingNeeded(args, user);
+    },
+
+    currentUser(_, args, {user}) {
+      console.log(user);
+      if (user == null || user.name == null) {
+        return null;
+      }
+      return {
+        id: user.name.replace(/ /, '|||'), // TODO: Have actual user IDs
+        name: user.name,
+        email: user.email || null,
+      }
     }
   },
 
@@ -259,6 +271,10 @@ const Resolvers = {
 
     name(ds) {
       return ds._source.ds_name;
+    },
+
+    uploadDT(ds) {
+      return ds._source.ds_upload_dt;
     },
 
     configJson(ds) {

--- a/metaspace/graphql/resolvers.js
+++ b/metaspace/graphql/resolvers.js
@@ -239,7 +239,6 @@ const Resolvers = {
     },
 
     currentUser(_, args, {user}) {
-      console.log(user);
       if (user == null || user.name == null) {
         return null;
       }

--- a/metaspace/graphql/schema.graphql
+++ b/metaspace/graphql/schema.graphql
@@ -55,6 +55,7 @@ type FdrCounts {
 type Dataset {
   id: String!
   name: String!
+  uploadDT: String!
 
   institution: String
   submitter: Person!
@@ -190,6 +191,7 @@ input DatasetFilter {
 
   # exact match
   group: ID
+  hasGroup: Boolean
 
   polarity: Polarity
 

--- a/metaspace/graphql/schemas/user.graphql
+++ b/metaspace/graphql/schemas/user.graphql
@@ -16,7 +16,7 @@ input UpdateUserInput {
 }
 
 type Query {
-  currentUser: User!
+  currentUser: User
   user(id: ID!): User                # For admins
   allUsers(query: String): [User!]!  # For admins
 }

--- a/metaspace/webapp/package.json
+++ b/metaspace/webapp/package.json
@@ -142,8 +142,12 @@
       "^.+\\.vue$": "<rootDir>/node_modules/vue-jest",
       "^.+\\.[jt]sx?$": "<rootDir>/node_modules/ts-jest"
     },
+    "moduleNameMapper": {
+      "lodash-es": "lodash"
+    },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "setupTestFrameworkScriptFile": "<rootDir>/tests/utils/setupTestFramework.ts",
+    "restoreMocks": true,
     "moduleFileExtensions": [
       "ts",
       "js",

--- a/metaspace/webapp/package.json
+++ b/metaspace/webapp/package.json
@@ -117,7 +117,6 @@
     "less-loader": "~4.1.0",
     "markdown-loader": "~2.0.2",
     "marky-mark": "~1.2.1",
-    "node-fetch": "1.7.3",
     "passwordless-memorystore": "^0.0.1",
     "postcss-loader": "~2.1.5",
     "source-map-loader": "0.2.3",
@@ -144,6 +143,7 @@
       "^.+\\.[jt]sx?$": "<rootDir>/node_modules/ts-jest"
     },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "setupTestFrameworkScriptFile": "<rootDir>/tests/utils/setupTestFramework.ts",
     "moduleFileExtensions": [
       "ts",
       "js",

--- a/metaspace/webapp/package.json
+++ b/metaspace/webapp/package.json
@@ -31,6 +31,7 @@
     "d3-color": "^1.0.3",
     "d3-scale": "^1.0.5",
     "d3-svg-legend": "^2.24.0",
+    "date-fns": "^1.29.0",
     "deepcopy": "^0.6.3",
     "dom-to-image": "2.6.0",
     "ejs": "^2.5.5",

--- a/metaspace/webapp/package.json
+++ b/metaspace/webapp/package.json
@@ -11,7 +11,8 @@
     "test": "jest",
     "test-e2e": "testcafe firefox:headless tests/e2e/annotations.js --app 'yarn run dev' --no-color --app-init-delay=20000 --quarantine-mode --assertion-timeout=20000",
     "cucumber-test": "cucumber-js --compiler ts:ts-node/register tests/e2e/ --fail-fast",
-    "coverage": "jest --coverage"
+    "coverage": "jest --coverage",
+    "deref-schema": "node ./deref_schema.js src/assets"
   },
   "dependencies": {
     "@types/js-cookie": "^2.1.0",

--- a/metaspace/webapp/src/App.vue
+++ b/metaspace/webapp/src/App.vue
@@ -3,7 +3,12 @@
     <metaspace-header>
     </metaspace-header>
 
-    <router-view class="main-content">
+    <!--
+      :key="$route.path" is used to force the content to be remounted if a non-querystring param in the URL changes.
+      This ensures that a loading screen is displayed and no unnecessary state is retained when e.g. switching
+      between group profile pages or datasets
+    -->
+    <router-view class="main-content" :key="$route.path">
     </router-view>
 
     <!--metaspace-footer>

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -1,42 +1,100 @@
 import gql from 'graphql-tag';
 
-export const datasetListQuery =
-  gql`query GetDatasets($dFilter: DatasetFilter, $query: String, $inpFdrLvls: [Int!]!, $checkLvl: Int!) {
-    allDatasets(offset: 0, limit: 100, filter: $dFilter, simpleQuery: $query) {
+// Prefixing these with `Gql` because differently-cased variants are used elsewhere
+export type GqlPolarity = 'POSITIVE' | 'NEGATIVE';
+export type GqlJobStatus = 'NEW' | 'QUEUED' | 'ANNOTATING' | 'INDEXING' | 'FINISHED' | 'FAILED';
+
+export interface DatasetDetailItem {
+  id: string;
+  name: string;
+  institution: string | null;
+  submitter: {
+    id: string | null;
+    name: string;
+  };
+  polarity: GqlPolarity;
+  ionisationSource: string;
+  analyzer: {
+    type: string;
+    resolvingPower: number;
+  };
+  organism: string | null;
+  organismPart: string | null;
+  condition: string | null;
+  growthConditions: string | null;
+  metadataJson: string;
+  isPublic: Boolean;
+  molDBs: string[];
+  status: GqlJobStatus | null;
+  metadataType: string;
+  fdrCounts: {
+    dbName: string;
+    levels: number[];
+    counts: number[];
+  };
+  opticalImage: string;
+}
+
+export const datasetDetailItemFragment =
+  gql`fragment DatasetDetailItem on Dataset {
+    id
+    name
+    institution
+    submitter {
       id
       name
-      institution
-      submitter {
-        id
-        name
-      }
-      polarity
-      ionisationSource
-      analyzer {
-        type
-        resolvingPower(mz: 400)
-      }
-      organism
-      organismPart
-      condition
-      growthConditions
-      metadataJson
-      isPublic
-      molDBs
-      status
-      metadataType
-      fdrCounts(inpFdrLvls: $inpFdrLvls, checkLvl: $checkLvl) {
-        dbName
-        levels
-        counts
-      }
-      opticalImage
+      email
     }
+    polarity
+    ionisationSource
+    analyzer {
+      type
+      resolvingPower(mz: 400)
+    }
+    organism
+    organismPart
+    condition
+    growthConditions
+    metadataJson
+    isPublic
+    molDBs
+    status
+    metadataType
+    fdrCounts(inpFdrLvls: $inpFdrLvls, checkLvl: $checkLvl) {
+      dbName
+      levels
+      counts
+    }
+    opticalImage
   }`;
+
+export const datasetDetailItemsQuery =
+  gql`query GetDatasets($dFilter: DatasetFilter, $query: String, $inpFdrLvls: [Int!]!, $checkLvl: Int!) {
+    allDatasets(offset: 0, limit: 100, filter: $dFilter, simpleQuery: $query) {
+      ...DatasetDetailItem
+    }
+  }
+  ${datasetDetailItemFragment}
+  `;
 
 export const datasetCountQuery =
   gql`query CountDatasets($dFilter: DatasetFilter, $query: String) {
     countDatasets(filter: $dFilter, simpleQuery: $query)
+  }`;
+
+export interface DatasetListItem {
+  id: string;
+  name: string;
+  uploadDT: string;
+}
+
+export const datasetListItemsQuery =
+  gql`query GetDatasets($dFilter: DatasetFilter, $query: String) {
+    allDatasets(offset: 0, limit: 100, filter: $dFilter, simpleQuery: $query) {
+      id
+      name
+      uploadDT
+    }
   }`;
 
 export const opticalImageQuery =

--- a/metaspace/webapp/src/api/group.ts
+++ b/metaspace/webapp/src/api/group.ts
@@ -1,4 +1,3 @@
-import graphqlClient from '../graphqlClient';
 import gql from 'graphql-tag';
 
 export const requestAccessToGroupMutation =
@@ -19,24 +18,3 @@ export const leaveGroupMutation =
   gql`mutation leaveGroup($groupId: ID!) { 
     leaveGroup(groupId: $groupId)
   }`;
-
-export const requestAccessToGroup = async (groupId: string, bringDatasets: string[] = []) => {
-  await graphqlClient.mutate({
-    mutation: requestAccessToGroupMutation,
-    variables: { groupId, bringDatasets },
-  });
-};
-
-export const acceptGroupInvitation = async (groupId: string, bringDatasets: string[] = []) => {
-  await graphqlClient.mutate({
-    mutation: acceptGroupInvitationMutation,
-    variables: { groupId, bringDatasets },
-  });
-};
-
-export const leaveGroup = async (groupId: string) => {
-  await graphqlClient.mutate({
-    mutation: leaveGroupMutation,
-    variables: { groupId },
-  });
-};

--- a/metaspace/webapp/src/api/group.ts
+++ b/metaspace/webapp/src/api/group.ts
@@ -1,0 +1,42 @@
+import graphqlClient from '../graphqlClient';
+import gql from 'graphql-tag';
+
+export const requestAccessToGroupMutation =
+  gql`mutation requestAccessToGroup($groupId: ID!, $bringDatasets: [ID!]!) { 
+    requestAccessToGroup(groupId: $groupId, bringDatasets: $bringDatasets) {
+      role
+    }
+  }`;
+
+export const acceptGroupInvitationMutation =
+  gql`mutation acceptGroupInvitation($groupId: ID!, $bringDatasets: [ID!]!) { 
+    acceptGroupInvitation(groupId: $groupId, bringDatasets: $bringDatasets) {
+      role
+    }
+  }`;
+
+export const leaveGroupMutation =
+  gql`mutation leaveGroup($groupId: ID!) { 
+    leaveGroup(groupId: $groupId)
+  }`;
+
+export const requestAccessToGroup = async (groupId: string, bringDatasets: string[] = []) => {
+  await graphqlClient.mutate({
+    mutation: requestAccessToGroupMutation,
+    variables: { groupId, bringDatasets },
+  });
+};
+
+export const acceptGroupInvitation = async (groupId: string, bringDatasets: string[] = []) => {
+  await graphqlClient.mutate({
+    mutation: acceptGroupInvitationMutation,
+    variables: { groupId, bringDatasets },
+  });
+};
+
+export const leaveGroup = async (groupId: string) => {
+  await graphqlClient.mutate({
+    mutation: leaveGroupMutation,
+    variables: { groupId },
+  });
+};

--- a/metaspace/webapp/src/api/metadata.ts
+++ b/metaspace/webapp/src/api/metadata.ts
@@ -36,6 +36,10 @@ export const fetchOptionListsQuery = gql`{
     id
     name
   }
+  groups: allGroups {
+    id
+    name
+  }
   adducts: adductSuggestions{adduct, charge}
 }`;
 

--- a/metaspace/webapp/src/components/DatasetTable.vue
+++ b/metaspace/webapp/src/components/DatasetTable.vue
@@ -48,7 +48,7 @@
 </template>
 
 <script>
- import {datasetListQuery, datasetCountQuery} from '../api/dataset';
+ import {datasetDetailItemsQuery, datasetCountQuery} from '../api/dataset';
  import {metadataExportQuery} from '../api/metadata';
  import DatasetItem from './DatasetItem.vue';
  import FilterPanel from './FilterPanel.vue';
@@ -139,7 +139,7 @@
 
      started: {
        fetchPolicy: 'cache-and-network',
-       query: datasetListQuery,
+       query: datasetDetailItemsQuery,
        update: data => data.allDatasets,
        variables () {
          return this.queryVariables('ANNOTATING');
@@ -148,7 +148,7 @@
 
      queued: {
        fetchPolicy: 'cache-and-network',
-       query: datasetListQuery,
+       query: datasetDetailItemsQuery,
        update: data => data.allDatasets,
        variables () {
          return this.queryVariables('QUEUED');
@@ -157,7 +157,7 @@
 
      finished: {
        fetchPolicy: 'cache-and-network',
-       query: datasetListQuery,
+       query: datasetDetailItemsQuery,
        update: data => data.allDatasets,
        variables () {
          return this.queryVariables('FINISHED');

--- a/metaspace/webapp/src/components/FilterPanel.vue
+++ b/metaspace/webapp/src/components/FilterPanel.vue
@@ -36,6 +36,7 @@
    'database',
    'fdrLevel',
    'institution',
+   'group',
    'submitter',
    'datasetIds',
    'compoundName',

--- a/metaspace/webapp/src/components/MetaspaceHeader.vue
+++ b/metaspace/webapp/src/components/MetaspaceHeader.vue
@@ -93,7 +93,7 @@
   import gql from 'graphql-tag';
  import {signOut} from '../api/auth';
  import {encodeParams} from '../url';
- import tokenAutorefresh from '../tokenAutorefresh';
+  import { refreshLoginStatus } from '../graphqlClient';
  import * as config from '../clientConfig.json';
 
  export default {
@@ -202,7 +202,7 @@
        } else {
          await fetch('/logout', {credentials: 'include'});
        }
-       await tokenAutorefresh.refreshJwt(true);
+       await refreshLoginStatus();
      },
 
      handleSubmenuEnter(submenu) {

--- a/metaspace/webapp/src/components/MetaspaceHeader.vue
+++ b/metaspace/webapp/src/components/MetaspaceHeader.vue
@@ -1,68 +1,51 @@
 <template>
   <div class="b-header">
-    <div>
-      <div class="header-item" id="metasp-logo">
-        <router-link to="/" style="display: flex">
-          <img src="../assets/logo.png"
-              alt="Metaspace" title="Metaspace"
-              style="border: 0px;"
-              class="vc"></img>
-        </router-link>
-      </div>
-
-      <router-link :to="uploadHref">
-        <div class="header-item vc page-link" id='upload-link'>
-          <div class="vc">Upload</div>
-        </div>
+    <div class="header-items">
+      <router-link to="/" class="header-item logo">
+        <img src="../assets/logo.png" alt="Metaspace" title="Metaspace"/>
       </router-link>
 
-      <router-link :to="datasetsHref">
-        <div class="header-item vc page-link" id='datasets-link'>
-          <div class="vc">Datasets</div>
-        </div>
+      <router-link :to="uploadHref" class="header-item page-link" id='upload-link'>
+        Upload
       </router-link>
 
-      <router-link :to="annotationsHref">
-        <div class="header-item vc page-link" id='annotations-link'>
-          <div class="vc">Annotations</div>
-        </div>
+      <router-link :to="datasetsHref" class="header-item page-link" id='datasets-link'>
+        Datasets
       </router-link>
 
-      <router-link to="/about">
-        <div class="header-item vc page-link">
-          <div class="vc">About</div>
-        </div>
+      <router-link :to="annotationsHref" class="header-item page-link" id='annotations-link'>
+        Annotations
       </router-link>
 
-      <router-link to="/help">
-        <div class="header-item vc page-link">
-          <div class="vc">Help</div>
-        </div>
+      <router-link to="/about" class="header-item page-link">
+        About
+      </router-link>
+
+      <router-link to="/help" class="header-item page-link">
+        Help
       </router-link>
     </div>
 
-    <div v-if="!this.$store.state.authenticated">
-      <div v-if="features.newAuth">
-        <div class="header-item vc page-link" @click="showCreateAccount">
-          <div class="vc">Create account</div>
+    <div v-if="!this.$store.state.authenticated" class="header-items">
+      <div v-if="features.newAuth" class="header-items">
+        <div class="header-item page-link" @click="showCreateAccount">
+          Create account
         </div>
 
-        <div class="header-item vc page-link" @click="showSignIn">
-          <div class="vc">Sign in</div>
+        <div class="header-item page-link" @click="showSignIn">
+          Sign in
         </div>
       </div>
-      <div v-else>
-        <el-popover ref="login-popover"
-                    placement="bottom"
-                    trigger="click"
-                    style="text-align:center;">
+      <div v-else class="header-items">
+        <el-popover placement="bottom" trigger="click" class="header-items">
+          <div slot="reference" class="header-item page-link">
+            Sign in
+          </div>
           <div id="email-link-container">
             <el-button type="primary" @click="sendLoginLink">Send a link to</el-button>
             <span>
-            <el-input v-model="loginEmail"
-                      placeholder="e-mail address">
-            </el-input>
-          </span>
+              <el-input v-model="loginEmail" placeholder="e-mail address" />
+            </span>
           </div>
 
           <div style="text-align: center;">
@@ -72,26 +55,42 @@
             </a>
           </div>
         </el-popover>
-
-        <div class="header-item vc page-link" v-popover:login-popover>
-          <div class="vc">Sign in</div>
-        </div>
       </div>
     </div>
-    <div v-else>
-      <div class="header-item vc">
-        <div class="vc" style="color: white;">
-          {{ userNameOrEmail }}
+    <div v-else class="header-items">
+      <router-link
+        v-if="currentUser && currentUser.primaryGroup"
+        :to="`/group/${currentUser.primaryGroup.group.id}`"
+        class="header-item page-link">
+        <div class="limit-width">
+          {{currentUser.primaryGroup.group.shortName}}
         </div>
-      </div>
-      <div class="header-item vc page-link" @click="logout">
-        <div class="vc">Sign out</div>
+      </router-link>
+      <div class="submenu-container user-submenu"
+           :class="{'submenu-container-open': openSubmenu === 'user'}"
+           @mouseenter="handleSubmenuEnter('user')"
+           @mouseleave="handleSubmenuLeave('user')">
+        <div class="header-item submenu-header"
+             :class="{'router-link-active': matchesRoute('/user/me')}">
+          <div class="limit-width" style="color: white;">
+          {{ userNameOrEmail }}
+          </div>
+        </div>
+        <div class="submenu">
+          <router-link to="/user/me" class="submenu-item page-link">
+            My Account
+          </router-link>
+          <div class="submenu-item page-link" @click="logout">
+            Sign out
+          </div>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <script>
+  import gql from 'graphql-tag';
  import {signOut} from '../api/auth';
  import {encodeParams} from '../url';
  import tokenAutorefresh from '../tokenAutorefresh';
@@ -127,8 +126,26 @@
 
    data() {
      return {
-       loginEmail: (this.$store.state.user ? this.$store.state.user.email : '')
+       loginEmail: (this.$store.state.user ? this.$store.state.user.email : ''),
+       currentUser: null,
+       openSubmenu: null
      };
+   },
+
+   apollo: {
+     currentUser: {
+       query: gql`query {
+         currentUser {
+           primaryGroup {
+             group {
+               id
+               shortName
+               name
+             }
+           }
+         }
+       }`
+     }
    },
 
    methods: {
@@ -141,6 +158,12 @@
          query: encodeParams(f, path, this.$store.state.filterLists)
        };
        return link;
+     },
+
+     matchesRoute(path) {
+       // WORKAROUND: vue-router hides its util function "isIncludedRoute", which would be perfect here
+       // return isIncludedRoute(this.$route, path);
+       return this.$route.path.startsWith(path);
      },
 
      sendLoginLink() {
@@ -180,13 +203,21 @@
          await fetch('/logout', {credentials: 'include'});
        }
        await tokenAutorefresh.refreshJwt(true);
-     }
+     },
+
+     handleSubmenuEnter(submenu) {
+       this.openSubmenu = submenu;
+     },
+     handleSubmenuLeave(submenu) {
+       if (this.openSubmenu === submenu) {
+         this.openSubmenu = null;
+       }
+     },
    }
  }
 </script>
 
-<style>
- /* bits and pieces copy-pasted from metasp.eu */
+<style scoped>
  .b-header {
    background-color: rgba(0, 105, 224, 0.85);
    position: fixed;
@@ -196,16 +227,27 @@
    right: 0;
    height: 62px;
    display: flex;
+   align-items: center;
    justify-content: space-between;
+ }
+
+ .header-items {
+   display: flex;
+   align-items: center;
+   height: 100%
  }
 
  .header-item {
    display: flex;
-   float: left;
    border: none;
    padding: 0px 20px;
-   height: 62px;
    font-size: 16px;
+   align-self: stretch;
+   align-items: center;
+   justify-content: center;
+ }
+ .header-item.logo {
+   padding-left: 15px;
  }
 
  @media (max-width: 1000px) {
@@ -215,47 +257,70 @@
    }
  }
 
- /* vertically centered */
- .vc {
-   align-self: center;
- }
-
- .btn-link {
-   text-decoration: none;
-   color: inherit;
- }
-
  .page-link {
    text-align: center;
    color: #eee;
    cursor: pointer;
+   text-decoration: none;
  }
 
- .router-link-active > .page-link, .page-link:hover {
+ .router-link-active.page-link, .page-link:hover,
+ .submenu-container:not(.submenu-container-open) > .router-link-active.submenu-header {
    background: rgba(0, 0, 0, 0.1);
+   outline-offset: -1px;
    outline-color: rgba(0, 0, 0, 0.3);
    outline-style: solid;
    outline-width: 1px;
+   color: white;
  }
 
- .page-link:hover {
-   background: rgba(0, 0, 0, 0.1);
-   outline-color: rgba(0, 0, 0, 0.3);
-   outline-style: solid;
-   outline-width: 1px;
- }
-
- .router-link-active > .page-link {
+ .router-link-active.page-link {
    font-weight: 700;
-   color: white;
+ }
+ .page-link a {
+   text-decoration: none;
  }
 
- .page-link:hover > .vc {
-   color: white;
+ .submenu-container {
+   position: relative;
+   display: flex;
+   align-items: center;
+   height: 100%
  }
+ .submenu {
+   display: none;
+   position: absolute;
+   flex-direction: column;
+   top: 100%;
+   right: 0;
+   width: 100%;
+   min-width: 140px;
+   max-width: 200px;
 
- #metasp-logo {
-   padding-left: 15px;
+   background-color: rgba(0, 105, 224, 0.85);
+   /*background-color: rgb(38, 128, 229);*/
+ }
+ .submenu-container-open > .submenu {
+   display: flex;
+ }
+ .submenu-item {
+   padding: 20px;
+   font-size: 16px;
+   align-self: stretch;
+   justify-content: center;
+ }
+ .limit-width {
+   max-width: 250px;
+   overflow-wrap: break-word;
+   text-align: center;
+   overflow: hidden;
+   line-height: 1.2em;
+   max-height: 2.4em;
+ }
+ @media (max-width: 1000px) {
+   .limit-width {
+     max-width: 150px;
+   }
  }
 
  #email-link-container {

--- a/metaspace/webapp/src/components/plots/DatasetUploadTimeline.vue
+++ b/metaspace/webapp/src/components/plots/DatasetUploadTimeline.vue
@@ -22,6 +22,12 @@
  export default {
   name: 'upload-timeline-plot',
 
+  data() {
+    return {
+      uploadDates: []
+    }
+  },
+
   apollo: {
     uploadDates: {
       query: query,

--- a/metaspace/webapp/src/components/plots/MSSetupSummaryPlot.vue
+++ b/metaspace/webapp/src/components/plots/MSSetupSummaryPlot.vue
@@ -116,6 +116,12 @@
  export default {
   name: 'mass-spec-setup-plot',
 
+  data() {
+    return {
+      counts: []
+    }
+  },
+
   apollo: {
     counts: {
       query: query,

--- a/metaspace/webapp/src/components/plots/OrganismSummaryPlot.vue
+++ b/metaspace/webapp/src/components/plots/OrganismSummaryPlot.vue
@@ -74,6 +74,12 @@
  export default {
   name: 'organism-summary-plot',
 
+  data() {
+    return {
+      counts: []
+    }
+  },
+
   apollo: {
     counts: {
       query: query,

--- a/metaspace/webapp/src/components/plots/SubmitterSummaryPlot.vue
+++ b/metaspace/webapp/src/components/plots/SubmitterSummaryPlot.vue
@@ -41,6 +41,12 @@
  export default {
   name: 'submitter-summary-plot',
 
+  data() {
+    return {
+      counts: []
+    }
+  },
+
   apollo: {
     counts: {
       query: query,

--- a/metaspace/webapp/src/element-ui.d.ts
+++ b/metaspace/webapp/src/element-ui.d.ts
@@ -1,2 +1,1 @@
 declare module "element-ui/lib/locale/lang/en";
-declare module "element-ui/lib/locale";

--- a/metaspace/webapp/src/filterSpecs.js
+++ b/metaspace/webapp/src/filterSpecs.js
@@ -145,6 +145,22 @@ const FILTER_SPECIFICATIONS = {
     options: 'institutionNames' // take from Vue instance
   },
 
+  group: {
+    type: SingleSelectFilter,
+    name: 'Group',
+    description: 'Select group',
+    levels: ['annotation', 'dataset'],
+    initialValue: undefined,
+    encoding: 'json',
+    options: lists => lists.groups.map(x => {
+      const {id, name} = x;
+      return {id, name};
+    }),
+    optionFormatter: ({name}) => name,
+    valueFormatter: ({name}) => name,
+    valueKey: 'id',
+  },
+
   submitter: {
     type: SingleSelectFilter,
     name: 'Submitter',

--- a/metaspace/webapp/src/graphqlClient.ts
+++ b/metaspace/webapp/src/graphqlClient.ts
@@ -49,4 +49,9 @@ const apolloClient = new ApolloClient({
   cache: new InMemoryCache(),
 });
 
+export const refreshLoginStatus = async () => {
+  await tokenAutorefresh.refreshJwt(true);
+  await apolloClient.resetStore();
+};
+
 export default apolloClient;

--- a/metaspace/webapp/src/main.ts
+++ b/metaspace/webapp/src/main.ts
@@ -33,11 +33,12 @@ const isProd = process.env.NODE_ENV === 'production';
 
 import VueAnalytics from 'vue-analytics';
 import { setErrorNotifier } from './lib/reportError'
+
 Vue.use(VueAnalytics, {
   id: 'UA-73509518-1',
   router,
   autoTracking: {
-    exception: true
+    exception: isProd // disabled in dev because it impairs "break on uncaught exception"
   },
   debug: {
     enabled: !isProd,

--- a/metaspace/webapp/src/modules/Account/components/ResetPasswordPage.vue
+++ b/metaspace/webapp/src/modules/Account/components/ResetPasswordPage.vue
@@ -83,13 +83,11 @@
     }
 
     validatePassword(rule: object, value: string, callback: Function) {
-      console.log(arguments);
       (this.$refs.form as Form).validateField('confirmPassword', () => {});
       callback();
     };
 
     validateConfirmPassword(rule: object, value: string, callback: Function) {
-      console.log(arguments, this.model.confirmPassword);
       if (value && this.model.password && value !== this.model.password) {
         callback(new Error('Passwords must match'));
       } else {

--- a/metaspace/webapp/src/modules/Account/components/ResetPasswordPage.vue
+++ b/metaspace/webapp/src/modules/Account/components/ResetPasswordPage.vue
@@ -44,7 +44,7 @@
   import { Form } from 'element-ui';
   import { validatePasswordResetToken, resetPassword } from '../../../api/auth';
   import reportError from '../../../lib/reportError';
-  import tokenAutorefresh from '../../../tokenAutorefresh';
+  import { refreshLoginStatus } from '../../../graphqlClient';
 
   interface Model {
     password: string;
@@ -102,7 +102,7 @@
       try {
         this.isSubmitting = true;
         await resetPassword(this.token, this.email, this.model.password);
-        await tokenAutorefresh.refreshJwt(true);
+        await refreshLoginStatus();
         this.$router.push('/');
         this.$alert('Your password has been successfully reset.', 'Password reset', {type: 'success'});
       } catch (err) {

--- a/metaspace/webapp/src/modules/Account/components/SignInDialog.spec.ts
+++ b/metaspace/webapp/src/modules/Account/components/SignInDialog.spec.ts
@@ -13,9 +13,9 @@ jest.mock('../../../api/auth');
 import * as _mockAuthApi from '../../../api/auth';
 const mockAuthApi = _mockAuthApi as jest.Mocked<typeof _mockAuthApi>;
 
-jest.mock('../../../tokenAutorefresh');
-import _mockTokenAutorefresh from '../../../tokenAutorefresh';
-const mockTokenAutorefresh = _mockTokenAutorefresh as jest.Mocked<typeof _mockTokenAutorefresh>;
+jest.mock('../../../graphqlClient');
+import {refreshLoginStatus as _mockRefreshLoginStatus} from '../../../graphqlClient';
+const mockRefreshLoginStatus = _mockRefreshLoginStatus as jest.Mocked<typeof _mockRefreshLoginStatus>;
 
 Vue.use(ElementUI);
 registerMockComponent('el-dialog');
@@ -68,7 +68,7 @@ describe('SignInDialog', () => {
 
     // Assert
     expect(mockAuthApi.signInByEmail).toBeCalledWith(email, password);
-    expect(mockTokenAutorefresh.refreshJwt).toBeCalledWith(true);
+    expect(mockRefreshLoginStatus).toBeCalled();
     expect(store.state.account.dialog).toBe(null);
   });
 });

--- a/metaspace/webapp/src/modules/Account/components/SignInDialog.vue
+++ b/metaspace/webapp/src/modules/Account/components/SignInDialog.vue
@@ -62,7 +62,7 @@
   import GoogleButton from './GoogleButton.vue';
   import InterDialogLink from './InterDialogLink';
   import { signInByEmail } from '../../../api/auth';
-  import tokenAutorefresh from '../../../tokenAutorefresh';
+  import { refreshLoginStatus } from '../../../graphqlClient';
   import reportError from '../../../lib/reportError';
 
   interface Model {
@@ -107,7 +107,7 @@
         this.isSubmitting = true;
         const authenticated = await signInByEmail(email, password);
         if (authenticated) {
-          await tokenAutorefresh.refreshJwt(true);
+          await refreshLoginStatus();
           this.onClose();
         } else {
           form.clearValidate();

--- a/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.spec.ts
+++ b/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.spec.ts
@@ -1,0 +1,56 @@
+import { mount, Wrapper } from '@vue/test-utils';
+import VueRouter from 'vue-router';
+import ElementUI from 'element-ui';
+import Vuex from 'vuex';
+import Vue from 'vue';
+import TransferDatasetsDialog from './TransferDatasetsDialog.vue';
+import router from '../../router';
+import registerMockComponent from '../../../tests/utils/registerMockComponent';
+jest.mock('../../components/DatasetItem.vue', () => require('../../../tests/utils/mockComponent')('dataset-item'));
+
+Vue.use(ElementUI);
+registerMockComponent('el-dialog');
+Vue.use(VueRouter);
+Vue.use(Vuex);
+
+describe('TransferDatasetsDialog', () => {
+  const mockDatasets = [
+    { "id": "2018-06-28_13h23m10s", "name": "Untreated_3_434", "uploadDT": "2018-06-28T13:23:10.837000" },
+    { "id": "2018-06-28_13h21m36s", "name": "Dataset 2", "uploadDT": "2018-06-28T13:21:36.973867" },
+    { "id": "2018-06-28_12h03m36s", "name": "Dataset 3", "uploadDT": "2018-06-28T12:03:36.409743" },
+    { "id": "2018-06-28_13h20m44s", "name": "Dataset 4", "uploadDT": "2018-06-28T13:20:44.736472" },
+  ];
+  const mockProps = {
+    currentUserId: 'current user id',
+    groupName: 'Group Name',
+    isInvited: true
+  };
+  [false, true].forEach(hasDatasets => {
+    [false, true].forEach(isInvited => {
+      it(`should match snapshot (${hasDatasets ? 'datasets to import' : 'no datasets'}, ${isInvited ? 'invited' : 'requesting access'})`, () => {
+        const propsData = { ...mockProps, isInvited };
+        const wrapper = mount(TransferDatasetsDialog, { router, propsData });
+        wrapper.setData({ allDatasets: hasDatasets ? mockDatasets : [] });
+
+        expect(wrapper).toMatchSnapshot();
+      });
+    })
+  });
+
+  it('should call back on success when some datasets are selected', async () => {
+    const wrapper = mount(TransferDatasetsDialog, { router, propsData: mockProps });
+    wrapper.setData({ allDatasets: mockDatasets });
+
+    wrapper.find(ElementUI.Checkbox).trigger('click');
+    wrapper.findAll(ElementUI.Button)
+      .filter((b: Wrapper<ElementUI.Button>) => b.props().type === 'primary')
+      .at(0)
+      .trigger('click');
+    await Vue.nextTick();
+
+    expect(wrapper.emitted('accept')).toEqual([
+      [mockDatasets.slice(1).map(ds => ds.id)]
+    ])
+  })
+
+});

--- a/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.vue
@@ -1,0 +1,139 @@
+<template>
+    <el-dialog class="dialog"
+               visible
+               :title="allDatasets.length > 0 ? 'Transfer datasets' : 'Join group'"
+               @close="handleClose">
+      <div v-loading="loading">
+        <div v-if="allDatasets.length > 0">
+          <p style="margin-top: 0">
+            You have previously uploaded one or more datasets without a group. Do you want to transfer any of these datasets to {{groupName}}?
+          </p>
+          <div class="dataset-list">
+            <div v-for="dataset in allDatasets">
+              <el-checkbox v-model="selectedDatasets[dataset.id]">{{dataset.name}}</el-checkbox>
+            </div>
+          </div>
+          <div class="select-buttons">
+            <a href="#" @click.prevent="handleSelectNone">Select none</a>
+            <span> | </span>
+            <a href="#" @click.prevent="handleSelectAll">Select all</a>
+          </div>
+          <p v-if="!isInvited">
+            An email will be sent to the group's principal investigator to confirm your access.
+          </p>
+          <div class="button-bar">
+            <el-button :disabled="isSubmitting" @click="handleClose">Cancel</el-button>
+            <el-button type="primary" :loading="isSubmitting" @click="handleAccept">{{acceptText}}</el-button>
+          </div>
+        </div>
+        <div v-else>
+          <p v-if="!isInvited" style="margin-top: 0">
+            An email will be sent to the group's principal investigator to confirm your access.
+          </p>
+          <p v-else style="margin-top: 0">
+            Are you sure you want to join {{groupName}}?
+          </p>
+          <div class="button-bar">
+            <el-button :disabled="isSubmitting" @click="handleClose">Cancel</el-button>
+            <el-button type="primary" :loading="isSubmitting" @click="handleAccept">{{acceptText}}</el-button>
+          </div>
+        </div>
+      </div>
+    </el-dialog>
+</template>
+<script lang="ts">
+  import Vue from 'vue';
+  import { Component, Prop, Watch } from 'vue-property-decorator';
+  import { DatasetListItem, datasetListItemsQuery } from '../../api/dataset';
+  import { fromPairs } from 'lodash-es';
+
+  @Component({
+    apollo: {
+      allDatasets: {
+        query: datasetListItemsQuery,
+        loadingKey: 'loading',
+        variables(this: TransferDatasetsDialog) {
+          return {
+            dFilter: {
+              submitter: this.currentUserId,
+              hasGroup: false,
+            }
+          };
+        }
+      }
+    }
+  })
+  export default class TransferDatasetsDialog extends Vue {
+    @Prop({ required: true })
+    currentUserId!: string; //TODO: It's weird to have this as a prop. It would be better to grab it from Vuex.
+    @Prop({ required: true })
+    groupName!: string;
+    @Prop({ required: true })
+    isInvited!: boolean; // True to show "Accept/reject invitation", false to show "Request access/cancel"
+
+    loading: number = 0;
+    allDatasets: DatasetListItem[] = [];
+    selectedDatasets: Record<string, boolean> = {};
+    isSubmitting: Boolean = false;
+
+    get numSelected() {
+      return Object.values(this.selectedDatasets).filter(selected => selected).length;
+    }
+
+    get acceptText() {
+      const action = this.isInvited ? 'Join group' : 'Request access';
+      return this.numSelected === 0
+        ? action
+        : `${action} and transfer ${this.numSelected} ${this.numSelected === 1 ? 'dataset' : 'datasets'}`
+    }
+
+    @Watch('allDatasets')
+    populateSelectedDatasets() {
+      //Rebuild `selectedDatasets` so that the keys are in sync with the ids from `datasets`
+      this.selectedDatasets = fromPairs(this.allDatasets.map(({id}) => {
+        return [id, id in this.selectedDatasets ? this.selectedDatasets[id] : true];
+      }));
+    }
+
+    handleClose() {
+      if (!this.isSubmitting) {
+        this.$emit('close');
+      }
+    }
+
+    handleSelectNone() {
+      Object.keys(this.selectedDatasets).forEach(key => this.selectedDatasets[key] = false);
+    }
+
+    handleSelectAll() {
+      Object.keys(this.selectedDatasets).forEach(key => this.selectedDatasets[key] = true);
+    }
+
+    handleAccept() {
+      const selectedDatasetIds = Object.keys(this.selectedDatasets).filter(key => this.selectedDatasets[key]);
+      this.$emit('accept', selectedDatasetIds);
+      this.isSubmitting = true;
+    }
+  }
+</script>
+<style scoped lang="scss">
+  .dialog /deep/ .el-dialog {
+    max-width: 600px;
+  }
+  .dataset-list {
+    margin: 20px;
+    max-height: 50vh;
+    overflow: auto;
+  }
+  .select-buttons {
+    text-align: right;
+    margin: 20px;
+  }
+  .button-bar {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    margin-top: 20px;
+  }
+
+</style>

--- a/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.vue
@@ -10,7 +10,10 @@
           </p>
           <div class="dataset-list">
             <div v-for="dataset in allDatasets">
-              <el-checkbox v-model="selectedDatasets[dataset.id]">{{dataset.name}}</el-checkbox>
+              <el-checkbox v-model="selectedDatasets[dataset.id]">
+                {{dataset.name}}
+                <span class="reset-color">(Submitted {{ formatDate(dataset.uploadDT) }})</span>
+              </el-checkbox>
             </div>
           </div>
           <div class="select-buttons">
@@ -46,6 +49,7 @@
   import { Component, Prop, Watch } from 'vue-property-decorator';
   import { DatasetListItem, datasetListItemsQuery } from '../../api/dataset';
   import { fromPairs } from 'lodash-es';
+  import format from 'date-fns/format';
 
   @Component({
     apollo: {
@@ -87,6 +91,10 @@
         : `${action} and transfer ${this.numSelected} ${this.numSelected === 1 ? 'dataset' : 'datasets'}`
     }
 
+    formatDate(date) {
+      return `${format(date, 'YYYY-MM-DD')} at ${format(date, 'HH:mm')}`;
+    }
+
     @Watch('allDatasets')
     populateSelectedDatasets() {
       //Rebuild `selectedDatasets` so that the keys are in sync with the ids from `datasets`
@@ -117,6 +125,7 @@
   }
 </script>
 <style scoped lang="scss">
+  @import "~element-ui/packages/theme-chalk/src/common/var";
   .dialog /deep/ .el-dialog {
     max-width: 600px;
   }
@@ -134,6 +143,9 @@
     flex-wrap: wrap;
     justify-content: flex-end;
     margin-top: 20px;
+  }
+  .reset-color {
+    color: $--color-text-regular;
   }
 
 </style>

--- a/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.vue
@@ -91,7 +91,7 @@
         : `${action} and transfer ${this.numSelected} ${this.numSelected === 1 ? 'dataset' : 'datasets'}`
     }
 
-    formatDate(date) {
+    formatDate(date: string) {
       return `${format(date, 'YYYY-MM-DD')} at ${format(date, 'HH:mm')}`;
     }
 

--- a/metaspace/webapp/src/modules/GroupProfile/ViewGroupProfile.spec.ts
+++ b/metaspace/webapp/src/modules/GroupProfile/ViewGroupProfile.spec.ts
@@ -1,0 +1,56 @@
+import { mount, Stubs } from '@vue/test-utils';
+import VueRouter from 'vue-router';
+import ElementUI from 'element-ui';
+import Vue from 'vue';
+import ViewGroupProfile from './ViewGroupProfile.vue';
+import router from '../../router';
+
+Vue.use(ElementUI);
+Vue.use(VueRouter);
+
+
+describe('ViewGroupProfile', () => {
+
+  const mockData = {
+    currentUser: { id: 'userid' },
+    group: {
+      id: 'groupId',
+      name: 'group name',
+      shortName: 'groupShortName'
+    },
+    currentUserRoleInGroup: null,
+    allDatasets: [
+      { id: 'datasetId1', name: 'dataset name 1' },
+      { id: 'datasetId2', name: 'dataset name 2' },
+      { id: 'datasetId3', name: 'dataset name 3' },
+    ],
+    countDatasets: 3
+  };
+
+  const stubs: Stubs = {
+    DatasetItem: true
+  };
+
+  it('should match snapshot (non-member)', () => {
+    const wrapper = mount(ViewGroupProfile, { router, stubs });
+    wrapper.setData({
+      loaded: true,
+      data: mockData,
+      maxVisibleDatasets: 2
+    });
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should match snapshot (invited)', () => {
+    const wrapper = mount<Vue>(ViewGroupProfile, { router, stubs });
+    wrapper.setData({
+      loaded: true,
+      data: {
+        ...mockData,
+        currentUserRoleInGroup: 'INVITED'
+      },
+      maxVisibleDatasets: 2
+    });
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/metaspace/webapp/src/modules/GroupProfile/ViewGroupProfile.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/ViewGroupProfile.vue
@@ -205,7 +205,6 @@
       await this.doSubmit('rejectInvite', async () => {
         await this.$apollo.mutate({
           mutation: leaveGroupMutation,
-          loadingKey: 'loading',
           variables: { groupId: this.groupId },
         });
         await this.$apollo.queries.data.refetch();
@@ -221,7 +220,6 @@
         await this.doSubmit('acceptInvite', async () => {
           await this.$apollo.mutate({
             mutation: acceptGroupInvitationMutation,
-            loadingKey: 'loading',
             variables: { groupId: this.groupId, bringDatasets: selectedDatasetIds },
           });
           await this.$apollo.queries.data.refetch();
@@ -230,7 +228,6 @@
         await this.doSubmit('requestAccess', async () => {
           await this.$apollo.mutate({
             mutation: requestAccessToGroupMutation,
-            loadingKey: 'loading',
             variables: { groupId: this.groupId, bringDatasets: selectedDatasetIds },
           });
           await this.$apollo.queries.data.refetch();

--- a/metaspace/webapp/src/modules/GroupProfile/ViewGroupProfile.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/ViewGroupProfile.vue
@@ -126,29 +126,30 @@
             groupId: this.groupId
           }
         },
-        update(this: ViewGroupProfile, data: ViewGroupProfileData) {
-          this.loaded = true;
-          this.currentUserId = data.currentUser ? data.currentUser.id : null;
-          this.group = data.group;
-          this.roleInGroup = data.currentUserRoleInGroup;
-          this.groupDatasets = data.allDatasets;
-          this.countDatasets = data.countDatasets;
+        watchLoading(this: ViewGroupProfile, isLoading: boolean) {
+          // Not using 'loadingKey' pattern here to avoid getting a full-page loading spinner when the user clicks a
+          // button that causes this query to refetch
+          if (!isLoading) {
+            this.loaded = true;
+          }
+        },
+        update(data) {
           return data;
         }
       },
     }
   })
   export default class ViewGroupProfile extends Vue {
-    loaded = false; // Not using 'loadingKey' pattern as the full-page loading spinner doesn't look good when refreshing data
+    loaded = false;
     showTransferDatasetsDialog: boolean = false;
-    data?: ViewGroupProfileData;
+    data: ViewGroupProfileData | null = null;
 
-    currentUserId: string | null = null;
-    group: GroupInfo | null = null;
-    roleInGroup: UserGroupRole | null = null;
-    groupDatasets: DatasetDetailItem[] = [];
+    get currentUserId(): string | null { return this.data && this.data.currentUser && this.data.currentUser.id }
+    get group(): GroupInfo | null { return this.data && this.data.group; }
+    get roleInGroup(): UserGroupRole | null { return this.data && this.data.currentUserRoleInGroup; }
+    get groupDatasets(): DatasetDetailItem[] { return this.data && this.data.allDatasets || []; }
+    get countDatasets(): number { return this.data && this.data.countDatasets || 0; }
     maxVisibleDatasets = 8;
-    countDatasets: number = 0;
     submitAction: SubmitActionType = null; // Used for indicating which button is loading
 
 

--- a/metaspace/webapp/src/modules/GroupProfile/ViewGroupProfile.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/ViewGroupProfile.vue
@@ -1,0 +1,302 @@
+<template>
+  <div>
+    <div v-loading="!loaded" class="page">
+      <div v-if="group != null" class="page-content">
+        <transfer-datasets-dialog
+          v-if="showTransferDatasetsDialog"
+          :currentUserId="currentUserId"
+          :groupName="group.name"
+          :isInvited="isInvited"
+          @accept="handleAcceptTransferDatasets"
+          @close="handleCloseTransferDatasetsDialog"
+        />
+        <div class="header-row">
+          <div class="header-names">
+            <h1>{{group.name}}</h1>
+            <h2 class="short-name">({{group.shortName}})</h2>
+          </div>
+
+          <div class="header-buttons">
+            <el-button v-if="roleInGroup == null"
+                       type="primary"
+                       @click="handleRequestAccess"
+                       :disabled="!!submitAction"
+                       :loading="submitAction === 'requestAccess'">
+              Request access
+            </el-button>
+            <el-button v-if="roleInGroup === 'PENDING'"
+                       disabled>
+              Request sent
+            </el-button>
+            <el-button v-if="roleInGroup === 'PRINCIPAL_INVESTIGATOR'"
+                       type="primary"
+                       @click="handleManageGroup">
+              Manage group
+            </el-button>
+          </div>
+          <el-alert v-if="roleInGroup === 'INVITED'"
+                    type="info"
+                    show-icon
+                    :closable="false"
+                    title="">
+            <div style="padding: 0 0 20px 20px;">
+              <p>
+                You have been invited to join {{group.name}}.
+              </p>
+              <div>
+                <el-button type="danger" @click="handleRejectInvite" :disabled="!!submitAction" :loading="submitAction === 'rejectInvite'">
+                  Decline invitation
+                </el-button>
+                <el-button type="primary" @click="handleAcceptInvite" :disabled="!!submitAction">
+                  Join group
+                </el-button>
+              </div>
+            </div>
+          </el-alert>
+        </div>
+        <div v-if="groupDatasets.length > 0">
+          <h1>Datasets</h1>
+
+          <div class="dataset-list">
+            <dataset-item v-for="(dataset, i) in groupDatasets.slice(0,8)"
+                          :dataset="dataset" :key="dataset.id"
+                          :class="[i%2 ? 'even': 'odd']" />
+          </div>
+          <div class="dataset-list-footer">
+            <router-link v-if="countDatasets > maxVisibleDatasets" :to="datasetsListLink">See all datasets</router-link>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+  import Vue from 'vue';
+  import { Component } from 'vue-property-decorator';
+  import { DatasetDetailItem, datasetDetailItemFragment } from '../../api/dataset';
+  import DatasetItem from '../../components/DatasetItem.vue';
+  import { acceptGroupInvitationMutation, leaveGroupMutation, requestAccessToGroupMutation } from '../../api/group';
+  import gql from 'graphql-tag';
+  import reportError from '../../lib/reportError';
+  import TransferDatasetsDialog from './TransferDatasetsDialog.vue';
+
+  type UserGroupRole = 'INVITED' | 'PENDING' | 'MEMBER' | 'PRINCIPAL_INVESTIGATOR';
+
+  type SubmitActionType = null | 'requestAccess' | 'rejectInvite' | 'acceptInvite';
+
+  interface GroupInfo {
+    name: string;
+    shortName: string;
+  }
+
+  interface ViewGroupProfileData {
+    currentUser: { id: string; } | null;
+    group: GroupInfo | null;
+    currentUserRoleInGroup: UserGroupRole | null;
+    allDatasets: DatasetDetailItem[];
+    countDatasets: number;
+  }
+
+  @Component({
+    components: {
+      DatasetItem,
+      TransferDatasetsDialog,
+    },
+    apollo: {
+      data: {
+        query: gql`query ViewGroupProfile($groupId: ID!, $maxVisibleDatasets: Int!, $inpFdrLvls: [Int!] = [10], $checkLvl: Int = 10) {
+          currentUser {
+            id
+          }
+          group(id: $groupId) {
+            name
+            shortName
+          }
+          currentUserRoleInGroup(groupId: $groupId)
+          allDatasets(offset: 0, limit: $maxVisibleDatasets, filter: { group: $groupId }) {
+            ...DatasetDetailItem
+          }
+          countDatasets(filter: { group: $groupId })
+        }
+
+        ${datasetDetailItemFragment}`,
+        variables(this: ViewGroupProfile) {
+          return {
+            maxVisibleDatasets: this.maxVisibleDatasets,
+            groupId: this.groupId
+          }
+        },
+        update(this: ViewGroupProfile, data: ViewGroupProfileData) {
+          this.loaded = true;
+          this.currentUserId = data.currentUser ? data.currentUser.id : null;
+          this.group = data.group;
+          this.roleInGroup = data.currentUserRoleInGroup;
+          this.groupDatasets = data.allDatasets;
+          this.countDatasets = data.countDatasets;
+          return data;
+        }
+      },
+    }
+  })
+  export default class ViewGroupProfile extends Vue {
+    loaded = false; // Not using 'loadingKey' pattern as the full-page loading spinner doesn't look good when refreshing data
+    showTransferDatasetsDialog: boolean = false;
+    data?: ViewGroupProfileData;
+
+    currentUserId: string | null = null;
+    group: GroupInfo | null = null;
+    roleInGroup: UserGroupRole | null = null;
+    groupDatasets: DatasetDetailItem[] = [];
+    maxVisibleDatasets = 8;
+    countDatasets: number = 0;
+    submitAction: SubmitActionType = null; // Used for indicating which button is loading
+
+
+    get groupId(): string {
+      return this.$route.params.groupId;
+    }
+
+    get isInvited(): boolean {
+      return this.data != null && this.data.currentUserRoleInGroup === 'INVITED';
+    }
+
+    get datasetsListLink() {
+      return {
+        path: '/datasets',
+        query: {
+          group: this.groupId
+        }
+      }
+    }
+
+    async doSubmit(type: SubmitActionType, func: () => Promise<void>) {
+      // Wrapper for functions that submit, so that loading indicators are consistent
+      if (this.submitAction != null) {
+        return;
+      }
+      this.submitAction = type;
+      try {
+        await func();
+      } catch (err) {
+        reportError(err);
+      } finally {
+        this.submitAction = null;
+      }
+    }
+
+    async handleRequestAccess() {
+      this.showTransferDatasetsDialog = true;
+    }
+
+    async handleAcceptInvite() {
+      this.showTransferDatasetsDialog = true;
+    }
+
+    async handleRejectInvite() {
+      try {
+        await this.$confirm(
+          "Are you sure?",
+          "Decline invitation", {
+            confirmButtonText: "Decline invitation"
+          });
+      } catch (err) {
+        return; // User clicked Cancel
+      }
+      await this.doSubmit('rejectInvite', async () => {
+        await this.$apollo.mutate({
+          mutation: leaveGroupMutation,
+          loadingKey: 'loading',
+          variables: { groupId: this.groupId },
+        });
+        await this.$apollo.queries.data.refetch();
+      });
+    }
+
+    handleManageGroup() {
+      this.$router.push(`/group/${this.groupId}/edit`);
+    }
+
+    async handleAcceptTransferDatasets(selectedDatasetIds: string[]) {
+      if (this.isInvited) {
+        await this.doSubmit('acceptInvite', async () => {
+          await this.$apollo.mutate({
+            mutation: acceptGroupInvitationMutation,
+            loadingKey: 'loading',
+            variables: { groupId: this.groupId, bringDatasets: selectedDatasetIds },
+          });
+          await this.$apollo.queries.data.refetch();
+        })
+      } else {
+        await this.doSubmit('requestAccess', async () => {
+          await this.$apollo.mutate({
+            mutation: requestAccessToGroupMutation,
+            loadingKey: 'loading',
+            variables: { groupId: this.groupId, bringDatasets: selectedDatasetIds },
+          });
+          await this.$apollo.queries.data.refetch();
+        })
+      }
+      this.showTransferDatasetsDialog = false;
+    }
+
+    handleCloseTransferDatasetsDialog() {
+      this.showTransferDatasetsDialog = false;
+    }
+  }
+
+</script>
+<style scoped lang="scss">
+
+  .page {
+    display: flex;
+    justify-content: center;
+    min-height: 80vh; // Ensure there's space for the loading spinner before is visible
+  }
+  .page-content {
+    width: 820px;
+
+    @media (min-width: 1650px) {
+      /* 2 datasets per row on wide screens */
+      width: 1620px;
+    }
+  }
+
+  .header-row {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  .header-names {
+    display: flex;
+    align-items: baseline;
+  }
+  .short-name {
+    margin-left: 16px;
+    color: grey;
+  }
+  .header-buttons {
+    display: flex;
+    justify-content: flex-end;
+    flex-grow: 1;
+    align-self: center;
+    margin-right: 3px;
+  }
+
+  .even {
+    background-color: #e6f1ff;
+
+    @media (min-width: 1650px) {
+      background-color: white;
+    }
+  }
+
+  .odd {
+    background-color: white;
+  }
+
+  .dataset-list {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: stretch;
+  }
+</style>

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/TransferDatasetsDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/TransferDatasetsDialog.spec.ts.snap
@@ -1,0 +1,177 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TransferDatasetsDialog should match snapshot (datasets to import, invited) 1`] = `
+<mock-el-dialog visible="" title="Transfer datasets" class="dialog">
+  <div>
+    <div>
+      <p style="margin-top: 0px;">
+        You have previously uploaded one or more datasets without a group. Do you want to transfer any of these datasets to Group Name?
+      </p>
+      <div class="dataset-list">
+        <div>
+          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
+            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
+            </span><span class="el-checkbox__label">
+            Untreated_3_434
+            <span class="reset-color">(Submitted 2018-06-28 at 13:23)</span>
+            <!---->
+            </span>
+          </label>
+        </div>
+        <div>
+          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
+            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
+            </span><span class="el-checkbox__label">
+            Dataset 2
+            <span class="reset-color">(Submitted 2018-06-28 at 13:21)</span>
+            <!---->
+            </span>
+          </label>
+        </div>
+        <div>
+          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
+            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
+            </span><span class="el-checkbox__label">
+            Dataset 3
+            <span class="reset-color">(Submitted 2018-06-28 at 12:03)</span>
+            <!---->
+            </span>
+          </label>
+        </div>
+        <div>
+          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
+            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
+            </span><span class="el-checkbox__label">
+            Dataset 4
+            <span class="reset-color">(Submitted 2018-06-28 at 13:20)</span>
+            <!---->
+            </span>
+          </label>
+        </div>
+      </div>
+      <div class="select-buttons">
+        <a href="#">Select none</a> <span> | </span>
+        <a href="#">Select all</a>
+      </div>
+      <!---->
+      <div class="button-bar">
+        <button type="button" class="el-button el-button--default">
+          <!---->
+          <!----><span>Cancel</span></button>
+        <button type="button" class="el-button el-button--primary">
+          <!---->
+          <!----><span>Join group and transfer 4 datasets</span></button>
+      </div>
+    </div>
+  </div>
+</mock-el-dialog>
+`;
+
+exports[`TransferDatasetsDialog should match snapshot (datasets to import, requesting access) 1`] = `
+<mock-el-dialog visible="" title="Transfer datasets" class="dialog">
+  <div>
+    <div>
+      <p style="margin-top: 0px;">
+        You have previously uploaded one or more datasets without a group. Do you want to transfer any of these datasets to Group Name?
+      </p>
+      <div class="dataset-list">
+        <div>
+          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
+            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
+            </span><span class="el-checkbox__label">
+            Untreated_3_434
+            <span class="reset-color">(Submitted 2018-06-28 at 13:23)</span>
+            <!---->
+            </span>
+          </label>
+        </div>
+        <div>
+          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
+            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
+            </span><span class="el-checkbox__label">
+            Dataset 2
+            <span class="reset-color">(Submitted 2018-06-28 at 13:21)</span>
+            <!---->
+            </span>
+          </label>
+        </div>
+        <div>
+          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
+            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
+            </span><span class="el-checkbox__label">
+            Dataset 3
+            <span class="reset-color">(Submitted 2018-06-28 at 12:03)</span>
+            <!---->
+            </span>
+          </label>
+        </div>
+        <div>
+          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
+            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
+            </span><span class="el-checkbox__label">
+            Dataset 4
+            <span class="reset-color">(Submitted 2018-06-28 at 13:20)</span>
+            <!---->
+            </span>
+          </label>
+        </div>
+      </div>
+      <div class="select-buttons">
+        <a href="#">Select none</a> <span> | </span>
+        <a href="#">Select all</a>
+      </div>
+      <p>
+        An email will be sent to the group's principal investigator to confirm your access.
+      </p>
+      <div class="button-bar">
+        <button type="button" class="el-button el-button--default">
+          <!---->
+          <!----><span>Cancel</span></button>
+        <button type="button" class="el-button el-button--primary">
+          <!---->
+          <!----><span>Request access and transfer 4 datasets</span></button>
+      </div>
+    </div>
+  </div>
+</mock-el-dialog>
+`;
+
+exports[`TransferDatasetsDialog should match snapshot (no datasets, invited) 1`] = `
+<mock-el-dialog visible="" title="Join group" class="dialog">
+  <div>
+    <div>
+      <p style="margin-top: 0px;">
+        Are you sure you want to join Group Name?
+      </p>
+      <div class="button-bar">
+        <button type="button" class="el-button el-button--default">
+          <!---->
+          <!----><span>Cancel</span></button>
+        <button type="button" class="el-button el-button--primary">
+          <!---->
+          <!----><span>Join group</span></button>
+      </div>
+    </div>
+  </div>
+</mock-el-dialog>
+`;
+
+exports[`TransferDatasetsDialog should match snapshot (no datasets, requesting access) 1`] = `
+<mock-el-dialog visible="" title="Join group" class="dialog">
+  <div>
+    <div>
+      <p style="margin-top: 0px;">
+        An email will be sent to the group's principal investigator to confirm your access.
+      </p>
+      <div class="button-bar">
+        <button type="button" class="el-button el-button--default">
+          <!---->
+          <!----><span>Cancel</span></button>
+        <button type="button" class="el-button el-button--primary">
+          <!---->
+          <!----><span>Request access</span></button>
+      </div>
+    </div>
+  </div>
+</mock-el-dialog>
+`;

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupProfile.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupProfile.spec.ts.snap
@@ -1,0 +1,94 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ViewGroupProfile should match snapshot (invited) 1`] = `
+<div>
+  <div class="page">
+    <div class="page-content">
+      <!---->
+      <div class="header-row">
+        <div class="header-names">
+          <h1>group name</h1>
+          <h2 class="short-name">(groupShortName)</h2>
+        </div>
+        <div class="header-buttons">
+          <!---->
+          <!---->
+          <!---->
+        </div>
+        <div role="alert" class="el-alert el-alert--info el-alert-fade-enter el-alert-fade-enter-active">
+          <i class="el-alert__icon el-icon-info is-big"></i>
+          <div class="el-alert__content">
+            <!---->
+            <div style="padding: 0px 0px 20px 20px;">
+              <p>
+                You have been invited to join group name.
+              </p>
+              <div>
+                <button type="button" class="el-button el-button--danger">
+                  <!---->
+                  <!----><span>
+                Decline invitation
+              </span></button>
+                <button type="button" class="el-button el-button--primary">
+                  <!---->
+                  <!----><span>
+                Join group
+              </span></button>
+              </div>
+            </div>
+            <i class="el-alert__closebtn el-icon-close" style="display: none;"></i>
+          </div>
+        </div>
+      </div>
+      <div>
+        <h1>Datasets</h1>
+        <div class="dataset-list">
+          <datasetitem-stub dataset="[object Object]" class="odd"></datasetitem-stub>
+          <datasetitem-stub dataset="[object Object]" class="even"></datasetitem-stub>
+          <datasetitem-stub dataset="[object Object]" class="odd"></datasetitem-stub>
+        </div>
+        <div class="dataset-list-footer">
+          <a href="#/datasets" class="">See all datasets</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ViewGroupProfile should match snapshot (non-member) 1`] = `
+<div>
+  <div class="page">
+    <div class="page-content">
+      <!---->
+      <div class="header-row">
+        <div class="header-names">
+          <h1>group name</h1>
+          <h2 class="short-name">(groupShortName)</h2>
+        </div>
+        <div class="header-buttons">
+          <button type="button" class="el-button el-button--primary">
+            <!---->
+            <!----><span>
+            Request access
+          </span></button>
+          <!---->
+          <!---->
+        </div>
+        <!---->
+      </div>
+      <div>
+        <h1>Datasets</h1>
+        <div class="dataset-list">
+          <datasetitem-stub dataset="[object Object]" class="odd"></datasetitem-stub>
+          <datasetitem-stub dataset="[object Object]" class="even"></datasetitem-stub>
+          <datasetitem-stub dataset="[object Object]" class="odd"></datasetitem-stub>
+        </div>
+        <div class="dataset-list-footer">
+          <a href="#/datasets" class="">See all datasets</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/metaspace/webapp/src/modules/GroupProfile/index.ts
+++ b/metaspace/webapp/src/modules/GroupProfile/index.ts
@@ -1,0 +1,1 @@
+export {default as ViewGroupProfile} from './ViewGroupProfile.vue'

--- a/metaspace/webapp/src/plotly.js.d.ts
+++ b/metaspace/webapp/src/plotly.js.d.ts
@@ -1,7 +1,0 @@
-interface ColorScale {
-  domain: number[]
-  range: any[]
-}
-
-declare module "plotly.js/src/components/colorscale/scales.js"
-declare module "plotly.js/src/components/colorscale/extract_scale.js"

--- a/metaspace/webapp/src/router.ts
+++ b/metaspace/webapp/src/router.ts
@@ -42,7 +42,9 @@ const router = new VueRouter({
       { path: '/account/create-account', component: DialogPage, props: {dialog: 'createAccount'} },
       { path: '/account/forgot-password', component: DialogPage, props: {dialog: 'forgotPassword'} },
       { path: '/account/reset-password', component: ResetPasswordPage },
-    ] : [])
+    ] : []),
+
+    { path: '/group/:groupId', component: async () => (await import(/* webpackPrefetch: true, webpackChunkName: "GroupPage" */ './modules/GroupProfile')).ViewGroupProfile },
   ]
 });
 

--- a/metaspace/webapp/src/store/getters.js
+++ b/metaspace/webapp/src/store/getters.js
@@ -40,11 +40,12 @@ export default {
 
   gqlDatasetFilter(state, getters) {
     const filter = getters.filter;
-    const {institution, submitter, datasetIds, polarity,
+    const {institution, group, submitter, datasetIds, polarity,
            organism, organismPart, condition, growthConditions,
            ionisationSource, analyzerType, maldiMatrix, metadataType} = filter;
     return {
       institution,
+      group: group && group.id,
       submitter: submitter && submitter.id,
 
       // temporary workaround because of array-related bugs in apollo-client

--- a/metaspace/webapp/src/url.ts
+++ b/metaspace/webapp/src/url.ts
@@ -10,6 +10,7 @@ interface Dictionary<T> {
 const FILTER_TO_URL: Dictionary<string> = {
   database: 'db',
   institution: 'lab',
+  group: 'grp',
   submitter: 'subm',
   datasetIds: 'ds',
   minMSM: 'msm',

--- a/metaspace/webapp/src/vue-shims.d.ts
+++ b/metaspace/webapp/src/vue-shims.d.ts
@@ -3,13 +3,10 @@ declare module "*.vue" {
   export default Vue;
 }
 
-declare module 'vue-apollo';
 declare module 'vue-analytics';
 declare module 'raven-js/plugins/vue';
 
 declare module "plotly.js/src/components/colorscale/scales.js"
 declare module "plotly.js/src/components/colorscale/extract_scale.js"
-
-declare module "vue-slide-up-down";
 
 declare module "vue-slide-up-down";

--- a/metaspace/webapp/tests/utils/setupTestFramework.ts
+++ b/metaspace/webapp/tests/utils/setupTestFramework.ts
@@ -1,0 +1,1 @@
+window.fetch = jest.fn();

--- a/metaspace/webapp/yarn.lock
+++ b/metaspace/webapp/yarn.lock
@@ -4253,12 +4253,6 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  dependencies:
-    iconv-lite "~0.4.13"
-
 end-of-stream@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.0.0.tgz#d4596e702734a93e40e9af864319eabd99ff2f0e"
@@ -6315,7 +6309,7 @@ iconv-lite@0.4.11:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.11.tgz#2ecb42fd294744922209a2e7c404dac8793d8ade"
 
-iconv-lite@0.4.19, iconv-lite@~0.4.13:
+iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
@@ -6813,7 +6807,7 @@ is-scoped@^1.0.0:
   dependencies:
     scoped-regex "^1.0.0"
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -8744,13 +8738,6 @@ node-cache@^4.1.1:
 node-dir@0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.8.tgz#55fb8deb699070707fb67f91a460f0448294c77d"
-
-node-fetch@1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-forge@0.7.5:
   version "0.7.5"

--- a/metaspace/webapp/yarn.lock
+++ b/metaspace/webapp/yarn.lock
@@ -3798,7 +3798,7 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.0.0"
     whatwg-url "^6.4.0"
 
-date-fns@^1.27.2:
+date-fns@^1.27.2, date-fns@^1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
 


### PR DESCRIPTION
Asana task: https://app.asana.com/0/474912821417535/739618576152066

This adds UI for users to be able to see a group and its datasets, request to join the group and import previously submitted datasets as they join a group.

Changes:
* Added UI for seeing a group, requesting access to a group, importing datasets into a group
* Refactored the menu bar a bit to add the user's current group, and a sub-menu to hold the Log Out link
* Added a `hasGroup` filter, a `Dataset.uploadDT` field, and stub code for the `currentUser` query to graphql
* Made logging in/out refresh all graphql data on the page (via `refreshLoginStatus`)
* Fixed a bug that caused the summary plots to not render. I think this was introduced with the `vue-apollo` upgrade
