### PR TITLE
Better reporting of TypeScript errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           name: Upload coverage
           command: |
             yarn run test --coverage
-            codecov -F webapp -p ../..
+            codecov --root ../.. -F webapp
 
   test-webapp-e2e:
     docker:
@@ -188,7 +188,7 @@ jobs:
           command: |
             source docker/env.sh
             #while true; do echo '---'; sleep 5; done   # uncomment this line for debugging
-            codecov -F engine -p ../..
+            codecov --root ../.. -F engine
 
   test-engine-sci:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           name: Upload coverage
           command: |
             yarn run test --coverage
-            codecov -F webapp
+            codecov -F webapp -p ../..
 
   test-webapp-e2e:
     docker:
@@ -188,7 +188,7 @@ jobs:
           command: |
             source docker/env.sh
             #while true; do echo '---'; sleep 5; done   # uncomment this line for debugging
-            codecov -F engine
+            codecov -F engine -p ../..
 
   test-engine-sci:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,9 +61,18 @@ jobs:
             cp ci/conf.js .
             cp ci/clientConfig.json src/
       - run:
+          name: Compile
+          command: |
+            yarn run build
+      - run:
           name: Run tests
           command: |
             yarn run test
+      - run:
+          name: Upload coverage
+          command: |
+            yarn run test --coverage
+            codecov
 
   test-webapp-e2e:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run:
           name: Compile
           command: |
-            yarn run build
+            yarn run build-ci
       - run:
           name: Run tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           name: Upload coverage
           command: |
             yarn run test --coverage
-            codecov
+            codecov -F webapp
 
   test-webapp-e2e:
     docker:
@@ -188,7 +188,7 @@ jobs:
           command: |
             source docker/env.sh
             #while true; do echo '---'; sleep 5; done   # uncomment this line for debugging
-            codecov
+            codecov -F engine
 
   test-engine-sci:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs:
           name: Install npm packages
           command: |
             yarn install
+            npm install -g codecov
       - save_cache:
           key: yarn-cache-{{checksum "yarn.lock"}}-{{checksum "../graphql/yarn.lock"}}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           name: Upload coverage
           command: |
             yarn run test --coverage
-            codecov --root ../.. -F webapp
+            codecov -p ../.. -F webapp
 
   test-webapp-e2e:
     docker:

--- a/metaspace/webapp/src/main.ts
+++ b/metaspace/webapp/src/main.ts
@@ -40,7 +40,7 @@ Vue.use(VueAnalytics, {
     exception: true
   },
   debug: {
-    enabled: !isProd,
+    // enabled: !isProd,
     sendHitTask: isProd
   }
 });

--- a/metaspace/webapp/webpack.common.js
+++ b/metaspace/webapp/webpack.common.js
@@ -88,6 +88,7 @@ module.exports.plugins = [
   new ForkTsCheckerWebpackPlugin({
     vue: true,
     workers: 2,
+    async: false,
     tsconfig: 'tsconfig.client.json'
   }),
 ];

--- a/metaspace/webapp/webpack.dev.config.js
+++ b/metaspace/webapp/webpack.dev.config.js
@@ -7,7 +7,7 @@ derefSchema('src/assets/');
 module.exports = {
   mode: 'development',
   entry: [
-    'webpack-hot-middleware/client?path=/__webpack_hmr&timeout=20000',
+    'webpack-hot-middleware/client?path=/__webpack_hmr&timeout=20000&overlay=false&reload=true',
     './src/main.ts'
   ],
   output,


### PR DESCRIPTION
* Adds a build step for webapp to CircleCI so that it 
* Adds codecov upload to CircleCI for webapp. Coverage is run as a separate pass from the normal tests because the `--coverage` instrumentation causes there to be inaccurate line numbers in stack traces, which would make debugging failed tests much.
* Outputs TypeScript errors to browser console, e.g.
![image](https://user-images.githubusercontent.com/26366936/43719658-911c6044-998e-11e8-8b3f-f40d47b2d2c0.png)

* Turns off `vue-analytics` debug mode so that there's less spam in the browser console.