### PR TITLE
Fixes

### DIFF
--- a/ansible/aws/group_vars_all.yml.template
+++ b/ansible/aws/group_vars_all.yml.template
@@ -163,6 +163,7 @@ sm_graphql_google_callback_url: "http://{{ sm_webapp_hostname }}/auth/google/cal
 sm_graphql_cookie_secret: COOKIE_SECRET
 sm_graphql_features:
   newAuth: false
+  graphqlMocks: false
 
 sm_webapp_hostname: "{{ web_host }}"
 sm_webapp_home: "{{ metaspace_home }}/metaspace/webapp"

--- a/ansible/aws/group_vars_all.yml.template
+++ b/ansible/aws/group_vars_all.yml.template
@@ -150,7 +150,7 @@ sm_graphql_rabbitmq_host: "{{ rabbitmq_host }}"
 sm_graphql_rabbitmq_user: "{{ rabbitmq_user }}"
 sm_graphql_rabbitmq_password: "{{ rabbitmq_password }}"
 sm_graphql_ws_public_endpoint: "ws://{{ sm_graphql_hostname }}/ws"
-sm_graphql_default_adducts: "{{ sm_default_adducts }}"
+sm_graphql_default_adducts: {{ sm_default_adducts }}
 sm_graphql_img_storage_backend: fs
 sm_graphql_redis_host: localhost
 sm_graphql_redis_port: 6379

--- a/metaspace/graphql/config/config.js.template
+++ b/metaspace/graphql/config/config.js.template
@@ -71,8 +71,8 @@ config.cookie.secret = "{{ sm_graphql_cookie_secret }}";
 
 config.google = {};
 config.google.client_id = "{{ sm_graphql_google_client_id }}";
-config.google.client_secret = "{{ sm_graphql_google_client_id }}";
-config.google.callback_url = "{{ sm_graphql_google_client_id }}";
+config.google.client_secret = "{{ sm_graphql_google_client_secret }}";
+config.google.callback_url = "{{ sm_graphql_google_callback_url }}";
 
 config.web_public_url = "{{ web_public_url }}";
 config.websocket_public_url = "{{ sm_graphql_ws_public_endpoint }}";

--- a/metaspace/graphql/resolvers.js
+++ b/metaspace/graphql/resolvers.js
@@ -263,6 +263,10 @@ const Resolvers = {
       } else {
         return null;
       }
+    },
+
+    allGroups() {
+      return []
     }
   },
 
@@ -327,7 +331,13 @@ const Resolvers = {
     metadataType(ds) { return dsField(ds, 'metadataType'); },
 
     submitter(ds) {
-      return _.get(ds._source.ds_meta, 'Submitted_By.Submitter');
+      const submitter = _.get(ds._source.ds_meta, 'Submitted_By.Submitter');
+      const name = submitter && (submitter.Name || `${submitter.First_Name} ${submitter.Surname}`) || 'Name';
+      return {
+        id: name, //FIXME: get from database
+        name: name,
+        ...submitter,
+      }
     },
 
     principalInvestigator(ds) {

--- a/metaspace/graphql/resolvers.js
+++ b/metaspace/graphql/resolvers.js
@@ -263,10 +263,6 @@ const Resolvers = {
       } else {
         return null;
       }
-    },
-
-    allGroups() {
-      return []
     }
   },
 
@@ -331,13 +327,7 @@ const Resolvers = {
     metadataType(ds) { return dsField(ds, 'metadataType'); },
 
     submitter(ds) {
-      const submitter = _.get(ds._source.ds_meta, 'Submitted_By.Submitter');
-      const name = submitter && (submitter.Name || `${submitter.First_Name} ${submitter.Surname}`) || 'Name';
-      return {
-        id: name, //FIXME: get from database
-        name: name,
-        ...submitter,
-      }
+      return _.get(ds._source.ds_meta, 'Submitted_By.Submitter');
     },
 
     principalInvestigator(ds) {

--- a/metaspace/graphql/server.js
+++ b/metaspace/graphql/server.js
@@ -65,6 +65,7 @@ function createHttpServerAsync(config) {
 
       if (config.features.graphqlMocks) {
         // TODO: Remove this when it's no longer needed for demoing
+        // TODO: Add test that runs assertResolveFunctionsPresent against schema + resolvers
         addMockFunctionsToSchema({
           schema,
           preserveResolvers: true,

--- a/metaspace/graphql/server.js
+++ b/metaspace/graphql/server.js
@@ -63,9 +63,30 @@ function createHttpServerAsync(config) {
       addResolveFunctionsToSchema(schema, Resolvers);
       addErrorLoggingToSchema(schema, logger);
 
-      if (process.env.NODE_ENV === 'development') {
-        addMockFunctionsToSchema({schema, preserveResolvers: true});
-      } else {
+      if (config.features.graphqlMocks) {
+        // TODO: Remove this when it's no longer needed for demoing
+        addMockFunctionsToSchema({
+          schema,
+          preserveResolvers: true,
+          mocks: {
+            // Make IDs somewhat deterministic
+            ID: (source, args, context, info) => {
+              let idx = 0;
+              let cur = info.path;
+              while (cur != null) {
+                if (/[0-9]+/.test(cur.key)) {
+                  idx = cur.key;
+                  break;
+                }
+                cur = cur.prev;
+              }
+              return `${info.parentType.name}_${idx}`
+            },
+          }
+        });
+      }
+
+      if (process.env.NODE_ENV !== 'development') {
         maskErrors(schema);
       }
 

--- a/metaspace/webapp/src/components/DatasetItem.vue
+++ b/metaspace/webapp/src/components/DatasetItem.vue
@@ -166,7 +166,7 @@
      },
 
      formatInstitution() {
-       return this.dataset.institution.replace(/\s/g, '&nbsp;');
+       return this.dataset.institution ? this.dataset.institution.replace(/\s/g, '&nbsp;') : '';
      },
 
      formatDatasetName() {
@@ -236,9 +236,9 @@
        const {user} = this.$store.state;
        if (!user)
          return false;
-       if (user.role == 'admin')
+       if (user.role === 'admin')
          return true;
-       if (user.email == this.dataset.submitter.email)
+       if (user.email != null && user.email === this.dataset.submitter.email)
          return true;
        return false;
      },

--- a/metaspace/webapp/src/components/MetadataEditor/DataManagementSection.vue
+++ b/metaspace/webapp/src/components/MetadataEditor/DataManagementSection.vue
@@ -240,10 +240,8 @@
     }
 
     get groupOptions() {
-      if (this.submitter == null || this.submitter.groups == null) {
-        return [];
-      }
-      const options = this.submitter.groups.map(({group: {id, name}}) => ({
+      const groups = this.submitter != null && this.submitter.groups || [];
+      const options = groups.map(({group: {id, name}}) => ({
         value: id,
         label: name,
       }));

--- a/metaspace/webapp/src/components/MetaspaceHeader.vue
+++ b/metaspace/webapp/src/components/MetaspaceHeader.vue
@@ -136,6 +136,7 @@
      currentUser: {
        query: gql`query {
          currentUser {
+           id
            primaryGroup {
              group {
                id

--- a/metaspace/webapp/src/graphqlClient.ts
+++ b/metaspace/webapp/src/graphqlClient.ts
@@ -50,8 +50,21 @@ const apolloClient = new ApolloClient({
 });
 
 export const refreshLoginStatus = async () => {
+  // Problem: `refreshJwt` updates the Vuex store, which sometimes immediately triggers new queries.
+  // `apolloClient.resetStore()` has an error if there are any in-flight queries, so it's not suitable to run it
+  // immediately after `refreshJwt`.
+  // Solution: Split the `resetStore` into two parts: invalidate old data before `refreshJwt` updates Vuex,
+  // then ensure that all queries are refetched.
+
+  await apolloClient.queryManager.clearStore();
   await tokenAutorefresh.refreshJwt(true);
-  await apolloClient.resetStore();
+  try {
+    await apolloClient.reFetchObservableQueries();
+  } catch (err) {
+    // reFetchObservableQueries throws an error if any queries fail.
+    // Let the source of the query handle it instead of breaking `refreshLoginStatus`.
+    console.error(err);
+  }
 };
 
 export default apolloClient;

--- a/metaspace/webapp/src/modules/GroupProfile/EditGroupMembersList.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/EditGroupMembersList.vue
@@ -26,7 +26,7 @@
         </template>
       </el-table-column>
 
-      <el-table-column label="Datasets" width="80" align="center">
+      <el-table-column label="Datasets" width="90" align="center">
         <template slot-scope="scope">
           <router-link :to="datasetsListLink(scope.row.user)">{{scope.row.numDatasets}}</router-link>
         </template>

--- a/metaspace/webapp/src/modules/GroupProfile/ViewGroupProfile.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/ViewGroupProfile.vue
@@ -123,14 +123,10 @@
             groupId: this.groupId
           }
         },
-        watchLoading(this: ViewGroupProfile, isLoading: boolean) {
+        update(data) {
           // Not using 'loadingKey' pattern here to avoid getting a full-page loading spinner when the user clicks a
           // button that causes this query to refetch
-          if (!isLoading) {
-            this.loaded = true;
-          }
-        },
-        update(data) {
+          this.loaded = true;
           return data;
         }
       },

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/EditGroupProfile.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/EditGroupProfile.spec.ts.snap
@@ -61,12 +61,12 @@ exports[`EditGroupProfile should match snapshot 1`] = `
           <div></div>
         </div>
         <div class="el-table__header-wrapper">
-          <table cellspacing="0" cellpadding="0" border="0" class="el-table__header" style="width: 840px;">
+          <table cellspacing="0" cellpadding="0" border="0" class="el-table__header" style="width: 850px;">
             <colgroup>
               <col name="el-table_1_column_1" width="200">
               <col name="el-table_1_column_2" width="200">
               <col name="el-table_1_column_3" width="160">
-              <col name="el-table_1_column_4" width="80">
+              <col name="el-table_1_column_4" width="90">
               <col name="el-table_1_column_5" width="200">
             </colgroup>
             <thead class="">
@@ -91,12 +91,12 @@ exports[`EditGroupProfile should match snapshot 1`] = `
           </table>
         </div>
         <div class="el-table__body-wrapper is-scrolling-left">
-          <table cellspacing="0" cellpadding="0" border="0" class="el-table__body" style="width: 840px;">
+          <table cellspacing="0" cellpadding="0" border="0" class="el-table__body" style="width: 850px;">
             <colgroup>
               <col name="el-table_1_column_1" width="200">
               <col name="el-table_1_column_2" width="200">
               <col name="el-table_1_column_3" width="160">
-              <col name="el-table_1_column_4" width="80">
+              <col name="el-table_1_column_4" width="90">
               <col name="el-table_1_column_5" width="200">
             </colgroup>
             <tbody>


### PR DESCRIPTION
This fixes several issues I came across when I deployed to Staging last week, as well as improving the mocked graphql data.

Fixed issues:
* sm-graphql's `config.defaults.adducts` was unexpectedly being set as a string instead of a JS object
* All 3 `config.google` settings were all being set to the `client_id`
* Datasets were all showing up as editable to anonymous users because `user.email` was `undefined` and `dataset.submitter.email` was undefined, causing `user.email === dataset.submitter.email` to be true.
* When a user isn't in any groups, the group selector in `MetadataEditor` wasn't showing any options
* The Apollo cache logged an error while it was being reset due to login/logout. The previous reset operation also triggered redundant queries.
* `ViewGroupProfile` wouldn't hide the loading spinner if data was loaded from cache

The mocked graphql data has been improved so that IDs are deterministically generated based on type and position in an array (e.g. `group_1`).