### PR TITLE
Create Project dialog

### DIFF
--- a/metaspace/graphql/schema.graphql
+++ b/metaspace/graphql/schema.graphql
@@ -243,6 +243,7 @@ input DatasetCreateInput {
   uploadDT: String
   submitterId: ID
   groupId: ID
+  projectIds: [ID!] = []
   principalInvestigator: PersonInput
   isPublic: Boolean! = true
   molDBs: [String!]!
@@ -256,6 +257,7 @@ input DatasetUpdateInput {
   metadataJson: String
   submitterId: ID
   groupId: ID
+  projectIds: [ID!] = []
   principalInvestigator: PersonInput
   isPublic: Boolean = true
   molDBs: [String!]

--- a/metaspace/webapp/src/api/annotation.ts
+++ b/metaspace/webapp/src/api/annotation.ts
@@ -78,6 +78,7 @@ export const tableExportQuery =
 export const annotationQuery =
   gql`query GetAnnotation($id: String!) {
     annotation(id: $id) {
+      id
       peakChartData
       isotopeImages {
         mz
@@ -93,6 +94,7 @@ export const allAdductsQuery =
     }, filter: {
       sumFormula: $molFormula, database: $db
     }) {
+      id
       mz
       adduct
       msmScore

--- a/metaspace/webapp/src/api/dataManagement.ts
+++ b/metaspace/webapp/src/api/dataManagement.ts
@@ -56,6 +56,14 @@ export const oneGroupQuery =
   }
 }`;
 
+export const oneProjectQuery =
+  gql`query($projectId: ID!) {
+  project(projectId:$projectId) {
+    id
+    name
+  }
+}`;
+
 export const allGroupsQuery =
 gql`query($query: String) {
   allGroups(query:$query) {

--- a/metaspace/webapp/src/api/metadata.ts
+++ b/metaspace/webapp/src/api/metadata.ts
@@ -8,6 +8,11 @@ export const editDatasetFragment =
     isPublic
     group {
       id
+      name
+    }
+    projects {
+      id
+      name
     }
     principalInvestigator {
       name

--- a/metaspace/webapp/src/api/user.ts
+++ b/metaspace/webapp/src/api/user.ts
@@ -46,6 +46,14 @@ export const userProfileQuery =
         name
       }
     }
+    projects {
+      role
+      numDatasets
+      project {
+        id
+        name
+      }
+    }
   }
 }
 `;
@@ -65,6 +73,12 @@ export interface DatasetSubmitterFragment {
       name: string;
     }
   }[] | null;
+  projects: {
+    project: {
+      id: string;
+      name: string;
+    }
+  }[] | null;
 }
 
 export const datasetSubmitterFragment =
@@ -79,6 +93,12 @@ export const datasetSubmitterFragment =
     }
     groups {
       group {
+        id
+        name
+      }
+    }
+    projects {
+      project {
         id
         name
       }

--- a/metaspace/webapp/src/components/DatasetCheckboxList.vue
+++ b/metaspace/webapp/src/components/DatasetCheckboxList.vue
@@ -36,7 +36,6 @@
       const selectedDatasets = fromPairs(this.datasets.map(({id}) => {
         return [id, id in this.selectedDatasets ? this.selectedDatasets[id] : true];
       }));
-      console.log(selectedDatasets);
       this.$emit('input', selectedDatasets);
     }
 

--- a/metaspace/webapp/src/components/DatasetCheckboxList.vue
+++ b/metaspace/webapp/src/components/DatasetCheckboxList.vue
@@ -1,0 +1,75 @@
+<template>
+  <div>
+    <div class="dataset-checkbox-list">
+      <div v-for="dataset in datasets">
+        <el-checkbox v-model="selectedDatasets[dataset.id]">
+          {{dataset.name}}
+          <span class="reset-color">(Submitted {{ formatDate(dataset.uploadDT) }})</span>
+        </el-checkbox>
+      </div>
+    </div>
+    <div class="select-buttons">
+      <a href="#" @click.prevent="handleSelectNone">Select none</a>
+      <span> | </span>
+      <a href="#" @click.prevent="handleSelectAll">Select all</a>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+  import Vue from 'vue';
+  import { Component, Model, Prop, Watch } from 'vue-property-decorator';
+  import { DatasetListItem } from '../api/dataset';
+  import { fromPairs } from 'lodash-es';
+  import format from 'date-fns/format';
+
+  @Component
+  export default class DatasetCheckboxList extends Vue {
+    @Prop({ type: Array, required: true })
+    datasets!: DatasetListItem[];
+
+    @Model('input')
+    selectedDatasets!: Record<string, boolean>;
+
+    @Watch('datasets')
+    populateSelectedDatasetIds() {
+      //Rebuild `selectedDatasets` so that the keys are in sync with the ids from `datasets`
+      const selectedDatasets = fromPairs(this.datasets.map(({id}) => {
+        return [id, id in this.selectedDatasets ? this.selectedDatasets[id] : true];
+      }));
+      console.log(selectedDatasets);
+      this.$emit('input', selectedDatasets);
+    }
+
+    created() {
+      this.populateSelectedDatasetIds();
+    }
+
+    formatDate(date: string) {
+      return `${format(date, 'YYYY-MM-DD')} at ${format(date, 'HH:mm')}`;
+    }
+
+    handleSelectNone() {
+      Object.keys(this.selectedDatasets).forEach(key => this.selectedDatasets[key] = false);
+    }
+
+    handleSelectAll() {
+      Object.keys(this.selectedDatasets).forEach(key => this.selectedDatasets[key] = true);
+    }
+  }
+</script>
+<style scoped lang="scss">
+  @import "~element-ui/packages/theme-chalk/src/common/var";
+
+  .dataset-checkbox-list {
+    margin: 20px;
+    max-height: 50vh;
+    overflow: auto;
+  }
+  .select-buttons {
+    text-align: right;
+    margin: 20px;
+  }
+  .reset-color {
+    color: $--color-text-regular;
+  }
+</style>

--- a/metaspace/webapp/src/components/MetadataEditor/DataManagementSection.vue
+++ b/metaspace/webapp/src/components/MetadataEditor/DataManagementSection.vue
@@ -1,48 +1,16 @@
 <template>
   <div class="metadata-section">
-    <el-dialog
-      custom-class="find-group-dialog"
-      :visible.sync="showFindGroupDialog"
-      :lockScroll="false">
-      <h2>Find a group</h2>
-      <p>If you are not member of a group, you can request access here and your dataset will be
-      automatically added to the group once your access has been approved.</p>
-      <el-form >
-        <el-form-item label="Your group:">
-          <el-row>
-            <el-select
-              v-model="groupSearchSelectedId"
-              filterable
-              remote
-              :remote-method="handleGroupSearch"
-              placeholder="Enter group name"
-              :loading="groupSearchLoading !== 0">
-              <el-option
-                v-for="group in groupSearchResults"
-                :key="group.id"
-                :label="group.name"
-                :value="group.id" />
-            </el-select>
-          </el-row>
-        </el-form-item>
-      </el-form>
-
-      <el-row style="margin: 15px 0">
-        <el-button @click="onCancelFindGroupDialog">Cancel</el-button>
-        <el-button
-          type="primary"
-          :disabled="groupSearchSelectedId == null"
-          :loading="isGroupAccessLoading"
-          @click="onRequestGroupAccess">Request access
-        </el-button>
-      </el-row>
-      <el-row>
-        <p>
-          <b>Can't find your group?</b> <a href="mailto:contact@metaspace2020.eu">Contact us</a> to get your team started,
-          or <a href="#" @click.prevent="handleSelectNoGroup" style="cursor: pointer">fill in your Principal Investigator</a> instead.
-        </p>
-      </el-row>
-    </el-dialog>
+    <find-group-dialog
+      v-if="showFindGroupDialog"
+      @close="hideFindGroupDialog"
+      @selectGroup="handleSelectGroup"
+    />
+    <create-project-dialog
+      v-if="showCreateProjectDialog && currentUser != null"
+      :currentUserId="currentUser && currentUser.id"
+      @close="hideCreateProjectDialog"
+      @create="handleSelectProject"
+    />
     <el-row>
       <el-col :span="6">
         <div class="metadata-section__title">Data management</div>
@@ -69,14 +37,15 @@
                 name="Group"
                 required />
             </el-col>
-            <!--Uncomment when projects are introduced-->
-            <!--<el-col :span="8">-->
-            <!--<form-field-->
-            <!--type="selectMulti"-->
-            <!--name="Project"-->
-            <!--required-->
-            <!--/>-->
-            <!--</el-col>-->
+            <el-col :span="8">
+              <form-field
+                v-model="projectIds"
+                :error="error && error.projectIds"
+                :options="projectOptions"
+                type="selectMulti"
+                name="Projects"
+                required />
+            </el-col>
           </el-form>
         </el-row>
       </el-col>
@@ -123,57 +92,31 @@
   import FormField from './FormField.vue';
   import { MetaspaceOptions } from './formStructure';
   import {
-    allGroupsQuery,
-    requestAccessToGroupMutation,
     GroupListItem,
-    oneGroupQuery,
+    oneGroupQuery, oneProjectQuery,
   } from '../../api/dataManagement';
-  import reportError from "../../lib/reportError";
   import { DatasetSubmitterFragment } from '../../api/user';
   import './FormSection.scss';
+  import gql from 'graphql-tag';
+  import FindGroupDialog from './FindGroupDialog.vue';
+  import {CreateProjectDialog} from '../../modules/Project';
 
   const FIND_GROUP = 'FIND_GROUP';
   const NO_GROUP = 'NO_GROUP';
+  const CREATE_PROJECT = 'CREATE_PROJECT';
 
   @Component<DataManagementSection>({
     components: {
-      FormField
+      FormField,
+      FindGroupDialog,
+      CreateProjectDialog,
     },
     apollo: {
-      groupSearchResults: {
-        query: allGroupsQuery,
-        loadingKey: 'groupSearchLoading',
-        variables() {
-          return {
-            query: this.groupSearchQuery
-          };
-        },
-        skip() {
-          return this.groupSearchQuery === '';
-        },
-        update: data => data.allGroups
-      },
-      unknownGroup: {
-        // If the dataset is saved with a groupId for a group that the user isn't a member of, do an extra query for it.
-        query: oneGroupQuery,
-        variables() {
-          return {
-            groupId: this.groupId
-          }
-        },
-        skip() {
-          return !this.groupIdIsUnknown;
-        },
-        update(data){
-          return {
-            ...data.group,
-            id: this.groupId, //FIXME: Needed for testing because mocked server returns random IDs
-          }
-        }
-      }
+      currentUser: gql`query {
+        currentUser { id }
+      }`
     }
   })
-
   export default class DataManagementSection extends Vue {
     @Prop({type: Object, required: true})
     value!: MetaspaceOptions;
@@ -182,16 +125,21 @@
     @Prop({type: Object })
     error?: Record<string, any>;
 
-    groupSearchQuery: string = '';
-    groupSearchResults: GroupListItem[] | null = null;
-    groupSearchLoading = 0;
-    groupSearchSelectedId: string | null = null;
+    $apollo: any; // Type fixes in PR: https://github.com/Akryum/vue-apollo/pull/367
+
+    currentUser: {id: string} | null = null;
     unknownGroup: GroupListItem | null = null;
+    unknownProjects: {id: string, name: string}[] = [];
     showFindGroupDialog: boolean = false;
+    showCreateProjectDialog: boolean = false;
     loading: boolean = false;
-    isGroupAccessLoading: boolean = false;
     hasSelectedNoGroup: boolean = false;
     lastPrincipalInvestigator: MetaspaceOptions['principalInvestigator'] = null;
+
+    created() {
+      this.fetchGroupIfUnknown();
+      this.fetchProjectsIfUnknown();
+    }
 
     get showPI() {
       return this.hasSelectedNoGroup || this.value.principalInvestigator != null;
@@ -239,18 +187,90 @@
       this.$emit('input', {...this.value, groupId, principalInvestigator})
     }
 
+    get projectIds() {
+      return this.value.projectIds;
+    }
+    set projectIds(projectIds: string[]) {
+      if (projectIds.includes(CREATE_PROJECT)) {
+        this.showCreateProjectDialog = true;
+      } else {
+        this.$emit('input', {
+          ...this.value,
+          projectIds: projectIds,
+        })
+      }
+    }
+
     get groupOptions() {
       const groups = this.submitter != null && this.submitter.groups || [];
       const options = groups.map(({group: {id, name}}) => ({
         value: id,
         label: name,
       }));
-      if (this.groupIdIsUnknown && this.unknownGroup != null) {
+      if (this.groupIdIsUnknown && this.unknownGroup != null && this.unknownGroup.id === this.value.groupId) {
         options.push({value: this.unknownGroup.id, label: this.unknownGroup.name });
       }
+      // TODO: Handle case where submitter isn't the editor, either by removing the Find my group option,
+      // or not requesting access as part of the search.
       options.push({value: FIND_GROUP, label: "Find my group..."});
       options.push({value: NO_GROUP, label: "No group (Enter PI instead)"});
       return options;
+    }
+
+    get projectOptions() {
+      const projects = this.submitter != null && this.submitter.projects || [];
+      const options = projects.map(({project: {id, name}}) => ({
+        value: id,
+        label: name,
+      }));
+      this.unknownProjects.forEach(project => {
+        if (!projects.some(p2 => project.id === p2.project.id)) {
+          options.push({ value: project.id, label: project.name });
+        }
+      });
+      options.push({value: CREATE_PROJECT, label: "Create a new project..."});
+      return options;
+    }
+
+    @Watch('submitter')
+    @Watch('value.groupId')
+    async fetchGroupIfUnknown() {
+      // If the dataset is saved with a groupId for a group that the user isn't a member of, or the group
+      // was selected through the find dialog, the drop-down list won't have an entry for it, so do an extra query for it.
+      const groupId = this.value.groupId;
+      if (this.groupIdIsUnknown && (!this.unknownGroup || this.unknownGroup.id !== groupId)) {
+        const {data} = await this.$apollo.query({
+          query: oneGroupQuery,
+          variables: { groupId }
+        });
+        // Double-check the value hasn't changed before setting unknownGroup
+        if (this.value.groupId === groupId) {
+          this.unknownGroup = data.group;
+        }
+      }
+    }
+
+    @Watch('submitter')
+    @Watch('value.projectIds')
+    async fetchProjectsIfUnknown() {
+      if (this.submitter == null) return; // Still loading
+
+      const loadedProjects = this.submitter.projects;
+      const projectIds = this.value.projectIds;
+      const unknownProjectIds = projectIds
+        .filter(id => loadedProjects == null
+          || loadedProjects.some(project => project.project.id === id));
+
+      if (unknownProjectIds.length > 0) {
+        const promises = unknownProjectIds.map(projectId => this.$apollo.query({
+          query: oneProjectQuery,
+          variables: { projectId }
+        }));
+        const datas = await Promise.all(promises);
+        if (this.value.projectIds === projectIds) {
+          this.unknownProjects = datas.map(({data}) => data.project);
+        }
+      }
     }
 
     @Watch('value.principalInvestigator')
@@ -261,13 +281,6 @@
       }
     }
 
-    handleSelectNoGroup() {
-      const principalInvestigator = this.value.principalInvestigator || this.lastPrincipalInvestigator || {name: '', email: ''};
-
-      this.$emit('input', {...this.value, groupId: null, principalInvestigator});
-      this.showFindGroupDialog = false;
-    }
-
     handleInputPI(field: 'name' | 'email', value: string) {
       const principalInvestigator = {
         ...this.value.principalInvestigator,
@@ -276,51 +289,32 @@
       this.$emit('input', {...this.value, principalInvestigator});
     }
 
-    handleGroupSearch(query: string) {
-      this.groupSearchQuery = query;
+    hideFindGroupDialog() {
+      this.showFindGroupDialog = false;
+    }
+    hideCreateProjectDialog() {
+      this.showCreateProjectDialog = false;
     }
 
-    onCancelFindGroupDialog() {
+    async handleSelectGroup(group: {id: string, name: string} | null) {
+      if (group != null) {
+        this.groupId = group.id;
+        this.unknownGroup = group;
+      } else {
+        const principalInvestigator = this.value.principalInvestigator || this.lastPrincipalInvestigator || {name: '', email: ''};
+        this.$emit('input', {...this.value, groupId: null, principalInvestigator});
+      }
       this.showFindGroupDialog = false;
     }
 
-    async onRequestGroupAccess() {
-      try {
-        this.isGroupAccessLoading = true;
-        await this.$apollo.mutate({
-          mutation: requestAccessToGroupMutation,
-          variables: { groupId: this.groupSearchSelectedId }
-        });
-
-        this.groupId = this.groupSearchSelectedId;
-        await this.$apollo.queries.unknownGroup.refresh(); // wait for new group to load
-
-        this.showFindGroupDialog = false;
-        this.$message({
-          message: 'Your request was successfully sent!',
-          type: 'success'
-        });
-      } catch(err) {
-        reportError(err);
-      } finally {
-        this.isGroupAccessLoading = false;
-      }
+    async handleSelectProject(project: {id: string, name: string}) {
+      this.unknownProjects.push(project);
+      this.value.projectIds.push(project.id);
+      this.showCreateProjectDialog = false;
     }
   }
 </script>
 
 <style lang="scss">
   //@import './FormSection.scss';
-
-  .find-group-dialog {
-    .el-dialog__body {
-      padding: 10px 25px;
-    }
-    .el-select .el-input__inner {
-      cursor: text;
-    }
-    .el-select .el-input__suffix {
-      display: none;
-    }
-  }
 </style>

--- a/metaspace/webapp/src/components/MetadataEditor/DataManagementSection.vue
+++ b/metaspace/webapp/src/components/MetadataEditor/DataManagementSection.vue
@@ -137,8 +137,7 @@
     lastPrincipalInvestigator: MetaspaceOptions['principalInvestigator'] = null;
 
     created() {
-      this.fetchGroupIfUnknown();
-      this.fetchProjectsIfUnknown();
+      this.fetchUnknowns();
     }
 
     get showPI() {
@@ -210,9 +209,10 @@
       if (this.groupIdIsUnknown && this.unknownGroup != null && this.unknownGroup.id === this.value.groupId) {
         options.push({value: this.unknownGroup.id, label: this.unknownGroup.name });
       }
-      // TODO: Handle case where submitter isn't the editor, either by removing the Find my group option,
-      // or not requesting access as part of the search.
-      options.push({value: FIND_GROUP, label: "Find my group..."});
+      // TODO: Uncomment when userIDs are fully implemented so that "Find my group" is hidden when editing someone else's dataset
+      // if (this.submitter != null && this.currentUser != null && this.submitter.id === this.currentUser.id) {
+      options.push({ value: FIND_GROUP, label: "Find my group..." });
+      // }
       options.push({value: NO_GROUP, label: "No group (Enter PI instead)"});
       return options;
     }
@@ -233,6 +233,11 @@
     }
 
     @Watch('submitter')
+    fetchUnknowns() {
+      this.fetchGroupIfUnknown();
+      this.fetchProjectsIfUnknown();
+    }
+
     @Watch('value.groupId')
     async fetchGroupIfUnknown() {
       // If the dataset is saved with a groupId for a group that the user isn't a member of, or the group
@@ -250,7 +255,6 @@
       }
     }
 
-    @Watch('submitter')
     @Watch('value.projectIds')
     async fetchProjectsIfUnknown() {
       if (this.submitter == null) return; // Still loading

--- a/metaspace/webapp/src/components/MetadataEditor/DataManagementSection.vue
+++ b/metaspace/webapp/src/components/MetadataEditor/DataManagementSection.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="metadata-section">
     <find-group-dialog
-      v-if="showFindGroupDialog"
+      :visible="showFindGroupDialog"
       @close="hideFindGroupDialog"
       @selectGroup="handleSelectGroup"
     />
     <create-project-dialog
-      v-if="showCreateProjectDialog && currentUser != null"
+      :visible="showCreateProjectDialog && currentUser != null"
       :currentUserId="currentUser && currentUser.id"
       @close="hideCreateProjectDialog"
       @create="handleSelectProject"

--- a/metaspace/webapp/src/components/MetadataEditor/DataManagementSection.vue
+++ b/metaspace/webapp/src/components/MetadataEditor/DataManagementSection.vue
@@ -258,8 +258,7 @@
       const loadedProjects = this.submitter.projects;
       const projectIds = this.value.projectIds;
       const unknownProjectIds = projectIds
-        .filter(id => loadedProjects == null
-          || loadedProjects.some(project => project.project.id === id));
+        .filter(id => loadedProjects == null || !loadedProjects.some(project => project.project.id === id));
 
       if (unknownProjectIds.length > 0) {
         const promises = unknownProjectIds.map(projectId => this.$apollo.query({

--- a/metaspace/webapp/src/components/MetadataEditor/DataManagementSection.vue
+++ b/metaspace/webapp/src/components/MetadataEditor/DataManagementSection.vue
@@ -310,7 +310,7 @@
 </script>
 
 <style lang="scss">
-  @import './FormSection.scss';
+  //@import './FormSection.scss';
 
   .find-group-dialog {
     .el-dialog__body {

--- a/metaspace/webapp/src/components/MetadataEditor/FindGroupDialog.vue
+++ b/metaspace/webapp/src/components/MetadataEditor/FindGroupDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <el-dialog
-    visible
+    :visible="visible"
     custom-class="find-group-dialog"
     @close="handleClose"
     :lockScroll="false">
@@ -73,8 +73,10 @@
       }
     }
   })
-
   export default class FindGroupDialog extends Vue {
+    @Prop({ default: false })
+    visible!: boolean;
+
     query: string = '';
     searchResults: GroupListItem[] | null = null;
     searchLoading = 0;

--- a/metaspace/webapp/src/components/MetadataEditor/FindGroupDialog.vue
+++ b/metaspace/webapp/src/components/MetadataEditor/FindGroupDialog.vue
@@ -1,0 +1,130 @@
+<template>
+  <el-dialog
+    visible
+    custom-class="find-group-dialog"
+    @close="handleClose"
+    :lockScroll="false">
+    <h2>Find a group</h2>
+    <p>If you are not member of a group, you can request access here and your dataset will be
+      automatically added to the group once your access has been approved.</p>
+    <el-form >
+      <el-form-item label="Your group:">
+        <el-row>
+          <el-select
+            v-model="groupId"
+            filterable
+            remote
+            :remote-method="handleGroupSearch"
+            placeholder="Enter group name"
+            :loading="searchLoading !== 0">
+            <el-option
+              v-for="group in searchResults"
+              :key="group.id"
+              :label="group.name"
+              :value="group.id" />
+          </el-select>
+        </el-row>
+      </el-form-item>
+    </el-form>
+
+    <el-row style="margin: 15px 0">
+      <el-button @click="handleClose">Cancel</el-button>
+      <el-button
+        type="primary"
+        :disabled="groupId == null"
+        :loading="isGroupAccessLoading"
+        @click="handleRequestGroupAccess">Request access
+      </el-button>
+    </el-row>
+    <el-row>
+      <p>
+        <b>Can't find your group?</b> <a href="mailto:contact@metaspace2020.eu">Contact us</a> to get your team started,
+        or <a href="#" @click.prevent="handleSelectNoGroup" style="cursor: pointer">fill in your Principal Investigator</a> instead.
+      </p>
+    </el-row>
+  </el-dialog>
+</template>
+
+<script lang="ts">
+  import Vue from 'vue';
+  import { Component, Prop } from 'vue-property-decorator';
+  import {
+    allGroupsQuery,
+    requestAccessToGroupMutation,
+    GroupListItem,
+  } from '../../api/dataManagement';
+  import reportError from "../../lib/reportError";
+  import './FormSection.scss';
+
+  @Component<FindGroupDialog>({
+    apollo: {
+      searchResults: {
+        query: allGroupsQuery,
+        loadingKey: 'searchLoading',
+        variables() {
+          return {
+            query: this.query
+          };
+        },
+        skip() {
+          return this.query === '';
+        },
+        update: data => data.allGroups
+      }
+    }
+  })
+
+  export default class FindGroupDialog extends Vue {
+    query: string = '';
+    searchResults: GroupListItem[] | null = null;
+    searchLoading = 0;
+    groupId: string | null = null;
+    isGroupAccessLoading: boolean = false;
+
+    handleSelectNoGroup() {
+      this.$emit('selectGroup', null);
+    }
+
+    handleGroupSearch(query: string) {
+      this.query = query;
+    }
+
+    handleClose() {
+      this.$emit('close');
+    }
+
+    async handleRequestGroupAccess() {
+      try {
+        const group = this.searchResults!.find(g => g.id === this.groupId);
+        this.isGroupAccessLoading = true;
+        await this.$apollo.mutate({
+          mutation: requestAccessToGroupMutation,
+          variables: { groupId: this.groupId }
+        });
+
+        this.$message({
+          message: 'Your request was successfully sent!',
+          type: 'success'
+        });
+        this.$emit('selectGroup', group);
+      } catch(err) {
+        reportError(err);
+        this.isGroupAccessLoading = false;
+      }
+    }
+  }
+</script>
+
+<style lang="scss">
+  .find-group-dialog {
+    .el-dialog__body {
+      padding: 10px 25px;
+    }
+    .el-select .el-input__inner {
+      cursor: text;
+    }
+    .el-select .el-input__suffix {
+      display: none;
+    }
+  }
+</style>

--- a/metaspace/webapp/src/components/MetadataEditor/FormSection.scss
+++ b/metaspace/webapp/src/components/MetadataEditor/FormSection.scss
@@ -1,5 +1,5 @@
 .metadata-section {
-  padding-top: 12px;
+  margin: 16px 0;
   display: block;
   max-width: 950px;
 }

--- a/metaspace/webapp/src/components/MetadataEditor/FormSection.vue
+++ b/metaspace/webapp/src/components/MetadataEditor/FormSection.vue
@@ -44,6 +44,7 @@
   import { memoize } from 'lodash-es'
   import { FormSectionProperty } from './formStructure'
   import FormField from './FormField.vue';
+  import './FormSection.scss';
 
   @Component({
     components: {
@@ -76,5 +77,5 @@
 </script>
 
 <style lang="scss">
-  @import './FormSection.scss';
+  //@import './FormSection.scss'; // Imported in JS so that Webpack de-duplicates redundant copies
 </style>

--- a/metaspace/webapp/src/components/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/components/MetadataEditor/MetadataEditor.vue
@@ -81,7 +81,8 @@
    molDBs: [],
    adducts: [],
    name: '',
-   groupId: ''
+   groupId: null,
+   projectIds: []
  };
  
  function safeJsonParse(json) {
@@ -167,9 +168,10 @@
    methods: {
      async loadDataset() {
        const metaspaceOptionsFromDataset = (dataset) => {
-         const {isPublic, molDBs, adducts, name, group, principalInvestigator} = dataset;
+         const {isPublic, molDBs, adducts, name, group, projects, principalInvestigator} = dataset;
          return {
            groupId: group ? group.id : null,
+           projectIds: projects.map(p => p.id),
            principalInvestigator: principalInvestigator == null ? null : omit(principalInvestigator, '__typename'),
            isPublic, molDBs, adducts, name,
          };

--- a/metaspace/webapp/src/components/MetadataEditor/MetaspaceOptionsSection.vue
+++ b/metaspace/webapp/src/components/MetadataEditor/MetaspaceOptionsSection.vue
@@ -57,6 +57,7 @@
   import DatabaseDescriptions from './DatabaseDescriptions.vue';
   import { MetaspaceOptions } from './formStructure';
   import { MAX_MOL_DBS } from '../../lib/constants';
+  import './FormSection.scss';
 
   @Component({
     components: {
@@ -84,5 +85,5 @@
 </script>
 
 <style lang="scss">
-  @import './FormSection.scss';
+  //@import './FormSection.scss';
 </style>

--- a/metaspace/webapp/src/components/MetadataEditor/VisibilityOptionSection.vue
+++ b/metaspace/webapp/src/components/MetadataEditor/VisibilityOptionSection.vue
@@ -42,5 +42,5 @@
 </script>
 
 <style lang="scss">
-  @import './FormSection.scss';
+  //@import './FormSection.scss';
 </style>

--- a/metaspace/webapp/src/components/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/components/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -37,7 +37,7 @@ Object {
     "adducts.0.adduct",
     "adducts.1.adduct",
   ],
-  "groupId": "dataset.group.id",
+  "groupId": "123",
   "isPublic": true,
   "molDBs": Array [
     "molecularDatabases.1.name",
@@ -47,6 +47,10 @@ Object {
     "email": "dataset.principalInvestigator.email",
     "name": "dataset.principalInvestigator.name",
   },
+  "projectIds": Array [
+    "dataset.projects.0.id",
+    "dataset.projects.1.id",
+  ],
 }
 `;
 
@@ -326,7 +330,7 @@ exports[`MetadataEditor should match snapshot 1`] = `
             <button disabled="disabled" type="button" class="el-button el-button--primary is-disabled">
               <!---->
               <!----><span>Request access
-      </span></button>
+    </span></button>
           </div>
           <div class="el-row">
             <p>
@@ -334,6 +338,85 @@ exports[`MetadataEditor should match snapshot 1`] = `
               <a href="mailto:contact@metaspace2020.eu">Contact us</a> to get your team started, or
               <a href="#" style="cursor: pointer;">fill in your Principal Investigator</a> instead.
             </p>
+          </div>
+        </mock-el-dialog>
+        <mock-el-dialog append-to-body="" title="Create project" class="dialog">
+          <div class="">
+            <form class="el-form el-form--label-top" size="mini">
+              <div>
+                <div class="el-form-item name is-required">
+                  <label for="name" class="el-form-item__label">Name</label>
+                  <div class="el-form-item__content">
+                    <div class="el-input">
+                      <!---->
+                      <input type="text" autocomplete="off" maxlength="50" class="el-input__inner">
+                      <!---->
+                      <!---->
+                      <!---->
+                    </div>
+                    <!---->
+                  </div>
+                </div>
+                <div class="el-form-item isPublic">
+                  <!---->
+                  <div class="el-form-item__content">
+                    <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
+                      <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
+                      </span><span class="el-checkbox__label">Allow other users to see this project<!----></span></label>
+                    <!---->
+                  </div>
+                </div>
+              </div>
+            </form>
+            <div>
+              <h4 style="margin-top: 0px;">
+                Would you like to include any of your previously submitted datasets?
+              </h4>
+              <div>
+                <div class="dataset-checkbox-list">
+                  <div>
+                    <label role="checkbox" class="el-checkbox is-checked" aria-checked="true"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
+                      <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
+                      </span><span class="el-checkbox__label">
+        allDatasets.0.name
+        <span class="reset-color">(Submitted Invalid Date at Invalid Date)</span>
+                      <!---->
+                      </span>
+                    </label>
+                  </div>
+                  <div>
+                    <label role="checkbox" class="el-checkbox is-checked" aria-checked="true"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
+                      <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
+                      </span><span class="el-checkbox__label">
+        allDatasets.1.name
+        <span class="reset-color">(Submitted Invalid Date at Invalid Date)</span>
+                      <!---->
+                      </span>
+                    </label>
+                  </div>
+                </div>
+                <div class="select-buttons">
+                  <a href="#">Select none</a> <span> | </span>
+                  <a href="#">Select all</a>
+                </div>
+              </div>
+            </div>
+            <div class="button-bar">
+              <button type="button" class="el-button el-button--default">
+                <!---->
+                <!----><span>Cancel</span></button>
+              <button type="button" class="el-button el-button--primary">
+                <!---->
+                <!----><span>Create project and include 2 datasets</span></button>
+            </div>
+            <div class="el-loading-mask" style="display: none;">
+              <div class="el-loading-spinner">
+                <svg viewBox="25 25 50 50" class="circular">
+                  <circle cx="50" cy="50" r="20" fill="none" class="path"></circle>
+                </svg>
+                <!---->
+              </div>
+            </div>
           </div>
         </mock-el-dialog>
         <div class="el-row">
@@ -368,12 +451,27 @@ exports[`MetadataEditor should match snapshot 1`] = `
                       </span>
                     </label>
                     <div class="el-form-item__content">
-                      <mock-el-select value="" required="true">
+                      <mock-el-select required="true">
                         <mock-el-option value="currentUser.groups.0.group.id" label="currentUser.groups.0.group.name"></mock-el-option>
                         <mock-el-option value="currentUser.groups.1.group.id" label="currentUser.groups.1.group.name"></mock-el-option>
-                        <mock-el-option value="" label="group.name"></mock-el-option>
                         <mock-el-option value="FIND_GROUP" label="Find my group..."></mock-el-option>
                         <mock-el-option value="NO_GROUP" label="No group (Enter PI instead)"></mock-el-option>
+                      </mock-el-select>
+                      <!---->
+                    </div>
+                  </div>
+                </div>
+                <div class="el-col el-col-8" style="padding-left: 4px; padding-right: 4px;">
+                  <div class="el-form-item md-form-field el-form-item--medium">
+                    <label class="el-form-item__label"><span class="field-label"><span>Projects</span><span style="color: red;">*</span>
+                      <!---->
+                      </span>
+                    </label>
+                    <div class="el-form-item__content">
+                      <mock-el-select value="" required="true" multiple="">
+                        <mock-el-option value="currentUser.projects.0.project.id" label="currentUser.projects.0.project.name"></mock-el-option>
+                        <mock-el-option value="currentUser.projects.1.project.id" label="currentUser.projects.1.project.name"></mock-el-option>
+                        <mock-el-option value="CREATE_PROJECT" label="Create a new project..."></mock-el-option>
                       </mock-el-select>
                       <!---->
                     </div>

--- a/metaspace/webapp/src/components/MetadataEditor/formStructure.ts
+++ b/metaspace/webapp/src/components/MetadataEditor/formStructure.ts
@@ -48,6 +48,7 @@ export interface MetaspaceOptions {
   molDBs: string[];
   adducts: string[];
   groupId: string | null;
+  projectIds: string[];
   principalInvestigator: {
     name: string;
     email: string;

--- a/metaspace/webapp/src/graphqlClient.ts
+++ b/metaspace/webapp/src/graphqlClient.ts
@@ -46,7 +46,18 @@ const link = authLink.split(
 
 const apolloClient = new ApolloClient({
   link,
-  cache: new InMemoryCache(),
+  cache: new InMemoryCache({
+    cacheRedirects: {
+      Query: {
+        // Allow get-by-id queries to use cached data that originated from other kinds of queries
+        dataset: (_, args, { getCacheKey}) => getCacheKey({ __typename: 'Dataset', id: args.id }),
+        annotation: (_, args, { getCacheKey}) => getCacheKey({ __typename: 'Annotation', id: args.id }),
+        user: (_, args, { getCacheKey}) => getCacheKey({ __typename: 'User', id: args.userId }),
+        group: (_, args, { getCacheKey}) => getCacheKey({ __typename: 'Group', id: args.groupId }),
+        project: (_, args, { getCacheKey}) => getCacheKey({ __typename: 'Project', id: args.projectId }),
+      }
+    }
+  }),
 });
 
 export const refreshLoginStatus = async () => {

--- a/metaspace/webapp/src/lib/reportError.ts
+++ b/metaspace/webapp/src/lib/reportError.ts
@@ -10,6 +10,7 @@ export function setErrorNotifier(_$notify: ElNotification) {
 export default function reportError(err: Error, message?: string) {
   try {
     Raven.captureException(err);
+    console.error(err);
     if ($notify != null) {
       $notify.error(message || 'Oops! Something went wrong. Please refresh the page and try again.');
     }

--- a/metaspace/webapp/src/modules/GroupProfile/CreateGroupPage.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/CreateGroupPage.vue
@@ -74,12 +74,12 @@
       try {
         await (this.$refs.form as any).validate();
         try {
-          const {data} = await this.$apollo.mutate<{data: CreateGroupMutation}>({
+          const {data} = await this.$apollo.mutate({
             mutation: createGroupMutation,
             variables: { groupDetails: this.model },
           });
           this.$message({ message: `${this.model.name} was created`, type: 'success' });
-          this.$router.push(`/group/${data.createGroup.id}/edit`);
+          this.$router.push(`/group/${data!.createGroup.id}/edit`);
         } catch (err) {
           reportError(err);
         }

--- a/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.spec.ts
+++ b/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.spec.ts
@@ -29,7 +29,7 @@ describe('TransferDatasetsDialog', () => {
     [false, true].forEach(isInvited => {
       it(`should match snapshot (${hasDatasets ? 'datasets to import' : 'no datasets'}, ${isInvited ? 'invited' : 'requesting access'})`, () => {
         const propsData = { ...mockProps, isInvited };
-        const wrapper = mount(TransferDatasetsDialog, { router, propsData });
+        const wrapper = mount(TransferDatasetsDialog, { router, propsData, sync: false });
         wrapper.setData({ allDatasets: hasDatasets ? mockDatasets : [] });
 
         expect(wrapper).toMatchSnapshot();
@@ -38,8 +38,9 @@ describe('TransferDatasetsDialog', () => {
   });
 
   it('should call back on success when some datasets are selected', async () => {
-    const wrapper = mount(TransferDatasetsDialog, { router, propsData: mockProps });
+    const wrapper = mount(TransferDatasetsDialog, { router, propsData: mockProps, sync: false });
     wrapper.setData({ allDatasets: mockDatasets });
+    await Vue.nextTick();
 
     wrapper.find(ElementUI.Checkbox).trigger('click');
     wrapper.findAll(ElementUI.Button)

--- a/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.vue
@@ -9,19 +9,7 @@
           <p style="margin-top: 0">
             You have previously uploaded one or more datasets without a group. Do you want to transfer any of these datasets to {{groupName}}?
           </p>
-          <div class="dataset-list">
-            <div v-for="dataset in allDatasets">
-              <el-checkbox v-model="selectedDatasets[dataset.id]">
-                {{dataset.name}}
-                <span class="reset-color">(Submitted {{ formatDate(dataset.uploadDT) }})</span>
-              </el-checkbox>
-            </div>
-          </div>
-          <div class="select-buttons">
-            <a href="#" @click.prevent="handleSelectNone">Select none</a>
-            <span> | </span>
-            <a href="#" @click.prevent="handleSelectAll">Select all</a>
-          </div>
+          <dataset-checkbox-list :datasets="allDatasets" v-model="selectedDatasets" />
           <p v-if="!isInvited">
             An email will be sent to the group's principal investigator to confirm your access.
           </p>
@@ -49,10 +37,12 @@
   import Vue from 'vue';
   import { Component, Prop, Watch } from 'vue-property-decorator';
   import { DatasetListItem, datasetListItemsQuery } from '../../api/dataset';
-  import { fromPairs } from 'lodash-es';
-  import format from 'date-fns/format';
+  import DatasetCheckboxList from '../../components/DatasetCheckboxList.vue';
 
   @Component({
+    components: {
+      DatasetCheckboxList
+    },
     apollo: {
       allDatasets: {
         query: datasetListItemsQuery,
@@ -92,30 +82,10 @@
         : `${action} and transfer ${this.numSelected} ${this.numSelected === 1 ? 'dataset' : 'datasets'}`
     }
 
-    formatDate(date: string) {
-      return `${format(date, 'YYYY-MM-DD')} at ${format(date, 'HH:mm')}`;
-    }
-
-    @Watch('allDatasets')
-    populateSelectedDatasets() {
-      //Rebuild `selectedDatasets` so that the keys are in sync with the ids from `datasets`
-      this.selectedDatasets = fromPairs(this.allDatasets.map(({id}) => {
-        return [id, id in this.selectedDatasets ? this.selectedDatasets[id] : true];
-      }));
-    }
-
     handleClose() {
       if (!this.isSubmitting) {
         this.$emit('close');
       }
-    }
-
-    handleSelectNone() {
-      Object.keys(this.selectedDatasets).forEach(key => this.selectedDatasets[key] = false);
-    }
-
-    handleSelectAll() {
-      Object.keys(this.selectedDatasets).forEach(key => this.selectedDatasets[key] = true);
     }
 
     handleAccept() {
@@ -126,18 +96,8 @@
   }
 </script>
 <style scoped lang="scss">
-  @import "~element-ui/packages/theme-chalk/src/common/var";
   .dialog /deep/ .el-dialog {
     max-width: 600px;
-  }
-  .dataset-list {
-    margin: 20px;
-    max-height: 50vh;
-    overflow: auto;
-  }
-  .select-buttons {
-    text-align: right;
-    margin: 20px;
   }
   .button-bar {
     display: flex;
@@ -145,8 +105,4 @@
     justify-content: flex-end;
     margin-top: 20px;
   }
-  .reset-color {
-    color: $--color-text-regular;
-  }
-
 </style>

--- a/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.vue
@@ -15,7 +15,7 @@
           </p>
           <div class="button-bar">
             <el-button :disabled="isSubmitting" @click="handleClose">Cancel</el-button>
-            <el-button type="primary" :loading="isSubmitting" @click="handleAccept">{{acceptText}}</el-button>
+            <el-button type="primary" :loading="isSubmitting" @click="handleCreate">{{acceptText}}</el-button>
           </div>
         </div>
         <div v-else>
@@ -27,7 +27,7 @@
           </p>
           <div class="button-bar">
             <el-button :disabled="isSubmitting" @click="handleClose" size="small">Cancel</el-button>
-            <el-button type="primary" :loading="isSubmitting" @click="handleAccept" size="small">{{acceptText}}</el-button>
+            <el-button type="primary" :loading="isSubmitting" @click="handleCreate" size="small">{{acceptText}}</el-button>
           </div>
         </div>
       </div>

--- a/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.vue
@@ -15,7 +15,7 @@
           </p>
           <div class="button-bar">
             <el-button :disabled="isSubmitting" @click="handleClose">Cancel</el-button>
-            <el-button type="primary" :loading="isSubmitting" @click="handleCreate">{{acceptText}}</el-button>
+            <el-button type="primary" :loading="isSubmitting" @click="handleAccept">{{acceptText}}</el-button>
           </div>
         </div>
         <div v-else>
@@ -27,7 +27,7 @@
           </p>
           <div class="button-bar">
             <el-button :disabled="isSubmitting" @click="handleClose" size="small">Cancel</el-button>
-            <el-button type="primary" :loading="isSubmitting" @click="handleCreate" size="small">{{acceptText}}</el-button>
+            <el-button type="primary" :loading="isSubmitting" @click="handleAccept" size="small">{{acceptText}}</el-button>
           </div>
         </div>
       </div>

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/TransferDatasetsDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/TransferDatasetsDialog.spec.ts.snap
@@ -1,66 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TransferDatasetsDialog should match snapshot (datasets to import, invited) 1`] = `
-<mock-el-dialog visible="" append-to-body="" title="Transfer datasets" class="dialog">
+<mock-el-dialog visible="" append-to-body="" title="Join group" class="dialog">
   <div>
     <div>
       <p style="margin-top: 0px;">
-        You have previously uploaded one or more datasets without a group. Do you want to transfer any of these datasets to Group Name?
+        Are you sure you want to join Group Name?
       </p>
-      <div class="dataset-list">
-        <div>
-          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
-            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
-            </span><span class="el-checkbox__label">
-            Untreated_3_434
-            <span class="reset-color">(Submitted 2018-06-28 at 13:23)</span>
-            <!---->
-            </span>
-          </label>
-        </div>
-        <div>
-          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
-            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
-            </span><span class="el-checkbox__label">
-            Dataset 2
-            <span class="reset-color">(Submitted 2018-06-28 at 13:21)</span>
-            <!---->
-            </span>
-          </label>
-        </div>
-        <div>
-          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
-            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
-            </span><span class="el-checkbox__label">
-            Dataset 3
-            <span class="reset-color">(Submitted 2018-06-28 at 12:03)</span>
-            <!---->
-            </span>
-          </label>
-        </div>
-        <div>
-          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
-            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
-            </span><span class="el-checkbox__label">
-            Dataset 4
-            <span class="reset-color">(Submitted 2018-06-28 at 13:20)</span>
-            <!---->
-            </span>
-          </label>
-        </div>
-      </div>
-      <div class="select-buttons">
-        <a href="#">Select none</a> <span> | </span>
-        <a href="#">Select all</a>
-      </div>
-      <!---->
       <div class="button-bar">
-        <button type="button" class="el-button el-button--default">
+        <button type="button" class="el-button el-button--default el-button--small">
           <!---->
           <!----><span>Cancel</span></button>
-        <button type="button" class="el-button el-button--primary">
+        <button type="button" class="el-button el-button--primary el-button--small">
           <!---->
-          <!----><span>Join group and transfer 4 datasets</span></button>
+          <!----><span>Join group</span></button>
       </div>
     </div>
   </div>
@@ -68,68 +21,19 @@ exports[`TransferDatasetsDialog should match snapshot (datasets to import, invit
 `;
 
 exports[`TransferDatasetsDialog should match snapshot (datasets to import, requesting access) 1`] = `
-<mock-el-dialog visible="" append-to-body="" title="Transfer datasets" class="dialog">
+<mock-el-dialog visible="" append-to-body="" title="Join group" class="dialog">
   <div>
     <div>
       <p style="margin-top: 0px;">
-        You have previously uploaded one or more datasets without a group. Do you want to transfer any of these datasets to Group Name?
-      </p>
-      <div class="dataset-list">
-        <div>
-          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
-            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
-            </span><span class="el-checkbox__label">
-            Untreated_3_434
-            <span class="reset-color">(Submitted 2018-06-28 at 13:23)</span>
-            <!---->
-            </span>
-          </label>
-        </div>
-        <div>
-          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
-            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
-            </span><span class="el-checkbox__label">
-            Dataset 2
-            <span class="reset-color">(Submitted 2018-06-28 at 13:21)</span>
-            <!---->
-            </span>
-          </label>
-        </div>
-        <div>
-          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
-            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
-            </span><span class="el-checkbox__label">
-            Dataset 3
-            <span class="reset-color">(Submitted 2018-06-28 at 12:03)</span>
-            <!---->
-            </span>
-          </label>
-        </div>
-        <div>
-          <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
-            <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
-            </span><span class="el-checkbox__label">
-            Dataset 4
-            <span class="reset-color">(Submitted 2018-06-28 at 13:20)</span>
-            <!---->
-            </span>
-          </label>
-        </div>
-      </div>
-      <div class="select-buttons">
-        <a href="#">Select none</a> <span> | </span>
-        <a href="#">Select all</a>
-      </div>
-      <p>
         An email will be sent to the group's principal investigator to confirm your access.
       </p>
       <div class="button-bar">
-        <button type="button" class="el-button el-button--default">
+        <button type="button" class="el-button el-button--default el-button--small">
           <!---->
           <!----><span>Cancel</span></button>
-        <button type="button" class="el-button el-button--primary">
+        <button type="button" class="el-button el-button--primary el-button--small">
           <!---->
-          <!----><span>Request access and transfer 4 datasets</span></button>
+          <!----><span>Request access</span></button>
       </div>
     </div>
   </div>

--- a/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
+++ b/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
@@ -1,0 +1,137 @@
+<template>
+  <el-dialog class="dialog"
+             visible
+             append-to-body
+             title="Create project"
+             @close="handleClose">
+    <div v-loading="loading">
+      <edit-project-form ref="form" v-model="project" size="mini" />
+      <div v-if="allDatasets.length > 0">
+        <h4 style="margin-top: 0">
+          Would you like to include any of your previously submitted datasets?
+        </h4>
+        <dataset-checkbox-list :datasets="allDatasets" v-model="selectedDatasets" />
+      </div>
+      <div class="button-bar">
+        <el-button :disabled="isSubmitting" @click="handleClose">Cancel</el-button>
+        <el-button type="primary" :loading="isSubmitting" @click="handleCreate">{{acceptText}}</el-button>
+      </div>
+    </div>
+  </el-dialog>
+</template>
+<script lang="ts">
+  import Vue from 'vue';
+  import { Component, Prop } from 'vue-property-decorator';
+  import { DatasetListItem, datasetListItemsQuery } from '../../api/dataset';
+  import EditProjectForm from './EditProjectForm.vue';
+  import DatasetCheckboxList from '../../components/DatasetCheckboxList.vue';
+  import { createProjectMutation, importDatasetsIntoProjectMutation } from '../../api/project';
+  import reportError from '../../lib/reportError';
+
+  @Component({
+    components: {
+      EditProjectForm,
+      DatasetCheckboxList
+    },
+    apollo: {
+      allDatasets: {
+        query: datasetListItemsQuery,
+        loadingKey: 'loading',
+        variables(this: TransferDatasetsDialog) {
+          return {
+            dFilter: {
+              // submitter: this.currentUserId,
+            }
+          };
+        }
+      }
+    }
+  })
+  export default class TransferDatasetsDialog extends Vue {
+    @Prop({ required: true })
+    currentUserId!: string;
+
+    $apollo: any; // Type fixes in PR: https://github.com/Akryum/vue-apollo/pull/367
+
+    loading: number = 0;
+    allDatasets: DatasetListItem[] = [];
+    selectedDatasets: Record<string, boolean> = {};
+    isSubmitting: Boolean = false;
+    project = {
+      name: '',
+      isPublic: true,
+      urlSlug: ''
+    };
+
+    get numSelected() {
+      return Object.values(this.selectedDatasets).filter(selected => selected).length;
+    }
+
+    get acceptText() {
+      const action = 'Create project';
+      return this.numSelected === 0
+        ? action
+        : `${action} and include ${this.numSelected} ${this.numSelected === 1 ? 'dataset' : 'datasets'}`
+    }
+
+    handleClose() {
+      if (!this.isSubmitting) {
+        this.$emit('close');
+      }
+    }
+
+    async handleCreate() {
+      try {
+        await (this.$refs.form as any).validate();
+      } catch (err) {
+        return;
+      }
+      this.isSubmitting = true;
+      try {
+        const selectedDatasetIds = Object.keys(this.selectedDatasets).filter(key => this.selectedDatasets[key]);
+        const { name, isPublic, urlSlug } = this.project;
+        const { data } = await this.$apollo.mutate({
+          mutation: createProjectMutation,
+          variables: {
+            projectDetails: {
+              name,
+              isPublic,
+              urlSlug: urlSlug != null && urlSlug !== '' ? urlSlug : null,
+            }
+          }
+        });
+        const projectId = data!.createProject.id;
+        if (selectedDatasetIds.length > 0) {
+          await this.$apollo.mutate({
+            mutation: importDatasetsIntoProjectMutation,
+            variables: { projectId, datasetIds: selectedDatasetIds }
+          });
+        }
+
+        this.$emit('create', { id: projectId, name });
+      } catch (err) {
+        reportError(err);
+      } finally {
+        this.isSubmitting = false;
+      }
+    }
+  }
+</script>
+<style scoped lang="scss">
+  .dialog /deep/ .el-dialog {
+    max-width: 600px;
+
+    .el-form-item {
+      margin-bottom: 10px;
+    }
+    .el-form-item__label {
+      line-height: 1.2em;
+    }
+  }
+  .button-bar {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    margin-top: 20px;
+  }
+</style>

--- a/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
+++ b/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <el-dialog class="dialog"
-             visible
+             :visible="visible"
              append-to-body
              title="Create project"
              @close="handleClose">
@@ -28,7 +28,7 @@
   import { createProjectMutation, importDatasetsIntoProjectMutation } from '../../api/project';
   import reportError from '../../lib/reportError';
 
-  @Component({
+  @Component<CreateProjectDialog>({
     components: {
       EditProjectForm,
       DatasetCheckboxList
@@ -37,19 +37,21 @@
       allDatasets: {
         query: datasetListItemsQuery,
         loadingKey: 'loading',
-        variables(this: TransferDatasetsDialog) {
+        variables() {
           return {
             dFilter: {
-              // submitter: this.currentUserId,
+              submitter: this.currentUserId,
             }
           };
         }
       }
     }
   })
-  export default class TransferDatasetsDialog extends Vue {
+  export default class CreateProjectDialog extends Vue {
     @Prop({ required: true })
     currentUserId!: string;
+    @Prop({ default: false })
+    visible!: boolean;
 
     $apollo: any; // Type fixes in PR: https://github.com/Akryum/vue-apollo/pull/367
 
@@ -121,6 +123,10 @@
   .dialog /deep/ .el-dialog {
     max-width: 600px;
 
+    .el-form {
+      margin-left: 10px;
+      margin-right: 10px;
+    }
     .el-form-item {
       margin-bottom: 10px;
     }

--- a/metaspace/webapp/src/modules/Project/EditProjectForm.vue
+++ b/metaspace/webapp/src/modules/Project/EditProjectForm.vue
@@ -1,18 +1,28 @@
 <template>
-  <el-form ref="form" :model="model" :disabled="disabled" :rules="rules" label-position="top">
+  <el-form
+    ref="form"
+    :model="value"
+    :disabled="disabled"
+    :rules="rules"
+    label-position="top"
+  >
     <div>
       <el-form-item label="Name" prop="name" class="name">
-        <el-input v-model="model.name" :maxLength="50" />
+        <el-input v-model="value.name" :maxLength="50" />
       </el-form-item>
       <el-form-item prop="isPublic" class="isPublic">
-        <el-checkbox v-model="model.isPublic">Allow other users to see this project</el-checkbox>
+        <el-checkbox v-model="value.isPublic">Allow other users to see this project</el-checkbox>
       </el-form-item>
+      <!--<h2 v-if="showUrlSlug">Custom URL</h2>-->
+      <!--<el-form-item v-if="showUrlSlug" prop="urlSlug" class="urlSlug">-->
+        <!--http://metaspace2020.eu/#/projects/<el-input v-model="value.urlSlug" :maxLength="30" size="mini" placeholder="project-name-here" />-->
+      <!--</el-form-item>-->
     </div>
   </el-form>
 </template>
 <script lang="ts">
   import Vue from 'vue';
-  import { Component, Prop } from 'vue-property-decorator';
+  import { Component, Model, Prop } from 'vue-property-decorator';
   import { ElForm } from 'element-ui/types/form';
 
   interface Model {
@@ -21,10 +31,12 @@
 
   @Component
   export default class EditProjectForm extends Vue {
-    @Prop({type: Object, required: true})
-    model!: Model;
+    @Model('input', {type: Object, required: true})
+    value!: Model;
     @Prop({type: Boolean, default: false})
     disabled!: Boolean;
+    @Prop({type: Boolean, default: true})
+    showUrlSlug!: Boolean;
 
     rules = {
       name: [{type: 'string', required: true, min: 2, message: 'Name is required', trigger: 'manual'}],
@@ -42,6 +54,15 @@
   }
 
   .isPublic {
-    margin-left: 10px;
+    margin-left: 20px;
   }
+  /*.urlSlug {*/
+    /*/deep/ .el-input {*/
+      /*display: inline-block;*/
+      /*width: 150px;*/
+      /*input {*/
+        /*padding: 0 5px;*/
+      /*}*/
+    /*}*/
+  /*}*/
 </style>

--- a/metaspace/webapp/src/modules/Project/EditProjectForm.vue
+++ b/metaspace/webapp/src/modules/Project/EditProjectForm.vue
@@ -50,7 +50,6 @@
 </script>
 <style scoped lang="scss">
   .name {
-    width: 400px;
   }
 
   .isPublic {

--- a/metaspace/webapp/src/modules/Project/EditProjectPage.vue
+++ b/metaspace/webapp/src/modules/Project/EditProjectPage.vue
@@ -15,7 +15,7 @@
             </el-button>
           </div>
         </div>
-        <edit-project-form :model="model" :disabled="isSaving || !canEdit" />
+        <edit-project-form v-model="model" :disabled="isSaving || !canEdit" />
         <members-list
           :loading="projectLoading !== 0"
           :members="project && project.members || []"

--- a/metaspace/webapp/src/modules/Project/index.ts
+++ b/metaspace/webapp/src/modules/Project/index.ts
@@ -1,2 +1,3 @@
 export {default as EditProjectPage} from './EditProjectPage.vue';
 export {default as ViewProjectPage} from './ViewProjectPage.vue';
+export {default as CreateProjectDialog} from './CreateProjectDialog.vue';

--- a/metaspace/webapp/src/modules/Project/index.ts
+++ b/metaspace/webapp/src/modules/Project/index.ts
@@ -1,3 +1,5 @@
 export {default as EditProjectPage} from './EditProjectPage.vue';
 export {default as ViewProjectPage} from './ViewProjectPage.vue';
+// TODO: Figure out a way to allow this module to be correctly split across bundles
+// Currently MetadataEditor's direct import of CreateProjectDialog is inadvertently bringing EditProjectPage and ViewProjectPage into the bundle
 export {default as CreateProjectDialog} from './CreateProjectDialog.vue';

--- a/metaspace/webapp/src/vue-shims.d.ts
+++ b/metaspace/webapp/src/vue-shims.d.ts
@@ -10,3 +10,11 @@ declare module "plotly.js/src/components/colorscale/scales.js"
 declare module "plotly.js/src/components/colorscale/extract_scale.js"
 
 declare module "vue-slide-up-down";
+
+declare module "vue-apollo/types/vue-apollo" {
+  import { ApolloProperty } from 'vue-apollo/types/vue-apollo';
+  import { ApolloClient } from 'apollo-client';
+
+  export interface ApolloProperty<V> {
+  }
+}

--- a/metaspace/webapp/tests/utils/mockGraphqlClient.ts
+++ b/metaspace/webapp/tests/utils/mockGraphqlClient.ts
@@ -19,9 +19,23 @@ const getPath = (info: GraphQLResolveInfo) => {
   return path.reverse().join('.');
 };
 
+const getID = (info: GraphQLResolveInfo) => {
+  let path = getPath(info);
+  if(!/[0-9]/.test(path)) {
+    // If there's no ID in the path, it's probably a get-by-id query so look through the query variables to find the id
+    const IDs = Object.keys(info.variableValues)
+      .filter(key => /^id$|Id$/.test(key) && typeof info.variableValues[key] === 'string')
+      .map(key => info.variableValues[key]);
+    if (IDs.length > 0) {
+      return IDs.join(',');
+    }
+  }
+  return path;
+};
+
 const baseMocks: IMocks = {
   // Replace primitive types with non-randomized versions
-  ID: (source, args, context, info) => getPath(info),
+  ID: (source, args, context, info) => getID(info),
   String: (source, args, context, info) => getPath(info),
   Boolean: (source, args, context, info) => (lazyHash(getPath(info)) & 1) === 1,
   Int: (source, args, context, info) => lazyHash(getPath(info)),


### PR DESCRIPTION
Also:
* Extracted `DatasetCheckboxList` to be reused
* Extracted `FindGroupDialog` because `DataManagementSection` was getting huge
* Commented out SCSS `@import './FormSection.scss';`s in favor of JS `import './FormSection.scss';`s because the scss imports don't get deduplicated.
* Added missing `projectIds` field to graphql dataset mutations
* Added some cache optimization to apollo-client