### PR TITLE
Update readme & handle missing JWT in graphql playground

### DIFF
--- a/metaspace/graphql/README.md
+++ b/metaspace/graphql/README.md
@@ -5,10 +5,10 @@ GraphQL interface to SM engine
 ## Development setup
 
 0. Copy `config.json.template` to `config.json` and edit credentials to match your SM engine installation.
-1. `npm install`
-2. `npm install -g babel-cli nodemon`
-3. Run `nodemon --exec babel-node server.js`, it will automatically restart Node.JS server when the code changes.
-4. Open `localhost:3010/graphiql` in the browser to play with queries.
+1. `yarn install`
+2. `yarn run gen-binding` to generate `src/binding.ts`, which contains the TypeScript types for the GraphQL schema.
+3. Run `yarn run dev`, it will automatically restart Node.JS server when the code changes.
+4. Open `localhost:3010/graphql` in the browser to play with queries.
 
 ## Funding
 

--- a/metaspace/graphql/server.js
+++ b/metaspace/graphql/server.js
@@ -69,7 +69,7 @@ async function createHttpServerAsync(config) {
     context: ({req}) => {
       // if (!req.user) throw new UserError('You must be logged in');
       return {
-        user: req.user.user,
+        user: req.user != null ? req.user.user : null,
         connection
       };
     },

--- a/metaspace/webapp/README.md
+++ b/metaspace/webapp/README.md
@@ -11,11 +11,22 @@ Web application for browsing results produced by [METASPACE engine](../engine).
 
 ## Running in development mode
 
-```bash
-NODE_ENV=development nodemon server.js
-```
+`yarn run dev` will start webpack-dev-server, which will serve and dynamically rebuild client-side code.
+However, there is a small amount of server-side code in this project that won't be automatically reloaded when changed.
+If you are changing the server-side code and want it to hot-reload, use `NODE_ENV=development nodemon server.js`.
+Note that using `nodemon` is much slower for client-side development, as it completely restarts the process
+instead of allowing webpack-dev-server to do an incremental rebuild.
 
-This will take care of hot reloading after both server and client code changes.
+## Testing
+
+The tests rely on having a local copy of the GraphQL schema in `tests/utils/graphql-schema.json`.
+This file can either be retrieved from the Production server by running `yarn run fetch-prod-graphql-schema`, or
+it can be generated from the local code by running `yarn run generate-local-graphql-schema` (you may need to run
+`yarn install` in `../graphql` first)
+
+To run the unit tests: `yarn run test`
+To run the unit tests automatically whenever code is changed: `yarn run test --watch`
+To check code coverage: `yarn run coverage` then open `coverage/lcov-report/index.html`
 
 ## Running in production
 


### PR DESCRIPTION
@Ren22 Here's the documentation for the new steps needed to set up your dev environment

This also fixes an issue in `graphql/server.js` which threw an error if the authorization header wasn't set, e.g. if you were using GraphQL Playground per the README instructions. Btw, Apollo changed to use GraphQL Playground instead of GraphiQL, so now you go to `/graphql` instead of `/graphiql` to get to the query UI.