### PR TITLE
GraphQL ES partial updates

### DIFF
--- a/ansible/aws/group_vars_all.yml.template
+++ b/ansible/aws/group_vars_all.yml.template
@@ -150,7 +150,6 @@ sm_graphql_rabbitmq_host: "{{ rabbitmq_host }}"
 sm_graphql_rabbitmq_user: "{{ rabbitmq_user }}"
 sm_graphql_rabbitmq_password: "{{ rabbitmq_password }}"
 sm_graphql_ws_public_endpoint: "ws://{{ sm_graphql_hostname }}/ws"
-sm_graphql_default_adducts: {{ sm_default_adducts }}
 sm_graphql_img_storage_backend: fs
 sm_graphql_redis_host: localhost
 sm_graphql_redis_port: 6379

--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -127,5 +127,9 @@
             "level": "INFO"
         }
     }
+  },
+  ds_config_defaults: {
+    adducts: {{ sm_default_adducts | to_json }},
+    moldb_names: ["HMDB-v4"]
   }
 }

--- a/metaspace/engine/conf/test_config.json
+++ b/metaspace/engine/conf/test_config.json
@@ -113,5 +113,12 @@
             "level": "INFO"
         }
     }
+  },
+  "ds_config_defaults": {
+    "adducts": {
+      "+": ["+H", "+Na", "+K"],
+      "-": ["-H", "+Cl" ]
+    },
+    "moldb_names": ["HMDB-v4"]
   }
 }

--- a/metaspace/engine/sm/engine/dataset.py
+++ b/metaspace/engine/sm/engine/dataset.py
@@ -2,6 +2,7 @@ import json
 import logging
 
 from sm.engine.errors import UnknownDSID
+from sm.engine.util import SMConfig
 
 logger = logging.getLogger('engine')
 
@@ -31,18 +32,32 @@ class DatasetStatus(object):
     DELETED = 'DELETED'  # only for the status queue
 
 
+RESOL_POWER_PARAMS = {
+    '70K': {'sigma': 0.00247585727028, 'fwhm': 0.00583019832869, 'pts_per_mz': 2019},
+    '100K': {'sigma': 0.0017331000892, 'fwhm': 0.00408113883008, 'pts_per_mz': 2885},
+    '140K': {'sigma': 0.00123792863514, 'fwhm': 0.00291509916435, 'pts_per_mz': 4039},
+    '200K': {'sigma': 0.000866550044598, 'fwhm': 0.00204056941504, 'pts_per_mz': 5770},
+    '250K': {'sigma': 0.000693240035678, 'fwhm': 0.00163245553203, 'pts_per_mz': 7212},
+    '280K': {'sigma': 0.00061896431757, 'fwhm': 0.00145754958217, 'pts_per_mz': 8078},
+    '500K': {'sigma': 0.000346620017839, 'fwhm': 0.000816227766017, 'pts_per_mz': 14425},
+    '750K': {'sigma': 0.000231080011893, 'fwhm': 0.000544151844011, 'pts_per_mz': 21637},
+    '1000K': {'sigma': 0.00017331000892, 'fwhm': 0.000408113883008, 'pts_per_mz': 28850},
+}
+
+
 class Dataset(object):
-    """ Model class for representing a dataset """
-    DS_SEL = ('SELECT id, name, input_path, upload_dt, metadata, config, status, is_public, mol_dbs, adducts '
+    """ Class for representing an IMS dataset
+    """
+    DS_SEL = ('SELECT id, name, input_path, upload_dt, metadata, status, is_public, mol_dbs, adducts '
               'FROM dataset WHERE id = %s')
     DS_UPD = ('UPDATE dataset set name=%(name)s, input_path=%(input_path)s, upload_dt=%(upload_dt)s, '
               'metadata=%(metadata)s, config=%(config)s, status=%(status)s, is_public=%(is_public)s, '
               'mol_dbs=%(mol_dbs)s, adducts=%(adducts)s where id=%(id)s')
-    DS_CONFIG_SEL = 'SELECT config FROM dataset WHERE id = %s'
     DS_INSERT = ('INSERT INTO dataset (id, name, input_path, upload_dt, metadata, config, status, '
                  'is_public, mol_dbs, adducts) '
                  'VALUES (%(id)s, %(name)s, %(input_path)s, %(upload_dt)s, %(metadata)s, %(config)s, %(status)s, '
                  '%(is_public)s, %(mol_dbs)s, %(adducts)s)')
+    # NOTE: config is saved to but never read from the database
 
     ACQ_GEOMETRY_SEL = 'SELECT acq_geometry FROM dataset WHERE id = %s'
     ACQ_GEOMETRY_UPD = 'UPDATE dataset SET acq_geometry = %s WHERE id = %s'
@@ -50,19 +65,31 @@ class Dataset(object):
     IMG_STORAGE_TYPE_UPD = 'UPDATE dataset SET ion_img_storage_type = %s WHERE id = %s'
 
     def __init__(self, id=None, name=None, input_path=None, upload_dt=None,
-                 metadata=None, config=None, status=DatasetStatus.NEW,
+                 metadata=None, status=DatasetStatus.NEW,
                  is_public=True, mol_dbs=None, adducts=None, img_storage_type='fs'):
         self.id = id
         self.name = name
         self.input_path = input_path
         self.upload_dt = upload_dt
-        self.metadata = metadata
-        self.config = config
         self.status = status
         self.is_public = is_public
         self.mol_dbs = mol_dbs
         self.adducts = adducts
         self.ion_img_storage_type = img_storage_type
+
+        self._metadata = None
+        self.config = None
+        self._sm_config = SMConfig.get_conf()
+        self.metadata = metadata  # triggers config generation
+
+    @property
+    def metadata(self):
+        return self._metadata
+
+    @metadata.setter
+    def metadata(self, value):
+        self._metadata = value
+        self._generate_config()
 
     def __str__(self):
         return str(self.__dict__)
@@ -79,7 +106,6 @@ class Dataset(object):
         docs = db.select_with_fields(cls.DS_SEL, params=(ds_id,))
         if docs:
             return Dataset(**docs[0])
-            # ds.name, ds.input_path, ds.upload_dt, ds.metadata, ds.config, ds.status, ds.is_public, ds.mol_dbs = r
         else:
             raise UnknownDSID('Dataset does not exist: {}'.format(ds_id))
 
@@ -87,16 +113,14 @@ class Dataset(object):
         r = db.select_one(self.DS_SEL, params=(self.id,))
         return True if r else False
 
-    def save(self, db, es, status_queue=None):
-        assert self.id and self.name and self.input_path and self.upload_dt and self.config and self.status \
-               and self.is_public is not None
+    def save(self, db, es=None, status_queue=None):
         doc = {
             'id': self.id,
             'name': self.name,
             'input_path': self.input_path,
             'upload_dt': self.upload_dt,
-            'metadata': json.dumps(self.metadata),
-            'config': json.dumps(self.config),
+            'metadata': json.dumps(self.metadata or {}),
+            'config': json.dumps(self.config or {}),
             'status': self.status,
             'is_public': self.is_public,
             'mol_dbs': self.mol_dbs,
@@ -108,7 +132,8 @@ class Dataset(object):
             db.alter(self.DS_UPD, params=doc)
         logger.info("Inserted into dataset table: %s, %s", self.id, self.name)
 
-        es.sync_dataset(self.id)
+        if es:
+            es.sync_dataset(self.id)
         if status_queue:
             status_queue.publish({'ds_id': self.id, 'status': self.status})
 
@@ -143,3 +168,55 @@ class Dataset(object):
         if email:
             msg['user_email'] = email.lower()
         return msg
+
+    def _generate_config(self):
+        if not self._metadata or 'MS_Analysis' not in self._metadata:
+            return None
+
+        polarity_dict = {'Positive': '+', 'Negative': '-'}
+        polarity = polarity_dict[self._metadata['MS_Analysis']['Polarity']]
+        instrument = self._metadata['MS_Analysis']['Analyzer']
+        rp = self._metadata['MS_Analysis']['Detector_Resolving_Power']
+        rp_mz = float(rp['mz'])
+        rp_resolution = float(rp['Resolving_Power'])
+
+        if instrument == 'FTICR':
+            rp200 = rp_resolution * rp_mz / 200.0
+        elif instrument == 'Orbitrap':
+            rp200 = rp_resolution * (rp_mz / 200.0)**0.5
+        else:
+            rp200 = rp_resolution
+
+        if rp200 < 85000: params = RESOL_POWER_PARAMS['70K']
+        elif rp200 < 120000: params = RESOL_POWER_PARAMS['100K']
+        elif rp200 < 195000: params = RESOL_POWER_PARAMS['140K']
+        elif rp200 < 265000: params = RESOL_POWER_PARAMS['250K']
+        elif rp200 < 390000: params = RESOL_POWER_PARAMS['280K']
+        elif rp200 < 625000: params = RESOL_POWER_PARAMS['500K']
+        elif rp200 < 875000: params = RESOL_POWER_PARAMS['750K']
+        else: params = RESOL_POWER_PARAMS['1000K']
+
+        for default_moldb in self._sm_config['ds_config_defaults']['moldb_names']:
+            if default_moldb not in self.mol_dbs:
+                self.mol_dbs.append(default_moldb)
+        if not self.adducts:
+            self.adducts = self._sm_config['ds_config_defaults']['adducts'][polarity]
+
+        self.config = {
+            'databases': self.mol_dbs,
+            'isotope_generation': {
+                'adducts': self.adducts,
+                'charge': {
+                    'polarity': polarity,
+                    'n_charges': 1
+                },
+                'isocalc_sigma': float(f"{params['sigma']:f}"),
+                'isocalc_pts_per_mz': int(params['pts_per_mz'])
+            },
+            'image_generation': {
+                'ppm': 3,
+                'nlevels': 30,
+                'q': 99,
+                'do_preprocessing': False
+            }
+        }

--- a/metaspace/engine/sm/engine/msm_basic/msm_basic_search.py
+++ b/metaspace/engine/sm/engine/msm_basic/msm_basic_search.py
@@ -45,13 +45,12 @@ class MSMBasicSearch(SearchAlgorithm):
                           .apply(lambda df: df.int.tolist()).to_dict())
         all_sf_metrics_df = sf_image_metrics(sf_images=sf_images, metrics=self.metrics, ds=self._ds,
                                              ds_reader=self._ds_reader, ion_centr_ints=ion_centr_ints, sc=self._sc)
-        return all_sf_metrics_df
+        return all_sf_metrics_df.join(self._centr_gen.ion_df)
 
     def estimate_fdr(self, ion_metrics_df):
-        ion_metrics_sf_adduct_df = ion_metrics_df.join(self._centr_gen.ion_df)
         sf_adduct_fdr_df = self._fdr.estimate_fdr(
-            ion_metrics_sf_adduct_df.set_index(['sf', 'adduct']).msm)
-        ion_metrics_sf_adduct_fdr_df = pd.merge(ion_metrics_sf_adduct_df.reset_index(),
+            ion_metrics_df.set_index(['sf', 'adduct']).msm)
+        ion_metrics_sf_adduct_fdr_df = pd.merge(ion_metrics_df.reset_index(),
                                                 sf_adduct_fdr_df.reset_index(),
                                                 how='inner', on=['sf', 'adduct']).set_index('ion_i')
         return ion_metrics_sf_adduct_fdr_df

--- a/metaspace/engine/sm/engine/sm_daemons.py
+++ b/metaspace/engine/sm/engine/sm_daemons.py
@@ -57,7 +57,6 @@ class SMDaemonManager(object):
         if del_first:
             self.logger.warning('Deleting all results for dataset: {}'.format(ds.id))
             self._del_iso_images(ds)
-            # self._es.delete_ds(ds.id)
             self._db.alter('DELETE FROM job WHERE ds_id=%s', params=(ds.id,))
         ds.save(self._db, self.es)
         search_job_factory(img_store=self._img_store).run(ds)
@@ -283,7 +282,7 @@ class SMUpdateDaemon(object):
 
         if msg['action'] == 'index':
             self._manager.index(ds=ds)
-        if msg['action'] == 'update':
+        elif msg['action'] == 'update':
             self._manager.update(ds, msg['fields'])
         elif msg['action'] == 'delete':
             self._manager.delete(ds=ds)

--- a/metaspace/engine/sm/engine/tests/msm_basic/test_msm_basic_search.py
+++ b/metaspace/engine/sm/engine/tests/msm_basic/test_msm_basic_search.py
@@ -27,10 +27,10 @@ def test_filter_sf_images(spark_context):
     assert dict(flt_iso_images.take(1)).keys() == dict(sf_iso_images.take(1)).keys()
 
 
-def test_add_sf_image_est_fdr():
-    sf_metrics_df = (pd.DataFrame([[0, 0.9, 0.9, 0.9, [100.], [0], [10.], 0.9**3],
-                                  [1, 0.5, 0.5, 0.5, [100.], [0], [10.], 0.5**3]],
-                                  columns=['ion_i', 'chaos', 'spatial', 'spectral',
+def test_estimate_fdr():
+    sf_metrics_df = (pd.DataFrame([['H2O', '+H', 0, 0.9, 0.9, 0.9, [100.], [0], [10.], 0.9**3],
+                                  ['C2H2', '+H', 1, 0.5, 0.5, 0.5, [100.], [0], [10.], 0.5**3]],
+                                  columns=['sf', 'adduct', 'ion_i', 'chaos', 'spatial', 'spectral',
                                            'total_iso_ints', 'min_iso_ints', 'max_iso_ints', 'msm'])
                      .set_index(['ion_i']))
 
@@ -46,10 +46,9 @@ def test_add_sf_image_est_fdr():
                                 centr_gen=centr_gen_mock, fdr=fdr_mock, ds_config=None)
     res_metrics_df = search_alg.estimate_fdr(sf_metrics_df)
 
-    exp_col_list = ['ion_i', 'chaos', 'spatial', 'spectral',
-                    'total_iso_ints', 'min_iso_ints', 'max_iso_ints', 'msm',
-                    'sf', 'adduct', 'fdr']
-    exp_metrics_df = pd.DataFrame([[0, 0.9, 0.9, 0.9, [100.], [0], [10.], 0.9**3, 'H2O', '+H', 0.99],
-                                   [1, 0.5, 0.5, 0.5, [100.], [0], [10.], 0.5**3, 'C2H2', '+H', 0.5]],
+    exp_col_list = ['sf', 'adduct', 'ion_i', 'chaos', 'spatial', 'spectral',
+                    'total_iso_ints', 'min_iso_ints', 'max_iso_ints', 'msm', 'fdr']
+    exp_metrics_df = pd.DataFrame([['H2O', '+H', 0, 0.9, 0.9, 0.9, [100.], [0], [10.], 0.9**3, 0.99],
+                                   ['C2H2', '+H', 1, 0.5, 0.5, 0.5, [100.], [0], [10.], 0.5**3, 0.5]],
                                   columns=exp_col_list).set_index(['ion_i'])
     assert_frame_equal(res_metrics_df, exp_metrics_df)

--- a/metaspace/engine/sm/engine/tests/test_isocalc_wrapper.py
+++ b/metaspace/engine/sm/engine/tests/test_isocalc_wrapper.py
@@ -23,8 +23,8 @@ def test_isotopic_pattern_h20(ds_config):
     isocalc_wrapper = IsocalcWrapper(ds_config['isotope_generation'])
     mzs, ints = isocalc_wrapper.ion_centroids('H2O', '+H')
 
-    assert_array_almost_equal(mzs, np.array([19.018,  20.023,  21.023]), decimal=3)
-    assert_array_almost_equal(ints, np.array([100.,   0.072,   0.205]), decimal=2)
+    assert_array_almost_equal(mzs, np.array([19.018, 20.022, 20.024, 21.022]), decimal=3)
+    assert_array_almost_equal(ints, np.array([1.00e+02, 3.83e-02, 3.48e-02, 2.06e-01]), decimal=2)
 
 
 def test_isotopic_pattern_has_n_peaks(ds_config):

--- a/metaspace/engine/sm/engine/tests/util.py
+++ b/metaspace/engine/sm/engine/tests/util.py
@@ -2,13 +2,13 @@ import json
 import logging
 from pathlib import Path
 from unittest.mock import MagicMock
-
 import pytest
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 from fabric.api import local
 from pysparkling import Context
 import pandas as pd
+import uuid
 
 from sm.engine.db import DB
 from sm.engine.mol_db import MolecularDB
@@ -24,6 +24,44 @@ init_loggers(SMConfig.get_conf()['logs'])
 @pytest.fixture(scope='session')
 def sm_config():
     return SMConfig.get_conf(update=True)
+
+
+@pytest.fixture()
+def metadata():
+    return {
+        "Data_Type": "Imaging MS",
+        "MS_Analysis": {
+            "Polarity": "Positive",
+            "Ionisation_Source": "MALDI",
+            "Detector_Resolving_Power": {
+                "Resolving_Power": 80000,
+                "mz": 700
+            },
+            "Analyzer": "FTICR"
+        }
+    }
+
+
+@pytest.fixture()
+def ds_config():
+    return {
+        "image_generation": {
+            "q": 99,
+            "do_preprocessing": False,
+            "nlevels": 30,
+            "ppm": 3
+        },
+        "isotope_generation": {
+            "adducts": ["+H", "+Na", "+K"],
+            "charge": {
+                "polarity": "+",
+                "n_charges": 1
+            },
+            "isocalc_sigma": 0.000619,
+            "isocalc_pts_per_mz": 8078
+        },
+        "databases": ["HMDB-v4"]
+    }
 
 
 class SparkContext(Context):
@@ -58,6 +96,28 @@ def test_db(sm_config, request):
         sm_config['db']['host'], sm_config['db']['user'],
         Path(proj_root()) / 'scripts/create_schema.sql'))
 
+    db_config = dict(**sm_config['db'])
+    db = DB(db_config, autocommit=True)
+    db.alter('''
+        CREATE SCHEMA IF NOT EXISTS graphql;
+        CREATE TABLE graphql.dataset (
+            id        text,
+            user_id   uuid,
+            group_id  uuid
+        );
+        CREATE TABLE graphql.user (
+            id     uuid,
+            name   text,
+            email  text
+        );
+        CREATE TABLE graphql.group (
+            id          uuid,
+            name        text,
+            short_name  text
+        );'''
+    )
+    db.close()
+
     def fin():
         db = DB(db_config, autocommit=True)
         try:
@@ -70,15 +130,14 @@ def test_db(sm_config, request):
 
 
 @pytest.fixture()
-def fill_db(test_db, sm_config, ds_config):
+def fill_db(test_db, sm_config, metadata, ds_config):
     upload_dt = '2000-01-01 00:00:00'
     ds_id = '2000-01-01'
-    meta = {"meta": "data"}
     db = DB(sm_config['db'])
     db.insert('INSERT INTO dataset (id, name, input_path, upload_dt, metadata, config, '
               'status, is_public, mol_dbs, adducts) values (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)',
               rows=[(ds_id, 'ds_name', 'input_path', upload_dt,
-                     json.dumps(meta), json.dumps(ds_config), 'FINISHED',
+                     json.dumps(metadata), json.dumps(ds_config), 'FINISHED',
                      True, ['HMDB-v4'], ['+H'])])
     db.insert("INSERT INTO job (id, db_id, ds_id) VALUES (%s, %s, %s)",
               rows=[(0, 0, ds_id)])
@@ -87,31 +146,15 @@ def fill_db(test_db, sm_config, ds_config):
     db.insert(("INSERT INTO iso_image_metrics (job_id, db_id, sf, adduct, iso_image_ids) "
                "VALUES (%s, %s, %s, %s, %s)"),
               rows=[(0, 0, 'H2O', '+H', ['iso_image_1_id', 'iso_image_2_id'])])
+    user_id = str(uuid.uuid4())
+    db.insert("INSERT INTO graphql.user (id, name, email) VALUES (%s, %s, %s)",
+              rows=[(user_id, 'name', 'name@embl.de')])
+    group_id = str(uuid.uuid4())
+    db.insert("INSERT INTO graphql.group (id, name, short_name) VALUES (%s, %s, %s)",
+              rows=[(group_id, 'group name', 'short name')])
+    db.insert("INSERT INTO graphql.dataset (id, user_id, group_id) VALUES (%s, %s, %s)",
+              rows=[('dataset id', user_id, group_id)])
     db.close()
-
-
-@pytest.fixture()
-def ds_config():
-    return {
-        "databases": [
-            "HMDB-v4"
-        ],
-        "isotope_generation": {
-            "adducts": ["+H", "+Na"],
-            "charge": {
-                "polarity": "+",
-                "n_charges": 1
-            },
-            "isocalc_sigma": 0.01,
-            "isocalc_pts_per_mz": 10000
-        },
-        "image_generation": {
-            "ppm": 1.0,
-            "nlevels": 30,
-            "q": 99,
-            "do_preprocessing": False
-        }
-    }
 
 
 @pytest.fixture()

--- a/metaspace/engine/sm/engine/util.py
+++ b/metaspace/engine/sm/engine/util.py
@@ -8,8 +8,6 @@ from pathlib import Path
 import re
 from fnmatch import translate
 
-from sm.engine.dataset import Dataset
-
 
 def proj_root():
     return os.getcwd()
@@ -135,7 +133,9 @@ def create_ds_from_files(ds_id, ds_name, ds_input_path):
                   if re.match(regexp, str(f))][0]
     ms_file_type_config = SMConfig.get_ms_file_handler(str(imzml_path))
     img_storage_type = ms_file_type_config['img_storage_type']
-    return Dataset(ds_id, ds_name, str(ds_input_path), datetime.now(), metadata, ds_config,
+
+    from sm.engine.dataset import Dataset
+    return Dataset(ds_id, ds_name, str(ds_input_path), datetime.now(), metadata,
                    is_public=True,
                    mol_dbs=ds_config['databases'],
                    adducts=ds_config['isotope_generation']['adducts'],

--- a/metaspace/engine/tests/test_api_dataset_manager.py
+++ b/metaspace/engine/tests/test_api_dataset_manager.py
@@ -1,7 +1,5 @@
-from unittest.mock import patch, MagicMock, call
-import json
+from unittest.mock import MagicMock, call
 from datetime import datetime
-import pytest
 from PIL import Image
 
 from sm.engine.db import DB
@@ -10,7 +8,7 @@ from sm.engine.queue import QueuePublisher
 from sm.rest.dataset_manager import SMapiDatasetManager
 from sm.rest.dataset_manager import Dataset, DatasetActionPriority, DatasetStatus
 from sm.engine.png_generator import ImageStoreServiceWrapper
-from sm.engine.tests.util import pysparkling_context, sm_config, ds_config, test_db, fill_db
+from sm.engine.tests.util import sm_config, metadata, ds_config, test_db, fill_db
 
 
 def create_api_ds_man(sm_config, db=None, es=None, img_store=None,
@@ -22,71 +20,74 @@ def create_api_ds_man(sm_config, db=None, es=None, img_store=None,
     status_queue_mock = status_queue or MagicMock(QueuePublisher)
     img_store_mock = img_store or MagicMock(spec=ImageStoreServiceWrapper)
 
-    return SMapiDatasetManager(db=db, es=es_mock,
-                               image_store=img_store_mock,
-                               annot_queue=annot_queue_mock,
-                               update_queue=update_queue_mock,
-                               status_queue=status_queue_mock)
+    return db, SMapiDatasetManager(db=db, es=es_mock,
+                                   image_store=img_store_mock,
+                                   annot_queue=annot_queue_mock,
+                                   update_queue=update_queue_mock,
+                                   status_queue=status_queue_mock)
 
 
-def create_ds(ds_id='2000-01-01', ds_name='ds_name', input_path='input_path', upload_dt=None,
-              metadata=None, ds_config=None, status=DatasetStatus.NEW, mol_dbs=None, adducts=None):
+def create_ds_doc(ds_id='2000-01-01', ds_name='ds_name', input_path='input_path', upload_dt=None,
+                  metadata=None, status=DatasetStatus.NEW, mol_dbs=None, adducts=None):
     upload_dt = upload_dt or datetime.now()
     if not mol_dbs:
         mol_dbs = ['HMDB-v4']
     if not adducts:
         adducts = ['+H', '+Na', '+K']
-    return Dataset(ds_id, ds_name, input_path, upload_dt, metadata or {}, ds_config or {},
-                   status=status, mol_dbs=mol_dbs, adducts=adducts, img_storage_type='fs')
+    return dict(
+        id=ds_id, name=ds_name, input_path=input_path, upload_dt=upload_dt, metadata=metadata,
+        status=status, mol_dbs=mol_dbs, adducts=adducts, img_storage_type='fs', is_public=True
+    )
 
 
 class TestSMapiDatasetManager:
 
     def test_add_new_ds(self, test_db, sm_config, ds_config):
         action_queue_mock = MagicMock(spec=QueuePublisher)
-        ds_man = create_api_ds_man(sm_config, annot_queue=action_queue_mock)
+        _, ds_man = create_api_ds_man(sm_config, annot_queue=action_queue_mock)
 
         ds_id = '2000-01-01'
-        ds = create_ds(ds_id=ds_id, ds_config=ds_config)
+        ds_doc = create_ds_doc(ds_id=ds_id)
 
-        ds_man.add(ds, priority=DatasetActionPriority.HIGH)
+        ds_man.add(ds_doc, priority=DatasetActionPriority.HIGH)
 
         msg = {'ds_id': ds_id, 'ds_name': 'ds_name', 'action': 'annotate'}
         action_queue_mock.publish.assert_has_calls([call(msg, DatasetActionPriority.HIGH)])
 
     def test_delete_ds(self, test_db, sm_config, ds_config):
         update_queue = MagicMock(spec=QueuePublisher)
-        ds_man = create_api_ds_man(sm_config, update_queue=update_queue)
-
+        db, ds_man = create_api_ds_man(sm_config, update_queue=update_queue)
         ds_id = '2000-01-01'
-        ds = create_ds(ds_id=ds_id, ds_config=ds_config)
+        ds = Dataset(**create_ds_doc(ds_id=ds_id))
+        ds.save(db)
 
-        ds_man.delete(ds)
+        ds_man.delete(ds_id)
 
         msg = {'ds_id': ds_id, 'ds_name': 'ds_name', 'action': 'delete'}
         update_queue.publish.assert_has_calls([call(msg, DatasetActionPriority.STANDARD)])
 
     def test_add_optical_image(self, fill_db, sm_config, ds_config):
-        db = DB(sm_config['db'])
         action_queue_mock = MagicMock(spec=QueuePublisher)
         es_mock = MagicMock(spec=ESExporter)
         img_store_mock = MagicMock(ImageStoreServiceWrapper)
         img_store_mock.post_image.side_effect = ['opt_img_id1', 'opt_img_id2', 'opt_img_id3', 'thumbnail_id']
         img_store_mock.get_image_by_id.return_value = Image.new('RGB', (100, 100))
 
-        ds_man = create_api_ds_man(sm_config=sm_config, db=db, es=es_mock,
-                                   img_store=img_store_mock, annot_queue=action_queue_mock)
+        db, ds_man = create_api_ds_man(sm_config=sm_config, es=es_mock,
+                                       img_store=img_store_mock, annot_queue=action_queue_mock)
         ds_man._annotation_image_shape = MagicMock(return_value=(100, 100))
 
         ds_id = '2000-01-01'
-        ds = create_ds(ds_id=ds_id, ds_config=ds_config)
+        ds = Dataset(**create_ds_doc(ds_id=ds_id))
+        ds.save(db)
 
         zoom_levels = [1, 2, 3]
         raw_img_id = 'raw_opt_img_id'
-        ds_man.add_optical_image(ds, raw_img_id, [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        ds_man.add_optical_image(ds_id, raw_img_id, [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
                                  zoom_levels=zoom_levels)
         assert db.select('SELECT * FROM optical_image') == [
-                ('opt_img_id{}'.format(i + 1), ds.id, zoom)
-                for i, zoom in enumerate(zoom_levels)]
+            ('opt_img_id{}'.format(i + 1), ds.id, zoom)
+            for i, zoom in enumerate(zoom_levels)
+        ]
         assert db.select('SELECT optical_image FROM dataset where id = %s', params=(ds_id,)) == [(raw_img_id,)]
         assert db.select('SELECT thumbnail FROM dataset where id = %s', params=(ds_id,)) == [('thumbnail_id',)]

--- a/metaspace/engine/tests/test_dataset.py
+++ b/metaspace/engine/tests/test_dataset.py
@@ -1,21 +1,19 @@
 from datetime import datetime
 import json
 from unittest.mock import MagicMock
-
 from pytest import fixture
 
 from sm.engine.dataset import DatasetStatus, Dataset
 from sm.engine.db import DB
 from sm.engine.es_export import ESExporter
 from sm.engine.queue import QueuePublisher
-from sm.engine.tests.util import pysparkling_context, sm_config, ds_config, test_db
+from sm.engine.tests.util import sm_config, test_db, metadata, ds_config
 
 
 @fixture
-def fill_db(test_db, sm_config, ds_config):
+def fill_db(test_db, sm_config, metadata, ds_config):
     upload_dt = '2000-01-01 00:00:00'
     ds_id = '2000-01-01'
-    metadata = {"meta": "data"}
     db = DB(sm_config['db'])
     db.insert(('INSERT INTO dataset (id, name, input_path, upload_dt, metadata, config, status, '
                'is_public, mol_dbs, adducts) '
@@ -25,29 +23,37 @@ def fill_db(test_db, sm_config, ds_config):
                      True, ['HMDB-v4'], ['+H', '+Na', '+K'])])
 
 
-def test_dataset_load_existing_ds_works(fill_db, sm_config, ds_config):
+def test_config_field_generated(sm_config, metadata, ds_config):
+    ds = Dataset(id='2000-01-01', name='ds_name', input_path='input_path', upload_dt=datetime.now(),
+                 metadata=metadata, mol_dbs=['HMDB-v4'])
+
+    assert ds.config == ds_config
+
+
+def test_dataset_load_existing_ds_works(fill_db, sm_config, metadata, ds_config):
     db = DB(sm_config['db'])
-    upload_dt = datetime.strptime('2000-01-01 00:00:00', "%Y-%m-%d %H:%M:%S")
+    upload_dt = datetime.strptime('2000-01-01 00:00:00', '%Y-%m-%d %H:%M:%S')
     ds_id = '2000-01-01'
-    metadata = {"meta": "data"}
 
     ds = Dataset.load(db, ds_id)
 
-    assert ds.__dict__ == dict(id=ds_id, name='ds_name', input_path='input_path', upload_dt=upload_dt,
-                               metadata=metadata, config=ds_config, status=DatasetStatus.FINISHED,
-                               is_public=True, mol_dbs=['HMDB-v4'], adducts=['+H', '+Na', '+K'],
-                               ion_img_storage_type='fs')
+    assert ds.metadata == metadata
+    ds_fields = {k: v for k, v in ds.__dict__.items() if not k.startswith('_')}
+    assert ds_fields == dict(
+        id=ds_id, name='ds_name', input_path='input_path', upload_dt=upload_dt,
+        config=ds_config, status=DatasetStatus.FINISHED, is_public=True,
+        mol_dbs=['HMDB-v4'], adducts=['+H', '+Na', '+K'], ion_img_storage_type='fs'
+    )
 
 
-def test_dataset_save_overwrite_ds_works(fill_db, sm_config, ds_config):
+def test_dataset_save_overwrite_ds_works(fill_db, sm_config, metadata, ds_config):
     db = DB(sm_config['db'])
     es_mock = MagicMock(spec=ESExporter)
     status_queue_mock = MagicMock(spec=QueuePublisher)
 
     upload_dt = datetime.now()
     ds_id = '2000-01-01'
-    ds = Dataset(ds_id, 'ds_name', 'input_path', upload_dt, {}, ds_config,
-                 mol_dbs=['HMDB'], adducts=['+H'])
+    ds = Dataset(ds_id, 'ds_name', 'input_path', upload_dt, metadata, mol_dbs=['HMDB'])
 
     ds.save(db, es_mock, status_queue_mock)
 
@@ -56,15 +62,14 @@ def test_dataset_save_overwrite_ds_works(fill_db, sm_config, ds_config):
     status_queue_mock.publish.assert_called_with({'ds_id': ds_id, 'status': DatasetStatus.NEW})
 
 
-def test_dataset_update_status_works(fill_db, sm_config, ds_config):
+def test_dataset_update_status_works(fill_db, sm_config, metadata):
     db = DB(sm_config['db'])
     es_mock = MagicMock(spec=ESExporter)
     status_queue_mock = MagicMock(spec=QueuePublisher)
 
     upload_dt = datetime.now()
     ds_id = '2000-01-01'
-    ds = Dataset(ds_id, 'ds_name', 'input_path', upload_dt, {}, ds_config, DatasetStatus.INDEXING,
-                 mol_dbs=['HMDB'], adducts=['+H'])
+    ds = Dataset(ds_id, 'ds_name', 'input_path', upload_dt, metadata, DatasetStatus.INDEXING, mol_dbs=['HMDB'])
 
     ds.set_status(db, es_mock, status_queue_mock, DatasetStatus.FINISHED)
 
@@ -72,14 +77,11 @@ def test_dataset_update_status_works(fill_db, sm_config, ds_config):
     status_queue_mock.publish.assert_called_once_with({'ds_id': ds_id, 'status': DatasetStatus.FINISHED})
 
 
-def test_dataset_to_queue_message_works():
+def test_dataset_to_queue_message_works(metadata, ds_config):
     upload_dt = datetime.now()
     ds_id = '2000-01-01'
-    meta = {'Submitted_By': {'Submitter': {'Email': 'user@example.com'}}}
-    ds = Dataset(ds_id, 'ds_name', 'input_path', upload_dt, meta, ds_config,
-                 mol_dbs=['HDMB'], adducts=['+H'])
+    ds = Dataset(ds_id, 'ds_name', 'input_path', upload_dt, metadata, mol_dbs=['HDMB'])
 
     msg = ds.to_queue_message()
 
-    assert {'ds_id': ds_id, 'ds_name': 'ds_name', 'input_path': 'input_path',
-            'user_email': 'user@example.com'} == msg
+    assert {'ds_id': ds_id, 'ds_name': 'ds_name', 'input_path': 'input_path'} == msg

--- a/metaspace/engine/tests/test_search_job.py
+++ b/metaspace/engine/tests/test_search_job.py
@@ -1,3 +1,0 @@
-from unittest.mock import patch
-
-from sm.engine.tests.util import test_db, sm_config

--- a/metaspace/graphql/config/config.js.template
+++ b/metaspace/graphql/config/config.js.template
@@ -11,11 +11,6 @@ config.img_storage_port = 4201;
 config.log = {};
 config.log.level = 'info';
 
-config.defaults = {
-  adducts: {{ sm_graphql_default_adducts | to_json }},
-  moldb_names: ['HMDB-v4']
-}
-
 
 /* Settings for image storage.
    It's currently co-hosted with the GraphQL server. */

--- a/metaspace/graphql/datasetFilters.js
+++ b/metaspace/graphql/datasetFilters.js
@@ -147,7 +147,7 @@ const datasetFilters = {
   ids: new DatasetIdFilter(),
   status: new ExactMatchFilter('', {esField: 'ds_status', pgField: 'status'}),
   submitter: new PersonFilter('Submitted_By.Submitter'),
-  hasGroup: new NotNullFilter('GroupId'), // FIXME: Use a real field
+  hasGroup: new NotNullFilter('ds_group_id'),
   metadataType: new ExactMatchFilter('Data_Type', {}),
 };
 

--- a/metaspace/graphql/resolvers.js
+++ b/metaspace/graphql/resolvers.js
@@ -327,8 +327,21 @@ const Resolvers = {
     metadataType(ds) { return dsField(ds, 'metadataType'); },
 
     submitter(ds) {
-      return _.get(ds._source.ds_meta, 'Submitted_By.Submitter');
-      // TODO: return ds._source.ds_submitter;
+      return {
+        id: ds._source.ds_submitter_id,
+        name: ds._source.ds_submitter_name,
+        email: ds._source.ds_submitter_email,
+      };
+    },
+
+    group(ds) {
+      if (ds._source.ds_group_id) {
+        return {
+          id: ds._source.ds_group_id,
+          name: ds._source.ds_group_name,
+          shortName: ds._source.ds_group_short_name,
+        }
+      };
     },
 
     principalInvestigator(ds) {
@@ -507,8 +520,8 @@ const Resolvers = {
       return DSMutation.create(args, context);
     },
 
-    updateDataset: (_, args, {user}) => {
-      return DSMutation.update(args, user);
+    updateDataset: (_, args, context) => {
+      return DSMutation.update(args, context);
     },
 
     deleteDataset: (_, args, {user}) => {

--- a/metaspace/graphql/schema.graphql
+++ b/metaspace/graphql/schema.graphql
@@ -241,27 +241,27 @@ input DatasetCreateInput {
   name: String!
   inputPath: String!
   uploadDT: String
+  metadataJson: String!
+  molDBs: [String!]!
+  adducts: [String!]!
   submitterId: ID
   groupId: ID
   projectIds: [ID!] = []
   principalInvestigator: PersonInput
   isPublic: Boolean! = true
-  molDBs: [String!]!
-  adducts: [String!]!
-  metadataJson: String!
 }
 
 input DatasetUpdateInput {
   name: String
   uploadDT: String
   metadataJson: String
-  submitterId: ID
-  groupId: ID
-  projectIds: [ID!] = []
-  principalInvestigator: PersonInput
-  isPublic: Boolean = true
   molDBs: [String!]
   adducts: [String!]
+  submitterId: ID
+  groupId: ID
+  projectIds: [ID!]
+  principalInvestigator: PersonInput
+  isPublic: Boolean
 }
 
 type DatasetCountPerGroupListElement {

--- a/metaspace/graphql/server.js
+++ b/metaspace/graphql/server.js
@@ -67,7 +67,6 @@ async function createHttpServerAsync(config) {
   const apollo = new ApolloServer({
     schema: executableSchema,
     context: ({req}) => {
-      // if (!req.user) throw new UserError('You must be logged in');
       return {
         user: req.user.user,
         connection

--- a/metaspace/graphql/src/modules/user/controller.ts
+++ b/metaspace/graphql/src/modules/user/controller.ts
@@ -20,15 +20,6 @@ const hasAccess = (user: UserModel, userId?: string) => {
   }
 };
 
-export const addUserDataset = async ({userId, dsId}: any, {user, connection}: any) => {
-  hasAccess(user, userId);
-
-  return connection.getRepository(DatasetModel).insert({
-    id: dsId,
-    userId: userId
-  });
-};
-
 export const Resolvers = {
   User: {
     async primaryGroup(user: UserModel, _: any, {connection}: any) {

--- a/metaspace/graphql/src/modules/user/model.ts
+++ b/metaspace/graphql/src/modules/user/model.ts
@@ -38,14 +38,14 @@ export class Dataset {
   id: string;
 
   @Column({ type: 'text', name: 'user_id' })
-  userId: string;
+  userId: string; // dataset submitter and owner -> edit rights
 
   @ManyToOne(type => User, user => user.datasets)
   @JoinColumn({ name: 'user_id' })
   user: User;
 
   @Column({ type: 'text', name: 'group_id', nullable: true })
-  groupId: string;
+  groupId: string; // dataset belongs to group -> all members have view rights
 
   @ManyToOne(type => Group)
   @JoinColumn({ name: 'group_id' })

--- a/metaspace/graphql/utils.js
+++ b/metaspace/graphql/utils.js
@@ -9,19 +9,6 @@ const slack = require('node-slack'),
 
 const config = require('config');
 
-
-const RESOL_POWER_PARAMS = {
-    '70K': {sigma: 0.00247585727028, fwhm: 0.00583019832869, pts_per_mz: 2019},
-    '100K': {sigma: 0.0017331000892, fwhm: 0.00408113883008, pts_per_mz: 2885},
-    '140K': {sigma: 0.00123792863514, fwhm: 0.00291509916435, pts_per_mz: 4039},
-    '200K': {sigma: 0.000866550044598, fwhm: 0.00204056941504, pts_per_mz: 5770},
-    '250K': {sigma: 0.000693240035678, fwhm: 0.00163245553203, pts_per_mz: 7212},
-    '280K': {sigma: 0.00061896431757, fwhm: 0.00145754958217, pts_per_mz: 8078},
-    '500K': {sigma: 0.000346620017839, fwhm: 0.000816227766017, pts_per_mz: 14425},
-    '750K': {sigma: 0.000231080011893, fwhm: 0.000544151844011, pts_per_mz: 21637},
-    '1000K': {sigma: 0.00017331000892, fwhm: 0.000408113883008, pts_per_mz: 28850},
-};
-
 function metadataChangeSlackNotify(user, datasetId, oldMetadata, newMetadata) {
   const delta = jsondiffpatch.diff(oldMetadata, newMetadata),
     diff = jsondiffpatch.formatters.jsonpatch.format(delta);


### PR DESCRIPTION
- Partially update ES documents without full re-indexing when dataset metadata, user, group change
- Dataset config generated on the Engine side
- Export to ES reads from the Engine and GraphQL schemas