### PR TITLE
Custom URLs

### DIFF
--- a/metaspace/graphql/src/modules/auth/controller.ts
+++ b/metaspace/graphql/src/modules/auth/controller.ts
@@ -165,8 +165,8 @@ const configureGoogleAuth = (app: Express) => {
     }));
 
     app.get('/api_auth/google/callback', Passport.authenticate('google', {
-      successRedirect: '/#/datasets',
-      failureRedirect: '/#/account/sign-in',
+      successRedirect: '/datasets',
+      failureRedirect: '/account/sign-in',
     }));
   }
 };
@@ -191,12 +191,12 @@ const configureCreateAccount = (app: Express) => {
           next(err);
         } else {
           res.cookie('flashMessage', JSON.stringify({type: 'verify_email_success'}), {maxAge: 10*60*1000});
-          res.redirect('/#/');
+          res.redirect('/');
         }
       });
     } else {
       res.cookie('flashMessage', JSON.stringify({type: 'verify_email_failure'}), {maxAge: 10*60*1000});
-      res.redirect('/#/');
+      res.redirect('/');
     }
   });
 };

--- a/metaspace/graphql/src/modules/auth/operation.ts
+++ b/metaspace/graphql/src/modules/auth/operation.ts
@@ -172,7 +172,7 @@ export const sendResetPasswordToken = async (email: string): Promise<void> => {
   else {
     resetPasswordToken = cred.resetPasswordToken;
   }
-  const link = `${config.web_public_url}/#/account/reset-password?email=${encodeURIComponent(email)}&token=${encodeURIComponent(resetPasswordToken)}`;
+  const link = `${config.web_public_url}/account/reset-password?email=${encodeURIComponent(email)}&token=${encodeURIComponent(resetPasswordToken)}`;
   emailService.sendResetPasswordEmail(email, link);
   logger.debug(`Sent password reset email to ${email}: ${link}`);
 };

--- a/metaspace/webapp/package.json
+++ b/metaspace/webapp/package.json
@@ -26,6 +26,7 @@
     "apollo-link-ws": "^1.0.8",
     "aws-sdk": "^2.36.0",
     "body-parser": "^1.16.0",
+    "compression": "^1.6.2",
     "concat-files": "^0.1.1",
     "connect-history-api-fallback": "^1.5.0",
     "connect-redis": "^3.2.0",

--- a/metaspace/webapp/package.json
+++ b/metaspace/webapp/package.json
@@ -27,6 +27,7 @@
     "aws-sdk": "^2.36.0",
     "body-parser": "^1.16.0",
     "concat-files": "^0.1.1",
+    "connect-history-api-fallback": "^1.5.0",
     "connect-redis": "^3.2.0",
     "cookie-parser": "^1.4.3",
     "css-element-queries": "^0.4.0",

--- a/metaspace/webapp/server.js
+++ b/metaspace/webapp/server.js
@@ -100,8 +100,8 @@ const configureGoogleAuth = (app, knex) => {
 
     app.get('/auth/google/callback',
       passport.authenticate('google', {
-        successRedirect: '/#/datasets',
-        failureRedirect: '/#/help',
+        successRedirect: '/datasets',
+        failureRedirect: '/help',
       }))
   }
 };

--- a/metaspace/webapp/server.js
+++ b/metaspace/webapp/server.js
@@ -7,7 +7,8 @@ const AWS = require('aws-sdk'),
       favicon = require('serve-favicon'),
       session = require('express-session'),
       GoogleStrategy = require('passport-google-oauth20').Strategy,
-      Raven = require('raven');
+      Raven = require('raven'),
+      connectHistoryApiFallback = require('connect-history-api-fallback');
 
 const env = process.env.NODE_ENV || 'development';
 const conf = require('./conf.js');
@@ -249,8 +250,6 @@ const configureJwtMinting = (app, knex) => {
 };
 
 const configureAppServer = (app) => {
-  app.get('/', (req, res, next) =>
-    res.sendFile(__dirname + '/index.html'));
 
   if (env === 'development') {
     const webpackDevMiddleware = require('webpack-dev-middleware');
@@ -272,6 +271,9 @@ const configureAppServer = (app) => {
       maxAge: '10m'
     }));
   }
+
+  app.use(connectHistoryApiFallback({index: '/'})); // Rewrite unknown non-file paths to serve index.html
+  app.get('/', (req, res) => res.sendFile(__dirname + '/index.html'));
 };
 
 const configureRavenRequestHandler = (app) => {
@@ -317,8 +319,9 @@ const startServer = () => {
     });
 
   configureJwtMinting(app, knex);
-  configureAppServer(app);
   configureUploadHandler(app);
+  // Keep configureAppServer as the last route handler, because connectHistoryApiFallback rewrites unhandled routes to serve index.html
+  configureAppServer(app);
   configureRavenErrorHandler(app);
 
   app.listen(conf.PORT, () => {

--- a/metaspace/webapp/src/api/group.ts
+++ b/metaspace/webapp/src/api/group.ts
@@ -29,6 +29,7 @@ export interface UpdateGroupMutation {
     id: string;
     name: string;
     shortName: string;
+    urlSlug: string | null;
     currentUserRole: UserGroupRole | null;
   }
 }
@@ -38,6 +39,7 @@ export const updateGroupMutation =
       id
       name
       shortName
+      urlSlug
       currentUserRole
     }
   }`;
@@ -97,6 +99,7 @@ export const editGroupQuery =
       id
       name
       shortName
+      urlSlug
       currentUserRole
       members {
         role
@@ -114,6 +117,7 @@ export interface EditGroupQuery {
   id: string;
   name: string;
   shortName: string;
+  urlSlug: string | null;
   currentUserRole: UserGroupRole | null;
   members: EditGroupQueryMember[] | null;
 }

--- a/metaspace/webapp/src/api/project.ts
+++ b/metaspace/webapp/src/api/project.ts
@@ -132,6 +132,7 @@ const projectsListItemFragment =
   gql`fragment ProjectsListItem on Project {
       id
       name
+      urlSlug
       isPublic
       currentUserRole
       numMembers
@@ -180,6 +181,7 @@ export interface MyProjectsListQuery {
 export interface ProjectsListProject {
   id: string;
   name: string;
+  urlSlug: string | null;
   isPublic: boolean;
   currentUserRole: ProjectRole | null;
   numMembers: number;

--- a/metaspace/webapp/src/api/project.ts
+++ b/metaspace/webapp/src/api/project.ts
@@ -28,6 +28,7 @@ export interface UpdateProjectMutation {
   data: {
     id: string;
     name: string;
+    urlSlug: string | null;
     isPublic: boolean;
     currentUserRole: ProjectRole | null;
   }
@@ -37,6 +38,7 @@ export const updateProjectMutation =
     updateProject(projectId: $projectId, projectDetails: $projectDetails) {
       id
       name
+      urlSlug
       isPublic
       currentUserRole
     }
@@ -96,6 +98,7 @@ export const editProjectQuery =
     project(projectId: $projectId) {
       id
       name
+      urlSlug
       isPublic
       currentUserRole
       members {
@@ -113,6 +116,7 @@ export const editProjectQuery =
 export interface EditProjectQuery {
   id: string;
   name: string;
+  urlSlug: string | null;
   isPublic: boolean;
   currentUserRole: ProjectRole | null;
   members: EditProjectQueryMember[] | null;

--- a/metaspace/webapp/src/api/user.ts
+++ b/metaspace/webapp/src/api/user.ts
@@ -10,6 +10,7 @@ export interface UserProfileQueryGroup {
   group: {
     id: string,
     name: string
+    urlSlug: string | null;
   };
 }
 export interface UserProfileQueryProject {
@@ -18,6 +19,7 @@ export interface UserProfileQueryProject {
   project: {
     id: string,
     name: string
+    urlSlug: string | null;
   };
 }
 
@@ -50,6 +52,7 @@ export const userProfileQuery =
       project {
         id
         name
+        urlSlug
       }
     }
   }
@@ -60,6 +63,7 @@ fragment UserProfileQueryGroup on UserGroup {
   group {
     id
     name
+    urlSlug
   }
 }
 `;

--- a/metaspace/webapp/src/lib/isUuid.ts
+++ b/metaspace/webapp/src/lib/isUuid.ts
@@ -1,0 +1,1 @@
+export default (str: string) => /[0-9A-F]{8}-([0-9A-F]{4}-){3}[0-9A-F]{12}/i.test(str);

--- a/metaspace/webapp/src/modules/Account/components/__snapshots__/CreateAccountDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Account/components/__snapshots__/CreateAccountDialog.spec.ts.snap
@@ -105,7 +105,7 @@ exports[`CreateAccountDialog should match snapshot 1`] = `
     </div>
     <p style="margin-bottom: 0px;">
       Already registered?
-      <a href="#/account/sign-in">Sign in</a>
+      <a href="/account/sign-in">Sign in</a>
     </p>
   </div>
 </mock-el-dialog>

--- a/metaspace/webapp/src/modules/Account/components/__snapshots__/SignInDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Account/components/__snapshots__/SignInDialog.spec.ts.snap
@@ -68,11 +68,11 @@ exports[`SignInDialog should match snapshot 1`] = `
     </div>
   </div>
   <p>
-    <a href="#/account/forgot-password">Forgot password?</a>
+    <a href="/account/forgot-password">Forgot password?</a>
   </p>
   <p>
     New user?
-    <a href="#/account/create-account">Create an account</a>
+    <a href="/account/create-account">Create an account</a>
   </p>
   <p style="margin-bottom: 0px;">
     Submitted data previously but never set a password?
@@ -81,7 +81,7 @@ exports[`SignInDialog should match snapshot 1`] = `
   <div style="overflow: hidden; height: auto;">
     <p style="margin-bottom: 0px;">
       We now require that all METASPACE users have an account to upload and manage datasets. If you have submitted datasets to METASPACE previously, please
-      <a href="#/account/create-account">create an account</a> using the same email address that you used when submitting the datasets, and you will be reunited with them.
+      <a href="/account/create-account">create an account</a> using the same email address that you used when submitting the datasets, and you will be reunited with them.
       <a href="mailto:contact@metaspace2020.eu">Contact us</a> if you have lost access to any datasets that you submitted.
     </p>
   </div>

--- a/metaspace/webapp/src/modules/App/AboutPage.vue
+++ b/metaspace/webapp/src/modules/App/AboutPage.vue
@@ -11,19 +11,19 @@
       <el-row id="threePanelHeader" style="margin:20px 0px 50px 0px" :gutter=20>
         <el-col :span=6>
           <h2>Metabolite Annotation</h2>
-          <p><a href="/#/upload">Submit</a> your high-resolution imaging mass spectrometry data to our high-throughput metabolite annotation engine</p>
+          <p><router-link to="/upload">Submit</router-link> your high-resolution imaging mass spectrometry data to our high-throughput metabolite annotation engine</p>
         </el-col>
 
         <el-col :span=6>
           <h2>Explore the Knowledgebase</h2>
-          <p><a href="/#/annotations">Browse</a> annotations from all datasets using our interactive interface </p>
+          <p><router-link to="/annotations">Browse</router-link> annotations from all datasets using our interactive interface </p>
           <p>You can search, filter and compare youre annotations alongside those from the whole imaging mass spectrometry community</p>
         </el-col>
 
         <el-col :span=6>
           <h2>Get Going Fast</h2>
-          <p>Head to the <a href="/#/upload">upload </a> page to submit a dataset. </p>
-          <p> We also have interactive <a href="/#/help">tutorials</a> prepared to help you.</p>
+          <p>Head to the <router-link to="/upload">upload </router-link> page to submit a dataset. </p>
+          <p> We also have interactive <router-link to="/help">tutorials</router-link> prepared to help you.</p>
         </el-col>
 
         <el-col :span=6>

--- a/metaspace/webapp/src/modules/App/MetaspaceHeader.spec.ts
+++ b/metaspace/webapp/src/modules/App/MetaspaceHeader.spec.ts
@@ -51,7 +51,7 @@ describe('MetaspaceHeader', () => {
     const wrapper = mount(MetaspaceHeader, { store, router, provide, sync: false });
     await Vue.nextTick();
 
-    expect(wrapper.find('#annotations-link').attributes().href).toEqual("#/annotations?db=HMDB&organism=human");
-    expect(wrapper.find('#datasets-link').attributes().href).toEqual("#/datasets?organism=human"); // db isn't a valid filter for datasets
+    expect(wrapper.find('#annotations-link').attributes().href).toEqual("/annotations?db=HMDB&organism=human");
+    expect(wrapper.find('#datasets-link').attributes().href).toEqual("/datasets?organism=human"); // db isn't a valid filter for datasets
   });
 });

--- a/metaspace/webapp/src/modules/App/MetaspaceHeader.spec.ts
+++ b/metaspace/webapp/src/modules/App/MetaspaceHeader.spec.ts
@@ -33,7 +33,8 @@ describe('MetaspaceHeader', () => {
           primaryGroup: {
             group: {
               id: '456',
-              name: 'Test Group'
+              name: 'Test Group',
+              urlSlug: null
             }
           }
         })

--- a/metaspace/webapp/src/modules/App/MetaspaceHeader.vue
+++ b/metaspace/webapp/src/modules/App/MetaspaceHeader.vue
@@ -94,9 +94,12 @@
      },
 
      primaryGroupHref() {
-       return {
-         name: 'group',
-         params: {groupId: this.currentUser.primaryGroup.group.id}
+       if (this.currentUser && this.currentUser.primaryGroup) {
+         const { id, urlSlug } = this.currentUser.primaryGroup.group;
+         return {
+           name: 'group',
+           params: { groupIdOrSlug: urlSlug || id }
+         }
        }
      },
 
@@ -128,6 +131,7 @@
                id
                shortName
                name
+               urlSlug
              }
            }
          }

--- a/metaspace/webapp/src/modules/App/__snapshots__/MetaspaceHeader.spec.ts.snap
+++ b/metaspace/webapp/src/modules/App/__snapshots__/MetaspaceHeader.spec.ts.snap
@@ -3,29 +3,29 @@
 exports[`MetaspaceHeader should match snapshot (logged in) 1`] = `
 <div class="b-header">
   <div class="header-items">
-    <a href="#/" class="header-item logo router-link-active">
+    <a href="/" class="header-item logo router-link-active">
       <img src="../../assets/logo.png" alt="Metaspace" title="Metaspace">
     </a>
-    <a href="#/upload" class="header-item page-link" id="upload-link">
+    <a href="/upload" class="header-item page-link" id="upload-link">
       Upload
     </a>
-    <a href="#/annotations" class="header-item page-link" id="annotations-link">
+    <a href="/annotations" class="header-item page-link" id="annotations-link">
       Annotations
     </a>
-    <a href="#/datasets" class="header-item page-link" id="datasets-link">
+    <a href="/datasets" class="header-item page-link" id="datasets-link">
       Datasets
     </a>
-    <a href="#/projects" class="header-item page-link">
+    <a href="/projects" class="header-item page-link">
       Projects
     </a>
-    <a href="#/group/456" class="header-item page-link">
+    <a href="/group/456" class="header-item page-link">
       <div class="limit-width">
         currentUser.primaryGroup.group.shortName
       </div>
     </a>
   </div>
   <div class="header-items">
-    <a href="#/help" class="header-item page-link">
+    <a href="/help" class="header-item page-link">
       Help
     </a>
     <!---->
@@ -37,7 +37,7 @@ exports[`MetaspaceHeader should match snapshot (logged in) 1`] = `
           </div>
         </div>
         <div class="submenu">
-          <a href="#/user/me" class="submenu-item page-link">
+          <a href="/user/me" class="submenu-item page-link">
             My account
           </a>
           <div class="submenu-item page-link">
@@ -53,25 +53,25 @@ exports[`MetaspaceHeader should match snapshot (logged in) 1`] = `
 exports[`MetaspaceHeader should match snapshot (logged out) 1`] = `
 <div class="b-header">
   <div class="header-items">
-    <a href="#/" class="header-item logo router-link-active">
+    <a href="/" class="header-item logo router-link-active">
       <img src="../../assets/logo.png" alt="Metaspace" title="Metaspace">
     </a>
-    <a href="#/upload" class="header-item page-link" id="upload-link">
+    <a href="/upload" class="header-item page-link" id="upload-link">
       Upload
     </a>
-    <a href="#/annotations" class="header-item page-link" id="annotations-link">
+    <a href="/annotations" class="header-item page-link" id="annotations-link">
       Annotations
     </a>
-    <a href="#/datasets" class="header-item page-link" id="datasets-link">
+    <a href="/datasets" class="header-item page-link" id="datasets-link">
       Datasets
     </a>
-    <a href="#/projects" class="header-item page-link">
+    <a href="/projects" class="header-item page-link">
       Projects
     </a>
     <!---->
   </div>
   <div class="header-items">
-    <a href="#/help" class="header-item page-link">
+    <a href="/help" class="header-item page-link">
       Help
     </a>
     <div class="header-items">

--- a/metaspace/webapp/src/modules/App/__snapshots__/MetaspaceHeader.spec.ts.snap
+++ b/metaspace/webapp/src/modules/App/__snapshots__/MetaspaceHeader.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`MetaspaceHeader should match snapshot (logged in) 1`] = `
 <div class="b-header">
   <div class="header-items">
-    <a href="/" class="header-item logo router-link-active">
+    <a href="/" class="header-item logo router-link-exact-active router-link-active">
       <img src="../../assets/logo.png" alt="Metaspace" title="Metaspace">
     </a>
     <a href="/upload" class="header-item page-link" id="upload-link">
@@ -53,7 +53,7 @@ exports[`MetaspaceHeader should match snapshot (logged in) 1`] = `
 exports[`MetaspaceHeader should match snapshot (logged out) 1`] = `
 <div class="b-header">
   <div class="header-items">
-    <a href="/" class="header-item logo router-link-active">
+    <a href="/" class="header-item logo router-link-exact-active router-link-active">
       <img src="../../assets/logo.png" alt="Metaspace" title="Metaspace">
     </a>
     <a href="/upload" class="header-item page-link" id="upload-link">

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DatasetTable should be able to export a CSV 1`] = `
-"# URL: http://localhost/about
+"# URL: http://localhost/
 datasetId,datasetName,institution,submitter,PI,organism,organismPart,condition,growthConditions,ionisationSource,maldiMatrix,analyzer,resPower400,polarity,uploadDateTime,FDR@10% + DataBase,opticalImage
 FINISHED1,datasets.0.name,datasets.0.institution,datasets.0.submitter.name,datasets.0.principalInvestigator.name,datasets.0.organism,datasets.0.organismPart,datasets.0.condition,datasets.0.growthConditions,datasets.0.ionisationSource,datasets.0.maldiMatrix,datasets.0.analyzer.type,13,positive,datasets.0.uploadDateTime,1,2,20 HMDB-v2.5,http://localhostdatasets.0.opticalImage
 FINISHED2,datasets.1.name,datasets.1.institution,datasets.1.submitter.name,datasets.1.principalInvestigator.name,datasets.1.organism,datasets.1.organismPart,datasets.1.condition,datasets.1.growthConditions,datasets.1.ionisationSource,datasets.1.maldiMatrix,datasets.1.analyzer.type,13,positive,datasets.1.uploadDateTime,1,2,20 HMDB-v2.5,http://localhostdatasets.1.opticalImage

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DatasetTable should be able to export a CSV 1`] = `
-"# URL: http://localhost/#/about
+"# URL: http://localhost/about
 datasetId,datasetName,institution,submitter,PI,organism,organismPart,condition,growthConditions,ionisationSource,maldiMatrix,analyzer,resPower400,polarity,uploadDateTime,FDR@10% + DataBase,opticalImage
 FINISHED1,datasets.0.name,datasets.0.institution,datasets.0.submitter.name,datasets.0.principalInvestigator.name,datasets.0.organism,datasets.0.organismPart,datasets.0.condition,datasets.0.growthConditions,datasets.0.ionisationSource,datasets.0.maldiMatrix,datasets.0.analyzer.type,13,positive,datasets.0.uploadDateTime,1,2,20 HMDB-v2.5,http://localhostdatasets.0.opticalImage
 FINISHED2,datasets.1.name,datasets.1.institution,datasets.1.submitter.name,datasets.1.principalInvestigator.name,datasets.1.organism,datasets.1.organismPart,datasets.1.condition,datasets.1.growthConditions,datasets.1.ionisationSource,datasets.1.maldiMatrix,datasets.1.analyzer.type,13,positive,datasets.1.uploadDateTime,1,2,20 HMDB-v2.5,http://localhostdatasets.1.opticalImage
@@ -211,17 +211,17 @@ exports[`DatasetTable should match snapshot 1`] = `
             <span title="Filter by submitter" class="ds-add-filter">
         allDatasets.0.submitter.name</span>,
             <span title="Filter by this lab" class="s-inst ds-add-filter">allDatasets.0.institution</span></div>
-          <div class="ds-item-line"><span><a href="#/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">1, 2, 20 annotations</a>
+          <div class="ds-item-line"><span><a href="/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">1, 2, 20 annotations</a>
         @ FDR 0.05, 0.1, 0.5% (HMDB-v2.5)
       </span></div>
         </div>
         <div class="ds-actions"><span><i class="el-icon-picture"></i> <mock-el-popover trigger="hover" placement="top"><div slot-key="default"><div class="db-link-list">
           Select a database:
-          <div><a href="#/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
+          <div><a href="/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
               HMDB-v2.5
-            </a></div><div><a href="#/annotations?db=HMDB-v4&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
+            </a></div><div><a href="/annotations?db=HMDB-v4&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
               HMDB-v4
-            </a></div><div><a href="#/annotations?db=CHEBI&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
+            </a></div><div><a href="/annotations?db=CHEBI&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
               CHEBI
             </a></div></div> </div><div slot-key="reference"><a>Browse annotations</a></div></mock-el-popover> <br></span>
           <!---->

--- a/metaspace/webapp/src/modules/GroupProfile/EditGroupProfile.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/EditGroupProfile.vue
@@ -31,16 +31,20 @@
         <div style="margin-bottom: 2em">
           <h2>Custom URL</h2>
           <div v-if="canEditUrlSlug">
-            <a :href="groupUrlHref">{{groupUrlPrefix}}</a>
+            <router-link :href="groupUrlRoute">{{groupUrlPrefix}}</router-link>
             <input v-model="model.urlSlug" />
           </div>
           <div v-if="!canEditUrlSlug && group && group.urlSlug">
-            <a :href="groupUrlHref">
+            <router-link :to="groupUrlRoute">
               {{groupUrlPrefix}}<span class="urlSlug">{{group.urlSlug}}</span>
-            </a>
+            </router-link>
           </div>
           <div v-if="!canEditUrlSlug && group && !group.urlSlug">
-            <p><a :href="groupUrlHref">{{groupUrlPrefix}}<span class="urlSlug">{{group.id}}</span></a></p>
+            <p>
+              <router-link :to="groupUrlRoute">
+                {{groupUrlPrefix}}<span class="urlSlug">{{group.id}}</span>
+              </router-link>
+            </p>
             <p><a href="mailto:contact@metaspace2020.eu">Contact us</a> to set up a custom URL to showcase your group.</p>
           </div>
         </div>
@@ -150,10 +154,9 @@
         group: this.groupId,
       };
     }
-    get groupUrlHref() {
+    get groupUrlRoute() {
       const groupIdOrSlug = this.group ? this.group.urlSlug || this.group.id : '';
-      const {href} = this.$router.resolve({ name: 'group', params: { groupIdOrSlug } }, undefined, true);
-      return location.origin + href;
+      return { name: 'group', params: { groupIdOrSlug } };
     }
     get groupUrlPrefix() {
       const {href} = this.$router.resolve({ name: 'group', params: { groupIdOrSlug: 'REMOVE' } }, undefined, true);

--- a/metaspace/webapp/src/modules/GroupProfile/EditGroupProfile.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/EditGroupProfile.vue
@@ -153,11 +153,11 @@
     get groupUrlHref() {
       const groupIdOrSlug = this.group ? this.group.urlSlug || this.group.id : '';
       const {href} = this.$router.resolve({ name: 'group', params: { groupIdOrSlug } }, undefined, true);
-      return `${location.origin}/${href}`;
+      return location.origin + href;
     }
     get groupUrlPrefix() {
       const {href} = this.$router.resolve({ name: 'group', params: { groupIdOrSlug: 'REMOVE' } }, undefined, true);
-      return `${location.origin}/${href.replace('REMOVE', '')}`;
+      return location.origin + href.replace('REMOVE', '');
     }
 
     @Watch('group')

--- a/metaspace/webapp/src/modules/GroupProfile/ViewGroupProfile.spec.ts
+++ b/metaspace/webapp/src/modules/GroupProfile/ViewGroupProfile.spec.ts
@@ -2,55 +2,76 @@ import { mount, Stubs } from '@vue/test-utils';
 import Vue from 'vue';
 import ViewGroupProfile from './ViewGroupProfile.vue';
 import router from '../../router';
+import { initMockGraphqlClient, provide } from '../../../tests/utils/mockGraphqlClient';
 
 
 describe('ViewGroupProfile', () => {
 
-  const mockData = {
-    currentUser: { id: 'userid' },
-    group: {
-      id: 'groupId',
-      name: 'group name',
-      shortName: 'groupShortName',
-      currentUserRole: null,
-    },
-    allDatasets: [
-      { id: 'datasetId1', name: 'dataset name 1' },
-      { id: 'datasetId2', name: 'dataset name 2' },
-      { id: 'datasetId3', name: 'dataset name 3' },
-    ],
-    countDatasets: 3
+  const mockGroup = {
+    id: '00000000-1111-2222-3333-444444444444',
+    name: 'group name',
+    shortName: 'groupShortName',
+    urlSlug: null,
+    currentUserRole: null,
+  };
+  const mockGroupFn = jest.fn(() => mockGroup);
+  const graphqlMocks = {
+    Query: () => ({
+      currentUser: () => ({ id: 'userid' }),
+      group: mockGroupFn,
+      groupByUrlSlug: mockGroupFn,
+      allDatasets: () => ([
+        { id: 'datasetId1', name: 'dataset name 1' },
+        { id: 'datasetId2', name: 'dataset name 2' },
+        { id: 'datasetId3', name: 'dataset name 3' },
+        { id: 'datasetId4', name: 'dataset name 4' },
+      ]),
+      countDatasets: () => 4,
+    })
   };
 
   const stubs: Stubs = {
     DatasetItem: true
   };
 
-  router.replace({ name: 'group', params: { groupId: mockData.group.id } });
 
-  it('should match snapshot (non-member)', () => {
-    const wrapper = mount(ViewGroupProfile, { router, stubs });
-    wrapper.setData({
-      loaded: true,
-      data: mockData,
-      maxVisibleDatasets: 2
-    });
+  beforeEach(() => {
+    jest.clearAllMocks();
+    router.replace({ name: 'group', params: { groupIdOrSlug: mockGroup.id } });
+  });
+
+  it('should match snapshot (non-member)', async () => {
+    initMockGraphqlClient(graphqlMocks);
+    const wrapper = mount(ViewGroupProfile, { router, stubs, provide, sync: false });
+    wrapper.setData({ maxVisibleDatasets: 3 }); // Also test that the datasets list is correctly clipped
+    await Vue.nextTick();
+
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should match snapshot (invited)', () => {
-    const wrapper = mount<Vue>(ViewGroupProfile, { router, stubs });
-    wrapper.setData({
-      loaded: true,
-      data: {
-        ...mockData,
-        group: {
-          ...mockData.group,
-          currentUserRole: 'INVITED'
-        }
-      },
-      maxVisibleDatasets: 2
-    });
+  it('should match snapshot (invited)', async () => {
+    mockGroupFn.mockImplementation(() => ({...mockGroup, currentUserRole: 'INVITED'}));
+    initMockGraphqlClient(graphqlMocks);
+
+    const wrapper = mount(ViewGroupProfile, { router, stubs, provide, sync: false });
+    await Vue.nextTick();
+
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should correctly fetch data and update the route if the group has a urlSlug but is accessed by ID', async () => {
+    const urlSlug = 'group-url-slug';
+    mockGroupFn.mockImplementation(() => ({...mockGroup, urlSlug}));
+    initMockGraphqlClient(graphqlMocks);
+
+    const wrapper = mount(ViewGroupProfile, { router, stubs, provide, sync: false });
+    await Vue.nextTick();
+
+    expect(router.currentRoute.params.groupIdOrSlug).toEqual(urlSlug);
+    // Assert that the correct graphql calls were made. See the GraphQLFieldResolver type for details on the args here
+    expect(mockGroupFn.mock.calls[0][1].groupId).toEqual(mockGroup.id);
+    expect(mockGroupFn.mock.calls[0][3].fieldName).toEqual('group');
+    expect(mockGroupFn.mock.calls[1][1].urlSlug).toEqual(urlSlug);
+    expect(mockGroupFn.mock.calls[1][3].fieldName).toEqual('groupByUrlSlug');
   });
 });

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/EditGroupProfile.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/EditGroupProfile.spec.ts.snap
@@ -256,6 +256,18 @@ exports[`EditGroupProfile should match snapshot 1`] = `
       </div>
     </div>
     <div style="margin-bottom: 2em;">
+      <h2>Custom URL</h2>
+      <!---->
+      <!---->
+      <div>
+        <p>
+          <a href="http://localhost/#/group/2">http://localhost/#/group/<span class="urlSlug">2</span></a>
+        </p>
+        <p>
+          <a href="mailto:contact@metaspace2020.eu">Contact us</a> to set up a custom URL to showcase your group.</p>
+      </div>
+    </div>
+    <div style="margin-bottom: 2em;">
       <h2>Datasets</h2>
       <p>
         <a href="#/datasets?grp=2" class="">See all datasets</a>

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/EditGroupProfile.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/EditGroupProfile.spec.ts.snap
@@ -261,7 +261,8 @@ exports[`EditGroupProfile should match snapshot 1`] = `
       <!---->
       <div>
         <p>
-          <a href="http://localhost/group/2">http://localhost/group/<span class="urlSlug">2</span></a>
+          <a href="/group/2" class="router-link-active">
+            http://localhost/group/<span class="urlSlug">2</span></a>
         </p>
         <p>
           <a href="mailto:contact@metaspace2020.eu">Contact us</a> to set up a custom URL to showcase your group.</p>

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/EditGroupProfile.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/EditGroupProfile.spec.ts.snap
@@ -117,7 +117,7 @@ exports[`EditGroupProfile should match snapshot 1`] = `
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                   <div class="cell">
-                    <a href="#/datasets?grp=2&amp;subm=3" class="">123</a>
+                    <a href="/datasets?grp=2&amp;subm=3" class="">123</a>
                   </div>
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
@@ -147,7 +147,7 @@ exports[`EditGroupProfile should match snapshot 1`] = `
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                   <div class="cell">
-                    <a href="#/datasets?grp=2&amp;subm=4" class="">0</a>
+                    <a href="/datasets?grp=2&amp;subm=4" class="">0</a>
                   </div>
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
@@ -185,7 +185,7 @@ exports[`EditGroupProfile should match snapshot 1`] = `
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                   <div class="cell">
-                    <a href="#/datasets?grp=2&amp;subm=5" class="">0</a>
+                    <a href="/datasets?grp=2&amp;subm=5" class="">0</a>
                   </div>
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
@@ -219,7 +219,7 @@ exports[`EditGroupProfile should match snapshot 1`] = `
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                   <div class="cell">
-                    <a href="#/datasets?grp=2&amp;subm=6" class="">1</a>
+                    <a href="/datasets?grp=2&amp;subm=6" class="">1</a>
                   </div>
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
@@ -261,7 +261,7 @@ exports[`EditGroupProfile should match snapshot 1`] = `
       <!---->
       <div>
         <p>
-          <a href="http://localhost/#/group/2">http://localhost/#/group/<span class="urlSlug">2</span></a>
+          <a href="http://localhost/group/2">http://localhost/group/<span class="urlSlug">2</span></a>
         </p>
         <p>
           <a href="mailto:contact@metaspace2020.eu">Contact us</a> to set up a custom URL to showcase your group.</p>
@@ -270,7 +270,7 @@ exports[`EditGroupProfile should match snapshot 1`] = `
     <div style="margin-bottom: 2em;">
       <h2>Datasets</h2>
       <p>
-        <a href="#/datasets?grp=2" class="">See all datasets</a>
+        <a href="/datasets?grp=2" class="">See all datasets</a>
       </p>
     </div>
     <!---->

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/EditGroupProfile.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/EditGroupProfile.spec.ts.snap
@@ -51,7 +51,7 @@ exports[`EditGroupProfile should match snapshot 1`] = `
     </form>
     <div>
       <h2>Members</h2>
-      <div class="el-table el-table--fit el-table--scrollable-x el-table--enable-row-hover el-table--enable-row-transition" element-loading-text="Loading results from the server...">
+      <div class="el-table el-table--fit el-table--scrollable-x el-table--enable-row-hover el-table--enable-row-transition" element-loading-text="Loading results from the server..." mock-v-loading="false">
         <div class="hidden-columns">
           <div></div>
           <div></div>

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/TransferDatasetsDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/TransferDatasetsDialog.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`TransferDatasetsDialog should match snapshot (datasets to import, invited) 1`] = `
 <mock-el-dialog visible="" append-to-body="" title="Join group" class="dialog">
-  <div>
+  <div mock-v-loading="0">
     <div>
       <p style="margin-top: 0px;">
         Are you sure you want to join Group Name?
@@ -22,7 +22,7 @@ exports[`TransferDatasetsDialog should match snapshot (datasets to import, invit
 
 exports[`TransferDatasetsDialog should match snapshot (datasets to import, requesting access) 1`] = `
 <mock-el-dialog visible="" append-to-body="" title="Join group" class="dialog">
-  <div>
+  <div mock-v-loading="0">
     <div>
       <p style="margin-top: 0px;">
         An email will be sent to the group's principal investigator to confirm your access.
@@ -42,7 +42,7 @@ exports[`TransferDatasetsDialog should match snapshot (datasets to import, reque
 
 exports[`TransferDatasetsDialog should match snapshot (no datasets, invited) 1`] = `
 <mock-el-dialog visible="" append-to-body="" title="Join group" class="dialog">
-  <div>
+  <div mock-v-loading="0">
     <div>
       <p style="margin-top: 0px;">
         Are you sure you want to join Group Name?
@@ -62,7 +62,7 @@ exports[`TransferDatasetsDialog should match snapshot (no datasets, invited) 1`]
 
 exports[`TransferDatasetsDialog should match snapshot (no datasets, requesting access) 1`] = `
 <mock-el-dialog visible="" append-to-body="" title="Join group" class="dialog">
-  <div>
+  <div mock-v-loading="0">
     <div>
       <p style="margin-top: 0px;">
         An email will be sent to the group's principal investigator to confirm your access.

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupProfile.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupProfile.spec.ts.snap
@@ -85,7 +85,7 @@ exports[`ViewGroupProfile should match snapshot (non-member) 1`] = `
         <datasetitem-stub dataset="[object Object]" class="odd"></datasetitem-stub>
       </div>
       <div class="dataset-list-footer">
-        <a href="#/datasets?grp=00000000-1111-2222-3333-444444444444" class="">See all datasets</a>
+        <a href="/datasets?grp=00000000-1111-2222-3333-444444444444" class="">See all datasets</a>
       </div>
     </div>
   </div>

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupProfile.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupProfile.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ViewGroupProfile should match snapshot (invited) 1`] = `
-<div class="page">
+<div class="page" mock-v-loading="false">
   <div class="page-content">
     <!---->
     <div class="header-row">
@@ -57,7 +57,7 @@ exports[`ViewGroupProfile should match snapshot (invited) 1`] = `
 `;
 
 exports[`ViewGroupProfile should match snapshot (non-member) 1`] = `
-<div class="page">
+<div class="page" mock-v-loading="false">
   <div class="page-content">
     <!---->
     <div class="header-row">

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupProfile.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupProfile.spec.ts.snap
@@ -47,9 +47,10 @@ exports[`ViewGroupProfile should match snapshot (invited) 1`] = `
         <datasetitem-stub dataset="[object Object]" class="odd"></datasetitem-stub>
         <datasetitem-stub dataset="[object Object]" class="even"></datasetitem-stub>
         <datasetitem-stub dataset="[object Object]" class="odd"></datasetitem-stub>
+        <datasetitem-stub dataset="[object Object]" class="even"></datasetitem-stub>
       </div>
       <div class="dataset-list-footer">
-        <a href="#/datasets?grp=groupId" class="">See all datasets</a>
+        <!---->
       </div>
     </div>
   </div>
@@ -84,7 +85,7 @@ exports[`ViewGroupProfile should match snapshot (non-member) 1`] = `
         <datasetitem-stub dataset="[object Object]" class="odd"></datasetitem-stub>
       </div>
       <div class="dataset-list-footer">
-        <a href="#/datasets?grp=groupId" class="">See all datasets</a>
+        <a href="#/datasets?grp=00000000-1111-2222-3333-444444444444" class="">See all datasets</a>
       </div>
     </div>
   </div>

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -56,7 +56,7 @@ Object {
 
 exports[`MetadataEditor should match snapshot 1`] = `
 <div id="md-editor-container">
-  <div class="el-loading-parent--relative" style="position: relative;">
+  <div mock-v-loading="true" style="position: relative;">
     <div id="md-section-list">
       <div class="metadata-section">
         <form class="el-form el-form--label-top">
@@ -341,7 +341,7 @@ exports[`MetadataEditor should match snapshot 1`] = `
           </div>
         </mock-el-dialog>
         <mock-el-dialog append-to-body="" title="Create project" class="dialog">
-          <div class="">
+          <div mock-v-loading="0">
             <form class="el-form el-form--label-top" size="mini">
               <div>
                 <div class="el-form-item name is-required">
@@ -409,16 +409,6 @@ exports[`MetadataEditor should match snapshot 1`] = `
                 <!---->
                 <!----><span>Create project and include 2 datasets</span></button>
             </div>
-            <mock-transition name="el-loading-fade">
-              <div class="el-loading-mask" style="display: none;">
-                <div class="el-loading-spinner">
-                  <svg viewBox="25 25 50 50" class="circular">
-                    <circle cx="50" cy="50" r="20" fill="none" class="path"></circle>
-                  </svg>
-                  <!---->
-                </div>
-              </div>
-            </mock-transition>
           </div>
         </mock-el-dialog>
         <div class="el-row">

--- a/metaspace/webapp/src/modules/Project/EditProjectForm.vue
+++ b/metaspace/webapp/src/modules/Project/EditProjectForm.vue
@@ -13,10 +13,6 @@
       <el-form-item prop="isPublic" class="isPublic">
         <el-checkbox v-model="value.isPublic">Allow other users to see this project</el-checkbox>
       </el-form-item>
-      <!--<h2 v-if="showUrlSlug">Custom URL</h2>-->
-      <!--<el-form-item v-if="showUrlSlug" prop="urlSlug" class="urlSlug">-->
-        <!--http://metaspace2020.eu/#/projects/<el-input v-model="value.urlSlug" :maxLength="30" size="mini" placeholder="project-name-here" />-->
-      <!--</el-form-item>-->
     </div>
   </el-form>
 </template>
@@ -27,6 +23,7 @@
 
   interface Model {
     name: string;
+    isPublic: boolean;
   }
 
   @Component
@@ -35,8 +32,6 @@
     value!: Model;
     @Prop({type: Boolean, default: false})
     disabled!: Boolean;
-    @Prop({type: Boolean, default: true})
-    showUrlSlug!: Boolean;
 
     rules = {
       name: [{type: 'string', required: true, min: 2, message: 'Name is required', trigger: 'manual'}],

--- a/metaspace/webapp/src/modules/Project/EditProjectPage.vue
+++ b/metaspace/webapp/src/modules/Project/EditProjectPage.vue
@@ -150,11 +150,11 @@
     get projectUrlHref() {
       const projectIdOrSlug = this.project ? this.project.urlSlug || this.project.id : '';
       const {href} = this.$router.resolve({ name: 'project', params: { projectIdOrSlug } }, undefined, true);
-      return `${location.origin}/${href}`;
+      return location.origin + href;
     }
     get projectUrlPrefix() {
       const {href} = this.$router.resolve({ name: 'project', params: { projectIdOrSlug: 'REMOVE' } }, undefined, true);
-      return `${location.origin}/${href.replace('REMOVE', '')}`;
+      return location.origin + href.replace('REMOVE', '');
     }
 
     @Watch('project')

--- a/metaspace/webapp/src/modules/Project/EditProjectPage.vue
+++ b/metaspace/webapp/src/modules/Project/EditProjectPage.vue
@@ -31,16 +31,20 @@
         <div v-if="project && project.isPublic" style="margin-bottom: 2em">
           <h2>Custom URL</h2>
           <div v-if="canEditUrlSlug">
-            <a :href="projectUrlHref">{{projectUrlPrefix}}</a>
+            <router-link :to="projectUrlRoute">{{projectUrlPrefix}}</router-link>
             <input v-model="model.urlSlug" />
           </div>
           <div v-if="!canEditUrlSlug && project && project.urlSlug">
-            <a :href="projectUrlHref">
+            <router-link :to="projectUrlRoute">
               {{projectUrlPrefix}}<span class="urlSlug">{{project.urlSlug}}</span>
-            </a>
+            </router-link>
           </div>
           <div v-if="!canEditUrlSlug && project && !project.urlSlug">
-            <p><a :href="projectUrlHref">{{projectUrlPrefix}}<span class="urlSlug">{{project.id}}</span></a></p>
+            <p>
+              <router-link :to="projectUrlRoute">
+                {{projectUrlPrefix}}<span class="urlSlug">{{project.id}}</span>
+              </router-link>
+            </p>
             <p><a href="mailto:contact@metaspace2020.eu">Contact us</a> to set up a custom URL for your project.</p>
           </div>
         </div>
@@ -147,10 +151,9 @@
         project: this.projectId,
       };
     }
-    get projectUrlHref() {
+    get projectUrlRoute() {
       const projectIdOrSlug = this.project ? this.project.urlSlug || this.project.id : '';
-      const {href} = this.$router.resolve({ name: 'project', params: { projectIdOrSlug } }, undefined, true);
-      return location.origin + href;
+      return { name: 'project', params: { projectIdOrSlug } };
     }
     get projectUrlPrefix() {
       const {href} = this.$router.resolve({ name: 'project', params: { projectIdOrSlug: 'REMOVE' } }, undefined, true);

--- a/metaspace/webapp/src/modules/Project/ProjectsListItem.vue
+++ b/metaspace/webapp/src/modules/Project/ProjectsListItem.vue
@@ -46,7 +46,7 @@
     get projectLink() {
       return {
         name: 'project',
-        params: {projectId: this.project.id}
+        params: {projectIdOrSlug: this.project.urlSlug || this.project.id}
       }
     }
 

--- a/metaspace/webapp/src/modules/Project/ProjectsListPage.spec.ts
+++ b/metaspace/webapp/src/modules/Project/ProjectsListPage.spec.ts
@@ -15,11 +15,11 @@ describe('ProjectsListPage', () => {
 
   // These datetime strings are intentionally missing the `Z` at the end.
   // This makes them local time and prevents the snapshots from changing depending on which timezone they're run in.
-  const mockProject1: ProjectsListProject = { id: 'project 1', name: 'project one', isPublic: false, currentUserRole: 'MANAGER',
+  const mockProject1: ProjectsListProject = { id: 'project 1', name: 'project one', urlSlug: 'proj-one', isPublic: false, currentUserRole: 'MANAGER',
     numMembers: 1, numDatasets: 0, createdDT: '2018-08-29T05:00:00.000', latestUploadDT: null };
-  const mockProject2: ProjectsListProject = { id: 'project 2', name: 'project two', isPublic: true, currentUserRole: null,
+  const mockProject2: ProjectsListProject = { id: 'project 2', name: 'project two', urlSlug: null, isPublic: true, currentUserRole: null,
     numMembers: 20, numDatasets: 20, createdDT: '2018-01-01T07:00:00.000', latestUploadDT: '2018-08-01T09:00:00.000' };
-  const mockProject3: ProjectsListProject = { id: 'project 3', name: 'project three', isPublic: true, currentUserRole: 'MEMBER',
+  const mockProject3: ProjectsListProject = { id: 'project 3', name: 'project three', urlSlug: null, isPublic: true, currentUserRole: 'MEMBER',
     numMembers: 10, numDatasets: 5, createdDT: '2018-04-30T11:00:00.000', latestUploadDT: '2018-05-15T13:00:00.000' };
 
   const mockMyProjects: MyProjectsListQuery['myProjects'] = {

--- a/metaspace/webapp/src/modules/Project/ViewProjectPage.spec.ts
+++ b/metaspace/webapp/src/modules/Project/ViewProjectPage.spec.ts
@@ -2,56 +2,75 @@ import { mount, Stubs } from '@vue/test-utils';
 import Vue from 'vue';
 import ViewProjectPage from './ViewProjectPage.vue';
 import router from '../../router';
+import { initMockGraphqlClient, provide } from '../../../tests/utils/mockGraphqlClient';
 
 
 
 describe('ViewProjectPage', () => {
 
-  const mockData = {
-    currentUser: { id: 'userid' },
-    project: {
-      id: 'projectId',
-      name: 'project name',
-      shortName: 'projectShortName',
-      currentUserRole: null,
-    },
-    allDatasets: [
-      { id: 'datasetId1', name: 'dataset name 1' },
-      { id: 'datasetId2', name: 'dataset name 2' },
-      { id: 'datasetId3', name: 'dataset name 3' },
-    ],
-    countDatasets: 3
+  const mockProject = {
+    id: '00000000-1111-2222-3333-444444444444',
+    name: 'project name',
+    shortName: 'projectShortName',
+    urlSlug: null,
+    currentUserRole: null,
   };
-
+  const mockProjectFn = jest.fn(() => mockProject);
+  const graphqlMocks = {
+    Query: () => ({
+      currentUser: () => ({ id: 'userid' }),
+      project: mockProjectFn,
+      projectByUrlSlug: mockProjectFn,
+      allDatasets: () => ([
+        { id: 'datasetId1', name: 'dataset name 1' },
+        { id: 'datasetId2', name: 'dataset name 2' },
+        { id: 'datasetId3', name: 'dataset name 3' },
+        { id: 'datasetId4', name: 'dataset name 4' },
+      ]),
+      countDatasets: () => 4,
+    })
+  };
+  
   const stubs: Stubs = {
     DatasetItem: true
   };
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+    router.replace({ name: 'project', params: { projectIdOrSlug: mockProject.id } });
+  });
 
-  router.replace({ name: 'project', params: { projectId: mockData.project.id } });
+  it('should match snapshot (non-member)', async () => {
+    initMockGraphqlClient(graphqlMocks);
+    const wrapper = mount(ViewProjectPage, { router, stubs, provide, sync: false });
+    wrapper.setData({ maxVisibleDatasets: 3 }); // Also test that the datasets list is correctly clipped
+    await Vue.nextTick();
 
-  it('should match snapshot (non-member)', () => {
-    const wrapper = mount(ViewProjectPage, { router, stubs });
-    wrapper.setData({
-      loaded: true,
-      data: mockData,
-      maxVisibleDatasets: 2
-    });
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should match snapshot (invited)', () => {
-    const wrapper = mount<Vue>(ViewProjectPage, { router, stubs });
-    wrapper.setData({
-      loaded: true,
-      data: {
-        ...mockData,
-        project: {
-          ...mockData.project,
-          currentUserRole: 'INVITED'
-        }
-      },
-      maxVisibleDatasets: 2
-    });
+  it('should match snapshot (invited)', async () => {
+    mockProjectFn.mockImplementation(() => ({...mockProject, currentUserRole: 'INVITED'}));
+    initMockGraphqlClient(graphqlMocks);
+    const wrapper = mount(ViewProjectPage, { router, stubs, provide, sync: false });
+    await Vue.nextTick();
+
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should correctly fetch data and update the route if the project has a urlSlug but is accessed by ID', async () => {
+    const urlSlug = 'project-url-slug';
+    mockProjectFn.mockImplementation(() => ({...mockProject, urlSlug}));
+    initMockGraphqlClient(graphqlMocks);
+
+    const wrapper = mount(ViewProjectPage, { router, stubs, provide, sync: false });
+    await Vue.nextTick();
+
+    expect(router.currentRoute.params.projectIdOrSlug).toEqual(urlSlug);
+    // Assert that the correct graphql calls were made. See the GraphQLFieldResolver type for details on the args here
+    expect(mockProjectFn.mock.calls[0][1].projectId).toEqual(mockProject.id);
+    expect(mockProjectFn.mock.calls[0][3].fieldName).toEqual('project');
+    expect(mockProjectFn.mock.calls[1][1].urlSlug).toEqual(urlSlug);
+    expect(mockProjectFn.mock.calls[1][3].fieldName).toEqual('projectByUrlSlug');
   });
 });

--- a/metaspace/webapp/src/modules/Project/__snapshots__/EditProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/EditProjectPage.spec.ts.snap
@@ -253,7 +253,8 @@ exports[`EditProjectPage should match snapshot 1`] = `
         <!---->
         <div>
           <p>
-            <a href="http://localhost/project/2">http://localhost/project/<span class="urlSlug">2</span></a>
+            <a href="/project/2" class="router-link-active">
+              http://localhost/project/<span class="urlSlug">2</span></a>
           </p>
           <p>
             <a href="mailto:contact@metaspace2020.eu">Contact us</a> to set up a custom URL for your project.</p>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/EditProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/EditProjectPage.spec.ts.snap
@@ -248,6 +248,18 @@ exports[`EditProjectPage should match snapshot 1`] = `
         </div>
       </div>
       <div style="margin-bottom: 2em;">
+        <h2>Custom URL</h2>
+        <!---->
+        <!---->
+        <div>
+          <p>
+            <a href="http://localhost/#/project/2">http://localhost/#/project/<span class="urlSlug">2</span></a>
+          </p>
+          <p>
+            <a href="mailto:contact@metaspace2020.eu">Contact us</a> to set up a custom URL for your project.</p>
+        </div>
+      </div>
+      <div style="margin-bottom: 2em;">
         <h2>Datasets</h2>
         <p>
           <a href="#/datasets?prj=2" class="">See all datasets</a>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/EditProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/EditProjectPage.spec.ts.snap
@@ -43,7 +43,7 @@ exports[`EditProjectPage should match snapshot 1`] = `
       </form>
       <div>
         <h2>Members</h2>
-        <div class="el-table el-table--fit el-table--scrollable-x el-table--enable-row-hover el-table--enable-row-transition" element-loading-text="Loading results from the server...">
+        <div class="el-table el-table--fit el-table--scrollable-x el-table--enable-row-hover el-table--enable-row-transition" element-loading-text="Loading results from the server..." mock-v-loading="false">
           <div class="hidden-columns">
             <div></div>
             <div></div>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/EditProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/EditProjectPage.spec.ts.snap
@@ -109,7 +109,7 @@ exports[`EditProjectPage should match snapshot 1`] = `
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                     <div class="cell">
-                      <a href="#/datasets?prj=2&amp;subm=3" class="">123</a>
+                      <a href="/datasets?prj=2&amp;subm=3" class="">123</a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
@@ -139,7 +139,7 @@ exports[`EditProjectPage should match snapshot 1`] = `
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                     <div class="cell">
-                      <a href="#/datasets?prj=2&amp;subm=4" class="">0</a>
+                      <a href="/datasets?prj=2&amp;subm=4" class="">0</a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
@@ -177,7 +177,7 @@ exports[`EditProjectPage should match snapshot 1`] = `
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                     <div class="cell">
-                      <a href="#/datasets?prj=2&amp;subm=5" class="">0</a>
+                      <a href="/datasets?prj=2&amp;subm=5" class="">0</a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
@@ -211,7 +211,7 @@ exports[`EditProjectPage should match snapshot 1`] = `
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                     <div class="cell">
-                      <a href="#/datasets?prj=2&amp;subm=6" class="">1</a>
+                      <a href="/datasets?prj=2&amp;subm=6" class="">1</a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
@@ -253,7 +253,7 @@ exports[`EditProjectPage should match snapshot 1`] = `
         <!---->
         <div>
           <p>
-            <a href="http://localhost/#/project/2">http://localhost/#/project/<span class="urlSlug">2</span></a>
+            <a href="http://localhost/project/2">http://localhost/project/<span class="urlSlug">2</span></a>
           </p>
           <p>
             <a href="mailto:contact@metaspace2020.eu">Contact us</a> to set up a custom URL for your project.</p>
@@ -262,7 +262,7 @@ exports[`EditProjectPage should match snapshot 1`] = `
       <div style="margin-bottom: 2em;">
         <h2>Datasets</h2>
         <p>
-          <a href="#/datasets?prj=2" class="">See all datasets</a>
+          <a href="/datasets?prj=2" class="">See all datasets</a>
         </p>
       </div>
       <div>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -8,10 +8,10 @@ exports[`ProjectsListPage should match snapshot 1`] = `
     </div>
     <div mock-v-loading="false">
       <div class="project-item">
-        <a href="#/project/proj-one" class="underlay"></a>
+        <a href="/project/proj-one" class="underlay"></a>
         <div class="info">
           <div class="info-line project-name">
-            <a href="#/project/proj-one" class="">project one</a>
+            <a href="/project/proj-one" class="">project one</a>
           </div>
           <div class="info-line">
             <!---->
@@ -24,12 +24,12 @@ exports[`ProjectsListPage should match snapshot 1`] = `
         <img src="../../assets/padlock-icon.svg" title="This project is only visible to its members and METASPACE administrators" class="private-icon">
       </div>
       <div class="project-item">
-        <a href="#/project/project%203" class="underlay"></a>
+        <a href="/project/project%203" class="underlay"></a>
         <div class="info">
           <div class="info-line project-name">
-            <a href="#/project/project%203" class="">project three</a>
+            <a href="/project/project%203" class="">project three</a>
           </div>
-          <div class="info-line"><span><a href="#/datasets?prj=project%203" class="">5 Datasets</a>,
+          <div class="info-line"><span><a href="/datasets?prj=project%203" class="">5 Datasets</a>,
       </span> 10 Members
           </div>
           <div class="info-line"><span>
@@ -39,12 +39,12 @@ exports[`ProjectsListPage should match snapshot 1`] = `
         <!---->
       </div>
       <div class="project-item">
-        <a href="#/project/project%202" class="underlay"></a>
+        <a href="/project/project%202" class="underlay"></a>
         <div class="info">
           <div class="info-line project-name">
-            <a href="#/project/project%202" class="">project two</a>
+            <a href="/project/project%202" class="">project two</a>
           </div>
-          <div class="info-line"><span><a href="#/datasets?prj=project%202" class="">20 Datasets</a>,
+          <div class="info-line"><span><a href="/datasets?prj=project%202" class="">20 Datasets</a>,
       </span> 20 Members
           </div>
           <div class="info-line"><span>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -8,10 +8,10 @@ exports[`ProjectsListPage should match snapshot 1`] = `
     </div>
     <div mock-v-loading="false">
       <div class="project-item">
-        <a href="#/project/project%201" class="underlay"></a>
+        <a href="#/project/proj-one" class="underlay"></a>
         <div class="info">
           <div class="info-line project-name">
-            <a href="#/project/project%201" class="">project one</a>
+            <a href="#/project/proj-one" class="">project one</a>
           </div>
           <div class="info-line">
             <!---->

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -6,17 +6,7 @@ exports[`ProjectsListPage should match snapshot 1`] = `
     <div class="filter-panel">
       <!---->
     </div>
-    <div class="el-loading-parent--relative">
-      <mock-transition name="el-loading-fade">
-        <div class="el-loading-mask" style="display: none;">
-          <div class="el-loading-spinner">
-            <svg viewBox="25 25 50 50" class="circular">
-              <circle cx="50" cy="50" r="20" fill="none" class="path"></circle>
-            </svg>
-            <!---->
-          </div>
-        </div>
-      </mock-transition>
+    <div mock-v-loading="false">
       <div class="project-item">
         <a href="#/project/project%201" class="underlay"></a>
         <div class="info">

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
@@ -45,9 +45,10 @@ exports[`ViewProjectPage should match snapshot (invited) 1`] = `
         <datasetitem-stub dataset="[object Object]" class="odd"></datasetitem-stub>
         <datasetitem-stub dataset="[object Object]" class="even"></datasetitem-stub>
         <datasetitem-stub dataset="[object Object]" class="odd"></datasetitem-stub>
+        <datasetitem-stub dataset="[object Object]" class="even"></datasetitem-stub>
       </div>
       <div class="dataset-list-footer">
-        <a href="#/datasets?prj=projectId" class="">See all datasets</a>
+        <!---->
       </div>
     </div>
   </div>
@@ -80,7 +81,7 @@ exports[`ViewProjectPage should match snapshot (non-member) 1`] = `
         <datasetitem-stub dataset="[object Object]" class="odd"></datasetitem-stub>
       </div>
       <div class="dataset-list-footer">
-        <a href="#/datasets?prj=projectId" class="">See all datasets</a>
+        <a href="#/datasets?prj=00000000-1111-2222-3333-444444444444" class="">See all datasets</a>
       </div>
     </div>
   </div>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
@@ -81,7 +81,7 @@ exports[`ViewProjectPage should match snapshot (non-member) 1`] = `
         <datasetitem-stub dataset="[object Object]" class="odd"></datasetitem-stub>
       </div>
       <div class="dataset-list-footer">
-        <a href="#/datasets?prj=00000000-1111-2222-3333-444444444444" class="">See all datasets</a>
+        <a href="/datasets?prj=00000000-1111-2222-3333-444444444444" class="">See all datasets</a>
       </div>
     </div>
   </div>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ViewProjectPage should match snapshot (invited) 1`] = `
-<div class="page">
+<div class="page" mock-v-loading="false">
   <div class="page-content">
     <div class="header-row">
       <div class="header-names">
@@ -55,7 +55,7 @@ exports[`ViewProjectPage should match snapshot (invited) 1`] = `
 `;
 
 exports[`ViewProjectPage should match snapshot (non-member) 1`] = `
-<div class="page">
+<div class="page" mock-v-loading="false">
   <div class="page-content">
     <div class="header-row">
       <div class="header-names">

--- a/metaspace/webapp/src/modules/UserProfile/EditUserPage.spec.ts
+++ b/metaspace/webapp/src/modules/UserProfile/EditUserPage.spec.ts
@@ -14,17 +14,17 @@ describe('EditUserPage', () => {
     email: 'foo@bar.baz',
     role: 'user',
     groups: [
-      {role: 'MEMBER', numDatasets: 0, group: { id: 'AAA', name: 'Group A' }},
-      {role: 'INVITED', numDatasets: 0, group: { id: 'BBB', name: 'Group B' }},
-      {role: 'PENDING', numDatasets: 0, group: { id: 'CCC', name: 'Group C' }},
-      {role: 'PRINCIPAL_INVESTIGATOR', numDatasets: 20, group: { id: 'DDD', name: 'Group D' }},
+      {role: 'MEMBER', numDatasets: 0, group: { id: 'AAA', name: 'Group A', urlSlug: 'grp-a' }},
+      {role: 'INVITED', numDatasets: 0, group: { id: 'BBB', name: 'Group B', urlSlug: null }},
+      {role: 'PENDING', numDatasets: 0, group: { id: 'CCC', name: 'Group C', urlSlug: null }},
+      {role: 'PRINCIPAL_INVESTIGATOR', numDatasets: 20, group: { id: 'DDD', name: 'Group D', urlSlug: null }},
     ],
-    primaryGroup: {role: 'PRINCIPAL_INVESTIGATOR', numDatasets: 20, group: { id: 'DDD', name: 'Group D' }},
+    primaryGroup: {role: 'PRINCIPAL_INVESTIGATOR', numDatasets: 20, group: { id: 'DDD', name: 'Group D', urlSlug: null }},
     projects: [
-      {role: 'MEMBER', numDatasets: 0, project: { id: 'AA', name: 'Project A' }},
-      {role: 'INVITED', numDatasets: 0, project: { id: 'BB', name: 'Project B' }},
-      {role: 'PENDING', numDatasets: 0, project: { id: 'CC', name: 'Project C' }},
-      {role: 'MANAGER', numDatasets: 20, project: { id: 'DD', name: 'Project D' }},
+      {role: 'MEMBER', numDatasets: 0, project: { id: 'AA', name: 'Project A', urlSlug: 'proj-a' }},
+      {role: 'INVITED', numDatasets: 0, project: { id: 'BB', name: 'Project B', urlSlug: null }},
+      {role: 'PENDING', numDatasets: 0, project: { id: 'CC', name: 'Project C', urlSlug: null }},
+      {role: 'MANAGER', numDatasets: 20, project: { id: 'DD', name: 'Project D', urlSlug: null }},
     ],
   };
 

--- a/metaspace/webapp/src/modules/UserProfile/EditUserPage.vue
+++ b/metaspace/webapp/src/modules/UserProfile/EditUserPage.vue
@@ -127,7 +127,7 @@
           <!--</el-row>-->
         <!--</div>-->
       <!--</div>-->
-      <div style="margin-top: 45px">
+      <div>
         <h2>Delete account</h2>
         <p style="width: 100%;padding-left: 15px;">
           If you delete your METASPACE account, you can either delete all your datasets or keep them within METASPACE.

--- a/metaspace/webapp/src/modules/UserProfile/GroupsTable.vue
+++ b/metaspace/webapp/src/modules/UserProfile/GroupsTable.vue
@@ -109,12 +109,15 @@
       if (this.currentUser != null && this.currentUser.groups != null) {
         return this.currentUser.groups.map((item) => {
           const {group, numDatasets, role} = item;
-          const {id, name} = group;
+          const {id, name, urlSlug} = group;
 
           return {
             id, name, role, numDatasets,
             roleName: getRoleName(role),
-            route: `/group/${id}`,
+            route: {
+              name: 'group',
+              params: { groupIdOrSlug: urlSlug || id }
+            },
             datasetsRoute: {
               path: '/datasets',
               query: encodeParams({ submitter: this.currentUser!.id, group: id })

--- a/metaspace/webapp/src/modules/UserProfile/GroupsTable.vue
+++ b/metaspace/webapp/src/modules/UserProfile/GroupsTable.vue
@@ -8,58 +8,57 @@
       @accept="handleAcceptTransferDatasets"
       @close="handleCloseTransferDatasetsDialog"
     />
-    <el-table
-      :data="rows"
-      style="margin-left: 15px;"
-      class="table">
-      <el-table-column label="Group">
-        <template slot-scope="scope">
-          <router-link :to="scope.row.route">{{scope.row.name}}</router-link>
-        </template>
-      </el-table-column>
-      <el-table-column prop="roleName" label="Role" width="160" />
-      <el-table-column label="Datasets contributed" width="160" align="center">
-        <template slot-scope="scope">
-          <router-link v-if="scope.row.numDatasets > 0" :to="scope.row.datasetsRoute">
-            {{scope.row.numDatasets}}
-          </router-link>
-          <span v-if="scope.row.numDatasets === 0">{{scope.row.numDatasets}}</span>
-        </template>
-      </el-table-column>
-      <el-table-column width="240" align="right">
-        <template slot-scope="scope">
-          <el-button
-            v-if="scope.row.role === 'MEMBER'"
-            size="mini"
-            icon="el-icon-arrow-right"
-            @click="handleLeave(scope.row)">
-            Leave
-          </el-button>
-          <el-button
-            v-if="scope.row.role === 'PRINCIPAL_INVESTIGATOR'"
-            size="mini"
-            icon="el-icon-arrow-right"
-            disabled>
-            Leave
-          </el-button>
-          <el-button
-            v-if="scope.row.role === 'INVITED'"
-            size="mini"
-            type="success"
-            @click="handleAcceptInvitation(scope.row)"
-            icon="el-icon-check">
-            Accept
-          </el-button>
-          <el-button
-            v-if="scope.row.role === 'INVITED'"
-            size="mini"
-            icon="el-icon-close"
-            @click="handleDeclineInvitation(scope.row)">
-            Decline
-          </el-button>
-        </template>
-      </el-table-column>
-    </el-table>
+    <div style="padding-left: 15px;">
+      <el-table :data="rows" class="table">
+        <el-table-column label="Group">
+          <template slot-scope="scope">
+            <router-link :to="scope.row.route">{{scope.row.name}}</router-link>
+          </template>
+        </el-table-column>
+        <el-table-column prop="roleName" label="Role" width="160" />
+        <el-table-column label="Datasets contributed" width="160" align="center">
+          <template slot-scope="scope">
+            <router-link v-if="scope.row.numDatasets > 0" :to="scope.row.datasetsRoute">
+              {{scope.row.numDatasets}}
+            </router-link>
+            <span v-if="scope.row.numDatasets === 0">{{scope.row.numDatasets}}</span>
+          </template>
+        </el-table-column>
+        <el-table-column width="240" align="right">
+          <template slot-scope="scope">
+            <el-button
+              v-if="scope.row.role === 'MEMBER'"
+              size="mini"
+              icon="el-icon-arrow-right"
+              @click="handleLeave(scope.row)">
+              Leave
+            </el-button>
+            <el-button
+              v-if="scope.row.role === 'PRINCIPAL_INVESTIGATOR'"
+              size="mini"
+              icon="el-icon-arrow-right"
+              disabled>
+              Leave
+            </el-button>
+            <el-button
+              v-if="scope.row.role === 'INVITED'"
+              size="mini"
+              type="success"
+              @click="handleAcceptInvitation(scope.row)"
+              icon="el-icon-check">
+              Accept
+            </el-button>
+            <el-button
+              v-if="scope.row.role === 'INVITED'"
+              size="mini"
+              icon="el-icon-close"
+              @click="handleDeclineInvitation(scope.row)">
+              Decline
+            </el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+    </div>
 
   </div>
 </template>

--- a/metaspace/webapp/src/modules/UserProfile/GroupsTable.vue
+++ b/metaspace/webapp/src/modules/UserProfile/GroupsTable.vue
@@ -10,18 +10,15 @@
     />
     <el-table
       :data="rows"
-      style="width: 100%;padding-left: 15px;">
-      <el-table-column label="Group" width="180">
+      style="margin-left: 15px;"
+      class="table">
+      <el-table-column label="Group">
         <template slot-scope="scope">
           <router-link :to="scope.row.route">{{scope.row.name}}</router-link>
         </template>
       </el-table-column>
-      <el-table-column
-        prop="roleName"
-        label="Role"
-        width="280"
-      />
-      <el-table-column label="Datasets contributed">
+      <el-table-column prop="roleName" label="Role" width="160" />
+      <el-table-column label="Datasets contributed" width="160" align="center">
         <template slot-scope="scope">
           <router-link v-if="scope.row.numDatasets > 0" :to="scope.row.datasetsRoute">
             {{scope.row.numDatasets}}
@@ -29,7 +26,7 @@
           <span v-if="scope.row.numDatasets === 0">{{scope.row.numDatasets}}</span>
         </template>
       </el-table-column>
-      <el-table-column>
+      <el-table-column width="240" align="right">
         <template slot-scope="scope">
           <el-button
             v-if="scope.row.role === 'MEMBER'"
@@ -192,5 +189,8 @@
   }
 </script>
 
-<style>
+<style scoped>
+  .table.el-table /deep/ .cell {
+    word-break: normal !important;
+  }
 </style>

--- a/metaspace/webapp/src/modules/UserProfile/ProjectsTable.vue
+++ b/metaspace/webapp/src/modules/UserProfile/ProjectsTable.vue
@@ -1,66 +1,66 @@
 <template>
-  <div>
+  <el-row>
     <create-project-dialog
       :visible="showCreateProjectDialog && currentUser != null"
       :currentUserId="currentUser && currentUser.id"
-      @close="() => showCreateProjectDialog = false"
+      @close="handleCloseCreateProjectDialog"
       @create="createProject"
     />
-    <el-table
-      :data="rows"
-      style="margin-left: 15px;"
-    class="table">
-      <el-table-column label="Project">
-        <template slot-scope="scope">
-          <router-link :to="scope.row.route">{{scope.row.name}}</router-link>
-        </template>
-      </el-table-column>
-      <el-table-column prop="roleName" label="Role" width="160" />
-      <el-table-column label="Datasets contributed" width="160" align="center">
-        <template slot-scope="scope">
-          <router-link v-if="scope.row.numDatasets > 0" :to="scope.row.datasetsRoute">
-            {{scope.row.numDatasets}}
-          </router-link>
-          <span v-if="scope.row.numDatasets === 0">{{scope.row.numDatasets}}</span>
-        </template>
-      </el-table-column>
-      <el-table-column width="240" align="right">
-        <template slot-scope="scope">
-          <el-button
-            v-if="scope.row.role === 'MEMBER'"
-            size="mini"
-            icon="el-icon-arrow-right"
-            @click="handleLeave(scope.row)">
-            Leave
-          </el-button>
-          <el-button
-            v-if="scope.row.role === 'MANAGER'"
-            size="mini"
-            icon="el-icon-arrow-right"
-            disabled>
-            Leave
-          </el-button>
-          <el-button
-            v-if="scope.row.role === 'INVITED'"
-            size="mini"
-            type="success"
-            @click="handleAcceptInvitation(scope.row)"
-            icon="el-icon-check">
-            Accept
-          </el-button>
-          <el-button
-            v-if="scope.row.role === 'INVITED'"
-            size="mini"
-            icon="el-icon-close"
-            @click="handleDeclineInvitation(scope.row)">
-            Decline
-          </el-button>
-        </template>
-      </el-table-column>
-    </el-table>
-    <el-button style="float: right; margin: 10px 0;" @click="() => showCreateProjectDialog = true">Create project</el-button>
-    <div class="clearfix"/>
-  </div>
+    <div style="padding-left: 15px">
+      <el-table :data="rows" class="table">
+        <el-table-column label="Project">
+          <template slot-scope="scope">
+            <router-link :to="scope.row.route">{{scope.row.name}}</router-link>
+          </template>
+        </el-table-column>
+        <el-table-column prop="roleName" label="Role" width="160" />
+        <el-table-column label="Datasets contributed" width="160" align="center">
+          <template slot-scope="scope">
+            <router-link v-if="scope.row.numDatasets > 0" :to="scope.row.datasetsRoute">
+              {{scope.row.numDatasets}}
+            </router-link>
+            <span v-if="scope.row.numDatasets === 0">{{scope.row.numDatasets}}</span>
+          </template>
+        </el-table-column>
+        <el-table-column width="240" align="right">
+          <template slot-scope="scope">
+            <el-button
+              v-if="scope.row.role === 'MEMBER'"
+              size="mini"
+              icon="el-icon-arrow-right"
+              @click="handleLeave(scope.row)">
+              Leave
+            </el-button>
+            <el-button
+              v-if="scope.row.role === 'MANAGER'"
+              size="mini"
+              icon="el-icon-arrow-right"
+              disabled>
+              Leave
+            </el-button>
+            <el-button
+              v-if="scope.row.role === 'INVITED'"
+              size="mini"
+              type="success"
+              @click="handleAcceptInvitation(scope.row)"
+              icon="el-icon-check">
+              Accept
+            </el-button>
+            <el-button
+              v-if="scope.row.role === 'INVITED'"
+              size="mini"
+              icon="el-icon-close"
+              @click="handleDeclineInvitation(scope.row)">
+              Decline
+            </el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+    </div>
+    <el-row>
+      <el-button style="float: right; margin: 10px 0;" @click="handleOpenCreateProjectDialog">Create project</el-button>
+    </el-row>
+  </el-row>
 </template>
 
 <script lang="ts">
@@ -166,9 +166,14 @@
       }
     }
 
-    hideCreateProjectDialog() {
+    handleOpenCreateProjectDialog() {
+      this.showCreateProjectDialog = true;
+    }
+
+    handleCloseCreateProjectDialog() {
       this.showCreateProjectDialog = false;
     }
+
 
     async createProject() {
       await this.refetchData();

--- a/metaspace/webapp/src/modules/UserProfile/ProjectsTable.vue
+++ b/metaspace/webapp/src/modules/UserProfile/ProjectsTable.vue
@@ -1,19 +1,22 @@
 <template>
   <div>
+    <create-project-dialog
+      :visible="showCreateProjectDialog && currentUser != null"
+      :currentUserId="currentUser && currentUser.id"
+      @close="() => showCreateProjectDialog = false"
+      @create="createProject"
+    />
     <el-table
       :data="rows"
-      style="width: 100%;padding-left: 15px;">
-      <el-table-column label="Project" width="180">
+      style="margin-left: 15px;"
+    class="table">
+      <el-table-column label="Project">
         <template slot-scope="scope">
           <router-link :to="scope.row.route">{{scope.row.name}}</router-link>
         </template>
       </el-table-column>
-      <el-table-column
-        prop="roleName"
-        label="Role"
-        width="280"
-      />
-      <el-table-column label="Datasets contributed">
+      <el-table-column prop="roleName" label="Role" width="160" />
+      <el-table-column label="Datasets contributed" width="160" align="center">
         <template slot-scope="scope">
           <router-link v-if="scope.row.numDatasets > 0" :to="scope.row.datasetsRoute">
             {{scope.row.numDatasets}}
@@ -21,7 +24,7 @@
           <span v-if="scope.row.numDatasets === 0">{{scope.row.numDatasets}}</span>
         </template>
       </el-table-column>
-      <el-table-column>
+      <el-table-column width="240" align="right">
         <template slot-scope="scope">
           <el-button
             v-if="scope.row.role === 'MEMBER'"
@@ -55,6 +58,8 @@
         </template>
       </el-table-column>
     </el-table>
+    <el-button style="float: right; margin: 10px 0;" @click="() => showCreateProjectDialog = true">Create project</el-button>
+    <div class="clearfix"/>
   </div>
 </template>
 
@@ -66,6 +71,7 @@
   import reportError from '../../lib/reportError';
   import ConfirmAsync from '../../components/ConfirmAsync';
   import { encodeParams } from '../Filters';
+  import { CreateProjectDialog } from '../Project';
 
   interface ProjectRow {
     id: string;
@@ -76,7 +82,11 @@
   }
 
 
-  @Component
+  @Component({
+    components: {
+      CreateProjectDialog
+    }
+  })
   export default class ProjectsTable extends Vue {
     @Prop()
     currentUser!: UserProfileQuery | null;
@@ -84,6 +94,7 @@
     refetchData!: () => void;
 
     showTransferDatasetsDialog: boolean = false;
+    showCreateProjectDialog: boolean = false;
     invitingProject: ProjectRow | null = null;
 
     get rows(): ProjectRow[] {
@@ -154,8 +165,22 @@
         this.showTransferDatasetsDialog = false;
       }
     }
+
+    hideCreateProjectDialog() {
+      this.showCreateProjectDialog = false;
+    }
+
+    async createProject() {
+      await this.refetchData();
+      this.showCreateProjectDialog = false;
+    }
+
+
   }
 </script>
 
-<style>
+<style scoped>
+  .table.el-table /deep/ .cell {
+    word-break: normal !important;
+  }
 </style>

--- a/metaspace/webapp/src/modules/UserProfile/ProjectsTable.vue
+++ b/metaspace/webapp/src/modules/UserProfile/ProjectsTable.vue
@@ -90,12 +90,15 @@
       if (this.currentUser != null && this.currentUser.projects != null) {
         return this.currentUser.projects.map((item) => {
           const {project, numDatasets, role} = item;
-          const {id, name} = project;
+          const {id, name, urlSlug} = project;
 
           return {
             id, name, role, numDatasets,
             roleName: getRoleName(role),
-            route: `/project/${id}`,
+            route: {
+              name: 'project',
+              params: {projectIdOrSlug: urlSlug || id}
+            },
             datasetsRoute: {
               path: '/datasets',
               query: encodeParams({ submitter: this.currentUser!.id, project: id })

--- a/metaspace/webapp/src/modules/UserProfile/ProjectsTable.vue
+++ b/metaspace/webapp/src/modules/UserProfile/ProjectsTable.vue
@@ -4,7 +4,7 @@
       :visible="showCreateProjectDialog && currentUser != null"
       :currentUserId="currentUser && currentUser.id"
       @close="handleCloseCreateProjectDialog"
-      @create="createProject"
+      @create="handleCreateProject"
     />
     <div style="padding-left: 15px">
       <el-table :data="rows" class="table">
@@ -174,10 +174,8 @@
       this.showCreateProjectDialog = false;
     }
 
-
-    async createProject() {
-      await this.refetchData();
-      this.showCreateProjectDialog = false;
+    handleCreateProject({id}: {id: string}) {
+      this.$router.push({name: 'project', params: {projectIdOrSlug: id}});
     }
 
 

--- a/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
@@ -128,7 +128,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                 <tr class="el-table__row">
                   <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                     <div class="cell">
-                      <a href="#/group/grp-a" class="">Group A</a>
+                      <a href="/group/grp-a" class="">Group A</a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
@@ -154,7 +154,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                 <tr class="el-table__row">
                   <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                     <div class="cell">
-                      <a href="#/group/BBB" class="">Group B</a>
+                      <a href="/group/BBB" class="">Group B</a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
@@ -184,7 +184,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                 <tr class="el-table__row">
                   <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                     <div class="cell">
-                      <a href="#/group/CCC" class="">Group C</a>
+                      <a href="/group/CCC" class="">Group C</a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
@@ -206,7 +206,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                 <tr class="el-table__row">
                   <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                     <div class="cell">
-                      <a href="#/group/DDD" class="">Group D</a>
+                      <a href="/group/DDD" class="">Group D</a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
@@ -214,7 +214,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_3 is-center ">
                     <div class="cell">
-                      <a href="#/datasets?grp=DDD&amp;subm=22333" class="">
+                      <a href="/datasets?grp=DDD&amp;subm=22333" class="">
                         20
                       </a>
                       <!---->
@@ -375,7 +375,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                 <tr class="el-table__row">
                   <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
                     <div class="cell">
-                      <a href="#/project/proj-a" class="">Project A</a>
+                      <a href="/project/proj-a" class="">Project A</a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
@@ -401,7 +401,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                 <tr class="el-table__row">
                   <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
                     <div class="cell">
-                      <a href="#/project/BB" class="">Project B</a>
+                      <a href="/project/BB" class="">Project B</a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
@@ -431,7 +431,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                 <tr class="el-table__row">
                   <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
                     <div class="cell">
-                      <a href="#/project/CC" class="">Project C</a>
+                      <a href="/project/CC" class="">Project C</a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
@@ -453,7 +453,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                 <tr class="el-table__row">
                   <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
                     <div class="cell">
-                      <a href="#/project/DD" class="">Project D</a>
+                      <a href="/project/DD" class="">Project D</a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
@@ -461,7 +461,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_2_column_7 is-center ">
                     <div class="cell">
-                      <a href="#/datasets?prj=DD&amp;subm=22333" class="">
+                      <a href="/datasets?prj=DD&amp;subm=22333" class="">
                         20
                       </a>
                       <!---->

--- a/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
@@ -83,167 +83,169 @@ exports[`EditUserPage should match snapshot 1`] = `
       <h2>Groups</h2>
       <div>
         <!---->
-        <div class="el-table table el-table--fit el-table--scrollable-x el-table--enable-row-hover el-table--enable-row-transition" style="margin-left: 15px;">
-          <div class="hidden-columns">
-            <div></div>
-            <div></div>
-            <div></div>
-            <div></div>
-          </div>
-          <div class="el-table__header-wrapper">
-            <table cellspacing="0" cellpadding="0" border="0" class="el-table__header" style="width: 640px;">
-              <colgroup>
-                <col name="el-table_1_column_1" width="80">
-                <col name="el-table_1_column_2" width="160">
-                <col name="el-table_1_column_3" width="160">
-                <col name="el-table_1_column_4" width="240">
-              </colgroup>
-              <thead class="">
-                <tr class="">
-                  <th colspan="1" rowspan="1" class="el-table_1_column_1     is-leaf">
-                    <div class="cell">Group</div>
-                  </th>
-                  <th colspan="1" rowspan="1" class="el-table_1_column_2     is-leaf">
-                    <div class="cell">Role</div>
-                  </th>
-                  <th colspan="1" rowspan="1" class="el-table_1_column_3  is-center   is-leaf">
-                    <div class="cell">Datasets contributed</div>
-                  </th>
-                  <th colspan="1" rowspan="1" class="el-table_1_column_4  is-right   is-leaf">
-                    <div class="cell"></div>
-                  </th>
-                </tr>
-              </thead>
-            </table>
-          </div>
-          <div class="el-table__body-wrapper is-scrolling-left">
-            <table cellspacing="0" cellpadding="0" border="0" class="el-table__body" style="width: 640px;">
-              <colgroup>
-                <col name="el-table_1_column_1" width="80">
-                <col name="el-table_1_column_2" width="160">
-                <col name="el-table_1_column_3" width="160">
-                <col name="el-table_1_column_4" width="240">
-              </colgroup>
-              <tbody>
-                <tr class="el-table__row">
-                  <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
-                    <div class="cell">
-                      <a href="/group/grp-a" class="">Group A</a>
-                    </div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
-                    <div class="cell">Member</div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_3 is-center ">
-                    <div class="cell">
-                      <!----><span>0</span></div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_4 is-right ">
-                    <div class="cell">
-                      <button type="button" class="el-button el-button--default el-button--mini">
+        <div style="padding-left: 15px;">
+          <div class="el-table table el-table--fit el-table--scrollable-x el-table--enable-row-hover el-table--enable-row-transition">
+            <div class="hidden-columns">
+              <div></div>
+              <div></div>
+              <div></div>
+              <div></div>
+            </div>
+            <div class="el-table__header-wrapper">
+              <table cellspacing="0" cellpadding="0" border="0" class="el-table__header" style="width: 640px;">
+                <colgroup>
+                  <col name="el-table_1_column_1" width="80">
+                  <col name="el-table_1_column_2" width="160">
+                  <col name="el-table_1_column_3" width="160">
+                  <col name="el-table_1_column_4" width="240">
+                </colgroup>
+                <thead class="">
+                  <tr class="">
+                    <th colspan="1" rowspan="1" class="el-table_1_column_1     is-leaf">
+                      <div class="cell">Group</div>
+                    </th>
+                    <th colspan="1" rowspan="1" class="el-table_1_column_2     is-leaf">
+                      <div class="cell">Role</div>
+                    </th>
+                    <th colspan="1" rowspan="1" class="el-table_1_column_3  is-center   is-leaf">
+                      <div class="cell">Datasets contributed</div>
+                    </th>
+                    <th colspan="1" rowspan="1" class="el-table_1_column_4  is-right   is-leaf">
+                      <div class="cell"></div>
+                    </th>
+                  </tr>
+                </thead>
+              </table>
+            </div>
+            <div class="el-table__body-wrapper is-scrolling-left">
+              <table cellspacing="0" cellpadding="0" border="0" class="el-table__body" style="width: 640px;">
+                <colgroup>
+                  <col name="el-table_1_column_1" width="80">
+                  <col name="el-table_1_column_2" width="160">
+                  <col name="el-table_1_column_3" width="160">
+                  <col name="el-table_1_column_4" width="240">
+                </colgroup>
+                <tbody>
+                  <tr class="el-table__row">
+                    <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
+                      <div class="cell">
+                        <a href="/group/grp-a" class="">Group A</a>
+                      </div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
+                      <div class="cell">Member</div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_1_column_3 is-center ">
+                      <div class="cell">
+                        <!----><span>0</span></div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_1_column_4 is-right ">
+                      <div class="cell">
+                        <button type="button" class="el-button el-button--default el-button--mini">
+                          <!---->
+                          <i class="el-icon-arrow-right"></i><span>
+            Leave
+          </span></button>
                         <!---->
-                        <i class="el-icon-arrow-right"></i><span>
-          Leave
-        </span></button>
-                      <!---->
-                      <!---->
-                      <!---->
-                    </div>
-                  </td>
-                </tr>
-                <tr class="el-table__row">
-                  <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
-                    <div class="cell">
-                      <a href="/group/BBB" class="">Group B</a>
-                    </div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
-                    <div class="cell">Invited</div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_3 is-center ">
-                    <div class="cell">
-                      <!----><span>0</span></div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_4 is-right ">
-                    <div class="cell">
-                      <!---->
-                      <!---->
-                      <button type="button" class="el-button el-button--success el-button--mini">
                         <!---->
-                        <i class="el-icon-check"></i><span>
-          Accept
-        </span></button>
-                      <button type="button" class="el-button el-button--default el-button--mini">
                         <!---->
-                        <i class="el-icon-close"></i><span>
-          Decline
-        </span></button>
-                    </div>
-                  </td>
-                </tr>
-                <tr class="el-table__row">
-                  <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
-                    <div class="cell">
-                      <a href="/group/CCC" class="">Group C</a>
-                    </div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
-                    <div class="cell">Requesting access</div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_3 is-center ">
-                    <div class="cell">
-                      <!----><span>0</span></div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_4 is-right ">
-                    <div class="cell">
-                      <!---->
-                      <!---->
-                      <!---->
-                      <!---->
-                    </div>
-                  </td>
-                </tr>
-                <tr class="el-table__row">
-                  <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
-                    <div class="cell">
-                      <a href="/group/DDD" class="">Group D</a>
-                    </div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
-                    <div class="cell">Principal investigator</div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_3 is-center ">
-                    <div class="cell">
-                      <a href="/datasets?grp=DDD&amp;subm=22333" class="">
-                        20
-                      </a>
-                      <!---->
-                    </div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_4 is-right ">
-                    <div class="cell">
-                      <!---->
-                      <button disabled="disabled" type="button" class="el-button el-button--default el-button--mini is-disabled">
+                      </div>
+                    </td>
+                  </tr>
+                  <tr class="el-table__row">
+                    <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
+                      <div class="cell">
+                        <a href="/group/BBB" class="">Group B</a>
+                      </div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
+                      <div class="cell">Invited</div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_1_column_3 is-center ">
+                      <div class="cell">
+                        <!----><span>0</span></div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_1_column_4 is-right ">
+                      <div class="cell">
                         <!---->
-                        <i class="el-icon-arrow-right"></i><span>
-          Leave
-        </span></button>
-                      <!---->
-                      <!---->
-                    </div>
-                  </td>
-                </tr>
-                <!---->
-              </tbody>
-            </table>
+                        <!---->
+                        <button type="button" class="el-button el-button--success el-button--mini">
+                          <!---->
+                          <i class="el-icon-check"></i><span>
+            Accept
+          </span></button>
+                        <button type="button" class="el-button el-button--default el-button--mini">
+                          <!---->
+                          <i class="el-icon-close"></i><span>
+            Decline
+          </span></button>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr class="el-table__row">
+                    <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
+                      <div class="cell">
+                        <a href="/group/CCC" class="">Group C</a>
+                      </div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
+                      <div class="cell">Requesting access</div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_1_column_3 is-center ">
+                      <div class="cell">
+                        <!----><span>0</span></div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_1_column_4 is-right ">
+                      <div class="cell">
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                      </div>
+                    </td>
+                  </tr>
+                  <tr class="el-table__row">
+                    <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
+                      <div class="cell">
+                        <a href="/group/DDD" class="">Group D</a>
+                      </div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
+                      <div class="cell">Principal investigator</div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_1_column_3 is-center ">
+                      <div class="cell">
+                        <a href="/datasets?grp=DDD&amp;subm=22333" class="">
+                          20
+                        </a>
+                        <!---->
+                      </div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_1_column_4 is-right ">
+                      <div class="cell">
+                        <!---->
+                        <button disabled="disabled" type="button" class="el-button el-button--default el-button--mini is-disabled">
+                          <!---->
+                          <i class="el-icon-arrow-right"></i><span>
+            Leave
+          </span></button>
+                        <!---->
+                        <!---->
+                      </div>
+                    </td>
+                  </tr>
+                  <!---->
+                </tbody>
+              </table>
+              <!---->
+              <!---->
+            </div>
             <!---->
             <!---->
+            <!---->
+            <!---->
+            <div class="el-table__column-resize-proxy" style="display: none;"></div>
           </div>
-          <!---->
-          <!---->
-          <!---->
-          <!---->
-          <div class="el-table__column-resize-proxy" style="display: none;"></div>
         </div>
       </div>
       <div>
@@ -258,7 +260,7 @@ exports[`EditUserPage should match snapshot 1`] = `
     </div>
     <div style="margin-top: 40px;">
       <h2>Projects</h2>
-      <div>
+      <div class="el-row">
         <mock-el-dialog append-to-body="" title="Create project" class="dialog">
           <div mock-v-loading="1">
             <form class="el-form el-form--label-top" size="mini">
@@ -330,175 +332,178 @@ exports[`EditUserPage should match snapshot 1`] = `
             </div>
           </div>
         </mock-el-dialog>
-        <div class="el-table table el-table--fit el-table--scrollable-x el-table--enable-row-hover el-table--enable-row-transition" style="margin-left: 15px;">
-          <div class="hidden-columns">
-            <div></div>
-            <div></div>
-            <div></div>
-            <div></div>
-          </div>
-          <div class="el-table__header-wrapper">
-            <table cellspacing="0" cellpadding="0" border="0" class="el-table__header" style="width: 640px;">
-              <colgroup>
-                <col name="el-table_2_column_5" width="80">
-                <col name="el-table_2_column_6" width="160">
-                <col name="el-table_2_column_7" width="160">
-                <col name="el-table_2_column_8" width="240">
-              </colgroup>
-              <thead class="">
-                <tr class="">
-                  <th colspan="1" rowspan="1" class="el-table_2_column_5     is-leaf">
-                    <div class="cell">Project</div>
-                  </th>
-                  <th colspan="1" rowspan="1" class="el-table_2_column_6     is-leaf">
-                    <div class="cell">Role</div>
-                  </th>
-                  <th colspan="1" rowspan="1" class="el-table_2_column_7  is-center   is-leaf">
-                    <div class="cell">Datasets contributed</div>
-                  </th>
-                  <th colspan="1" rowspan="1" class="el-table_2_column_8  is-right   is-leaf">
-                    <div class="cell"></div>
-                  </th>
-                </tr>
-              </thead>
-            </table>
-          </div>
-          <div class="el-table__body-wrapper is-scrolling-left">
-            <table cellspacing="0" cellpadding="0" border="0" class="el-table__body" style="width: 640px;">
-              <colgroup>
-                <col name="el-table_2_column_5" width="80">
-                <col name="el-table_2_column_6" width="160">
-                <col name="el-table_2_column_7" width="160">
-                <col name="el-table_2_column_8" width="240">
-              </colgroup>
-              <tbody>
-                <tr class="el-table__row">
-                  <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
-                    <div class="cell">
-                      <a href="/project/proj-a" class="">Project A</a>
-                    </div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
-                    <div class="cell">Member</div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_7 is-center ">
-                    <div class="cell">
-                      <!----><span>0</span></div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_8 is-right ">
-                    <div class="cell">
-                      <button type="button" class="el-button el-button--default el-button--mini">
+        <div style="padding-left: 15px;">
+          <div class="el-table table el-table--fit el-table--scrollable-x el-table--enable-row-hover el-table--enable-row-transition">
+            <div class="hidden-columns">
+              <div></div>
+              <div></div>
+              <div></div>
+              <div></div>
+            </div>
+            <div class="el-table__header-wrapper">
+              <table cellspacing="0" cellpadding="0" border="0" class="el-table__header" style="width: 640px;">
+                <colgroup>
+                  <col name="el-table_2_column_5" width="80">
+                  <col name="el-table_2_column_6" width="160">
+                  <col name="el-table_2_column_7" width="160">
+                  <col name="el-table_2_column_8" width="240">
+                </colgroup>
+                <thead class="">
+                  <tr class="">
+                    <th colspan="1" rowspan="1" class="el-table_2_column_5     is-leaf">
+                      <div class="cell">Project</div>
+                    </th>
+                    <th colspan="1" rowspan="1" class="el-table_2_column_6     is-leaf">
+                      <div class="cell">Role</div>
+                    </th>
+                    <th colspan="1" rowspan="1" class="el-table_2_column_7  is-center   is-leaf">
+                      <div class="cell">Datasets contributed</div>
+                    </th>
+                    <th colspan="1" rowspan="1" class="el-table_2_column_8  is-right   is-leaf">
+                      <div class="cell"></div>
+                    </th>
+                  </tr>
+                </thead>
+              </table>
+            </div>
+            <div class="el-table__body-wrapper is-scrolling-left">
+              <table cellspacing="0" cellpadding="0" border="0" class="el-table__body" style="width: 640px;">
+                <colgroup>
+                  <col name="el-table_2_column_5" width="80">
+                  <col name="el-table_2_column_6" width="160">
+                  <col name="el-table_2_column_7" width="160">
+                  <col name="el-table_2_column_8" width="240">
+                </colgroup>
+                <tbody>
+                  <tr class="el-table__row">
+                    <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
+                      <div class="cell">
+                        <a href="/project/proj-a" class="">Project A</a>
+                      </div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
+                      <div class="cell">Member</div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_2_column_7 is-center ">
+                      <div class="cell">
+                        <!----><span>0</span></div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_2_column_8 is-right ">
+                      <div class="cell">
+                        <button type="button" class="el-button el-button--default el-button--mini">
+                          <!---->
+                          <i class="el-icon-arrow-right"></i><span>
+            Leave
+          </span></button>
                         <!---->
-                        <i class="el-icon-arrow-right"></i><span>
-          Leave
-        </span></button>
-                      <!---->
-                      <!---->
-                      <!---->
-                    </div>
-                  </td>
-                </tr>
-                <tr class="el-table__row">
-                  <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
-                    <div class="cell">
-                      <a href="/project/BB" class="">Project B</a>
-                    </div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
-                    <div class="cell">Invited</div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_7 is-center ">
-                    <div class="cell">
-                      <!----><span>0</span></div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_8 is-right ">
-                    <div class="cell">
-                      <!---->
-                      <!---->
-                      <button type="button" class="el-button el-button--success el-button--mini">
                         <!---->
-                        <i class="el-icon-check"></i><span>
-          Accept
-        </span></button>
-                      <button type="button" class="el-button el-button--default el-button--mini">
                         <!---->
-                        <i class="el-icon-close"></i><span>
-          Decline
-        </span></button>
-                    </div>
-                  </td>
-                </tr>
-                <tr class="el-table__row">
-                  <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
-                    <div class="cell">
-                      <a href="/project/CC" class="">Project C</a>
-                    </div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
-                    <div class="cell">Requesting access</div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_7 is-center ">
-                    <div class="cell">
-                      <!----><span>0</span></div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_8 is-right ">
-                    <div class="cell">
-                      <!---->
-                      <!---->
-                      <!---->
-                      <!---->
-                    </div>
-                  </td>
-                </tr>
-                <tr class="el-table__row">
-                  <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
-                    <div class="cell">
-                      <a href="/project/DD" class="">Project D</a>
-                    </div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
-                    <div class="cell">Project manager</div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_7 is-center ">
-                    <div class="cell">
-                      <a href="/datasets?prj=DD&amp;subm=22333" class="">
-                        20
-                      </a>
-                      <!---->
-                    </div>
-                  </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_8 is-right ">
-                    <div class="cell">
-                      <!---->
-                      <button disabled="disabled" type="button" class="el-button el-button--default el-button--mini is-disabled">
+                      </div>
+                    </td>
+                  </tr>
+                  <tr class="el-table__row">
+                    <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
+                      <div class="cell">
+                        <a href="/project/BB" class="">Project B</a>
+                      </div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
+                      <div class="cell">Invited</div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_2_column_7 is-center ">
+                      <div class="cell">
+                        <!----><span>0</span></div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_2_column_8 is-right ">
+                      <div class="cell">
                         <!---->
-                        <i class="el-icon-arrow-right"></i><span>
-          Leave
-        </span></button>
-                      <!---->
-                      <!---->
-                    </div>
-                  </td>
-                </tr>
-                <!---->
-              </tbody>
-            </table>
+                        <!---->
+                        <button type="button" class="el-button el-button--success el-button--mini">
+                          <!---->
+                          <i class="el-icon-check"></i><span>
+            Accept
+          </span></button>
+                        <button type="button" class="el-button el-button--default el-button--mini">
+                          <!---->
+                          <i class="el-icon-close"></i><span>
+            Decline
+          </span></button>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr class="el-table__row">
+                    <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
+                      <div class="cell">
+                        <a href="/project/CC" class="">Project C</a>
+                      </div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
+                      <div class="cell">Requesting access</div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_2_column_7 is-center ">
+                      <div class="cell">
+                        <!----><span>0</span></div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_2_column_8 is-right ">
+                      <div class="cell">
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                      </div>
+                    </td>
+                  </tr>
+                  <tr class="el-table__row">
+                    <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
+                      <div class="cell">
+                        <a href="/project/DD" class="">Project D</a>
+                      </div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
+                      <div class="cell">Project manager</div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_2_column_7 is-center ">
+                      <div class="cell">
+                        <a href="/datasets?prj=DD&amp;subm=22333" class="">
+                          20
+                        </a>
+                        <!---->
+                      </div>
+                    </td>
+                    <td rowspan="1" colspan="1" class="el-table_2_column_8 is-right ">
+                      <div class="cell">
+                        <!---->
+                        <button disabled="disabled" type="button" class="el-button el-button--default el-button--mini is-disabled">
+                          <!---->
+                          <i class="el-icon-arrow-right"></i><span>
+            Leave
+          </span></button>
+                        <!---->
+                        <!---->
+                      </div>
+                    </td>
+                  </tr>
+                  <!---->
+                </tbody>
+              </table>
+              <!---->
+              <!---->
+            </div>
             <!---->
             <!---->
+            <!---->
+            <!---->
+            <div class="el-table__column-resize-proxy" style="display: none;"></div>
           </div>
-          <!---->
-          <!---->
-          <!---->
-          <!---->
-          <div class="el-table__column-resize-proxy" style="display: none;"></div>
         </div>
-        <button type="button" class="el-button el-button--default" style="float: right; margin: 10px 0px;">
-          <!---->
-          <!----><span>Create project</span></button>
-        <div class="clearfix"></div>
+        <div class="el-row">
+          <button type="button" class="el-button el-button--default" style="float: right; margin: 10px 0px;">
+            <!---->
+            <!----><span>Create project</span></button>
+        </div>
       </div>
     </div>
-    <div style="margin-top: 45px;">
+    <div>
       <h2>Delete account</h2>
       <p style="width: 100%; padding-left: 15px;">
         If you delete your METASPACE account, you can either delete all your datasets or keep them within METASPACE. For the latter, the private data will still be accessible by the group members only.

--- a/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
@@ -83,7 +83,7 @@ exports[`EditUserPage should match snapshot 1`] = `
       <h2>Groups</h2>
       <div>
         <!---->
-        <div class="el-table el-table--fit el-table--scrollable-x el-table--enable-row-hover el-table--enable-row-transition" style="width: 100%; padding-left: 15px;">
+        <div class="el-table table el-table--fit el-table--scrollable-x el-table--enable-row-hover el-table--enable-row-transition" style="margin-left: 15px;">
           <div class="hidden-columns">
             <div></div>
             <div></div>
@@ -91,12 +91,12 @@ exports[`EditUserPage should match snapshot 1`] = `
             <div></div>
           </div>
           <div class="el-table__header-wrapper">
-            <table cellspacing="0" cellpadding="0" border="0" class="el-table__header" style="width: 620px;">
+            <table cellspacing="0" cellpadding="0" border="0" class="el-table__header" style="width: 640px;">
               <colgroup>
-                <col name="el-table_1_column_1" width="180">
-                <col name="el-table_1_column_2" width="280">
-                <col name="el-table_1_column_3" width="80">
-                <col name="el-table_1_column_4" width="80">
+                <col name="el-table_1_column_1" width="80">
+                <col name="el-table_1_column_2" width="160">
+                <col name="el-table_1_column_3" width="160">
+                <col name="el-table_1_column_4" width="240">
               </colgroup>
               <thead class="">
                 <tr class="">
@@ -106,10 +106,10 @@ exports[`EditUserPage should match snapshot 1`] = `
                   <th colspan="1" rowspan="1" class="el-table_1_column_2     is-leaf">
                     <div class="cell">Role</div>
                   </th>
-                  <th colspan="1" rowspan="1" class="el-table_1_column_3     is-leaf">
+                  <th colspan="1" rowspan="1" class="el-table_1_column_3  is-center   is-leaf">
                     <div class="cell">Datasets contributed</div>
                   </th>
-                  <th colspan="1" rowspan="1" class="el-table_1_column_4     is-leaf">
+                  <th colspan="1" rowspan="1" class="el-table_1_column_4  is-right   is-leaf">
                     <div class="cell"></div>
                   </th>
                 </tr>
@@ -117,12 +117,12 @@ exports[`EditUserPage should match snapshot 1`] = `
             </table>
           </div>
           <div class="el-table__body-wrapper is-scrolling-left">
-            <table cellspacing="0" cellpadding="0" border="0" class="el-table__body" style="width: 620px;">
+            <table cellspacing="0" cellpadding="0" border="0" class="el-table__body" style="width: 640px;">
               <colgroup>
-                <col name="el-table_1_column_1" width="180">
-                <col name="el-table_1_column_2" width="280">
-                <col name="el-table_1_column_3" width="80">
-                <col name="el-table_1_column_4" width="80">
+                <col name="el-table_1_column_1" width="80">
+                <col name="el-table_1_column_2" width="160">
+                <col name="el-table_1_column_3" width="160">
+                <col name="el-table_1_column_4" width="240">
               </colgroup>
               <tbody>
                 <tr class="el-table__row">
@@ -134,11 +134,11 @@ exports[`EditUserPage should match snapshot 1`] = `
                   <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
                     <div class="cell">Member</div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
+                  <td rowspan="1" colspan="1" class="el-table_1_column_3 is-center ">
                     <div class="cell">
                       <!----><span>0</span></div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_4  ">
+                  <td rowspan="1" colspan="1" class="el-table_1_column_4 is-right ">
                     <div class="cell">
                       <button type="button" class="el-button el-button--default el-button--mini">
                         <!---->
@@ -160,11 +160,11 @@ exports[`EditUserPage should match snapshot 1`] = `
                   <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
                     <div class="cell">Invited</div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
+                  <td rowspan="1" colspan="1" class="el-table_1_column_3 is-center ">
                     <div class="cell">
                       <!----><span>0</span></div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_4  ">
+                  <td rowspan="1" colspan="1" class="el-table_1_column_4 is-right ">
                     <div class="cell">
                       <!---->
                       <!---->
@@ -190,11 +190,11 @@ exports[`EditUserPage should match snapshot 1`] = `
                   <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
                     <div class="cell">Requesting access</div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
+                  <td rowspan="1" colspan="1" class="el-table_1_column_3 is-center ">
                     <div class="cell">
                       <!----><span>0</span></div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_4  ">
+                  <td rowspan="1" colspan="1" class="el-table_1_column_4 is-right ">
                     <div class="cell">
                       <!---->
                       <!---->
@@ -212,7 +212,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                   <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
                     <div class="cell">Principal investigator</div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
+                  <td rowspan="1" colspan="1" class="el-table_1_column_3 is-center ">
                     <div class="cell">
                       <a href="#/datasets?grp=DDD&amp;subm=22333" class="">
                         20
@@ -220,7 +220,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                       <!---->
                     </div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_1_column_4  ">
+                  <td rowspan="1" colspan="1" class="el-table_1_column_4 is-right ">
                     <div class="cell">
                       <!---->
                       <button disabled="disabled" type="button" class="el-button el-button--default el-button--mini is-disabled">
@@ -259,7 +259,78 @@ exports[`EditUserPage should match snapshot 1`] = `
     <div style="margin-top: 40px;">
       <h2>Projects</h2>
       <div>
-        <div class="el-table el-table--fit el-table--scrollable-x el-table--enable-row-hover el-table--enable-row-transition" style="width: 100%; padding-left: 15px;">
+        <mock-el-dialog append-to-body="" title="Create project" class="dialog">
+          <div mock-v-loading="1">
+            <form class="el-form el-form--label-top" size="mini">
+              <div>
+                <div class="el-form-item name is-required">
+                  <label for="name" class="el-form-item__label">Name</label>
+                  <div class="el-form-item__content">
+                    <div class="el-input">
+                      <!---->
+                      <input type="text" autocomplete="off" maxlength="50" class="el-input__inner">
+                      <!---->
+                      <!---->
+                      <!---->
+                    </div>
+                    <mock-transition name="el-zoom-in-top"></mock-transition>
+                  </div>
+                </div>
+                <div class="el-form-item isPublic">
+                  <!---->
+                  <div class="el-form-item__content">
+                    <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
+                      <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
+                      </span><span class="el-checkbox__label">Allow other users to see this project<!----></span></label>
+                    <mock-transition name="el-zoom-in-top"></mock-transition>
+                  </div>
+                </div>
+              </div>
+            </form>
+            <div>
+              <h4 style="margin-top: 0px;">
+                Would you like to include any of your previously submitted datasets?
+              </h4>
+              <div>
+                <div class="dataset-checkbox-list">
+                  <div>
+                    <label role="checkbox" class="el-checkbox is-checked" aria-checked="true"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
+                      <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
+                      </span><span class="el-checkbox__label">
+        allDatasets.0.name
+        <span class="reset-color">(Submitted Invalid Date at Invalid Date)</span>
+                      <!---->
+                      </span>
+                    </label>
+                  </div>
+                  <div>
+                    <label role="checkbox" class="el-checkbox is-checked" aria-checked="true"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
+                      <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="">
+                      </span><span class="el-checkbox__label">
+        allDatasets.1.name
+        <span class="reset-color">(Submitted Invalid Date at Invalid Date)</span>
+                      <!---->
+                      </span>
+                    </label>
+                  </div>
+                </div>
+                <div class="select-buttons">
+                  <a href="#">Select none</a> <span> | </span>
+                  <a href="#">Select all</a>
+                </div>
+              </div>
+            </div>
+            <div class="button-bar">
+              <button type="button" class="el-button el-button--default">
+                <!---->
+                <!----><span>Cancel</span></button>
+              <button type="button" class="el-button el-button--primary">
+                <!---->
+                <!----><span>Create project and include 2 datasets</span></button>
+            </div>
+          </div>
+        </mock-el-dialog>
+        <div class="el-table table el-table--fit el-table--scrollable-x el-table--enable-row-hover el-table--enable-row-transition" style="margin-left: 15px;">
           <div class="hidden-columns">
             <div></div>
             <div></div>
@@ -267,12 +338,12 @@ exports[`EditUserPage should match snapshot 1`] = `
             <div></div>
           </div>
           <div class="el-table__header-wrapper">
-            <table cellspacing="0" cellpadding="0" border="0" class="el-table__header" style="width: 620px;">
+            <table cellspacing="0" cellpadding="0" border="0" class="el-table__header" style="width: 640px;">
               <colgroup>
-                <col name="el-table_2_column_5" width="180">
-                <col name="el-table_2_column_6" width="280">
-                <col name="el-table_2_column_7" width="80">
-                <col name="el-table_2_column_8" width="80">
+                <col name="el-table_2_column_5" width="80">
+                <col name="el-table_2_column_6" width="160">
+                <col name="el-table_2_column_7" width="160">
+                <col name="el-table_2_column_8" width="240">
               </colgroup>
               <thead class="">
                 <tr class="">
@@ -282,10 +353,10 @@ exports[`EditUserPage should match snapshot 1`] = `
                   <th colspan="1" rowspan="1" class="el-table_2_column_6     is-leaf">
                     <div class="cell">Role</div>
                   </th>
-                  <th colspan="1" rowspan="1" class="el-table_2_column_7     is-leaf">
+                  <th colspan="1" rowspan="1" class="el-table_2_column_7  is-center   is-leaf">
                     <div class="cell">Datasets contributed</div>
                   </th>
-                  <th colspan="1" rowspan="1" class="el-table_2_column_8     is-leaf">
+                  <th colspan="1" rowspan="1" class="el-table_2_column_8  is-right   is-leaf">
                     <div class="cell"></div>
                   </th>
                 </tr>
@@ -293,12 +364,12 @@ exports[`EditUserPage should match snapshot 1`] = `
             </table>
           </div>
           <div class="el-table__body-wrapper is-scrolling-left">
-            <table cellspacing="0" cellpadding="0" border="0" class="el-table__body" style="width: 620px;">
+            <table cellspacing="0" cellpadding="0" border="0" class="el-table__body" style="width: 640px;">
               <colgroup>
-                <col name="el-table_2_column_5" width="180">
-                <col name="el-table_2_column_6" width="280">
-                <col name="el-table_2_column_7" width="80">
-                <col name="el-table_2_column_8" width="80">
+                <col name="el-table_2_column_5" width="80">
+                <col name="el-table_2_column_6" width="160">
+                <col name="el-table_2_column_7" width="160">
+                <col name="el-table_2_column_8" width="240">
               </colgroup>
               <tbody>
                 <tr class="el-table__row">
@@ -310,11 +381,11 @@ exports[`EditUserPage should match snapshot 1`] = `
                   <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
                     <div class="cell">Member</div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_7  ">
+                  <td rowspan="1" colspan="1" class="el-table_2_column_7 is-center ">
                     <div class="cell">
                       <!----><span>0</span></div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_8  ">
+                  <td rowspan="1" colspan="1" class="el-table_2_column_8 is-right ">
                     <div class="cell">
                       <button type="button" class="el-button el-button--default el-button--mini">
                         <!---->
@@ -336,11 +407,11 @@ exports[`EditUserPage should match snapshot 1`] = `
                   <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
                     <div class="cell">Invited</div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_7  ">
+                  <td rowspan="1" colspan="1" class="el-table_2_column_7 is-center ">
                     <div class="cell">
                       <!----><span>0</span></div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_8  ">
+                  <td rowspan="1" colspan="1" class="el-table_2_column_8 is-right ">
                     <div class="cell">
                       <!---->
                       <!---->
@@ -366,11 +437,11 @@ exports[`EditUserPage should match snapshot 1`] = `
                   <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
                     <div class="cell">Requesting access</div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_7  ">
+                  <td rowspan="1" colspan="1" class="el-table_2_column_7 is-center ">
                     <div class="cell">
                       <!----><span>0</span></div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_8  ">
+                  <td rowspan="1" colspan="1" class="el-table_2_column_8 is-right ">
                     <div class="cell">
                       <!---->
                       <!---->
@@ -388,7 +459,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                   <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
                     <div class="cell">Project manager</div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_7  ">
+                  <td rowspan="1" colspan="1" class="el-table_2_column_7 is-center ">
                     <div class="cell">
                       <a href="#/datasets?prj=DD&amp;subm=22333" class="">
                         20
@@ -396,7 +467,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                       <!---->
                     </div>
                   </td>
-                  <td rowspan="1" colspan="1" class="el-table_2_column_8  ">
+                  <td rowspan="1" colspan="1" class="el-table_2_column_8 is-right ">
                     <div class="cell">
                       <!---->
                       <button disabled="disabled" type="button" class="el-button el-button--default el-button--mini is-disabled">
@@ -421,6 +492,10 @@ exports[`EditUserPage should match snapshot 1`] = `
           <!---->
           <div class="el-table__column-resize-proxy" style="display: none;"></div>
         </div>
+        <button type="button" class="el-button el-button--default" style="float: right; margin: 10px 0px;">
+          <!---->
+          <!----><span>Create project</span></button>
+        <div class="clearfix"></div>
       </div>
     </div>
     <div style="margin-top: 45px;">

--- a/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
@@ -128,7 +128,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                 <tr class="el-table__row">
                   <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                     <div class="cell">
-                      <a href="#/group/AAA" class="">Group A</a>
+                      <a href="#/group/grp-a" class="">Group A</a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
@@ -304,7 +304,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                 <tr class="el-table__row">
                   <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
                     <div class="cell">
-                      <a href="#/project/AA" class="">Project A</a>
+                      <a href="#/project/proj-a" class="">Project A</a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_2_column_6  ">

--- a/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
@@ -26,7 +26,7 @@ exports[`EditUserPage should match snapshot 1`] = `
       <a href="mailto:contact@metaspace2020.eu">METASPACE administrators</a>.
     </p>
   </mock-el-dialog>
-  <div class="user-edit-page el-loading-parent--relative">
+  <div class="user-edit-page" mock-v-loading="false">
     <div class="el-row">
       <div class="el-col el-col-16">
         <h2>User details</h2>
@@ -436,16 +436,6 @@ exports[`EditUserPage should match snapshot 1`] = `
         Delete account
       </span></button>
     </div>
-    <mock-transition name="el-loading-fade">
-      <div class="el-loading-mask" style="display: none;">
-        <div class="el-loading-spinner">
-          <svg viewBox="25 25 50 50" class="circular">
-            <circle cx="50" cy="50" r="20" fill="none" class="path"></circle>
-          </svg>
-          <!---->
-        </div>
-      </div>
-    </mock-transition>
   </div>
 </div>
 `;

--- a/metaspace/webapp/src/router.ts
+++ b/metaspace/webapp/src/router.ts
@@ -50,9 +50,9 @@ const router = new VueRouter({
     { path: '/account/reset-password', component: ResetPasswordPage },
 
     { path: '/group/create', component: asyncPages.CreateGroupPage },
-    { path: '/group/:groupId', name: 'group', component: asyncPages.ViewGroupProfile },
+    { path: '/group/:groupIdOrSlug', name: 'group', component: asyncPages.ViewGroupProfile },
     { path: '/group/:groupId/edit', name: 'edit-group', component: asyncPages.EditGroupProfile },
-    { path: '/project/:projectId', name: 'project', component: asyncPages.ViewProjectPage },
+    { path: '/project/:projectIdOrSlug', name: 'project', component: asyncPages.ViewProjectPage },
     { path: '/project/:projectId/edit', name: 'edit-project', component: asyncPages.EditProjectPage },
     { path: '/projects', component: asyncPages.ProjectsListPage },
   ]

--- a/metaspace/webapp/src/router.ts
+++ b/metaspace/webapp/src/router.ts
@@ -25,7 +25,16 @@ const asyncPages = {
   ProjectsListPage: () => import(/* webpackPrefetch: true, webpackChunkName: "Bundle1" */ './modules/Project/ProjectsListPage.vue'),
 };
 
+const convertLegacyHashUrls = () => {
+  const {pathname, hash} = window.location;
+  if (pathname === '/' && hash && hash.startsWith('#/')) {
+    history.replaceState(undefined, undefined, hash.slice(1));
+  }
+};
+convertLegacyHashUrls();
+
 const router = new VueRouter({
+  mode: 'history',
   routes: [
     { path: '/', redirect: '/about' },
     { path: '/annotations', component: asyncPages.AnnotationsPage },

--- a/metaspace/webapp/src/router.ts
+++ b/metaspace/webapp/src/router.ts
@@ -36,7 +36,8 @@ convertLegacyHashUrls();
 const router = new VueRouter({
   mode: 'history',
   routes: [
-    { path: '/', redirect: '/about' },
+    { path: '/', component: AboutPage },
+    { path: '/about', component: AboutPage },
     { path: '/annotations', component: asyncPages.AnnotationsPage },
     {
       path: '/datasets',
@@ -49,7 +50,6 @@ const router = new VueRouter({
     { path: '/datasets/edit/:dataset_id', name: 'edit-metadata', component: asyncPages.MetadataEditPage },
     { path: '/datasets/:dataset_id/add-optical-image', name: 'add-optical-image', component: asyncPages.ImageAlignmentPage },
     { path: '/upload', component: asyncPages.UploadPage },
-    { path: '/about', component: AboutPage },
     { path: '/help', component: asyncPages.HelpPage },
     { path: '/user/me', component: asyncPages.EditUserPage },
 

--- a/metaspace/webapp/tests/e2e/annotations.js
+++ b/metaspace/webapp/tests/e2e/annotations.js
@@ -3,7 +3,7 @@ import config from '../../conf';
 import {ClientFunction, Selector} from 'testcafe';
 
 fixture `Annotations page`
-  .page `http://${config.HOST_NAME}:${config.PORT}/#/annotations`;
+  .page `http://${config.HOST_NAME}:${config.PORT}/annotations`;
 
 const table = new Selector('#annot-table');
 const filterPanel = new Selector('#annot-page .filter-panel');

--- a/metaspace/webapp/tests/e2e/upload.ts
+++ b/metaspace/webapp/tests/e2e/upload.ts
@@ -107,7 +107,7 @@ const uploadForm = new UploadForm();
 const datasetsPage = new DatasetsPage();
 
 fixture(`Upload page`)
-    .page(`http://${HOST_NAME}:${PORT}/#/upload`)
+    .page(`http://${HOST_NAME}:${PORT}/upload`)
     .beforeEach(async (t: TestController) => {
         const user: UserInfo = {
             firstName: 'Erica',
@@ -136,6 +136,6 @@ test('submitted dataset appears in the Datasets tab', async (t: TestController) 
     await t
         .typeText(datasetNameField, datasetName, {replace: true, paste: true})
         .click(uploadForm.submitButton)
-        .navigateTo('/#/datasets')
+        .navigateTo('/datasets')
         .expect(datasetsPage.findDataset(datasetName).exists).ok();
 });

--- a/metaspace/webapp/tests/utils/registerMockDirective.ts
+++ b/metaspace/webapp/tests/utils/registerMockDirective.ts
@@ -1,0 +1,12 @@
+import Vue from 'vue';
+
+export default (name: string) => {
+  const mockName = `mock-v-${name}`;
+  Vue.config.ignoredElements.push(mockName);
+  Vue.directive(name, (el, {value, arg, modifiers}) => {
+    const modifierString = Object.keys(modifiers).join('.');
+    const directiveSuffix = (arg ? `:${arg}` : '') + (modifierString ? `.${modifierString}` : '');
+
+    el.setAttribute(mockName + directiveSuffix, value);
+  });
+}

--- a/metaspace/webapp/tests/utils/setupTestFramework.ts
+++ b/metaspace/webapp/tests/utils/setupTestFramework.ts
@@ -3,6 +3,7 @@ import Vue from 'vue';
 import ElementUI from 'element-ui';
 import registerMockComponent from './registerMockComponent';
 import VueRouter from 'vue-router';
+import registerMockDirective from './registerMockDirective';
 
 window.fetch = jest.fn();
 
@@ -17,6 +18,9 @@ registerMockComponent('el-autocomplete');
 registerMockComponent('el-select');
 registerMockComponent('el-option');
 registerMockComponent('el-messagebox');
+
+// Mock problematic directives
+registerMockDirective('loading');
 
 // Mock error reporting
 jest.mock('../../src/lib/reportError', () => jest.fn(console.error));

--- a/metaspace/webapp/yarn.lock
+++ b/metaspace/webapp/yarn.lock
@@ -3756,6 +3756,10 @@ connect-history-api-fallback@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz#e51d17f8f0ef0db90a64fdb47de3051556e9f169"
 
+connect-history-api-fallback@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
+
 connect-redis@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-3.3.0.tgz#c9510c1a567ff710eb2510e6a7509fa92b2232df"

--- a/metaspace/webapp/yarn.lock
+++ b/metaspace/webapp/yarn.lock
@@ -3692,6 +3692,12 @@ component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
+compressible@~2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.14.tgz#326c5f507fbb055f54116782b969a81b67a29da7"
+  dependencies:
+    mime-db ">= 1.34.0 < 2"
+
 compressible@~2.0.8:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.10.tgz#feda1c7f7617912732b29bf8cf26252a20b9eecd"
@@ -3708,6 +3714,18 @@ compression@^1.5.2:
     debug "~2.2.0"
     on-headers "~1.0.1"
     vary "~1.1.0"
+
+compression@^1.6.2:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.3.tgz#27e0e176aaf260f7f2c2813c3e440adb9f1993db"
+  dependencies:
+    accepts "~1.3.5"
+    bytes "3.0.0"
+    compressible "~2.0.14"
+    debug "2.6.9"
+    on-headers "~1.0.1"
+    safe-buffer "5.1.2"
+    vary "~1.1.2"
 
 concat-files@^0.1.1:
   version "0.1.1"
@@ -9045,6 +9063,10 @@ miller-rabin@^4.0.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
 
+"mime-db@>= 1.34.0 < 2":
+  version "1.36.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
+
 mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
@@ -11813,7 +11835,7 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, s
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-safe-buffer@^5.1.2:
+safe-buffer@5.1.2, safe-buffer@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 


### PR DESCRIPTION
This adds support for custom URLs, e.g. http://localhost/group/embl, for groups and projects. It works by detecting whether or not the parameter in the route is a UUID, and switching between the `group`/`project` and `groupByUrlSlug`/`projectByUrlSlug` graphql queries. This only happens on the View Group/Project pages. For consistency, those pages will also automatically redirect to the custom URL if accessed with a UUID.

Other changes:
* I've changed the router to "History mode", which means no more "/#/" in URLs. I've also added code to redirect to the non-`/#/` path if the user follows an old link
* I've added global mocking for the `v-loading` directive in tests. I found that it inconsistently adds classes & the HTML for the loading spinner to the snapshots. Mocking it out makes the snapshots a bit more robust and saves some confusion.
* I've rebalanced the columns in the two tables in the My Account page, and added a Create Project button. I had those changes lying around after the demo I made for my presentation.
