### PR TITLE
Docker tweaks

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -16,3 +16,11 @@ METASPACE_BRANCH=master
 
 # Ports
 WWW_PORT=8999
+
+# To run containers as a non-root user so that they don't change file permissions,
+# append `:docker-compose.uid.yml` to COMPOSE_FILE, and put your user ID
+# and group ID here, separated by a colon i.e. `SM_USER=<user id>:<group id>`.
+# You can find your user ID and group ID with the `id` command in Linux.
+# To fix file permissions after running the containers as root, run:
+# `sudo chown -R <your user name>:<your user name> .` in this directory.
+SM_USER=1000:1000

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -2,6 +2,11 @@ version: '2'
 
 services:
 
+  elasticsearch:
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+
   kibana:
     image: kibana:5.5
     volumes:
@@ -13,11 +18,19 @@ services:
     depends_on:
       - elasticsearch
 
+  redis:
+    ports:
+      - "6379:6379"
+
   rabbitmq:
     image: rabbitmq:management
     ports:
       - "5672:5672"  # to use rabbitmq from host
       - "15672:15672" #management interface
+
+  postgres:
+    ports:
+      - "5432:5432"
 
   adminer:
     image: adminer

--- a/docker/docker-compose.uid.yml
+++ b/docker/docker-compose.uid.yml
@@ -1,0 +1,29 @@
+version: '2'
+
+services:
+
+  postgres:
+    # The default mount point for pgdata isn't accessible to other users, so move it
+    volumes:
+      - ./data/pgdata:/pgdata
+    environment:
+      PGDATA: /pgdata
+    user: "$SM_USER"
+
+  sm-mol-db:
+    user: "$SM_USER"
+
+  sm-api:
+    user: "$SM_USER"
+
+  sm-update-daemon:
+    user: "$SM_USER"
+
+  sm-annotate-daemon:
+    user: "$SM_USER"
+
+  sm-graphql:
+    user: "$SM_USER"
+
+  sm-webapp:
+    user: "$SM_USER"


### PR DESCRIPTION
Changes:
* Expose elasticsearch, redis and postgres ports. I had previously hidden those ports while trying to get Docker to work as an isolated, single-port system. That never worked out, but I often need to directly connect to ElasticSearch and Postgres.
* Add an additional docker-compose configuration file to run docker images in a user account. This prevents them from creating files with root permissions on shared volumes.

After this is merged, to get the opened ports you'll just need to `dc kill` and `dc up -d` the affected containers. To run containers as your user account you'll need to update your `.env` file per the instructions in `.env.example` and drop and recreate the affected containers with:

```bash
dc kill sm-webapp sm-graphql sm-api sm-update-daemon sm-annotate-daemon sm-mol-db postgres
dc rm -f sm-webapp sm-graphql sm-api sm-update-daemon sm-annotate-daemon sm-mol-db postgres
sudo chown -R $USER:$USER .
dc up -d sm-webapp sm-graphql sm-api sm-update-daemon sm-annotate-daemon sm-mol-db postgres
```