### PR TITLE
Read-only mode

### DIFF
--- a/metaspace/graphql/missing-types.d.ts
+++ b/metaspace/graphql/missing-types.d.ts
@@ -1,1 +1,9 @@
 declare module 'passport-google-oauth20';
+
+declare module 'graphql-errors' {
+  import { IResolverOptions } from 'graphql-tools/dist/Interfaces';
+  import { GraphQLObjectType, GraphQLSchema } from 'graphql';
+
+  class UserError extends Error {}
+  function maskErrors(thing: GraphQLSchema | GraphQLObjectType | IResolverOptions, fn?: (err: Error) => Error): void;
+}

--- a/metaspace/graphql/resolvers.js
+++ b/metaspace/graphql/resolvers.js
@@ -9,7 +9,8 @@ const config = require('config'),
   {datasetFilters, dsField, getPgField, SubstringMatchFilter} = require('./datasetFilters.js'),
   {pgDatasetsViewableByUser, fetchDS, fetchMolecularDatabases, deprecatedMolDBs,
     assertUserCanViewDataset, canUserViewPgDataset, wait, logger, pubsub, db} = require('./utils.js'),
-  {Mutation: DSMutation, Query: DSQuery} = require('./dsMutation.js');
+  {Mutation: DSMutation, Query: DSQuery} = require('./dsMutation.js'),
+  {Resolvers: SystemResolvers} = require('./src/modules/system/controller' /*TODO: Remove in merge with master*/);
 
 
 async function publishDatasetStatusUpdate(ds_id, status) {
@@ -249,7 +250,9 @@ const Resolvers = {
 
     reprocessingNeeded(_, args, {user}) {
       return DSQuery.reprocessingNeeded(args, user);
-    }
+    },
+
+    ...SystemResolvers.Query, //TODO: Remove in merge with master
   },
 
   Analyzer: {
@@ -502,7 +505,9 @@ const Resolvers = {
 
     deleteOpticalImage: (_, args, {user}) => {
       return DSMutation.deleteOpticalImage(args, user);
-    }
+    },
+
+    ...SystemResolvers.Mutation, //TODO: Remove in merge with master
   },
 
   Subscription: {
@@ -517,6 +522,8 @@ const Resolvers = {
         }
       }
     },
+
+    ...SystemResolvers.Subscription, //TODO: Remove in merge with master
   }
 };
 

--- a/metaspace/graphql/schema.graphql
+++ b/metaspace/graphql/schema.graphql
@@ -270,6 +270,18 @@ input AddOpticalImageInput {
   transform: [[Float]]!
 }
 
+type SystemHealth { # TODO: Remove in master branch - this belongs in system.graphql
+  canProcessDatasets: Boolean!
+  canMutate: Boolean!
+  message: String
+}
+
+input UpdateSystemHealthInput { # TODO: Remove in master branch - this belongs in system.graphql
+  canProcessDatasets: Boolean!
+  canMutate: Boolean!
+  message: String
+}
+
 type Query {
   dataset(id: String!): Dataset
   datasetByName(name: String!): Dataset
@@ -312,6 +324,8 @@ type Query {
   thumbnailImage(datasetId: String!): String,
 
   reprocessingNeeded(input: DatasetUpdateInput!): Boolean!
+
+  systemHealth: SystemHealth! # TODO: Remove in master branch - this belongs in system.graphql
 }
 
 type Mutation {
@@ -331,6 +345,8 @@ type Mutation {
   addOpticalImage(input: AddOpticalImageInput!): String!
 
   deleteOpticalImage(datasetId: String!): String!
+
+  updateSystemHealth(health: UpdateSystemHealthInput!): Boolean # TODO: Remove in master branch - this belongs in system.graphql
 }
 
 type DatasetStatusUpdate {
@@ -339,6 +355,8 @@ type DatasetStatusUpdate {
 
 type Subscription {
   datasetStatusUpdated: DatasetStatusUpdate
+
+  systemHealthUpdated: SystemHealth! # TODO: Remove in master branch - this belongs in system.graphql
 }
 
 schema {

--- a/metaspace/graphql/schemas/system.graphql
+++ b/metaspace/graphql/schemas/system.graphql
@@ -1,0 +1,23 @@
+type SystemHealth {
+  canMutate: Boolean!
+  canProcessDatasets: Boolean!
+  message: String
+}
+
+input UpdateSystemHealthInput {
+  canMutate: Boolean!
+  canProcessDatasets: Boolean!
+  message: String
+}
+
+type Query {
+  systemHealth: SystemHealth!
+}
+
+type Mutation {
+  updateSystemHealth(health: UpdateSystemHealthInput!): Boolean
+}
+
+type Subscription {
+  systemHealthChanged: SystemHealth!
+}

--- a/metaspace/graphql/server.js
+++ b/metaspace/graphql/server.js
@@ -10,7 +10,8 @@ const bodyParser = require('body-parser'),
   makeExecutableSchema = require('graphql-tools').makeExecutableSchema,
   {maskErrors} = require('graphql-errors'),
   {promisify} = require('util'),
-  readFile = promisify(require("fs").readFile);
+  readFile = promisify(require("fs").readFile),
+  {preventMutationsIfReadOnly} = require('./src/modules/system/controller');
 
 const {createImgServerAsync} = require('./imageUpload.js'),
   {configureAuth, initSchema} = require('./src/modules/auth'),
@@ -57,7 +58,10 @@ function createHttpServerAsync(config) {
     .then((contents) => {
       const schema = makeExecutableSchema({
         typeDefs: contents,
-        resolvers: Resolvers,
+        resolvers: {
+          ...Resolvers,
+          Mutation: preventMutationsIfReadOnly(Resolvers.Mutation),
+        },
         logger
       });
 

--- a/metaspace/graphql/src/modules/system/controller.ts
+++ b/metaspace/graphql/src/modules/system/controller.ts
@@ -1,0 +1,116 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as _ from 'lodash';
+import {promisify} from 'util';
+import { pubsub } from '../../../utils';
+import { IResolverObject } from 'graphql-tools/dist/Interfaces';
+import { GraphQLFieldResolver } from 'graphql';
+import {UserError} from 'graphql-errors';
+
+
+interface SystemHealth { // TODO: Get from binding.ts after merge with master
+  canMutate: Boolean;
+  canProcessDatasets: Boolean;
+  message: string | null;
+}
+
+interface UpdateSystemHealthInput { // TODO: Get from binding.ts after merge with master
+  canMutate: Boolean;
+  canProcessDatasets: Boolean;
+  message: string | null;
+}
+
+interface Context { // TODO: Get from Context.ts after merge with master
+  user?: {role: string}
+}
+
+const SYSTEM_HEALTH_CHANNEL = 'systemHealthUpdated';
+const healthFile = path.join(path.dirname(require.main!.filename), 'health.json');
+const defaultHealth: SystemHealth = {
+  canMutate: true,
+  canProcessDatasets: true,
+  message: null,
+};
+const datasetProcessingMutations = [
+  'createDataset',
+  'updateDataset',
+  'reprocessDataset',
+];
+
+let currentHealth: Promise<SystemHealth> = (async () => {
+  try {
+    return {
+      ...defaultHealth,
+      ...JSON.parse(await promisify(fs.readFile)(healthFile, 'utf8')),
+    };
+  } catch {
+    return defaultHealth;
+  }
+})();
+
+export const Resolvers = {
+  Query: {
+    async systemHealth(): Promise<SystemHealth> {
+      return await currentHealth;
+    },
+  },
+
+  Mutation: {
+    async updateSystemHealth(source: void, {health}: {health: UpdateSystemHealthInput}, {user}: Context) {
+      if (user && user.role === 'admin') {
+        const newHealth = {...defaultHealth, ...health};
+        currentHealth = Promise.resolve(newHealth);
+        pubsub.publish(SYSTEM_HEALTH_CHANNEL, newHealth);
+
+        // Don't persist to disk in development mode, as it triggers nodemon to restart the process
+        if (process.env.NODE_ENV !== 'development') {
+          if (_.isEqual(newHealth, defaultHealth)) {
+            const fileExists = await promisify(fs.stat)(healthFile).then(() => true, () => false);
+            if (fileExists) {
+              await promisify(fs.unlink)(healthFile);
+            }
+          } else {
+            await promisify(fs.writeFile)(healthFile, JSON.stringify(newHealth), 'utf-8');
+          }
+        }
+
+        return null;
+      } else {
+        throw new UserError('Not authorized');
+      }
+    },
+  },
+
+  Subscription: {
+    systemHealthUpdated: {
+      subscribe: () => pubsub.asyncIterator<SystemHealth>(SYSTEM_HEALTH_CHANNEL),
+      resolve: (payload: SystemHealth) => payload,
+    },
+  },
+};
+
+export const preventMutationsIfReadOnly = (Mutation: Record<string, GraphQLFieldResolver<any, any>>): IResolverObject => {
+  return _.mapValues(Mutation, (resolver: GraphQLFieldResolver<any, any>, key): GraphQLFieldResolver<any, any> => {
+
+    if (!_.isFunction(resolver)) {
+      throw new Error('filterMutations can\'t handle non-function resolvers')
+    }
+
+    if (key === 'updateSystemHealth') {
+      return resolver;
+    } else {
+      return async (source: any, args: any, context: any, info: any) => {
+        const health = await currentHealth;
+        const requiresDatasetProcesing = key === 'createDataset'
+          || key === 'reprocessDataset'
+          || (key === 'updateDataset' && args.reprocess !== false);
+
+        if (!health.canMutate || (!health.canProcessDatasets && requiresDatasetProcesing)) {
+          throw new UserError(JSON.stringify({ type: 'read_only_mode', message: health.message }));
+        } else {
+          return resolver(source, args, context, info);
+        }
+      }
+    }
+  })
+};

--- a/metaspace/webapp/ci/clientConfig.json
+++ b/metaspace/webapp/ci/clientConfig.json
@@ -3,7 +3,6 @@
   "wsGraphqlUrl": "ws://localhost:5666/graphql",
 
   "google_client_id": "clientid",
-  "enableUploads": true,
 
   "fineUploader": {
     "aws": {

--- a/metaspace/webapp/package.json
+++ b/metaspace/webapp/package.json
@@ -137,6 +137,10 @@
       "^.+\\.vue$": "<rootDir>/node_modules/vue-jest",
       "^.+\\.[jt]sx?$": "<rootDir>/node_modules/ts-jest"
     },
+    "moduleNameMapper": {
+      "lodash-es": "lodash",
+      "\\.scss$": "<rootDir>/tests/utils/scssMock.js"
+    },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
       "ts",

--- a/metaspace/webapp/src/App.vue
+++ b/metaspace/webapp/src/App.vue
@@ -90,7 +90,6 @@
  }
 
  .main-content {
-   padding-top: 70px;     /* see MetaspaceHeader.vue: 70 = 62 height + 8 margin */
    /* padding-bottom: 130px; see MetaspaceFooter.vue: 130 = 30 height + 100 margin */
  }
 

--- a/metaspace/webapp/src/api/system.ts
+++ b/metaspace/webapp/src/api/system.ts
@@ -1,0 +1,26 @@
+import gql from 'graphql-tag';
+
+export interface SystemHealth {
+  canMutate: Boolean
+  canProcessDatasets: Boolean
+  message?: String
+}
+
+export const getSystemHealthQuery = gql`query GetSystemHealth {
+  systemHealth { canMutate canProcessDatasets message }
+}`;
+
+export const getSystemHealthSubscribeToMore = {
+  document: gql`subscription SystemHealth {
+    systemHealthUpdated { canMutate canProcessDatasets message }
+  }`,
+  updateQuery(previousResult: any, {subscriptionData}: any) {
+    return {
+      systemHealth: subscriptionData.data.systemHealthUpdated
+    }
+  }
+};
+
+export const updateSystemHealthMutation = gql`mutation UpdateSystemHealth ($health: UpdateSystemHealthInput!) {
+  updateSystemHealth(health: $health)
+}`;

--- a/metaspace/webapp/src/clientConfig.json.template
+++ b/metaspace/webapp/src/clientConfig.json.template
@@ -3,7 +3,6 @@
   "wsGraphqlUrl": null,
 
   "google_client_id": "{{ sm_webapp_google_client_id }}",
-  "enableUploads": {{ sm_webapp_enable_uploads | to_json }},
 
   "fineUploader": {
     "aws": {

--- a/metaspace/webapp/src/components/DatasetItem.vue
+++ b/metaspace/webapp/src/components/DatasetItem.vue
@@ -132,6 +132,7 @@
  import {deleteDatasetQuery, thumbnailOptImageQuery} from '../api/dataset';
  import {mdTypeSupportsOpticalImages} from '../util';
  import {encodeParams} from '../url';
+ import reportError from '../lib/reportError';
 
  function removeUnderscores(str) {
    return str.replace(/_/g, ' ');
@@ -325,14 +326,8 @@
          });
        }
        catch (err) {
-         this.$message({
-           message: "Deletion failed :( Please contact us at contact@metaspace2020.eu",
-           type: 'error',
-           duration: 0,
-           showClose: true
-         });
          this.disabled = false;
-         throw err;
+         reportError(err, "Deletion failed :( Please contact us at contact@metaspace2020.eu");
        }
      },
 

--- a/metaspace/webapp/src/components/ImageAlignmentPage.vue
+++ b/metaspace/webapp/src/components/ImageAlignmentPage.vue
@@ -141,6 +141,7 @@
  import {renderMolFormula, prettifySign} from '../util';
 
  import gql from 'graphql-tag';
+ import reportError from '../lib/reportError';
 
  export default {
    name: 'image-alignment-page',
@@ -319,11 +320,7 @@
            });
            this.$router.go(-1);
          }).catch((e) => {
-           this.$message({
-             type: 'error',
-             message: 'Internal server error'
-           });
-           throw e;
+           reportError(e);
          });
          return;
        }
@@ -344,11 +341,7 @@
              });
              this.$router.go(-1);
            }).catch((e) => {
-             this.$message({
-               type: 'error',
-               message: 'Internal server error'
-             });
-             throw e;
+             reportError(e);
            });
          } else if (xhr.readyState == 4) {
            this.$message({
@@ -404,11 +397,7 @@
            this.destroyOptImage();
          }
        } catch(e) {
-         this.$message({
-           type: 'error',
-           message: "Couldn't delete optical image due to an error"
-         });
-         throw e;
+         reportError(e);
        }
      },
 

--- a/metaspace/webapp/src/graphqlClient.ts
+++ b/metaspace/webapp/src/graphqlClient.ts
@@ -3,9 +3,16 @@ import {SubscriptionClient, addGraphQLSubscriptions} from 'subscriptions-transpo
 import * as config from './clientConfig.json';
 import tokenAutorefresh from './tokenAutorefresh';
 import reportError from './lib/reportError'
+import { flatMap } from 'lodash-es';
 
 const graphqlUrl = config.graphqlUrl || `${window.location.origin}/graphql`;
 const wsGraphqlUrl = config.wsGraphqlUrl || `${window.location.origin.replace(/^http/, 'ws')}/ws`;
+
+let $alert: ((message: string, title: string) => void) | null = null;
+
+export function setMaintenanceMessageHandler(_$alert: (message: string, title: string) => void) {
+  $alert = _$alert;
+}
 
 const networkInterface = createBatchingNetworkInterface({
   uri: graphqlUrl,
@@ -28,6 +35,28 @@ networkInterface.use([{
       // and if `next` isn't called then it will prevent future requests, so force a server error with an invalid JWT
       // as a visible error is preferable to silently doing the wrong thing.
       (req.options.headers as Record<string, string>)['Authorization'] = 'Bearer invalid';
+    }
+    next();
+  }
+}]);
+
+const isReadOnlyError = (error: any) => {
+  try {
+    return JSON.parse(error.message).type === 'read_only_mode';
+  } catch {
+    return false;
+  }
+};
+
+networkInterface.useAfter([{
+  applyBatchAfterware({ responses }, next) {
+    const readOnlyErrors = flatMap(responses as any[], r => r.errors && r.errors.filter(isReadOnlyError) || []);
+    if (readOnlyErrors.length > 0) {
+      if ($alert != null) {
+        readOnlyErrors.forEach(err => { err.isHandled = true; });
+        $alert('This operation could not be completed. METASPACE is currently in read-only mode for scheduled maintenance. Please try again later.',
+          'Scheduled Maintenance');
+      }
     }
     next();
   }

--- a/metaspace/webapp/src/lib/reportError.ts
+++ b/metaspace/webapp/src/lib/reportError.ts
@@ -1,5 +1,6 @@
 import { ElNotification } from 'element-ui/types/notification';
 import * as Raven from 'raven-js';
+import { every } from 'lodash-es';
 
 let $notify: ElNotification;
 
@@ -7,11 +8,22 @@ export function setErrorNotifier(_$notify: ElNotification) {
   $notify = _$notify;
 }
 
+function isHandled(err: any) {
+  try {
+    if (err && err.graphQLErrors && every(err.graphQLErrors, e => e && e.isHandled)) {
+      return true;
+    }
+  } catch {}
+  return false;
+}
+
 export default function reportError(err: Error, message?: string) {
   try {
-    Raven.captureException(err);
-    if ($notify != null) {
-      $notify.error(message || 'Oops! Something went wrong. Please refresh the page and try again.');
+    if (!isHandled(err)) {
+      Raven.captureException(err);
+      if ($notify != null) {
+        $notify.error(message || 'Oops! Something went wrong. Please refresh the page and try again.');
+      }
     }
   } catch (ex) {
     console.error(ex);

--- a/metaspace/webapp/src/main.ts
+++ b/metaspace/webapp/src/main.ts
@@ -10,7 +10,7 @@ if(config.ravenDsn != null && config.ravenDsn !== '') {
 }
 
 import VueApollo from 'vue-apollo';
-import apolloClient from './graphqlClient';
+import apolloClient, { setMaintenanceMessageHandler } from './graphqlClient';
 Vue.use(VueApollo);
 
 const apolloProvider = new VueApollo({
@@ -62,6 +62,7 @@ const app = new Vue({
 })
 
 setErrorNotifier(app.$notify);
+setMaintenanceMessageHandler(app.$alert);
 
 import tokenAutorefresh from './tokenAutorefresh'
 tokenAutorefresh.addJwtListener((jwt, payload) => store.commit('setUser', payload));

--- a/metaspace/webapp/src/modules/Admin/SystemHealthPage.vue
+++ b/metaspace/webapp/src/modules/Admin/SystemHealthPage.vue
@@ -35,7 +35,7 @@
     computed: {
       isAdmin() {
         const {user} = this.$store.state;
-        return user && user.role === 'admin' || false;
+        return user && user.role === 'admin' || false; // TODO: Get current user role from GraphQL after merge into master
       }
     },
     apollo: {

--- a/metaspace/webapp/src/modules/Admin/SystemHealthPage.vue
+++ b/metaspace/webapp/src/modules/Admin/SystemHealthPage.vue
@@ -1,0 +1,89 @@
+<template>
+  <div v-if="isAdmin" v-loading="loading" style="width: 900px; margin: 20px auto;">
+    <el-form label-position="top">
+      <el-form-item>
+        <el-radio-group v-model="mode">
+          <el-radio border :label="0">Enable everything</el-radio>
+          <el-radio border :label="1">Disable dataset upload/reprocessing</el-radio>
+          <el-radio border :label="2">Read-only mode</el-radio>
+        </el-radio-group>
+      </el-form-item>
+      <el-form-item label="Maintenance message (optional)">
+        <el-input v-model="message" style="width: 450px;" />
+      </el-form-item>
+      <el-button :type="buttonType" :loading="isUpdating" @click="handleSubmit">{{buttonText}}</el-button>
+    </el-form>
+  </div>
+</template>
+
+<script>
+  import { getSystemHealthQuery, getSystemHealthSubscribeToMore, updateSystemHealthMutation } from '../../api/system';
+  import reportError from '../../lib/reportError';
+
+  export default {
+    name: 'system-health-page',
+    data() {
+      return {
+        mode: 0,
+        message: '',
+        loading: 0,
+        isUpdating: false,
+        buttonType: 'primary',
+        buttonText: 'Update',
+      };
+    },
+    computed: {
+      isAdmin() {
+        const {user} = this.$store.state;
+        return user && user.role === 'admin' || false;
+      }
+    },
+    apollo: {
+      systemHealth: {
+        query: getSystemHealthQuery,
+        subscribeToMore: getSystemHealthSubscribeToMore,
+        loadingKey: 'isLoadingInitial',
+        fetchPolicy: 'network-only',
+        result(res) {
+          const {canMutate, canProcessDatasets, message} = res.data.systemHealth;
+          this.mode = !canMutate ? 2 : !canProcessDatasets ? 1 : 0;
+          this.message = message;
+        }
+      }
+    },
+    methods: {
+      async handleSubmit() {
+        try {
+          this.isUpdating = true;
+          await this.$apollo.mutate({
+            mutation: updateSystemHealthMutation,
+            variables: {
+              health: {
+                canMutate: this.mode < 2,
+                canProcessDatasets: this.mode < 1,
+                message: this.message ? this.message : null,
+              }
+            }
+          });
+          this.buttonType = 'success';
+          this.buttonText = 'Updated';
+        } catch (err) {
+          reportError(err);
+          this.buttonType = 'danger';
+          this.buttonText = 'Error';
+        } finally {
+          this.isUpdating = false;
+        }
+      },
+    }
+  };
+</script>
+
+<style scoped>
+  .el-radio {
+    display: block;
+  }
+  .el-radio + .el-radio {
+    margin: 5px 0 !important;
+  }
+</style>

--- a/metaspace/webapp/src/router.ts
+++ b/metaspace/webapp/src/router.ts
@@ -36,6 +36,7 @@ const router = new VueRouter({
     },
     { path: '/about', component: AboutPage },
     { path: '/help', component: async () => await import(/* webpackPrefetch: true, webpackChunkName: "HelpPage" */ './components/HelpPage.vue') },
+    { path: '/admin/health', component: async () => await import('./modules/Admin/SystemHealthPage.vue') },
 
     ...(config.features.newAuth ? [
       { path: '/account/sign-in', component: DialogPage, props: {dialog: 'signIn'} },

--- a/metaspace/webapp/src/typings.d.ts
+++ b/metaspace/webapp/src/typings.d.ts
@@ -22,7 +22,6 @@ declare module "*/clientConfig.json" {
     wsGraphqlUrl: string | null
 
     google_client_id: string
-    enableUploads: boolean
 
     fineUploader: FineUploaderConfig
     ravenDsn: string | null


### PR DESCRIPTION
This adds a new "System Health" module to GraphQL, which allows admins to:
* Turn off all GraphQL mutations
* Turn off adding datasets to the processing queue
* Show a maintenance message

It also adds UI for setting the health, showing the health to users, and reacting to situations where the server rejects a request due to being in read-only mode.

It does not attempt to 

I've tried to keep this close to the patterns we have in `master`, but there will probably still be some pain merging, so I'll do that in a second PR after this is merged. In particular:
*  `graphqlClient.ts` uses `apollo-link` in `master`, which will require a completely different implementation. 
* the "Create Account", "Reset Password", etc. functions in the new authentication system will also need to be disabled. There's no point in doing it in this PR as it is significantly restructured in `master`.

# Screenshots

## Admin page ( http://localhost:8888/#/admin/health )
![image](https://user-images.githubusercontent.com/26366936/46012381-57468900-c0c9-11e8-9f7c-6fcc512417fb.png)
#### Maintenance message:
![image](https://user-images.githubusercontent.com/26366936/46012446-94128000-c0c9-11e8-9de7-40f9555dfdcc.png)
#### Read-only mode:
![image](https://user-images.githubusercontent.com/26366936/46012478-adb3c780-c0c9-11e8-87f7-d581b73000ad.png)
(This is the default message in Read-only mode, but it can be overridden. "Disable dataset upload/reprocessing" does not have any default message, but it's visible on the Upload page)

## Upload Page (existing behavior, new data source)

![image](https://user-images.githubusercontent.com/26366936/46013345-4ea38200-c0cc-11e8-8419-fa93ebac3817.png)

## Metadata Editor in "Disable dataset upload/reprocessing" mode

This only shows up if you make an edit that would trigger reprocessing:
![image](https://user-images.githubusercontent.com/26366936/46014159-a17e3900-c0ce-11e8-9c48-ee7284a8442b.png)

## Errors

The global error handler in `graphqlClient.ts` can't easily suppress the error handlers that wrap most GraphQL code. I've tried to address this by making `reportError` detect and ignore errors that have already been handled. Usually you'll only see this popup:

![image](https://user-images.githubusercontent.com/26366936/46014085-7398f480-c0ce-11e8-9c11-12ddcac22ff2.png)

However if I've missed any custom error handlers, it is potentially still possible to get two error messages at once e.g.:
![image](https://user-images.githubusercontent.com/26366936/46014278-0174df80-c0cf-11e8-9831-8a64ee35c217.png)

