### PR TITLE
Optimize ES Export

### DIFF
--- a/metaspace/engine/scripts/update_es_index.py
+++ b/metaspace/engine/scripts/update_es_index.py
@@ -33,7 +33,8 @@ def _reindex_all(conf):
 
 def _reindex_datasets(rows, es_exp):
     logger.info('Reindexing %s dataset(s)', len(rows))
-    for ds_id, ds_name, ds_config in rows:
+    for idx, (ds_id, ds_name, ds_config) in enumerate(rows):
+        logger.info(f'Reindexing {idx+1} out of {len(rows)}')
         try:
             es_exp.delete_ds(ds_id)
             for mol_db_name in ds_config['databases']:

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -283,7 +283,7 @@ class ESExporter(object):
 
         for success, info in parallel_bulk(self._es, actions=to_index, timeout='60s'):
             if not success:
-                print('Document failed: ', info)
+                logger.error(f'Document failed: {info}')
 
         for i, level in enumerate(fdr_levels[1:]):
             annotation_counts[level] += annotation_counts[fdr_levels[i]]


### PR DESCRIPTION
I accidentally killed my whole ElasticSearch index while trying to test changes to the migration, and decided to reimplement the optimizations that I had prototyped before so that I could easily reindex.

This does several things:
* Log progress during reindexing
* Use `parallel_bulk`, and let it handle batching
* Cache `_get_mol_by_sf_df`
* Reorganize `_get_mol_by_sf_df` so that it converts the DataFrame to Python-native structures prior to caching

Before the changes my computer could export 4.5 datasets per minute on average. After these changes, it runs at 18.5 datasets per minute.

Looking at the remaining bottlenecks, roughly 75% of the time is now spent inside the `for doc in annotation_docs` loop. It's hard to measure sub-millisecond operations, but I suspect that `isocalc.ion_centroids` is the bottleneck, and it doesn't look like it contains any easy wins. If we wanted to make this faster, I think it would have to be with multiprocessing.