### PR TITLE
UI Fixes

### DIFF
--- a/metaspace/webapp/src/api/dataManagement.ts
+++ b/metaspace/webapp/src/api/dataManagement.ts
@@ -1,55 +1,12 @@
 import gql from 'graphql-tag';
 
-export interface CurrentUserResult {
-  id: string;
-  name: string;
-  email: string | null;
-  groups: {
-    role: string;
-    group: {
-      id: string,
-      name: string
-    };
-  }[]
-  primaryGroup: {
-    group: {
-      id: string,
-      name: string
-    }
-  } | null;
-}
-
-export const currentUserQuery =
-gql`query {
-  currentUser {
-    id
-    name
-    role
-    email
-    groups {
-      role
-      group {
-        id
-        name
-      }
-    }
-    primaryGroup {
-      group {
-        id
-        name
-      }
-    }
-  }
-}
-`;
-
 export interface GroupListItem {
   id: string;
   name: string;
 }
 
 export const oneGroupQuery =
-  gql`query($groupId: ID!) {
+  gql`query oneGroupQuery($groupId: ID!) {
   group(groupId:$groupId) {
     id
     name
@@ -57,7 +14,7 @@ export const oneGroupQuery =
 }`;
 
 export const oneProjectQuery =
-  gql`query($projectId: ID!) {
+  gql`query oneProjectQuery($projectId: ID!) {
   project(projectId:$projectId) {
     id
     name
@@ -65,7 +22,7 @@ export const oneProjectQuery =
 }`;
 
 export const allGroupsQuery =
-gql`query($query: String) {
+gql`query allGroupsQuery($query: String) {
   allGroups(query:$query) {
     id
     name

--- a/metaspace/webapp/src/api/metadata.ts
+++ b/metaspace/webapp/src/api/metadata.ts
@@ -24,7 +24,7 @@ export const editDatasetFragment =
   }`;
 
 export const editDatasetQuery =
-  gql`query fetchMetadataQuery($id: String!) {
+  gql`query editDatasetQuery($id: String!) {
     dataset(id: $id) {
       ...EditDatasetFragment
       submitter {
@@ -37,7 +37,7 @@ export const editDatasetQuery =
   `;
 
 export const newDatasetQuery =
-  gql`query {
+  gql`query newDatasetQuery {
     currentUserLastSubmittedDataset {
       ...EditDatasetFragment
     }
@@ -60,7 +60,7 @@ export const updateDatasetQuery =
   }`;
 
 // TODO: use autocompletion for filter values, same as on the upload page
-export const fetchOptionListsQuery = gql`{
+export const fetchOptionListsQuery = gql`query fetchOptionListsQuery {
   institutionNames: metadataSuggestions(field: "Submitted_By.Institution", query: "", limit: 1000)
   organisms: metadataSuggestions(field: "Sample_Information.Organism", query: "", limit: 1000)
   organismParts: metadataSuggestions(field: "Sample_Information.Organism_Part", query: "", limit: 1000)
@@ -73,7 +73,7 @@ export const fetchOptionListsQuery = gql`{
   adducts: adductSuggestions{adduct, charge}
 }`;
 
-export const metadataOptionsQuery = gql`{
+export const metadataOptionsQuery = gql`query metadataOptionsQuery {
   molecularDatabases: molecularDatabases{name, default}
   adducts: adductSuggestions{adduct, charge}
 }`;

--- a/metaspace/webapp/src/api/user.ts
+++ b/metaspace/webapp/src/api/user.ts
@@ -34,7 +34,7 @@ export interface UserProfileQuery {
 }
 
 export const userProfileQuery =
-  gql`query {
+  gql`query UserProfileQuery {
   currentUser {
     id
     name
@@ -134,7 +134,7 @@ export interface CurrentUserIdResult {
 }
 
 export const currentUserIdQuery =
-  gql`query {
+  gql`query CurrentUserIdQuery {
   currentUser { id }
 }
 `;
@@ -145,7 +145,7 @@ export interface CurrentUserRoleResult {
 }
 
 export const currentUserRoleQuery =
-  gql`query {
+  gql`query CurrentUserRoleQuery {
   currentUser { id role }
 }
 `;

--- a/metaspace/webapp/src/components/MembersList.vue
+++ b/metaspace/webapp/src/components/MembersList.vue
@@ -73,7 +73,7 @@
                      :current-page.sync="page"
                      layout="prev,pager,next" />
       <div class="flex-spacer" />
-      <el-button v-if="canEdit" @click="handleAddMember">Add member</el-button>
+      <el-button v-if="canEdit" @click="() => handleAddMember()">Add member</el-button>
     </div>
   </div>
 </template>

--- a/metaspace/webapp/src/modules/App/MetaspaceHeader.vue
+++ b/metaspace/webapp/src/modules/App/MetaspaceHeader.vue
@@ -146,7 +146,7 @@
        subscribeToMore: getSystemHealthSubscribeToMore
      },
      currentUser: {
-       query: gql`query {
+       query: gql`query metaspaceHeaderCurrentUserQuery {
          currentUser {
            id
            name

--- a/metaspace/webapp/src/modules/Filters/filter-components/SearchableFilter.vue
+++ b/metaspace/webapp/src/modules/Filters/filter-components/SearchableFilter.vue
@@ -131,10 +131,13 @@
       }
 
       this.$nextTick(() => {
-        // WORKAROUND: The logic in this.joinedOptions creates labelless options for values that haven't been fetched yet.
-        // After fetching the options, el-select doesn't automatically refresh the label, showing the ID instead.
-        // Calling setSelected() forces it to recalculate the label.
-        (this.$refs.select as any).setSelected();
+        // ElSelect is mocked in tests - do nothing if the ref or the setSelected method are missing
+        if (this.$refs.select != null && (this.$refs.select as any).setSelected != null) {
+          // WORKAROUND: The logic in this.joinedOptions creates labelless options for values that haven't been fetched yet.
+          // After fetching the options, el-select doesn't automatically refresh the label, showing the ID instead.
+          // Calling setSelected() forces it to recalculate the label.
+          (this.$refs.select as any).setSelected();
+        }
       })
     }
 

--- a/metaspace/webapp/src/modules/GroupProfile/EditGroupProfile.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/EditGroupProfile.vue
@@ -31,7 +31,7 @@
         <div style="margin-bottom: 2em">
           <h2>Custom URL</h2>
           <div v-if="canEditUrlSlug">
-            <router-link :href="groupUrlRoute">{{groupUrlPrefix}}</router-link>
+            <router-link :to="groupUrlRoute">{{groupUrlPrefix}}</router-link>
             <input v-model="model.urlSlug" />
           </div>
           <div v-if="!canEditUrlSlug && group && group.urlSlug">

--- a/metaspace/webapp/src/modules/GroupProfile/EditGroupProfile.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/EditGroupProfile.vue
@@ -26,7 +26,7 @@
           @cancelInvite="handleRemoveUser"
           @acceptUser="handleAcceptUser"
           @rejectUser="handleRejectUser"
-          @addMember="handleAddMember"
+          @addMember="() => handleAddMember(/* Discard the event argument. ConfirmAsync adds an argument to the end of the arguments list, so the arguments list must be predictable */)"
         />
         <div style="margin-bottom: 2em">
           <h2>Custom URL</h2>
@@ -100,7 +100,7 @@
     role: UserRole;
   }
 
-  @Component({
+  @Component<EditGroupProfile>({
     components: {
       EditGroupForm,
       MembersList,
@@ -115,7 +115,7 @@
       group: {
         query: editGroupQuery,
         loadingKey: 'membersLoading',
-        variables(this: EditGroupProfile) { return { groupId: this.groupId } },
+        variables() { return { groupId: this.groupId } },
       },
     }
   })

--- a/metaspace/webapp/src/modules/MetadataEditor/sections/DataManagementSection.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/sections/DataManagementSection.vue
@@ -144,8 +144,7 @@
     get groupIdIsUnknown() {
       return this.value.groupId != null
         && this.submitter != null
-        && this.submitter.groups != null
-        && !this.submitter.groups.some(group => group.group.id === this.value.groupId);
+        && (this.submitter.groups == null || !this.submitter.groups.some(group => group.group.id === this.value.groupId));
     }
 
     get groupId() {
@@ -206,10 +205,9 @@
       if (this.groupIdIsUnknown && this.unknownGroup != null && this.unknownGroup.id === this.value.groupId) {
         options.push({value: this.unknownGroup.id, label: this.unknownGroup.name });
       }
-      // TODO: Uncomment when userIDs are fully implemented so that "Find my group" is hidden when editing someone else's dataset
-      // if (this.submitter != null && this.currentUser != null && this.submitter.id === this.currentUser.id) {
-      options.push({ value: FIND_GROUP, label: "Find my group..." });
-      // }
+      if (this.submitter != null && this.currentUser != null && this.submitter.id === this.currentUser.id) {
+        options.push({ value: FIND_GROUP, label: "Find my group..." });
+      }
       options.push({value: NO_GROUP, label: "No group (Enter PI instead)"});
       return options;
     }

--- a/metaspace/webapp/src/modules/Project/EditProjectPage.vue
+++ b/metaspace/webapp/src/modules/Project/EditProjectPage.vue
@@ -26,7 +26,7 @@
           @cancelInvite="handleRemoveUser"
           @acceptUser="handleAcceptUser"
           @rejectUser="handleRejectUser"
-          @addMember="handleAddMember"
+          @addMember="() => handleAddMember(/* Discard the event argument. ConfirmAsync adds an argument to the end of the arguments list, so the arguments list must be predictable */)"
         />
         <div v-if="project && project.isPublic" style="margin-bottom: 2em">
           <h2>Custom URL</h2>
@@ -100,7 +100,7 @@
     role: UserRole;
   }
 
-  @Component({
+  @Component<EditProjectProfile>({
     components: {
       EditProjectForm,
       MembersList,
@@ -115,7 +115,7 @@
       project: {
         query: editProjectQuery,
         loadingKey: 'membersLoading',
-        variables(this: EditProjectProfile) { return { projectId: this.projectId } },
+        variables() { return { projectId: this.projectId } },
       },
     }
   })

--- a/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
@@ -74,6 +74,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                   <mock-transition name="el-zoom-in-top"></mock-transition>
                 </div>
               </div>
+              <!---->
             </div>
           </div>
         </div>


### PR DESCRIPTION
* Fix bugs in dataset & group drop-downs:
    * Dataset filter didn't allow values to be selected if empty
    * Group filter would show the group ID instead of name if it wasn't a group the user belonged to, and the user refreshed the page
    * Group selector in MetadataEditor wouldn't look up unknown groups' names, showing their IDs instead.
* Fix broken `<router-link>` in Group Profile page
* Uncomment code for disabling the "Find my Group" option when editing someone else's dataset
* Add names to GraphQL queries to make debugging easier
* Fix usage of `inviteUserToGroup`/`inviteUserToProject` - it now passes the email as a string, not an object
* Change EditUserPage to only send fields that have changed, and to show a message when an email address change is pending. It's a bit ugly, but it should do for now:
![image](https://user-images.githubusercontent.com/26366936/46159961-d979ad80-c281-11e8-9e4c-c5e4a8af390d.png)
