### PR TITLE
Add impersonation

### DIFF
--- a/ansible/aws/group_vars_all.yml.template
+++ b/ansible/aws/group_vars_all.yml.template
@@ -164,6 +164,7 @@ sm_graphql_google_callback_url: "http://{{ sm_webapp_hostname }}/auth/google/cal
 sm_graphql_cookie_secret: COOKIE_SECRET
 sm_graphql_features:
   graphqlMocks: false
+  impersonation: false
 
 sm_webapp_home: "{{ metaspace_home }}/metaspace/webapp"
 sm_webapp_port: 8082

--- a/metaspace/graphql/src/utils/config.ts
+++ b/metaspace/graphql/src/utils/config.ts
@@ -69,6 +69,7 @@ export interface Config {
   };
   features: {
     graphqlMocks: boolean;
+    impersonation: boolean;
   };
   aws:  {
     aws_access_key_id: string;


### PR DESCRIPTION
Allows admins on test servers to sign in as other users by visiting urls such as: `http://localhost:8888/api_auth/impersonate?email=email.address@example.com` or `http://localhost:8888/api_auth/impersonate?id=26e835e8-d766-11e8-a21b-d70b073ca5b8`

Please make sure to add the feature flag to your ansible config when deploying to staging