### PR TITLE
Fix dataset submission bug on Staging

### DIFF
--- a/metaspace/graphql/metadataSchemas/metadataRegistry.ts
+++ b/metaspace/graphql/metadataSchemas/metadataRegistry.ts
@@ -1,0 +1,12 @@
+import metadataMapping from './metadataMapping';
+
+export const metadataTypes = Object.keys(metadataMapping);
+
+export const defaultMetadataType = metadataTypes.includes("Imaging MS") ? "Imaging MS" : metadataTypes[0];
+
+export const metadataSchemas: Record<string, any> = {};
+
+for (const mdType of metadataTypes) {
+  const mdFilename = metadataMapping[mdType];
+  metadataSchemas[mdType] = require(`./${mdFilename}`);
+}

--- a/metaspace/graphql/src/modules/dataset/controller/Mutation.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Mutation.ts
@@ -17,6 +17,7 @@ import {DatasetCreateInput, DatasetUpdateInput, Int, Mutation, String} from '../
 import {Context, ContextUser} from '../../../context';
 import {FieldResolversFor} from '../../../bindingTypes';
 import {getUserProjectRoles} from '../../../utils/db';
+import {metadataSchemas} from '../../../../metadataSchemas/metadataRegistry';
 
 type MetadataSchema = any;
 type MetadataRoot = any;
@@ -56,9 +57,7 @@ function trimEmptyFields(schema: MetadataSchema, value: MetadataNode) {
 
 function validateMetadata(metadata: MetadataNode) {
   const ajv = new Ajv({allErrors: true});
-  const mdType = metadata.Data_Type;
-  const mdSchemaPath = `./metadataSchemas/${metadataMapping[mdType]}`;
-  const mdSchema = require(mdSchemaPath);
+  const mdSchema = metadataSchemas[metadata.Data_Type];
   const validator = ajv.compile(mdSchema);
   const cleanValue = trimEmptyFields(mdSchema, metadata);
   validator(cleanValue);


### PR DESCRIPTION
The path to the metadata schemas became invalid when I refactored the dataset mutations into TypeScript. 

I overlooked this because we had a dynamic `require()` to load the schemas, which I didn't expect. To prevent this from happening again I copied `metadataRegistry` from webapp, which wraps the schemas with a statically exported lookup object.

I've put a temporary fix on Staging by just adding `../../../../` to the `require` statement.