### PR TITLE
Fix sm-graphql Dockerfile

### DIFF
--- a/docker/sm-graphql/Dockerfile
+++ b/docker/sm-graphql/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /opt/dev/metaspace/metaspace/graphql
 # RUN mv /opt/pkgcache/node_modules .
 # RUN yarn install
 
-RUN node deref_schema.js ./metadataSchemas/
+# RUN node deref_schema.js ./metadataSchemas/
 
 COPY docker-entrypoint.sh /
 


### PR DESCRIPTION
The issue was that `deref_schema.js` didn't exist because the steps to clone the metaspace repository were commented out.