### PR TITLE
Admin tools

### DIFF
--- a/metaspace/graphql/schemas/group.graphql
+++ b/metaspace/graphql/schemas/group.graphql
@@ -20,6 +20,10 @@ input UpdateGroupInput {
   urlSlug: String
 }
 
+input UpdateUserGroupInput {
+  role: UserGroupRole
+}
+
 # Many-to-many relationship between User and Group
 type UserGroup {
   user: User!
@@ -60,6 +64,8 @@ type Mutation {
   inviteUserToGroup(groupId: ID!, email: String!): UserGroup!  # For group managers
   acceptGroupInvitation(groupId: ID!): UserGroup!
   # Group can reject user with `removeUserFromGroup`
+
+  updateUserGroup(groupId: ID!, userId: ID!, update: UpdateUserGroupInput!): Boolean!
 
   importDatasetsIntoGroup(groupId: ID!, datasetIds: [ID!]!): Boolean!
   # TODO: add dataset removal from group

--- a/metaspace/graphql/schemas/project.graphql
+++ b/metaspace/graphql/schemas/project.graphql
@@ -23,6 +23,10 @@ input UpdateProjectInput {
   urlSlug: String
 }
 
+input UpdateUserProjectInput {
+  role: UserProjectRole
+}
+
 # Many-to-many relationship between User and Project
 type UserProject {
   user: User!
@@ -64,6 +68,8 @@ type Mutation {
   inviteUserToProject(projectId: ID!, email: String!): UserProject!
   acceptProjectInvitation(projectId: ID!): UserProject!
   # Project can reject user with `removeUserFromProject`
+
+  updateUserProject(projectId: ID!, userId: ID!, update: UpdateUserProjectInput!): Boolean!
 
   importDatasetsIntoProject(projectId: ID!, datasetIds: [ID!]!): Boolean!
 }

--- a/metaspace/graphql/src/modules/group/controller.ts
+++ b/metaspace/graphql/src/modules/group/controller.ts
@@ -155,9 +155,10 @@ export const Resolvers = {
 
     async allGroups(_: any, {query}: any, ctx: Context): Promise<LooselyCompatible<Group & Scope>[]|null> {
       const scopeRole = await resolveGroupScopeRole(ctx);
-      const groups = await ctx.connection.getRepository(GroupModel).find({
-        where: { 'name': Like(`%${query}%`) }
-      });
+      const groups = await ctx.connection.getRepository(GroupModel)
+        .createQueryBuilder('group')
+        .where('group.name ILIKE :query OR group.shortName ILIKE :query', {query: query ? `%${query}%` : '%'})
+        .getMany();
       return groups.map(g => ({...g, scopeRole}));
     }
   },

--- a/metaspace/graphql/src/modules/group/controller.ts
+++ b/metaspace/graphql/src/modules/group/controller.ts
@@ -1,5 +1,5 @@
 import {UserError} from 'graphql-errors';
-import {Connection, Like, In, EntityManager} from 'typeorm';
+import {Connection, In, EntityManager} from 'typeorm';
 
 import {Group as GroupModel, UserGroup as UserGroupModel, UserGroupRoleOptions} from './model';
 import {User as UserModel} from '../user/model';
@@ -371,6 +371,24 @@ export const Resolvers = {
         where: { userId: userId, groupId },
         relations: ['user', 'group']
       });
+    },
+
+    async updateUserGroup(_: any, {groupId, userId, update}: any, {user, connection}: Context): Promise<boolean> {
+      await assertCanEditGroup(connection, user, groupId);
+      logger.info(`Updating '${groupId}' '${userId}' membership by '${user!.id}' user...`);
+
+      if (update.role != null) {
+        await connection.getRepository(UserGroupModel).save({
+          userId, groupId, role: update.role
+        });
+      } else {
+        await connection.getRepository(UserGroupModel).delete({ userId, groupId });
+      }
+
+      const groupApproved = [UserGroupRoleOptions.MEMBER, UserGroupRoleOptions.GROUP_ADMIN].includes(update.role);
+      await updateUserGroupDatasets(connection, userId, groupId, groupApproved);
+
+      return true;
     },
 
     async importDatasetsIntoGroup(_: any, {groupId, datasetIds}: any, {user, connection}: Context): Promise<Boolean> {

--- a/metaspace/graphql/src/modules/project/controller/Mutation.ts
+++ b/metaspace/graphql/src/modules/project/controller/Mutation.ts
@@ -166,6 +166,12 @@ const MutationResolvers: FieldResolversFor<Mutation, void> = {
     return { ...userProject, user: convertUserToUserSource(userProject.user, SRO.OTHER) };
   },
 
+  async updateUserProject(source, {projectId, userId, update}, ctx): Promise<boolean> {
+    await asyncAssertCanEditProject(ctx, projectId);
+    await updateUserProjectRole(ctx, userId, projectId, update.role || null);
+    return true;
+  },
+
   async importDatasetsIntoProject(source, { projectId, datasetIds }, ctx): Promise<Boolean> {
     const userProjectRole = (await ctx.getCurrentUserProjectRoles())[projectId];
     if (userProjectRole == null) {

--- a/metaspace/graphql/src/modules/system/controller.ts
+++ b/metaspace/graphql/src/modules/system/controller.ts
@@ -6,11 +6,8 @@ import { pubsub } from '../../../utils';
 import {UserError} from 'graphql-errors';
 import {SystemHealth, UpdateSystemHealthInput} from '../../binding';
 import {IResolvers} from 'graphql-tools';
+import {Context} from '../../context';
 
-
-interface Context { // TODO: Get from Context.ts after merge with master
-  user?: {role: string}
-}
 
 const SYSTEM_HEALTH_CHANNEL = 'systemHealthUpdated';
 const healthFile = path.join(path.dirname(require.main!.filename), 'health.json');
@@ -34,7 +31,7 @@ let currentHealth: Promise<SystemHealth> = (async () => {
 
 export const getHealth = async () => await currentHealth;
 
-export const Resolvers: IResolvers<any, any> = {
+export const Resolvers: IResolvers<any, Context> = {
   Query: {
     async systemHealth(): Promise<SystemHealth> {
       return await currentHealth;
@@ -42,7 +39,7 @@ export const Resolvers: IResolvers<any, any> = {
   },
 
   Mutation: {
-    async updateSystemHealth(source: any, {health: _health}: any, {user}: any) {
+    async updateSystemHealth(source: any, {health: _health}: any, {user}: Context) {
       const health = _health as UpdateSystemHealthInput;
       if (user && user.role === 'admin') {
         const newHealth = {...defaultHealth, ...health};

--- a/metaspace/webapp/src/api/group.ts
+++ b/metaspace/webapp/src/api/group.ts
@@ -1,6 +1,12 @@
 import gql from 'graphql-tag';
 
 export type UserGroupRole = 'INVITED' | 'PENDING' | 'MEMBER' | 'GROUP_ADMIN';
+export const UserGroupRoleOptions: {[R in UserGroupRole]: R} = {
+  INVITED: 'INVITED',
+  PENDING: 'PENDING',
+  MEMBER: 'MEMBER',
+  GROUP_ADMIN: 'GROUP_ADMIN',
+};
 export const getRoleName = (role: UserGroupRole | null | undefined) => {
   switch (role) {
     case 'INVITED': return 'Invited';
@@ -85,6 +91,11 @@ export const acceptGroupInvitationMutation =
 export const leaveGroupMutation =
   gql`mutation leaveGroup($groupId: ID!) { 
     leaveGroup(groupId: $groupId)
+  }`;
+
+export const updateUserGroupMutation =
+  gql`mutation updateUserGroup($groupId: ID!, $userId: ID!, $update: UpdateUserGroupInput!) {
+    updateUserGroup(groupId: $groupId, userId: $userId, update: $update)
   }`;
 
 export const importDatasetsIntoGroupMutation =

--- a/metaspace/webapp/src/api/project.ts
+++ b/metaspace/webapp/src/api/project.ts
@@ -1,6 +1,12 @@
 import gql from 'graphql-tag';
 
 export type ProjectRole = 'INVITED' | 'PENDING' | 'MEMBER' | 'MANAGER';
+export const ProjectRoleOptions: {[R in ProjectRole]: R} = {
+  INVITED: 'INVITED',
+  PENDING: 'PENDING',
+  MEMBER: 'MEMBER',
+  MANAGER: 'MANAGER',
+};
 export const getRoleName = (role: ProjectRole | null | undefined) => {
   switch (role) {
     case 'INVITED': return 'Invited';
@@ -85,6 +91,11 @@ export const acceptProjectInvitationMutation =
 export const leaveProjectMutation =
   gql`mutation leaveProject($projectId: ID!) { 
     leaveProject(projectId: $projectId)
+  }`;
+
+export const updateUserProjectMutation =
+  gql`mutation updateUserProject($projectId: ID!, $userId: ID!, $update: UpdateUserProjectInput!) {
+    updateUserProject(projectId: $projectId, userId: $userId, update: $update)
   }`;
 
 export const importDatasetsIntoProjectMutation =

--- a/metaspace/webapp/src/modules/Admin/GroupsListItem.vue
+++ b/metaspace/webapp/src/modules/Admin/GroupsListItem.vue
@@ -1,0 +1,121 @@
+<template>
+  <div class="group-item">
+    <router-link :to="groupLink" class="underlay" />
+    <div class="item-body">
+      <div class="info">
+        <div class="info-line group-name">
+          <router-link :to="groupLink">
+            {{group.name}}
+            <i v-if="group.shortName !== group.name">({{group.shortName}})</i>
+          </router-link>
+        </div>
+        <div class="info-line" v-if="group.members != null">
+          {{group.members.length}} Member{{group.members.length === 1 ? '' : 's'}}
+        </div>
+      </div>
+      <div class="actions">
+        <div>
+          <i class="el-icon-picture" />
+          <router-link :to="datasetsLink">Browse datasets</router-link>
+        </div>
+        <div>
+          <i class="el-icon-edit"></i>
+          <router-link :to="manageLink">Manage group</router-link>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+  import Vue from 'vue';
+  import { Component, Prop } from 'vue-property-decorator';
+  import { encodeParams } from '../Filters';
+
+  @Component
+  export default class GroupsListItem extends Vue {
+    @Prop({type: Object, required: true})
+    group: any;
+
+    get groupLink() {
+      return {
+        name: 'group',
+        params: {groupIdOrSlug: this.group.urlSlug || this.group.id}
+      }
+    }
+
+    get datasetsLink() {
+      return {
+        path: '/datasets',
+        query: encodeParams({group: this.group.id })
+      }
+    }
+
+    get manageLink() {
+      return {
+        name: 'edit-group',
+        params: {groupId: this.group.id}
+      }
+    }
+  }
+
+</script>
+<style scoped lang="scss">
+  @import "~element-ui/packages/theme-chalk/src/common/var";
+
+  .group-item {
+    position: relative;
+    border-radius: 5px;
+    width: 100%;
+    max-width: 800px;
+    margin: 8px 0;
+    padding: 10px;
+    border: 1px solid #cce4ff;
+    box-sizing: border-box;
+    > * {
+      z-index: 1;
+    }
+    > .underlay {
+      z-index: 0;
+    }
+  }
+
+  .item-body {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    > * {
+      z-index: 1;
+    }
+  }
+
+  .info-line {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .group-name a {
+    font-size: 1.5em;
+    text-decoration: none;
+    color: $--color-text-regular;
+
+    i {
+      font-size: 0.75em;
+      color: grey;
+    }
+  }
+
+  .underlay {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+  }
+
+  .actions {
+    width: 170px;
+  }
+
+
+</style>

--- a/metaspace/webapp/src/modules/Admin/GroupsListPage.vue
+++ b/metaspace/webapp/src/modules/Admin/GroupsListPage.vue
@@ -1,0 +1,82 @@
+<template>
+  <div class="page" v-if="currentUser && currentUser.role === 'admin'">
+    <div class="page-content">
+      <search-box v-model="query" />
+      <el-row v-if="currentUser" type="flex" justify="end">
+        <el-button @click="handleCreateGroup">Create group</el-button>
+      </el-row>
+      <div class="clearfix"/>
+      <div v-loading="loading !== 0">
+        <groups-list-item v-for="group in allGroups"
+                            :key="group.id"
+                            :group="group" />
+      </div>
+    </div>
+  </div>
+</template>
+<script lang="ts">
+  import Vue from 'vue';
+  import { Component } from 'vue-property-decorator';
+  import { currentUserRoleQuery } from '../../api/user';
+  import { SearchBox } from '../Filters';
+  import GroupsListItem from './GroupsListItem.vue';
+  import gql from 'graphql-tag';
+
+  @Component({
+    components: {
+      SearchBox,
+      GroupsListItem,
+    },
+    apollo: {
+      currentUser: {
+        query: currentUserRoleQuery,
+        fetchPolicy: 'cache-first',
+        loadingKey: 'loading',
+      },
+      allGroups: {
+        query: gql`query ($query: String!) {
+          allGroups(query: $query, limit: 1000) {
+            id
+            name
+            shortName
+            members {
+              role
+              user {
+                name
+              }
+            }
+          }
+        }`,
+        loadingKey: 'loading',
+        variables() {
+          return {
+            query: this.query,
+          }
+        },
+      },
+    }
+  })
+  export default class GroupsListPage extends Vue {
+    loading = 0;
+    currentUser: any = null;
+    allGroups: any[] | null = null;
+
+    query = '';
+
+    handleCreateGroup() {
+      this.$router.push('/group/create');
+    }
+  }
+
+</script>
+<style scoped lang="scss">
+  .page {
+    display: flex;
+    justify-content: center;
+    min-height: 80vh; // Ensure there's space for the loading spinner before is visible
+  }
+
+  .page-content {
+    width: 800px;
+  }
+</style>

--- a/metaspace/webapp/src/modules/Filters/index.ts
+++ b/metaspace/webapp/src/modules/Filters/index.ts
@@ -1,5 +1,6 @@
 
 export {default as FilterPanel} from './FilterPanel.vue';
+export {default as SearchBox} from './filter-components/SearchBox.vue';
 
 export {
   FILTER_SPECIFICATIONS,

--- a/metaspace/webapp/src/modules/GroupProfile/EditGroupProfile.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/EditGroupProfile.vue
@@ -18,6 +18,7 @@
         <edit-group-form :model="model" :disabled="isSaving || !canEdit" />
         <members-list
           :loading="groupLoading !== 0"
+          :currentUser="currentUser"
           :members="group && group.members || []"
           type="group"
           :filter="datasetsListFilter"
@@ -27,6 +28,7 @@
           @acceptUser="handleAcceptUser"
           @rejectUser="handleRejectUser"
           @addMember="() => handleAddMember(/* Discard the event argument. ConfirmAsync adds an argument to the end of the arguments list, so the arguments list must be predictable */)"
+          @updateRole="handleUpdateRole"
         />
         <div style="margin-bottom: 2em">
           <h2>Custom URL</h2>
@@ -84,7 +86,7 @@
     inviteUserToGroupMutation,
     removeUserFromGroupMutation,
     UpdateGroupMutation,
-    updateGroupMutation,
+    updateGroupMutation, updateUserGroupMutation, UserGroupRole,
   } from '../../api/group';
   import EditGroupForm from './EditGroupForm.vue';
   import MembersList from '../../components/MembersList.vue';
@@ -282,6 +284,23 @@
         variables: { groupId: this.groupId, email },
       });
       await this.$apollo.queries.group.refetch();
+    }
+
+    async handleUpdateRole(member: EditGroupQueryMember, role: UserGroupRole | null) {
+      try {
+        this.groupLoading += 1;
+        await this.$apollo.mutate({
+          mutation: updateUserGroupMutation,
+          variables: {
+            groupId: this.groupId,
+            userId: member.user.id,
+            update: {role},
+          },
+        });
+        await this.$apollo.queries.group.refetch();
+      } finally {
+        this.groupLoading -= 1;
+      }
     }
   }
 

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/EditGroupProfile.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/EditGroupProfile.spec.ts.snap
@@ -50,6 +50,7 @@ exports[`EditGroupProfile should match snapshot 1`] = `
     <!---->
     </form>
     <div>
+      <!---->
       <h2>Members</h2>
       <div class="el-table el-table--fit el-table--scrollable-x el-table--enable-row-hover el-table--enable-row-transition" element-loading-text="Loading results from the server..." mock-v-loading="false">
         <div class="hidden-columns">
@@ -112,7 +113,9 @@ exports[`EditGroupProfile should match snapshot 1`] = `
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
                   <div class="cell">
-                    Group admin
+                    <a href="#" title="Change role">
+                      Group admin
+                    </a>
                   </div>
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
@@ -141,9 +144,9 @@ exports[`EditGroupProfile should match snapshot 1`] = `
                   </div>
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
-                  <div class="cell">
-                    Requesting access
-                  </div>
+                  <div class="cell"><span>
+          Requesting access
+        </span></div>
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                   <div class="cell">
@@ -179,9 +182,9 @@ exports[`EditGroupProfile should match snapshot 1`] = `
                   </div>
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
-                  <div class="cell">
-                    Invited
-                  </div>
+                  <div class="cell"><span>
+          Invited
+        </span></div>
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                   <div class="cell">
@@ -214,7 +217,9 @@ exports[`EditGroupProfile should match snapshot 1`] = `
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
                   <div class="cell">
-                    Member
+                    <a href="#" title="Change role">
+                      Member
+                    </a>
                   </div>
                 </td>
                 <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">

--- a/metaspace/webapp/src/modules/Project/__snapshots__/EditProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/EditProjectPage.spec.ts.snap
@@ -42,6 +42,7 @@ exports[`EditProjectPage should match snapshot 1`] = `
         </div>
       </form>
       <div>
+        <!---->
         <h2>Members</h2>
         <div class="el-table el-table--fit el-table--scrollable-x el-table--enable-row-hover el-table--enable-row-transition" element-loading-text="Loading results from the server..." mock-v-loading="false">
           <div class="hidden-columns">
@@ -104,7 +105,9 @@ exports[`EditProjectPage should match snapshot 1`] = `
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
                     <div class="cell">
-                      Project manager
+                      <a href="#" title="Change role">
+                        Project manager
+                      </a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
@@ -133,9 +136,9 @@ exports[`EditProjectPage should match snapshot 1`] = `
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
-                    <div class="cell">
-                      Requesting access
-                    </div>
+                    <div class="cell"><span>
+          Requesting access
+        </span></div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                     <div class="cell">
@@ -171,9 +174,9 @@ exports[`EditProjectPage should match snapshot 1`] = `
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
-                    <div class="cell">
-                      Invited
-                    </div>
+                    <div class="cell"><span>
+          Invited
+        </span></div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                     <div class="cell">
@@ -206,7 +209,9 @@ exports[`EditProjectPage should match snapshot 1`] = `
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
                     <div class="cell">
-                      Member
+                      <a href="#" title="Change role">
+                        Member
+                      </a>
                     </div>
                   </td>
                   <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">

--- a/metaspace/webapp/src/router.ts
+++ b/metaspace/webapp/src/router.ts
@@ -54,6 +54,7 @@ const router = new VueRouter({
     { path: '/user/me', component: asyncPages.EditUserPage },
 
     { path: '/admin/health', component: async () => await import('./modules/Admin/SystemHealthPage.vue') },
+    { path: '/admin/groups', component: async () => await import('./modules/Admin/GroupsListPage.vue') },
 
     { path: '/account/sign-in', component: DialogPage, props: {dialog: 'signIn'} },
     { path: '/account/create-account', component: DialogPage, props: {dialog: 'createAccount'} },


### PR DESCRIPTION
* Adds `/admin/groups` page to see a full list of groups
* Allows admins to freely change group member roles
* Allows group admins/project managers to shift other members between Member and Group Admin/Manager. I intentionally don't allow changes to/from Pending and Invited to force managers to use the intended sign up flow. I intentionally don't allow changes to the current user to prevent groups becoming broken with no admin/manager.