### PR TITLE
Make the release notes dialog cookie last longer

### DIFF
--- a/metaspace/webapp/src/modules/App/ReleaseNotesDialog.vue
+++ b/metaspace/webapp/src/modules/App/ReleaseNotesDialog.vue
@@ -57,7 +57,7 @@
     handleClose() {
       this.visible = false;
       if (this.dontShowAgain) {
-        cookie.set('hideReleaseNotes', CURRENT_VERSION as any);
+        cookie.set('hideReleaseNotes', CURRENT_VERSION as any, {expires: 365});
       }
     }
   }


### PR DESCRIPTION
`js-cookie` uses session cookies by default, which means that even when you check the box to make it not show again, the current welcome dialog comes back after restarting your browser. By adding an expiry, `js-cookie` stops making the cookie session-based.