### PR TITLE
Post release fixes

### DIFF
--- a/ansible/aws/provision/web_server.yml
+++ b/ansible/aws/provision/web_server.yml
@@ -62,8 +62,5 @@
     - role: sm_web
       tags: [sm-web]
 
-    - role: mol_db
-      tags: [sm-mol-db]
-
     - role: sm_cluster_autostart
       tags: [sm-cluster-autostart]

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -313,7 +313,6 @@ class ESExporter(object):
         })
         self._es.index(self.index, doc_type='dataset', body=ds_doc, id=ds_id)
 
-
     def update_ds(self, ds_id, fields):
         pipeline_id = 'update-ds-fields'
         if fields:
@@ -352,7 +351,11 @@ class ESExporter(object):
             self._es.update_by_query(
                 index=self.index,
                 body={'query': {'term': {'ds_id': ds_id}}},
-                params={'pipeline': pipeline_id, 'wait_for_completion': True})
+                params={
+                    'pipeline': pipeline_id,
+                    'wait_for_completion': True,
+                    'timeout': '60s',
+                })
 
     def delete_ds(self, ds_id, mol_db=None):
         """

--- a/metaspace/engine/sm/rest/api.py
+++ b/metaspace/engine/sm/rest/api.py
@@ -172,10 +172,10 @@ def update_ds(ds_man, ds_id, params):
     :return:
     """
     doc = params.get('doc', None)
-    if not doc:
+    force = params.get('force', False)
+    if not doc and not force:
         logger.info(f'Nothing to update for "{ds_id}"')
     else:
-        force = params.get('force', False)
         priority = params.get('priority', DatasetActionPriority.STANDARD)
         ds_man.update(ds_id=ds_id, doc=doc,
                       force=force, priority=priority)

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -583,7 +583,7 @@ class SMDataset(object):
 
 
 class SMInstance(object):
-    def __init__(self, host='http://metaspace2020.eu', verify_certificate=True):
+    def __init__(self, host='https://metaspace2020.eu', verify_certificate=True):
         self._config = get_config(host=host, verify_certificate=verify_certificate)
         if not verify_certificate:
             import warnings


### PR DESCRIPTION
* `https` for the default host in python client
* `force` argument in sm api dataset update to re-index the dataset without any updates
* Increased `update_by_query` timeout in es_export to 60s