### PR TITLE
More fixes

### DIFF
--- a/docker/sm-webapp/config/clientConfig.json
+++ b/docker/sm-webapp/config/clientConfig.json
@@ -15,6 +15,9 @@
     },
     "storage": "/opt/data/uploads"
   },
-  "ravenDsn": "https://16556a31185a4882b9ebf6a5abab9452@sentry.io/1203803",
-  "metadataTypes": ["ims","lcms"]
+  "ravenDsn": null,
+  "metadataTypes": ["ims", "lcms"],
+  "features": {
+    "newAuth": false
+  }
 }

--- a/metaspace/graphql/src/modules/auth/operation.ts
+++ b/metaspace/graphql/src/modules/auth/operation.ts
@@ -113,26 +113,6 @@ const createCredentials = async (userCred: UserCredentialsInput): Promise<Creden
   }
 };
 
-const updateCredentials = async (credId: string, userCred: UserCredentialsInput): Promise<void> => {
-  // TODO: Add a test case
-  if (userCred.password) {
-    await credRepo.update(credId, {
-      hash: await hashPassword(userCred.password),
-    });
-    logger.info(`${userCred.email} user credentials updated, password added`);
-  }
-  else if (userCred.googleId) {
-    await credRepo.update(credId, {
-      googleId: userCred.googleId,
-      emailVerified: true,
-    });
-    logger.info(`${userCred.email} user credentials updated, google id added`);
-  }
-  else {
-    logger.info('Nothing to update in credentials');
-  }
-};
-
 export const createUserCredentials = async (userCred: UserCredentialsInput): Promise<void> => {
   const existingUser = await findUserByEmail(userCred.email, 'email');
   if (existingUser) {

--- a/metaspace/graphql/src/modules/group/controller.ts
+++ b/metaspace/graphql/src/modules/group/controller.ts
@@ -12,6 +12,7 @@ import {sendInvitationEmail} from '../auth';
 import config from '../../utils/config';
 import {createInactiveUser} from '../auth/operation';
 import {smAPIUpdateDataset} from '../../utils/smAPI';
+import {getDatasetForEditing} from '../dataset/operation/getDatasetForEditing';
 
 const resolveGroupScopeRole = async (ctx: Context, groupId?: string): Promise<ScopeRole> => {
   let scopeRole = ScopeRoleOptions.OTHER;
@@ -406,6 +407,11 @@ export const Resolvers = {
       logger.info(`User '${user!.id}' importing datasets ${datasetIds} to '${groupId}' group...`);
 
       await connection.getRepository(GroupModel).findOneOrFail(groupId);
+
+      // Verify user is allowed to edit the datasets
+      await Promise.all(datasetIds.map(async (dsId: string) => {
+        await getDatasetForEditing(connection, user, dsId);
+      }));
 
       const dsRepo = connection.getRepository(DatasetModel);
       await Promise.all(datasetIds.map(async (dsId: string) => {


### PR DESCRIPTION
This fixes two security issues:
* Importing datasets into a group or project didn't check who owned the dataset, which could allow access to private datasets
* Activating an inactive account using Google didn't remove any previously set password. This was a problem because setting a password on an inactive account can be done without any sort of verification by just creating an account with the same email address.

It also fixes a couple bugs:
* `"features"` section is missing from the docker `clientConfig.json`
* Signing up using email/password to activate an inactive account wouldn't save the password. This is the problem Veronica saw earlier today.