### PR TITLE
Admin actions for recovering datasets

### DIFF
--- a/docker/sm-engine/conf/config.json
+++ b/docker/sm-engine/conf/config.json
@@ -126,5 +126,12 @@
             "level": "INFO"
         }
     }
+  },
+  "ds_config_defaults": {
+    "adducts": {
+      "+": ["+H", "+Na", "+K"],
+      "-": ["-H", "+Cl" ]
+    },
+    "moldb_names": ["HMDB-v4"]
   }
 }

--- a/docker/sm-graphql/config/development.js
+++ b/docker/sm-graphql/config/development.js
@@ -87,6 +87,12 @@ config.slack.channel = "";
 config.jwt = {};
 config.jwt.secret = "secret";
 
+config.aws = {
+  aws_access_key_id: "",
+  aws_secret_access_key: "",
+  aws_region: "eu-west-1"
+};
+
 config.features = {
   newAuth: false
 };

--- a/docker/sm-graphql/config/production.js
+++ b/docker/sm-graphql/config/production.js
@@ -87,6 +87,12 @@ config.slack.channel = "";
 config.jwt = {};
 config.jwt.secret = "secret";
 
+config.aws = {
+  aws_access_key_id: "",
+  aws_secret_access_key: "",
+  aws_region: "eu-west-1"
+};
+
 config.features = {
   newAuth: false
 };

--- a/metaspace/graphql/src/modules/dataset/controller/Mutation.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Mutation.ts
@@ -321,11 +321,11 @@ const MutationResolvers: FieldResolversFor<Mutation, void>  = {
   },
 
   deleteDataset: async (_, args, {user, connection}) => {
-    const {id: dsId, priority} = args;
+    const {id: dsId, force} = args;
     if (user == null) {
       throw new UserError('Unauthorized');
     }
-    const resp = await deleteDataset(connection, user, dsId);
+    const resp = await deleteDataset(connection, user, dsId, {force});
     return JSON.stringify(resp);
   },
 

--- a/metaspace/graphql/src/modules/dataset/controller/Mutation.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Mutation.ts
@@ -191,11 +191,12 @@ type CreateDatasetArgs = {
   id?: string,
   input: DatasetCreateInput,
   priority?: Int,
-  reprocess?: boolean, // Only used by reprocess
-  delFirst?: boolean,  // Only used by reprocess
+  reprocess?: boolean,       // Only used by reprocess
+  delFirst?: boolean,        // Only used by reprocess
+  skipValidation?: boolean,  // Only used by reprocess
 };
 const createDataset = async (args: CreateDatasetArgs, ctx: Context) => {
-  const {input, priority} = args;
+  const {input, priority, skipValidation} = args;
   const {user, connection, isAdmin, getUserIdOrFail} = ctx;
   const dsId = args.id || newDatasetId();
   const dsIdWasSpecified = !!args.id;
@@ -210,7 +211,9 @@ const createDataset = async (args: CreateDatasetArgs, ctx: Context) => {
   }
 
   const metadata = JSON.parse(input.metadataJson);
-  validateMetadata(metadata);
+  if (!skipValidation || !isAdmin) {
+    validateMetadata(metadata);
+  }
   // TODO: Many of the inputs are mistyped because of bugs in graphql-binding that should be reported and/or fixed
   await molDBsExist(input.molDBs as any || []);
 
@@ -250,6 +253,7 @@ const MutationResolvers: FieldResolversFor<Mutation, void>  = {
       input: ds as any, // TODO: map this properly
       priority: priority,
       reprocess: true,
+      skipValidation: true,
       delFirst: delFirst,
     }, ctx);
   },

--- a/metaspace/graphql/src/modules/dataset/controller/Subscription.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Subscription.ts
@@ -20,11 +20,11 @@ async function publishDatasetStatusUpdate(ds_id: string, status: DatasetStatus) 
       logger.debug(JSON.stringify({attempt, status}));
       const ds = await esDatasetByID(ds_id, null);
 
-      if (ds === null && status === 'DELETED') {
+      if (ds == null && status === 'DELETED') {
         await wait(1000);
         pubsub.publish('datasetStatusUpdated', {});
         return;
-      } else if (ds !== null && status !== 'DELETED') {
+      } else if (ds != null && status !== 'DELETED') {
         pubsub.publish('datasetStatusUpdated', {
           dataset: Object.assign({}, ds, { status }),
           dbDs: await fetchEngineDS({ id: ds_id })

--- a/metaspace/graphql/src/modules/dataset/operation/deleteDataset.ts
+++ b/metaspace/graphql/src/modules/dataset/operation/deleteDataset.ts
@@ -2,10 +2,11 @@ import {Connection, EntityManager} from 'typeorm';
 import {ContextUser} from '../../../context';
 import {logger} from '../../../../utils';
 import {getDatasetForEditing} from './getDatasetForEditing';
-import {smAPIRequest} from '../../../utils';
 import {Dataset as DatasetModel, DatasetProject as DatasetProjectModel} from '../model';
+import {DeleteDatasetArgs, smAPIDeleteDataset} from '../../../utils/smAPI';
 
-export const deleteDataset = async (connection: Connection | EntityManager, user: ContextUser, dsId: string) => {
+export const deleteDataset = async (connection: Connection | EntityManager, user: ContextUser, dsId: string,
+                                    args?: DeleteDatasetArgs) => {
   logger.info(`User '${user.id}' deleting '${dsId}' dataset...`);
   if (user.role !== 'admin') {
     // Skip this for admins so that datasets that are missing their graphql.dataset record can still be deleted
@@ -14,7 +15,7 @@ export const deleteDataset = async (connection: Connection | EntityManager, user
 
   await connection.getRepository(DatasetProjectModel).delete({ datasetId: dsId });
   await connection.getRepository(DatasetModel).delete(dsId);
-  const resp = await smAPIRequest(`/v1/datasets/${dsId}/delete`, {});
+  const resp = await smAPIDeleteDataset(dsId, args);
 
   logger.info(`Dataset '${dsId}' was deleted`);
   return resp;

--- a/metaspace/graphql/src/modules/project/controller/Query.spec.ts
+++ b/metaspace/graphql/src/modules/project/controller/Query.spec.ts
@@ -148,7 +148,7 @@ describe('modules/project/controller (queries)', () => {
           const {id, name} = otherMember!;
           expectedMembers = expect.arrayContaining([{id, name, email: null}]);
         } else {
-          expectedMembers = null;
+          expectedMembers = [];
         }
 
         expect(members).toEqual(expectedMembers);
@@ -290,10 +290,10 @@ describe('modules/project/controller (queries)', () => {
       const result = await doQuery(query);
 
       expect(result.projects).toEqual(expect.arrayContaining([
-        {role: UPRO.INVITED, numDatasets: 0, project: { members: null }},
-        {role: UPRO.PENDING, numDatasets: 1, project: { members: null }},
-        {role: UPRO.MEMBER, numDatasets: 2, project: { members: expect.anything() }},
-        {role: UPRO.MANAGER, numDatasets: 3, project: { members: expect.anything() }},
+        {role: UPRO.INVITED, numDatasets: 0, project: { members: [] }},
+        {role: UPRO.PENDING, numDatasets: 1, project: { members: [] }},
+        {role: UPRO.MEMBER, numDatasets: 2, project: { members: expect.arrayContaining([expect.anything()]) }},
+        {role: UPRO.MANAGER, numDatasets: 3, project: { members: expect.arrayContaining([expect.anything()]) }},
       ]));
     })
   });

--- a/metaspace/graphql/src/utils/smAPI.ts
+++ b/metaspace/graphql/src/utils/smAPI.ts
@@ -26,7 +26,7 @@ const fieldRenameMap = {
 };
 
 export const smAPIRequest = async (uri: string, args: any={}) => {
-  const body: SMAPIBody = args;
+  const body: SMAPIBody = args || {};
   // @ts-ignore
   body.doc = _.mapKeys(body.doc, (v, k) => fieldRenameMap[k] || k);
 
@@ -77,4 +77,13 @@ export const smAPIUpdateDataset = async (id: string, updates: UpdateDatasetArgs)
   } catch (err) {
     // TODO: Fix updates on busy datasets
   }
+};
+
+export interface DeleteDatasetArgs {
+  del_raw?: boolean;
+  force?: boolean;
+}
+
+export const smAPIDeleteDataset = async (dsId: string, args?: DeleteDatasetArgs) => {
+  return await smAPIRequest(`/v1/datasets/${dsId}/delete`, args);
 };

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -122,8 +122,8 @@ export const createDatasetQuery =
   }`;
 
 export const deleteDatasetQuery =
-  gql`mutation ($id: String!) {
-    deleteDataset(id: $id)
+  gql`mutation ($id: String!, $force: Boolean) {
+    deleteDataset(id: $id, force: $force)
   }`;
 
 export const addOpticalImageQuery =

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -126,6 +126,11 @@ export const deleteDatasetQuery =
     deleteDataset(id: $id, force: $force)
   }`;
 
+export const reprocessDatasetQuery =
+  gql`mutation ($id: String!) {
+    reprocessDataset(id: $id)
+  }`;
+
 export const addOpticalImageQuery =
   gql`mutation ($imageUrl: String!,
                 $datasetId: String!, $transform: [[Float]]!) {

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetList.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetList.vue
@@ -3,7 +3,8 @@
     <dataset-item v-for="(dataset, i) in datasets"
                   :dataset="dataset" :key="dataset.id"
                   :class="[i%2 ? 'odd': '']"
-                  @filterUpdate="filter => $emit('filterUpdate', filter)">
+                  @filterUpdate="filter => $emit('filterUpdate', filter)"
+                  @datasetMutated="$emit('datasetMutated')">
     </dataset-item>
   </div>
 </template>

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
@@ -13,6 +13,7 @@
           <el-checkbox class="cb-started" label="started">Processing {{ count('started') }}</el-checkbox>
           <el-checkbox class="cb-queued" label="queued">Queued {{ count('queued') }}</el-checkbox>
           <el-checkbox label="finished">Finished {{ count('finished') }}</el-checkbox>
+          <el-checkbox v-if="canSeeFailed" class="cb-failed" label="failed">Failed {{ count('failed') }}</el-checkbox>
         </el-checkbox-group>
       </el-form>
     </div>
@@ -37,7 +38,7 @@
         </el-button>
       </div>
 
-      <dataset-list :datasets="datasets" allowDoubleColumn />
+      <dataset-list :datasets="datasets" allowDoubleColumn @datasetMutated="handleDatasetMutated" />
     </div>
   </div>
 </template>
@@ -52,8 +53,9 @@
  import FileSaver from 'file-saver';
  import delay from '../../../lib/delay';
  import formatCsvRow from '../../../lib/formatCsvRow';
+  import {currentUserRoleQuery} from '../../../api/user';
 
- const processingStages = ['started', 'queued', 'finished'];
+ const processingStages = ['started', 'queued', 'failed', 'finished'];
 
  export default {
    name: 'dataset-table',
@@ -61,7 +63,7 @@
      return {
        recordsPerPage: 10,
        csvChunkSize: 1000,
-       categories: processingStages,
+       categories: ['started', 'queued', 'finished'],
        isExporting: false
      }
    },
@@ -98,6 +100,10 @@
            list = list.concat(this[category]);
        return list;
      },
+
+     canSeeFailed() {
+       return this.currentUser != null && this.currentUser.role === 'admin';
+     }
    },
 
    apollo: {
@@ -128,6 +134,23 @@
 
            this.refetchList();
          }
+       }
+     },
+
+     currentUser: {
+       query: currentUserRoleQuery,
+       fetchPolicy: 'cache-first',
+     },
+
+     failed: {
+       fetchPolicy: 'cache-and-network',
+       query: datasetDetailItemsQuery,
+       update: data => data.allDatasets,
+       skip() {
+         return !this.canSeeFailed;
+       },
+       variables () {
+         return this.queryVariables('FAILED');
        }
      },
 
@@ -206,6 +229,15 @@
        this.$apollo.queries.queued.refresh();
        this.$apollo.queries.finished.refresh();
        this.$apollo.queries.finishedCount.refresh();
+       if (this.canSeeFailed) {
+         this.$apollo.queries.failed.refresh();
+       }
+     },
+
+     handleDatasetMutated() {
+       // Reset the throttled function as the next datasetStatusUpdated message is probably related to the mutation that
+       // the user just triggered.
+       this.refetchList.flush();
      },
 
      async startExport() {
@@ -310,6 +342,10 @@
 
  .cb-queued .el-checkbox__input.is-checked .el-checkbox__inner {
    background: #72c8e5;
+ }
+
+ .cb-failed .el-checkbox__input.is-checked .el-checkbox__inner {
+   background: #f56c6c;
  }
 
  #dataset-list-header {

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -48,6 +48,7 @@ exports[`DatasetTable should match snapshot 1`] = `
         <label role="checkbox" aria-checked="true" class="el-checkbox is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
           <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="finished">
           </span><span class="el-checkbox__label">Finished (1)<!----></span></label>
+        <!---->
       </div>
     </form>
   </div>
@@ -168,6 +169,7 @@ exports[`DatasetTable should match snapshot 1`] = `
           <!---->
           <!---->
           <!---->
+          <!---->
         </div>
       </div>
       <div class="dataset-item odd">
@@ -272,6 +274,7 @@ exports[`DatasetTable should match snapshot 1`] = `
           <!----><span><div title="Waiting in the queue" class="striped-progressbar queued"></div></span>
           <i class="el-icon-view"></i>
           <a class="metadata-link">Show full metadata</a>
+          <!---->
           <!---->
           <!---->
           <!---->
@@ -389,6 +392,7 @@ exports[`DatasetTable should match snapshot 1`] = `
           <!---->
           <i class="el-icon-view"></i>
           <a class="metadata-link">Show full metadata</a>
+          <!---->
           <!---->
           <!---->
           <!---->


### PR DESCRIPTION
* (Unrelated) updates configs for docker projects
* (Unrelated) fixes dataset status updates for deleted datasets - the issue was that `ds` was `undefined`, not `null`
* (Unrelated) wraps SM Daemons' `_on_success` and `_on_failure` functions with error handlers, because deleting datasets while they are being reprocessed was causing sm-annotate-daemon to crash and exit
* Allows admins to use "Edit Metadata" and "Delete Dataset" on queued and failed datasets through the UI
* Adds a "Reprocess Dataset" button for admins
* Adds a filter category for failed datasets for admins

![image](https://user-images.githubusercontent.com/26366936/48419147-8091a600-e757-11e8-8879-ad265fdfc47b.png)
