### PR TITLE
Optimize dataset updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,12 @@ jobs:
 
   test-graphql:
     docker:
+      - image: intsco/sm-webapp:0.9
+
       - image: postgres:9.5-alpine
         environment:
           POSTGRES_USER: sm
           POSTGRES_PASSWORD: password
-
-      - image: node:8.11
 
     working_directory: ~/metaspace/metaspace/graphql
     steps:
@@ -30,9 +30,14 @@ jobs:
       - run:
           name: Run tests
           command: |
-            psql -h localhost -U postgres -c "CREATE DATABASE sm_test owner sm"
-            yarn run test
-            psql -h localhost -U postgres -c "DROP DATABASE sm_test"
+            psql -h localhost -U sm -c "CREATE ROLE postgres WITH LOGIN SUPERUSER PASSWORD 'postgres'"
+            psql -h localhost -U sm -c "CREATE DATABASE sm_test owner sm"
+            psql -h localhost -U sm -d sm_test -c "CREATE EXTENSION \"uuid-ossp\";"
+            psql -h localhost -U sm -d sm_test -c "CREATE SCHEMA graphql;"
+            yarn run gen-binding
+            yarn run deref-schema
+            NODE_ENV=test yarn run test --verbose --detectOpenHandles --forceExit
+            psql -h localhost -U sm -c "DROP DATABASE sm_test"
 
 
   generate-graphql-schema:
@@ -265,10 +270,10 @@ jobs:
       - run:
           name: Create and prefill the databases
           command: |
-            createdb -h localhost -U postgres sm_test
+            createdb -h localhost -U sm sm_test
             psql -U sm -h localhost -d sm_test < scripts/create_schema.sql
             wget -qN https://s3-eu-west-1.amazonaws.com/embl-sm-testing/dumps/2018-03-13/mol_db.dump
-            pg_restore -U sm -h localhost --no-owner --role=sm -d sm_test mol_db.dump
+            pg_restore -U sm -h localhost --no-owner --no-privileges --role=sm -d sm_test mol_db.dump
             cp docker/mol_db_conf.ini ../mol-db/conf/local.ini
       - run:
           name: Run mol db
@@ -281,14 +286,14 @@ jobs:
           name: Run scientific test
           command: |
             source docker/env.sh
-            python tests/sci_test_spheroid.py -r --mock-img-store
+            python tests/sci_test_spheroid.py -r --mock-img-store --mock-graphql-db
 
 workflows:
   version: 2
   commit:
     jobs:
       - test-engine
-      #- test-graphql
+      # - test-graphql
       - generate-graphql-schema
       - test-webapp:
           requires:

--- a/ansible/aws/group_vars_all.yml.template
+++ b/ansible/aws/group_vars_all.yml.template
@@ -70,6 +70,7 @@ miniconda_env:
       - PyArrow>=0.8.0
       - Pillow==4.2.1
       - pyopenms==2.2.0
+      - cherrypy<9
 
 sm_postgres_host: "{{ hostvars['web-1'].ansible_ec2_local_ipv4 }}"
 sm_postgres_password: POSTGRES_PASSWORD

--- a/docker/sm-engine/conf/config.json
+++ b/docker/sm-engine/conf/config.json
@@ -28,7 +28,8 @@
     "img_service_url": "http://sm-graphql:4201",
     "mol_db": "http://nginx:8999/mol_db/v1",
     "web_app_url": "http://nginx:8999",
-    "send_email": false
+    "send_email": false,
+    "update_daemon_threads": 4
   },
   "rabbitmq": {
     "host": "rabbitmq",

--- a/docker/sm-engine/conf/config.json
+++ b/docker/sm-engine/conf/config.json
@@ -2,8 +2,8 @@
   "bottle": {
     "host": "0.0.0.0",
     "port": 5123,
-    "refresh": true,
-    "debug": true
+    "debug": false,
+    "server": "cherrypy"
   },
   "defaults": {
     "adducts": {

--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -2,8 +2,8 @@
   "bottle": {
     "host": "localhost",
     "port": 5123,
-    "reloader": false,
-    "debug": false
+    "debug": false,
+    "server": "cherrypy"
   },
   "defaults": {
     "adducts": {{ sm_default_adducts | to_json }}
@@ -88,7 +88,7 @@
     "version": 1,
     "formatters": {
       "sm": {
-        "format": "%(asctime)s - %(levelname)s - %(name)s - %(filename)s:%(lineno)d - %(message)s"
+        "format": "%(asctime)s - %(levelname)s - %(name)s[%(thread)d] - %(filename)s:%(lineno)d - %(message)s"
       }
     },
     "handlers": {

--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -25,7 +25,8 @@
     "img_service_url": "{{ sm_img_service_url }}",
     "mol_db": "{{ mol_db_url }}",
     "web_app_url": "{{ web_public_url }}",
-    "send_email": {{ sm_send_email | to_json }}
+    "send_email": {{ sm_send_email | to_json }},
+    "update_daemon_threads": 4
   },
   "rabbitmq": {
     "host": "{{ rabbitmq_host }}",

--- a/metaspace/engine/conf/test_config.json
+++ b/metaspace/engine/conf/test_config.json
@@ -25,7 +25,8 @@
     "web_app_url": "http://localhost:8082",
     "img_service_url": "http://localhost:4201",
     "mol_db": "http://localhost:5001/v1",
-    "send_email": false
+    "send_email": false,
+    "update_daemon_threads": 1
   },
   "fs": {
     "base_path": "/opt/data/sm_test_data",

--- a/metaspace/engine/docker/sci_test_config.json
+++ b/metaspace/engine/docker/sci_test_config.json
@@ -33,7 +33,7 @@
     "s3_base_path": ""
   },
   "spark": {
-    "master": "local[4]",
+    "master": "local[2]",
     "executor.memory": "2g",
     "spark.sql.execution.arrow.enabled": true
   },

--- a/metaspace/engine/docker/sci_test_config.json
+++ b/metaspace/engine/docker/sci_test_config.json
@@ -22,8 +22,11 @@
     "password": "password"
   },
   "services": {
+    "web_app_url": "",
     "img_service_url": "",
-    "mol_db": "http://localhost:5001/v1"
+    "mol_db": "http://localhost:5001/v1",
+    "send_email": false,
+    "update_daemon_threads": 1
   },
   "fs": {
     "base_path": "/opt/data/sm_test_data",
@@ -102,10 +105,21 @@
             "handlers": ["console_debug"],
             "level": "INFO"
         },
-        "daemon": {
+        "update-daemon": {
+            "handlers": ["console_debug"],
+            "level": "INFO"
+        },
+        "annotate-daemon": {
             "handlers": ["console_debug"],
             "level": "INFO"
         }
     }
+  },
+  "ds_config_defaults": {
+    "adducts": {
+      "+": ["+H", "+Na", "+K"],
+      "-": ["-H", "+Cl" ]
+    },
+    "moldb_names": []
   }
 }

--- a/metaspace/engine/docker/sm_engine/environment.yml
+++ b/metaspace/engine/docker/sm_engine/environment.yml
@@ -33,3 +33,4 @@ dependencies:
     - Pillow==4.2.1
     - pyopenms==2.2.0
     - pysparkling
+    - cherrypy<9

--- a/metaspace/engine/environment.yml
+++ b/metaspace/engine/environment.yml
@@ -25,3 +25,6 @@ dependencies:
     - pysparkling
     - PyArrow>=0.8.0
     - Pillow==4.2.1
+    # bottle 0.12 only supports cherrypy<9. The as-yet unreleased bottle 0.13 supports cherrypy>=9 by changing the
+    # "server" setting to "cheroot"
+    - cherrypy<9

--- a/metaspace/engine/scripts/run_sm_daemon.py
+++ b/metaspace/engine/scripts/run_sm_daemon.py
@@ -24,27 +24,34 @@ if __name__ == "__main__":
     logger = logging.getLogger(f'{args.name}-daemon')
     logger.info(f'Starting {args.name}-daemon')
 
-    db = DB(sm_config['db'])
-    status_queue_pub = QueuePublisher(config=sm_config['rabbitmq'],
-                                      qdesc=SM_DS_STATUS,
-                                      logger=logger)
-    manager = SMDaemonManager(
-        db=db, es=ESExporter(db),
-        img_store=ImageStoreServiceWrapper(sm_config['services']['img_service_url']),
-        status_queue=status_queue_pub,
-        logger=logger
-    )
+    def get_manager():
+        db = DB(sm_config['db'])
+        status_queue_pub = QueuePublisher(config=sm_config['rabbitmq'],
+                                          qdesc=SM_DS_STATUS,
+                                          logger=logger)
+        return SMDaemonManager(
+            db=db, es=ESExporter(db),
+            img_store=ImageStoreServiceWrapper(sm_config['services']['img_service_url']),
+            status_queue=status_queue_pub,
+            logger=logger)
+    daemons = []
     if args.name == 'annotate':
-        daemon = SMAnnotateDaemon(manager=manager,
-                                  annot_qdesc=SM_ANNOTATE,
-                                  upd_qdesc=SM_UPDATE)
+        daemons.append(SMAnnotateDaemon(manager=get_manager(),
+                                        annot_qdesc=SM_ANNOTATE,
+                                        upd_qdesc=SM_UPDATE))
     elif args.name == 'update':
-        daemon = SMIndexUpdateDaemon(manager=manager,
-                                     update_qdesc=SM_UPDATE)
+        for i in range(8):
+            daemons.append(SMIndexUpdateDaemon(manager=get_manager(),
+                                               update_qdesc=SM_UPDATE))
     else:
         raise Exception(f'Wrong SM daemon name: {args.name}')
 
-    signal.signal(signal.SIGINT, lambda *args: daemon.stop())
-    signal.signal(signal.SIGTERM, lambda *args: daemon.stop())
+    def stop_daemons(*args):
+        for daemon in daemons:
+            daemon.stop()
 
-    daemon.start()
+    signal.signal(signal.SIGINT, stop_daemons)
+    signal.signal(signal.SIGTERM, stop_daemons)
+
+    for daemon in daemons:
+        daemon.start()

--- a/metaspace/engine/scripts/run_sm_daemon.py
+++ b/metaspace/engine/scripts/run_sm_daemon.py
@@ -40,15 +40,16 @@ if __name__ == "__main__":
                                         annot_qdesc=SM_ANNOTATE,
                                         upd_qdesc=SM_UPDATE))
     elif args.name == 'update':
-        for i in range(8):
-            daemons.append(SMIndexUpdateDaemon(manager=get_manager(),
-                                               update_qdesc=SM_UPDATE))
+        for i in range(sm_config['services']['update_daemon_threads']):
+            daemon = SMIndexUpdateDaemon(manager=get_manager(),
+                                         update_qdesc=SM_UPDATE)
+            daemons.append(daemon)
     else:
         raise Exception(f'Wrong SM daemon name: {args.name}')
 
     def stop_daemons(*args):
-        for daemon in daemons:
-            daemon.stop()
+        for d in daemons:
+            d.stop()
 
     signal.signal(signal.SIGINT, stop_daemons)
     signal.signal(signal.SIGTERM, stop_daemons)

--- a/metaspace/engine/sm/engine/dataset_locker.py
+++ b/metaspace/engine/sm/engine/dataset_locker.py
@@ -4,7 +4,7 @@ from zlib import adler32
 
 
 LOCK_KEY = 894951
-MIN_CONNS = 1
+MIN_CONNS = 0
 MAX_CONNS = 2
 
 class DatasetLocker(object):

--- a/metaspace/engine/sm/engine/dataset_locker.py
+++ b/metaspace/engine/sm/engine/dataset_locker.py
@@ -1,28 +1,23 @@
 from contextlib import contextmanager
-from psycopg2.pool import ThreadedConnectionPool
+from psycopg2 import connect
 from zlib import adler32
 
 
 LOCK_KEY = 894951
-MIN_CONNS = 0
-MAX_CONNS = 2
 
 class DatasetLocker(object):
     def __init__(self, dbconfig):
-        self._pool = ThreadedConnectionPool(MIN_CONNS, MAX_CONNS, **dbconfig)
+        self._dbconfig = dbconfig
 
     @contextmanager
     def lock(self, ds_id, timeout=60):
         hash = adler32(ds_id.encode('utf-8'))
-        conn = self._pool.getconn()
+        conn = connect(**self._dbconfig)
         try:
             with conn.cursor() as curs:
                 curs.execute('SET statement_timeout = %s;', (timeout * 1000,))
                 curs.execute('SELECT pg_advisory_lock(%s, %s);', (LOCK_KEY, hash))
                 yield None
                 curs.execute('SELECT pg_advisory_unlock(%s, %s);', (LOCK_KEY, hash))
-        except:
-            self._pool.putconn(conn, close=True)
-            raise
-        else:
-            self._pool.putconn(conn)
+        finally:
+            conn.close()

--- a/metaspace/engine/sm/engine/dataset_locker.py
+++ b/metaspace/engine/sm/engine/dataset_locker.py
@@ -5,7 +5,7 @@ from zlib import adler32
 
 LOCK_KEY = 894951
 MIN_CONNS = 1
-MAX_CONNS = 8
+MAX_CONNS = 2
 
 class DatasetLocker(object):
     def __init__(self, dbconfig):

--- a/metaspace/engine/sm/engine/dataset_locker.py
+++ b/metaspace/engine/sm/engine/dataset_locker.py
@@ -1,0 +1,28 @@
+from contextlib import contextmanager
+from psycopg2.pool import ThreadedConnectionPool
+from zlib import adler32
+
+
+LOCK_KEY = 894951
+MIN_CONNS = 1
+MAX_CONNS = 8
+
+class DatasetLocker(object):
+    def __init__(self, dbconfig):
+        self._pool = ThreadedConnectionPool(MIN_CONNS, MAX_CONNS, **dbconfig)
+
+    @contextmanager
+    def lock(self, ds_id, timeout=60):
+        hash = adler32(ds_id.encode('utf-8'))
+        conn = self._pool.getconn()
+        try:
+            with conn.cursor() as curs:
+                curs.execute('SET statement_timeout = %s;', (timeout * 1000,))
+                curs.execute('SELECT pg_advisory_lock(%s, %s);', (LOCK_KEY, hash))
+                yield None
+                curs.execute('SELECT pg_advisory_unlock(%s, %s);', (LOCK_KEY, hash))
+        except:
+            self._pool.putconn(conn, close=True)
+            raise
+        else:
+            self._pool.putconn(conn)

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -5,6 +5,7 @@ import logging
 from collections import defaultdict, MutableMapping
 import pandas as pd
 
+from sm.engine.dataset_locker import DatasetLocker
 from sm.engine.util import SMConfig
 
 logger = logging.getLogger('engine')
@@ -215,6 +216,7 @@ class ESExporter(object):
         self._es = init_es_conn(es_config)
         self._ingest = IngestClient(self._es)
         self._db = db
+        self._ds_locker = DatasetLocker(self.sm_config['db'])
         self.index = es_config['index']
         self._get_mol_by_sf_dict_cache = dict()
 
@@ -233,13 +235,14 @@ class ESExporter(object):
     def sync_dataset(self, ds_id):
         """ Warning: This will wait till ES index/update is completed
         """
-        ds = self._select_ds_by_id(ds_id)
-        if self._es.exists(index=self.index, doc_type='dataset', id=ds_id):
-            self._es.update(index=self.index, id=ds_id,
-                            doc_type='dataset', body={'doc': ds}, params={'refresh': 'wait_for'})
-        else:
-            self._es.index(index=self.index, id=ds_id,
-                           doc_type='dataset', body=ds, params={'refresh': 'wait_for'})
+        with self._ds_locker.lock(ds_id):
+            ds = self._select_ds_by_id(ds_id)
+            if self._es.exists(index=self.index, doc_type='dataset', id=ds_id):
+                self._es.update(index=self.index, id=ds_id,
+                                doc_type='dataset', body={'doc': ds}, params={'refresh': 'wait_for'})
+            else:
+                self._es.index(index=self.index, id=ds_id,
+                               doc_type='dataset', body=ds, params={'refresh': 'wait_for'})
 
     def _get_mol_by_sf_dict(self, mol_db):
         try:
@@ -262,100 +265,102 @@ class ESExporter(object):
                 ann_doc[f] = ds_doc[f]
 
     def index_ds(self, ds_id, mol_db, isocalc):
-        try:
-            ds_doc = self._remove_mol_db_from_dataset(ds_id, mol_db)
-        except NotFoundError:
-            ds_doc = self._select_ds_by_id(ds_id)
-        if 'annotation_counts' not in ds_doc:
-            ds_doc['annotation_counts'] = []
+        with self._ds_locker.lock(ds_id):
+            try:
+                ds_doc = self._remove_mol_db_from_dataset(ds_id, mol_db)
+            except NotFoundError:
+                ds_doc = self._select_ds_by_id(ds_id)
+            if 'annotation_counts' not in ds_doc:
+                ds_doc['annotation_counts'] = []
 
-        annotation_counts = defaultdict(int)
-        fdr_levels = [5, 10, 20, 50]
+            annotation_counts = defaultdict(int)
+            fdr_levels = [5, 10, 20, 50]
 
-        annotation_docs = self._db.select_with_fields(ANNOTATIONS_SEL, params=(ds_id, mol_db.id))
-        logger.info('Indexing {} documents: {}, {}'.format(len(annotation_docs), ds_id, mol_db))
+            annotation_docs = self._db.select_with_fields(ANNOTATIONS_SEL, params=(ds_id, mol_db.id))
+            logger.info('Indexing {} documents: {}, {}'.format(len(annotation_docs), ds_id, mol_db))
 
-        to_index = []
-        mol_by_sf = self._get_mol_by_sf_dict(mol_db)
-        for doc in annotation_docs:
-            self._add_ds_fields_to_ann(doc, ds_doc)
-            doc['db_name'] = mol_db.name
-            doc['db_version'] = mol_db.version
-            sf = doc['sf']
-            doc['comp_ids'], doc['comp_names'] = mol_by_sf[sf]
-            mzs, _ = isocalc.ion_centroids(sf, doc['adduct'])
-            doc['centroid_mzs'] = list(mzs)
-            doc['mz'] = mzs[0]
-            doc['ion_add_pol'] = '[M{}]{}'.format(doc['adduct'], doc['polarity'])
+            to_index = []
+            mol_by_sf = self._get_mol_by_sf_dict(mol_db)
+            for doc in annotation_docs:
+                self._add_ds_fields_to_ann(doc, ds_doc)
+                doc['db_name'] = mol_db.name
+                doc['db_version'] = mol_db.version
+                sf = doc['sf']
+                doc['comp_ids'], doc['comp_names'] = mol_by_sf[sf]
+                mzs, _ = isocalc.ion_centroids(sf, doc['adduct'])
+                doc['centroid_mzs'] = list(mzs)
+                doc['mz'] = mzs[0]
+                doc['ion_add_pol'] = '[M{}]{}'.format(doc['adduct'], doc['polarity'])
 
-            fdr = round(doc['fdr'] * 100, 2)
-            # assert fdr in fdr_levels
-            annotation_counts[fdr] += 1
+                fdr = round(doc['fdr'] * 100, 2)
+                # assert fdr in fdr_levels
+                annotation_counts[fdr] += 1
 
-            add_str = doc['adduct'].replace('+', 'plus_').replace('-', 'minus_')
-            to_index.append({
-                '_index': self.index,
-                '_type': 'annotation',
-                '_id': '{}_{}_{}_{}_{}'.format(doc['ds_id'], mol_db.name, mol_db.version,
-                                               doc['sf'], add_str),
-                '_source': doc
+                add_str = doc['adduct'].replace('+', 'plus_').replace('-', 'minus_')
+                to_index.append({
+                    '_index': self.index,
+                    '_type': 'annotation',
+                    '_id': '{}_{}_{}_{}_{}'.format(doc['ds_id'], mol_db.name, mol_db.version,
+                                                   doc['sf'], add_str),
+                    '_source': doc
+                })
+
+            for success, info in parallel_bulk(self._es, actions=to_index, timeout='60s'):
+                if not success:
+                    logger.error(f'Document failed: {info}')
+
+            for i, level in enumerate(fdr_levels[1:]):
+                annotation_counts[level] += annotation_counts[fdr_levels[i]]
+            ds_doc['annotation_counts'].append({
+                'db': {'name': mol_db.name, 'version': mol_db.version},
+                'counts': [{'level': level, 'n': annotation_counts[level]} for level in fdr_levels]
             })
-
-        for success, info in parallel_bulk(self._es, actions=to_index, timeout='60s'):
-            if not success:
-                logger.error(f'Document failed: {info}')
-
-        for i, level in enumerate(fdr_levels[1:]):
-            annotation_counts[level] += annotation_counts[fdr_levels[i]]
-        ds_doc['annotation_counts'].append({
-            'db': {'name': mol_db.name, 'version': mol_db.version},
-            'counts': [{'level': level, 'n': annotation_counts[level]} for level in fdr_levels]
-        })
-        self._es.index(self.index, doc_type='dataset', body=ds_doc, id=ds_id)
+            self._es.index(self.index, doc_type='dataset', body=ds_doc, id=ds_id)
 
     def update_ds(self, ds_id, fields):
-        pipeline_id = 'update-ds-fields'
-        if fields:
-            ds_doc = self._select_ds_by_id(ds_id)
+        with self._ds_locker.lock(ds_id):
+            pipeline_id = 'update-ds-fields'
+            if fields:
+                ds_doc = self._select_ds_by_id(ds_id)
 
-            ds_doc_upd = {}
-            for f in fields:
-                if f == 'submitter_id':
-                    ds_doc_upd['ds_submitter_id'] = ds_doc['ds_submitter_id']
-                    ds_doc_upd['ds_submitter_name'] = ds_doc['ds_submitter_name']
-                    ds_doc_upd['ds_submitter_email'] = ds_doc['ds_submitter_email']
-                elif f == 'group_id':
-                    ds_doc_upd['ds_group_id'] = ds_doc['ds_group_id']
-                    ds_doc_upd['ds_group_name'] = ds_doc['ds_group_name']
-                    ds_doc_upd['ds_group_short_name'] = ds_doc['ds_group_short_name']
-                    ds_doc_upd['ds_group_approved'] = ds_doc['ds_group_approved']
-                elif f == 'project_ids':
-                    ds_doc_upd['ds_project_ids'] = ds_doc['ds_project_ids']
-                    ds_doc_upd['ds_project_names'] = ds_doc['ds_project_names']
-                elif f == 'metadata':
-                    ds_meta_flat_doc = flatten_doc(ds_doc['ds_meta'], parent_key='ds_meta')
-                    ds_doc_upd.update(ds_meta_flat_doc)
-                elif f'ds_{f}' in ds_doc:
-                    ds_doc_upd[f'ds_{f}'] = ds_doc[f'ds_{f}']
+                ds_doc_upd = {}
+                for f in fields:
+                    if f == 'submitter_id':
+                        ds_doc_upd['ds_submitter_id'] = ds_doc['ds_submitter_id']
+                        ds_doc_upd['ds_submitter_name'] = ds_doc['ds_submitter_name']
+                        ds_doc_upd['ds_submitter_email'] = ds_doc['ds_submitter_email']
+                    elif f == 'group_id':
+                        ds_doc_upd['ds_group_id'] = ds_doc['ds_group_id']
+                        ds_doc_upd['ds_group_name'] = ds_doc['ds_group_name']
+                        ds_doc_upd['ds_group_short_name'] = ds_doc['ds_group_short_name']
+                        ds_doc_upd['ds_group_approved'] = ds_doc['ds_group_approved']
+                    elif f == 'project_ids':
+                        ds_doc_upd['ds_project_ids'] = ds_doc['ds_project_ids']
+                        ds_doc_upd['ds_project_names'] = ds_doc['ds_project_names']
+                    elif f == 'metadata':
+                        ds_meta_flat_doc = flatten_doc(ds_doc['ds_meta'], parent_key='ds_meta')
+                        ds_doc_upd.update(ds_meta_flat_doc)
+                    elif f'ds_{f}' in ds_doc:
+                        ds_doc_upd[f'ds_{f}'] = ds_doc[f'ds_{f}']
 
-            processors = []
-            for k, v in ds_doc_upd.items():
-                if v is None:
-                    processors.append({'remove': {'field': k}})
-                else:
-                    processors.append({'set': {'field': k, 'value': v}})
-            self._ingest.put_pipeline(
-                id=pipeline_id,
-                body={'processors': processors})
-            # Note: mind the time gap between the queries when called from different processes
-            self._es.update_by_query(
-                index=self.index,
-                body={'query': {'term': {'ds_id': ds_id}}},
-                params={
-                    'pipeline': pipeline_id,
-                    'wait_for_completion': True,
-                    'request_timeout': 60,
-                })
+                processors = []
+                for k, v in ds_doc_upd.items():
+                    if v is None:
+                        processors.append({'remove': {'field': k}})
+                    else:
+                        processors.append({'set': {'field': k, 'value': v}})
+                self._ingest.put_pipeline(
+                    id=pipeline_id,
+                    body={'processors': processors})
+                # Note: mind the time gap between the queries when called from different processes
+                self._es.update_by_query(
+                    index=self.index,
+                    body={'query': {'term': {'ds_id': ds_id}}},
+                    params={
+                        'pipeline': pipeline_id,
+                        'wait_for_completion': True,
+                        'request_timeout': 60,
+                    })
 
     def delete_ds(self, ds_id, mol_db=None):
         """
@@ -365,33 +370,34 @@ class ESExporter(object):
         :param mol_db: sm.engine.MolecularDB
         :return:
         """
-        logger.info('Deleting or updating dataset document in ES: %s, %s', ds_id, mol_db)
+        with self._ds_locker.lock(ds_id):
+            logger.info('Deleting or updating dataset document in ES: %s, %s', ds_id, mol_db)
 
-        must = [{'term': {'ds_id': ds_id}}]
-        body = {
-            'query': {
-                'constant_score': {
-                    'filter': {
-                        'bool': {'must': must}}}}
-        }
+            must = [{'term': {'ds_id': ds_id}}]
+            body = {
+                'query': {
+                    'constant_score': {
+                        'filter': {
+                            'bool': {'must': must}}}}
+            }
 
-        try:
+            try:
+                if mol_db:
+                    self._remove_mol_db_from_dataset(ds_id, mol_db)
+                else:
+                    self._es.delete(id=ds_id, index=self.index, doc_type='dataset')
+            except ElasticsearchException as e:
+                logger.warning('Dataset deletion failed: %s', e)
+
+            logger.info('Deleting annotation documents from ES: %s, %s', ds_id, mol_db)
+
             if mol_db:
-                self._remove_mol_db_from_dataset(ds_id, mol_db)
-            else:
-                self._es.delete(id=ds_id, index=self.index, doc_type='dataset')
-        except ElasticsearchException as e:
-            logger.warning('Dataset deletion failed: %s', e)
+                must.append({'term': {'db_name': mol_db.name}})
+                must.append({'term': {'db_version': mol_db.version}})
 
-        logger.info('Deleting annotation documents from ES: %s, %s', ds_id, mol_db)
-
-        if mol_db:
-            must.append({'term': {'db_name': mol_db.name}})
-            must.append({'term': {'db_version': mol_db.version}})
-
-        try:
-            resp = self._es.delete_by_query(index=self.index, body=body,
-                                            doc_type='annotation', conflicts='proceed')
-            logger.debug(resp)
-        except ElasticsearchException as e:
-            logger.warning('Annotation deletion failed: %s', e)
+            try:
+                resp = self._es.delete_by_query(index=self.index, body=body,
+                                                doc_type='annotation', conflicts='proceed')
+                logger.debug(resp)
+            except ElasticsearchException as e:
+                logger.warning('Annotation deletion failed: %s', e)

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -319,7 +319,7 @@ class ESExporter(object):
 
     def update_ds(self, ds_id, fields):
         with self._ds_locker.lock(ds_id):
-            pipeline_id = 'update-ds-fields'
+            pipeline_id = f'update-ds-fields-{ds_id}'
             if fields:
                 ds_doc = self._select_ds_by_id(ds_id)
 
@@ -361,6 +361,7 @@ class ESExporter(object):
                         'wait_for_completion': True,
                         'request_timeout': 60,
                     })
+                self._ingest.delete_pipeline(pipeline_id)
 
     def delete_ds(self, ds_id, mol_db=None):
         """

--- a/metaspace/engine/sm/engine/sm_daemons.py
+++ b/metaspace/engine/sm/engine/sm_daemons.py
@@ -272,8 +272,10 @@ class SMIndexUpdateDaemon(object):
 
     def _on_failure(self, msg):
         self.logger.error(f' SM update daemon: failure', exc_info=True)
-        ds = Dataset.load(self._db, msg['ds_id'])
-        ds.set_status(self._db, self._manager.es, self._manager.status_queue, DatasetStatus.FAILED)
+
+        if msg['action'] != 'update':
+            ds = Dataset.load(self._db, msg['ds_id'])
+            ds.set_status(self._db, self._manager.es, self._manager.status_queue, DatasetStatus.FAILED)
 
         self._manager.post_to_slack('hankey', f" [x] Failed to {msg['action']}: {json.dumps(msg)}")
 

--- a/metaspace/engine/sm/engine/tests/mock_graphql_schema.py
+++ b/metaspace/engine/sm/engine/tests/mock_graphql_schema.py
@@ -1,0 +1,28 @@
+MOCK_GRAPHQL_SCHEMA = '''
+    CREATE SCHEMA IF NOT EXISTS graphql;
+    CREATE TABLE IF NOT EXISTS graphql.dataset (
+        id              text,
+        user_id         uuid,
+        group_id        uuid,
+        group_approved  boolean
+    );
+    CREATE TABLE IF NOT EXISTS graphql.user (
+        id                  uuid,
+        name                text,
+        email               text,
+        not_verified_email  text
+    );
+    CREATE TABLE IF NOT EXISTS graphql.group (
+        id          uuid,
+        name        text,
+        short_name  text
+    );
+    CREATE TABLE IF NOT EXISTS graphql.dataset_project (
+        dataset_id  text,
+        project_id  uuid,
+        approved    boolean
+    );
+    CREATE TABLE IF NOT EXISTS graphql.project (
+        id          uuid,
+        name        text
+    );'''

--- a/metaspace/engine/sm/engine/tests/util.py
+++ b/metaspace/engine/sm/engine/tests/util.py
@@ -12,6 +12,7 @@ import uuid
 
 from sm.engine.db import DB
 from sm.engine.mol_db import MolecularDB
+from sm.engine.tests.mock_graphql_schema import MOCK_GRAPHQL_SCHEMA
 from sm.engine.util import proj_root, SMConfig, init_loggers
 from sm.engine.es_export import ESIndexManager
 
@@ -80,7 +81,7 @@ def pyspark_context(request):
     sc = SparkContext(master='local[2]')
     request.addfinalizer(lambda: sc.stop())
     return sc
-    
+
 
 @pytest.fixture()
 def test_db(sm_config, request):
@@ -98,35 +99,7 @@ def test_db(sm_config, request):
 
     db_config = dict(**sm_config['db'])
     db = DB(db_config, autocommit=True)
-    db.alter('''
-        CREATE SCHEMA IF NOT EXISTS graphql;
-        CREATE TABLE graphql.dataset (
-            id              text,
-            user_id         uuid,
-            group_id        uuid,
-            group_approved  boolean
-        );
-        CREATE TABLE graphql.user (
-            id                  uuid,
-            name                text,
-            email               text,
-            not_verified_email  text
-        );
-        CREATE TABLE graphql.group (
-            id          uuid,
-            name        text,
-            short_name  text
-        );
-        CREATE TABLE graphql.dataset_project (
-            dataset_id  text,
-            project_id  uuid,
-            approved    boolean
-        );
-        CREATE TABLE graphql.project (
-            id          uuid,
-            name        text
-        );'''
-    )
+    db.alter(MOCK_GRAPHQL_SCHEMA)
     db.close()
 
     def fin():

--- a/metaspace/engine/tests/sci_test_spheroid.py
+++ b/metaspace/engine/tests/sci_test_spheroid.py
@@ -12,6 +12,7 @@ from sm.engine.db import DB
 from sm.engine.mol_db import MolDBServiceWrapper
 from sm.engine.png_generator import ImageStoreServiceWrapper
 from sm.engine.util import proj_root, SMConfig, create_ds_from_files, init_loggers
+from sm.engine.tests.mock_graphql_schema import MOCK_GRAPHQL_SCHEMA
 
 SEARCH_RES_SELECT = ("select m.sf, m.adduct, m.stats "
                      "from iso_image_metrics m "
@@ -130,11 +131,14 @@ class SciTester(object):
 
         return ImageStoreMock()
 
-    def run_search(self, mock_img_store=False):
+    def run_search(self, mock_img_store=False, mock_graphql_db=False):
         if mock_img_store:
             img_store = self._create_img_store_mock()
         else:
             img_store = ImageStoreServiceWrapper(self.sm_config['services']['img_service_url'])
+        if mock_graphql_db:
+            self.db.alter(MOCK_GRAPHQL_SCHEMA)
+
         manager = SMDaemonManager(db=self.db, es=ESExporter(self.db),
                                  img_store=img_store)
 
@@ -155,6 +159,7 @@ if __name__ == '__main__':
                         default=join(proj_root(), 'conf/config.json'),
                         help='path to sm config file')
     parser.add_argument('--mock-img-store', action='store_true', help='whether to mock the Image Store Service')
+    parser.add_argument('--mock-graphql-db', action='store_true', help='whether to mock the graphql database schema')
     args = parser.parse_args()
 
     SMConfig.set_path(args.sm_config_path)
@@ -166,7 +171,7 @@ if __name__ == '__main__':
         run_search_successful = False
         search_results_different = False
         try:
-            sci_tester.run_search(args.mock_img_store)
+            sci_tester.run_search(args.mock_img_store, args.mock_graphql_db)
             run_search_successful = True
             search_results_different = sci_tester.search_results_are_different()
         except Exception as e:

--- a/metaspace/graphql/package.json
+++ b/metaspace/graphql/package.json
@@ -9,7 +9,8 @@
     "start": "ts-node src/index.ts",
     "test": "jest",
     "test-integration": "mocha --timeout 3000 tests/*RegrTest.js",
-    "gen-binding": "graphql-binding --language typescript --input schema.ts --outputBinding src/binding.ts"
+    "gen-binding": "graphql-binding --language typescript --input schema.ts --outputBinding src/binding.ts",
+    "deref-schema": "node deref_schema.js ./metadataSchemas/"
   },
   "license": "ISC",
   "dependencies": {

--- a/metaspace/graphql/src/modules/auth/operation.spec.ts
+++ b/metaspace/graphql/src/modules/auth/operation.spec.ts
@@ -89,7 +89,10 @@ describe('Database operations with user', () => {
     });
 
     let newCred = (await testEntityManager.findOne(Credentials)) as Credentials;
-    expect(newCred).toMatchObject(cred);
+    expect(newCred).toMatchObject({
+      ...cred,
+      hash: expect.anything(),
+    });
 
     expect(mockEmail.sendVerificationEmail).toHaveBeenCalledTimes(1);
     expect(mockEmail.sendVerificationEmail).toHaveBeenCalledWith('admin@localhost', expect.anything());
@@ -107,7 +110,7 @@ describe('Database operations with user', () => {
     });
 
     const newCred = (await testEntityManager.findOne(Credentials)) as Credentials;
-    expect(newCred.hash).toEqual(oldCred.hash);
+    expect(newCred.hash).not.toEqual(oldCred.hash);
     expect(newCred.emailVerificationToken).not.toEqual(oldCred.emailVerificationToken);
     expect(newCred.emailVerificationTokenExpires).toEqual(expect.anything());
     expect(newCred.emailVerificationTokenExpires!.valueOf())
@@ -127,7 +130,10 @@ describe('Database operations with user', () => {
     });
 
     const updCred = await testEntityManager.findOne(Credentials);
-    expect(updCred).toMatchObject(cred);
+    expect(updCred).toMatchObject({
+      ...cred,
+      hash: expect.anything(),
+    });
 
     expect(mockEmail.sendLoginEmail).toHaveBeenCalledTimes(1);
     expect(mockEmail.sendLoginEmail).toHaveBeenCalledWith('admin@localhost', expect.anything());

--- a/metaspace/graphql/src/modules/project/controller/Query.spec.ts
+++ b/metaspace/graphql/src/modules/project/controller/Query.spec.ts
@@ -148,7 +148,7 @@ describe('modules/project/controller (queries)', () => {
           const {id, name} = otherMember!;
           expectedMembers = expect.arrayContaining([{id, name, email: null}]);
         } else {
-          expectedMembers = null;
+          expectedMembers = [];
         }
 
         expect(members).toEqual(expectedMembers);
@@ -290,10 +290,10 @@ describe('modules/project/controller (queries)', () => {
       const result = await doQuery(query);
 
       expect(result.projects).toEqual(expect.arrayContaining([
-        {role: UPRO.INVITED, numDatasets: 0, project: { members: null }},
-        {role: UPRO.PENDING, numDatasets: 1, project: { members: null }},
-        {role: UPRO.MEMBER, numDatasets: 2, project: { members: expect.anything() }},
-        {role: UPRO.MANAGER, numDatasets: 3, project: { members: expect.anything() }},
+        {role: UPRO.INVITED, numDatasets: 0, project: { members: [] }},
+        {role: UPRO.PENDING, numDatasets: 1, project: { members: [] }},
+        {role: UPRO.MEMBER, numDatasets: 2, project: { members: expect.arrayContaining([expect.anything()]) }},
+        {role: UPRO.MANAGER, numDatasets: 3, project: { members: expect.arrayContaining([expect.anything()]) }},
       ]));
     })
   });

--- a/metaspace/graphql/src/utils/smAPI.ts
+++ b/metaspace/graphql/src/utils/smAPI.ts
@@ -75,6 +75,6 @@ export const smAPIUpdateDataset = async (id: string, updates: UpdateDatasetArgs)
       doc: updates
     });
   } catch (err) {
-    // TODO: Fix updates on busy datasets
+    logger.error('Failed to update dataset', err);
   }
 };


### PR DESCRIPTION
Review with white space comparison turned off, as most of the lines changed in es_export.py are only indentation changes.

Some compromises were needed. Discussion of alternatives is welcome:
* I had to [pick a different server backend](https://bottlepy.org/docs/dev/deployment.html#switching-the-server-backend) for bottle, because its default is single-threaded and can't dispatch messages fast enough to keep the update daemon workers working. I chose CherryPy because it is actively developed and doesn't rely on green threads or forks. CherryPy seems to default to 10 threads.
* I noticed that I now get a lot of these warnings about the Elasticsearch HTTP connections not being cleaned up:
    ```
    sm-api_1              | namedtuple_Column:14: ResourceWarning: unclosed <socket.socket fd=117, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('172.20.0.11', 34468), raddr=('172.20.0.3', 9200)>
    ```
    I compared against master - apparently I've always been getting warnings like this, but with CherryPy's multithreading they now come in large batches, all at once.
* Each `DatasetLocker` uses its own database connection. I found that psycopg2 can only apply transactions at the connection level, so I couldn't implement this using transactions. Also, Postgres 9.5 doesn't support the transaction-based advisory locks, so I was stuck using session-based advisory locks. Postgres defaults to a maximum of 100 connections, and I managed to hit that limit when I tried running with 32 worker threads. 
* Postgres' advisory locks don't support strings, only 32-bit and 64-bit integers. I've used a 32-bit hash of the dataset ID instead of locking on the exact ID itself.
* Using a single ElasticSearch pipeline name didn't scale to multiple threads, so now it uses a different name for each dataset and deletes the pipeline after use
* Updating a dataset doesn't change its status at all now. This means no status update is published, so the webapp won't automatically refresh the list after a name change. 

Locally, with these changes and 4 update daemon worker threads, it takes 160s to update the group name on 114 datasets. None of the Python processes use more than 1% CPU, and ElasticSearch uses 300-400%. I tried 8 and 16 threads and they took 120s but on 16 threads there was 1 request timeout failure and lagged everything else on my computer. I don't think the extra speed from 8 threads is worth the risk of lagging everything else on the system.

I also tried to fix the scientific test on CircleCI for extra certainty that I hadn't broken anything, but I couldn't get past this error: https://circleci.com/gh/metaspace2020/metaspace/1727