### PR TITLE
Add indicators for group/project invitations/requests

### DIFF
--- a/metaspace/graphql/schemas/group.graphql
+++ b/metaspace/graphql/schemas/group.graphql
@@ -4,6 +4,7 @@ type Group {
   shortName: String!
   urlSlug: String
   currentUserRole: UserGroupRole
+  hasPendingRequest: Boolean  # null if current user is not allowed to see
   numMembers: Int!
   members: [UserGroup!]    # null if current user is not allowed to see
 }

--- a/metaspace/graphql/schemas/project.graphql
+++ b/metaspace/graphql/schemas/project.graphql
@@ -4,6 +4,7 @@ type Project {
   isPublic: Boolean!
   urlSlug: String
   currentUserRole: UserProjectRole
+  hasPendingRequest: Boolean  # null if current user is not allowed to see
   members: [UserProject!]    # null if current user is not allowed to see
   numMembers: Int!
   numDatasets: Int!

--- a/metaspace/graphql/src/bindingTypes.ts
+++ b/metaspace/graphql/src/bindingTypes.ts
@@ -10,8 +10,7 @@ export type ScopeRole =
   | 'GROUP_MANAGER'
   | 'PROJECT_MEMBER'
   | 'PROJECT_MANAGER'
-  | 'OTHER'
-  | 'ADMIN';
+  | 'OTHER';
 
 export const ScopeRoleOptions: Record<ScopeRole, ScopeRole> = {
   PROFILE_OWNER: 'PROFILE_OWNER',
@@ -20,7 +19,6 @@ export const ScopeRoleOptions: Record<ScopeRole, ScopeRole> = {
   PROJECT_MEMBER: 'PROJECT_MEMBER',
   PROJECT_MANAGER: 'PROJECT_MANAGER',
   OTHER: 'OTHER',
-  ADMIN: 'ADMIN',
 };
 
 export interface Scope {

--- a/metaspace/graphql/src/modules/dataset/controller/Query.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Query.ts
@@ -10,24 +10,19 @@ import {Context} from '../../../context';
 const resolveDatasetScopeRole = async (ctx: Context, dsId: string) => {
   let scopeRole = SRO.OTHER;
   if (ctx.user) {
-    if (ctx.user.role === 'admin') {
-      scopeRole = SRO.ADMIN;
-    }
-    else {
-      if (dsId) {
-        const ds = await ctx.connection.getRepository(DatasetModel).findOne({
-          where: { id: dsId }
+    if (dsId) {
+      const ds = await ctx.connection.getRepository(DatasetModel).findOne({
+        where: { id: dsId }
+      });
+      if (ds) {
+        const userGroup = await ctx.connection.getRepository(UserGroupModel).findOne({
+          where: { userId: ctx.user.id, groupId: ds.groupId }
         });
-        if (ds) {
-          const userGroup = await ctx.connection.getRepository(UserGroupModel).findOne({
-            where: { userId: ctx.user.id, groupId: ds.groupId }
-          });
-          if (userGroup) {
-            if (userGroup.role === UserGroupRoleOptions.GROUP_ADMIN)
-              scopeRole = SRO.GROUP_MANAGER;
-            else if (userGroup.role === UserGroupRoleOptions.MEMBER)
-              scopeRole = SRO.GROUP_MEMBER;
-          }
+        if (userGroup) {
+          if (userGroup.role === UserGroupRoleOptions.GROUP_ADMIN)
+            scopeRole = SRO.GROUP_MANAGER;
+          else if (userGroup.role === UserGroupRoleOptions.MEMBER)
+            scopeRole = SRO.GROUP_MEMBER;
         }
       }
     }

--- a/metaspace/graphql/src/modules/dataset/util/getScopeRoleForEsDataset.ts
+++ b/metaspace/graphql/src/modules/dataset/util/getScopeRoleForEsDataset.ts
@@ -4,9 +4,7 @@ import {Context} from '../../../context';
 
 export default async (ds: DatasetSource, ctx: Context) => {
   if (ctx.user != null) {
-    if (ctx.isAdmin) {
-      return SRO.ADMIN;
-    } else if (ctx.user.id === ds._source.ds_submitter_id) {
+    if (ctx.user.id === ds._source.ds_submitter_id) {
       return SRO.PROFILE_OWNER;
     } else if (ctx.user && ctx.user.groupIds && ds._source.ds_group_id && ctx.user.groupIds.includes(ds._source.ds_group_id)) {
       return SRO.GROUP_MEMBER; //TODO: Differentiate manager vs member?

--- a/metaspace/graphql/src/modules/group/util/resolveGroupScopeRole.ts
+++ b/metaspace/graphql/src/modules/group/util/resolveGroupScopeRole.ts
@@ -1,0 +1,21 @@
+import {Context} from '../../../context';
+import {ScopeRole, ScopeRoleOptions} from '../../../bindingTypes';
+import {UserGroup as UserGroupModel, UserGroupRoleOptions} from '../model';
+
+export const resolveGroupScopeRole = async (ctx: Context, groupId?: string): Promise<ScopeRole> => {
+  let scopeRole = ScopeRoleOptions.OTHER;
+  if (ctx.user != null && groupId) {
+    const userGroup = await ctx.connection.getRepository(UserGroupModel).findOne({
+      where: { userId: ctx.user.id, groupId },
+    });
+    if (userGroup) {
+      if (userGroup.role == UserGroupRoleOptions.MEMBER) {
+        scopeRole = ScopeRoleOptions.GROUP_MEMBER;
+      }
+      else if (userGroup.role == UserGroupRoleOptions.GROUP_ADMIN) {
+        scopeRole = ScopeRoleOptions.GROUP_MANAGER;
+      }
+    }
+  }
+  return scopeRole;
+};

--- a/metaspace/graphql/src/modules/user/controller.ts
+++ b/metaspace/graphql/src/modules/user/controller.ts
@@ -16,6 +16,7 @@ import {convertUserToUserSource} from './util/convertUserToUserSource';
 import {smAPIUpdateDataset} from '../../utils/smAPI';
 import {deleteDataset} from '../dataset/operation/deleteDataset';
 import {patchPassportIntoLiveRequest} from '../auth/middleware';
+import {resolveGroupScopeRole} from '../group/util/resolveGroupScopeRole';
 
 const assertCanEditUser = (user: ContextUser | null, userId: string) => {
   if (!user || !user.id)
@@ -27,13 +28,8 @@ const assertCanEditUser = (user: ContextUser | null, userId: string) => {
 
 const resolveUserScopeRole = async (ctx: Context, userId?: string): Promise<ScopeRole> => {
   let scopeRole = SRO.OTHER;
-  if (ctx.isAdmin) {
-    scopeRole = SRO.ADMIN;
-  }
-  else {
-    if (userId && ctx.user != null && userId === ctx.user.id) {
-      scopeRole = SRO.PROFILE_OWNER;
-    }
+  if (userId && ctx.user != null && userId === ctx.user.id) {
+    scopeRole = SRO.PROFILE_OWNER;
   }
   return scopeRole;
 };
@@ -42,7 +38,7 @@ export const Resolvers = {
   User: {
     async primaryGroup({scopeRole, ...user}: UserSource, _: any,
                        ctx: Context): Promise<LooselyCompatible<UserGroup>|null> {
-      if ([SRO.ADMIN, SRO.PROFILE_OWNER].includes(scopeRole)) {
+      if (scopeRole === SRO.PROFILE_OWNER || ctx.isAdmin) {
         return await ctx.connection.getRepository(UserGroupModel).findOne({
           where: { userId: user.id, primary: true },
           relations: ['group', 'user']
@@ -52,17 +48,26 @@ export const Resolvers = {
     },
 
     async groups({scopeRole, ...user}: UserSource, _: any, ctx: Context): Promise<LooselyCompatible<UserGroup>[]|null> {
-      if ([SRO.ADMIN, SRO.PROFILE_OWNER].includes(scopeRole)) {
-        return await ctx.connection.getRepository(UserGroupModel).find({
+      if (scopeRole === SRO.PROFILE_OWNER || ctx.isAdmin) {
+        const userGroups = await ctx.connection.getRepository(UserGroupModel).find({
           where: { userId: user.id },
           relations: ['group', 'user']
         });
+        return await Promise.all(userGroups.map(async userGroup => {
+          return {
+            ...userGroup,
+            group: {
+              ...userGroup.group,
+              scopeRole: await resolveGroupScopeRole(ctx, userGroup.group.id)
+            }
+          };
+        }));
       }
       return null;
     },
 
     async projects(user: UserSource, args: any, ctx: Context): Promise<UserProjectSource[]|null> {
-      if ([SRO.ADMIN, SRO.PROFILE_OWNER].includes(user.scopeRole)) {
+      if (user.scopeRole === SRO.PROFILE_OWNER || ctx.isAdmin) {
         const userProjects = await ctx.connection.getRepository(UserProjectModel)
           .find({userId: user.id});
         return userProjects.map(userProject => ({ ...userProject, user }));
@@ -70,15 +75,15 @@ export const Resolvers = {
       return null;
     },
 
-    async email({scopeRole, ...user}: UserSource): Promise<string|null> {
-      if ([SRO.GROUP_MANAGER, SRO.PROJECT_MANAGER, SRO.ADMIN, SRO.PROFILE_OWNER].includes(scopeRole)) {
+    async email({scopeRole, ...user}: UserSource, args: any, ctx: Context): Promise<string|null> {
+      if ([SRO.GROUP_MANAGER, SRO.PROJECT_MANAGER, SRO.PROFILE_OWNER].includes(scopeRole) || ctx.isAdmin) {
         return user.email || user.notVerifiedEmail || null;
       }
       return null;
     },
 
-    async role({scopeRole, ...user}: UserSource): Promise<string|null> {
-      if ([SRO.ADMIN, SRO.PROFILE_OWNER].includes(scopeRole)) {
+    async role({scopeRole, ...user}: UserSource, args: any, ctx: Context): Promise<string|null> {
+      if (scopeRole === SRO.PROFILE_OWNER || ctx.isAdmin) {
         return user.role || null;
       }
       return null;

--- a/metaspace/webapp/package.json
+++ b/metaspace/webapp/package.json
@@ -147,6 +147,7 @@
     },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "setupTestFrameworkScriptFile": "<rootDir>/tests/utils/setupTestFramework.ts",
+    "clearMocks": true,
     "restoreMocks": true,
     "moduleFileExtensions": [
       "ts",

--- a/metaspace/webapp/src/api/user.ts
+++ b/metaspace/webapp/src/api/user.ts
@@ -11,6 +11,7 @@ export interface UserProfileQueryGroup {
     id: string,
     name: string
     urlSlug: string | null;
+    hasPendingRequest: boolean | null;
   };
 }
 export interface UserProfileQueryProject {
@@ -20,6 +21,7 @@ export interface UserProfileQueryProject {
     id: string,
     name: string
     urlSlug: string | null;
+    hasPendingRequest: boolean | null;
   };
 }
 
@@ -53,6 +55,7 @@ export const userProfileQuery =
         id
         name
         urlSlug
+        hasPendingRequest
       }
     }
   }
@@ -64,6 +67,7 @@ fragment UserProfileQueryGroup on UserGroup {
     id
     name
     urlSlug
+    hasPendingRequest
   }
 }
 `;

--- a/metaspace/webapp/src/components/NotificationIcon.vue
+++ b/metaspace/webapp/src/components/NotificationIcon.vue
@@ -1,0 +1,27 @@
+<template>
+  <el-tooltip v-if="tooltip != null" :content="tooltip" :placement="tooltipPlacement">
+    <span class="notification" />
+  </el-tooltip>
+  <span v-else class="notification" />
+</template>
+<script>
+  export default {
+    props: {
+      tooltip: String,
+      tooltipPlacement: String
+    }
+  }
+</script>
+<style scoped lang="scss">
+  @import "~element-ui/packages/theme-chalk/src/common/var";
+  .notification:before {
+    content: '';
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 5px;
+    margin-left: 4px;
+    vertical-align: middle;
+    background-color: $--color-success;
+  }
+</style>

--- a/metaspace/webapp/src/modules/App/MetaspaceHeader.spec.ts
+++ b/metaspace/webapp/src/modules/App/MetaspaceHeader.spec.ts
@@ -36,7 +36,15 @@ describe('MetaspaceHeader', () => {
               name: 'Test Group',
               urlSlug: null
             }
-          }
+          },
+          groups: [
+            {role: 'MEMBER', group: {hasPendingRequest: null}},
+            {role: 'GROUP_ADMIN', group: {hasPendingRequest: false}},
+          ],
+          projects: [
+            {role: 'PENDING', project: {hasPendingRequest: null}},
+            {role: 'MANAGER', project: {hasPendingRequest: true}},
+          ],
         })
       })
     });

--- a/metaspace/webapp/src/modules/App/MetaspaceHeader.vue
+++ b/metaspace/webapp/src/modules/App/MetaspaceHeader.vue
@@ -56,12 +56,14 @@
             <div class="header-item submenu-header"
                  :class="{'router-link-active': matchesRoute('/user/me')}">
               <div class="limit-width" style="color: white;">
-              {{ userNameOrEmail }}
+                {{ userNameOrEmail }}
+                <notification-icon v-if="pendingRequestMessage != null" :tooltip="pendingRequestMessage" tooltipPlacement="left" />
               </div>
             </div>
             <div class="submenu">
               <router-link to="/user/me" class="submenu-item page-link">
                 My account
+                <notification-icon v-if="pendingRequestMessage != null" :tooltip="pendingRequestMessage" tooltipPlacement="left" />
               </router-link>
               <div class="submenu-item page-link" @click="logout">
                 Sign out
@@ -81,11 +83,18 @@
   import gql from 'graphql-tag';
  import {signOut} from '../../api/auth';
   import {getSystemHealthQuery, getSystemHealthSubscribeToMore} from '../../api/system';
+  import {UserGroupRoleOptions as UGRO} from '../../api/group';
+  import {ProjectRoleOptions as UPRO} from '../../api/project';
  import {encodeParams} from '../Filters';
   import {refreshLoginStatus} from '../../graphqlClient';
+  import NotificationIcon from '../../components/NotificationIcon.vue';
 
  export default {
    name: 'metaspace-header',
+
+   components: {
+     NotificationIcon,
+   },
 
    computed: {
      uploadHref() {
@@ -127,6 +136,27 @@
      },
      healthSeverity() {
        return this.systemHealth && this.systemHealth.canMutate === false ? 'warning' : 'info';
+     },
+     pendingRequestMessage() {
+       if (this.currentUser != null) {
+         if (this.currentUser.groups != null) {
+           const invitedGroup = this.currentUser.groups.find(g => g.role === UGRO.INVITED);
+           const requestGroup = this.currentUser.groups.find(g => g.role === UGRO.GROUP_ADMIN && g.group.hasPendingRequest);
+           if (invitedGroup != null)
+             return `You have been invited to join ${invitedGroup.group.name}.`;
+           if (requestGroup != null)
+             return `${requestGroup.group.name} has a pending membership request.`;
+         }
+         if (this.currentUser.projects != null) {
+           const invitedProject = this.currentUser.projects.find(g => g.role === UPRO.INVITED);
+           const requestProject = this.currentUser.projects.find(g => g.role === UPRO.MANAGER && g.project.hasPendingRequest);
+           if (invitedProject != null)
+             return `You have been invited to join ${invitedProject.project.name}.`;
+           if (requestProject != null)
+             return `${requestProject.project.name} has a pending membership request.`;
+         }
+       }
+       return null;
      }
    },
 
@@ -157,6 +187,22 @@
                shortName
                name
                urlSlug
+             }
+           }
+           groups {
+             role
+             group {
+               id
+               name
+               hasPendingRequest
+             }
+           }
+           projects {
+             role
+             project {
+               id
+               name
+               hasPendingRequest
              }
            }
          }

--- a/metaspace/webapp/src/modules/App/__snapshots__/MetaspaceHeader.spec.ts.snap
+++ b/metaspace/webapp/src/modules/App/__snapshots__/MetaspaceHeader.spec.ts.snap
@@ -36,11 +36,13 @@ exports[`MetaspaceHeader should match snapshot (logged in) 1`] = `
           <div class="header-item submenu-header">
             <div class="limit-width" style="color: white;">
               Test User
+              <mock-el-tooltip content="currentUser.projects.1.project.name has a pending membership request." placement="left"><span class="notification"></span></mock-el-tooltip>
             </div>
           </div>
           <div class="submenu">
             <a href="/user/me" class="submenu-item page-link">
               My account
+              <mock-el-tooltip content="currentUser.projects.1.project.name has a pending membership request." placement="left"><span class="notification"></span></mock-el-tooltip>
             </a>
             <div class="submenu-item page-link">
               Sign out

--- a/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.spec.ts
+++ b/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.spec.ts
@@ -158,6 +158,7 @@ describe('ViewGroupPage', () => {
 
     expect(router.currentRoute.params.groupIdOrSlug).toEqual(urlSlug);
     // Assert that the correct graphql calls were made. See the GraphQLFieldResolver type for details on the args here
+    expect(mockGroupFn).toHaveBeenCalledTimes(2);
     expect(mockGroupFn.mock.calls[0][1].groupId).toEqual(mockGroup.id);
     expect(mockGroupFn.mock.calls[0][3].fieldName).toEqual('group');
     expect(mockGroupFn.mock.calls[1][1].urlSlug).toEqual(urlSlug);

--- a/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.vue
@@ -131,12 +131,12 @@
         query() {
           if (isUuid(this.$route.params.groupIdOrSlug)) {
             return gql`query GroupProfileById($groupIdOrSlug: ID!) {
-              group(groupId: $groupIdOrSlug) { ...ViewGroupFragment }
+              group(groupId: $groupIdOrSlug) { ...ViewGroupFragment hasPendingRequest }
             }
             ${ViewGroupFragment}`;
           } else {
             return gql`query GroupProfileBySlug($groupIdOrSlug: String!) {
-              group: groupByUrlSlug(urlSlug: $groupIdOrSlug) { ...ViewGroupFragment }
+              group: groupByUrlSlug(urlSlug: $groupIdOrSlug) { ...ViewGroupFragment hasPendingRequest }
             }
             ${ViewGroupFragment}`;
           }
@@ -144,6 +144,9 @@
         variables() {
           return {groupIdOrSlug: this.$route.params.groupIdOrSlug};
         },
+        // Can't be 'no-cache' because `refetchGroup` is used for updating the cache, which in turn updates
+        // MetaspaceHeader's primaryGroup & the group.hasPendingRequest notification
+        fetchPolicy: 'network-only',
         loadingKey: 'groupLoading'
       },
       data: {

--- a/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.vue
@@ -56,7 +56,7 @@
         <el-tab-pane name="members" lazy>
           <span slot="label">
             {{'Members' | optionalSuffixInParens(countMembers)}}
-            <span v-if="hasMembershipRequest" class="notification" />
+            <notification-icon v-if="hasMembershipRequest" />
           </span>
           <div style="max-width: 950px">
             <group-members-list
@@ -99,6 +99,7 @@
   import GroupSettings from './GroupSettings.vue';
   import {encodeParams} from '../Filters';
   import ConfirmAsync from '../../components/ConfirmAsync';
+  import NotificationIcon from '../../components/NotificationIcon.vue';
   import reportError from '../../lib/reportError';
   import {currentUserRoleQuery, CurrentUserRoleResult} from '../../api/user';
   import isUuid from '../../lib/isUuid';
@@ -117,6 +118,7 @@
       GroupMembersList,
       GroupSettings,
       TransferDatasetsDialog,
+      NotificationIcon,
     },
     filters: {
       optionalSuffixInParens,
@@ -383,17 +385,6 @@
     flex-grow: 1;
     align-self: center;
     margin-right: 3px;
-  }
-
-  .notification:before {
-    content: '';
-    display: inline-block;
-    width: 10px;
-    height: 10px;
-    border-radius: 5px;
-    margin-left: 4px;
-    vertical-align: middle;
-    background-color: $--color-success;
   }
 
   .hidden-members-text {

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupPage.spec.ts.snap
@@ -168,27 +168,27 @@ exports[`ViewGroupPage members tab should match snapshot (manager, including tab
                 <div class="el-table__header-wrapper">
                   <table cellspacing="0" cellpadding="0" border="0" class="el-table__header" style="width: 850px;">
                     <colgroup>
-                      <col name="el-table_2_column_5" width="200">
-                      <col name="el-table_2_column_6" width="200">
-                      <col name="el-table_2_column_7" width="160">
-                      <col name="el-table_2_column_8" width="90">
-                      <col name="el-table_2_column_9" width="200">
+                      <col name="el-table_1_column_1" width="200">
+                      <col name="el-table_1_column_2" width="200">
+                      <col name="el-table_1_column_3" width="160">
+                      <col name="el-table_1_column_4" width="90">
+                      <col name="el-table_1_column_5" width="200">
                     </colgroup>
                     <thead class="">
                       <tr class="">
-                        <th colspan="1" rowspan="1" class="el-table_2_column_5     is-leaf">
+                        <th colspan="1" rowspan="1" class="el-table_1_column_1     is-leaf">
                           <div class="cell">Name</div>
                         </th>
-                        <th colspan="1" rowspan="1" class="el-table_2_column_6     is-leaf">
+                        <th colspan="1" rowspan="1" class="el-table_1_column_2     is-leaf">
                           <div class="cell">Email</div>
                         </th>
-                        <th colspan="1" rowspan="1" class="el-table_2_column_7     is-leaf">
+                        <th colspan="1" rowspan="1" class="el-table_1_column_3     is-leaf">
                           <div class="cell">Role</div>
                         </th>
-                        <th colspan="1" rowspan="1" class="el-table_2_column_8  is-center   is-leaf">
+                        <th colspan="1" rowspan="1" class="el-table_1_column_4  is-center   is-leaf">
                           <div class="cell">Datasets</div>
                         </th>
-                        <th colspan="1" rowspan="1" class="el-table_2_column_9     is-leaf">
+                        <th colspan="1" rowspan="1" class="el-table_1_column_5     is-leaf">
                           <div class="cell"></div>
                         </th>
                       </tr>
@@ -198,37 +198,37 @@ exports[`ViewGroupPage members tab should match snapshot (manager, including tab
                 <div class="el-table__body-wrapper is-scrolling-left">
                   <table cellspacing="0" cellpadding="0" border="0" class="el-table__body" style="width: 850px;">
                     <colgroup>
-                      <col name="el-table_2_column_5" width="200">
-                      <col name="el-table_2_column_6" width="200">
-                      <col name="el-table_2_column_7" width="160">
-                      <col name="el-table_2_column_8" width="90">
-                      <col name="el-table_2_column_9" width="200">
+                      <col name="el-table_1_column_1" width="200">
+                      <col name="el-table_1_column_2" width="200">
+                      <col name="el-table_1_column_3" width="160">
+                      <col name="el-table_1_column_4" width="90">
+                      <col name="el-table_1_column_5" width="200">
                     </colgroup>
                     <tbody>
                       <tr class="el-table__row">
-                        <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                           <div class="cell">
                             me
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
                           <div class="cell">
                             my-email@example.com
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_7  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
                           <div class="cell">
                             <a href="#" title="Change role">
                               Group admin
                             </a>
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_8 is-center ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                           <div class="cell">
                             <a href="/datasets?grp=00000000-1111-2222-3333-444444444444&amp;subm=3" class="">123</a>
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_9  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
                           <div class="cell">
                             <!---->
                             <!---->
@@ -238,27 +238,27 @@ exports[`ViewGroupPage members tab should match snapshot (manager, including tab
                         </td>
                       </tr>
                       <tr class="el-table__row">
-                        <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                           <div class="cell">
                             Person who asked to join
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
                           <div class="cell">
                             access@requestor.com
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_7  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
                           <div class="cell"><span>
           Requesting access
         </span></div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_8 is-center ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                           <div class="cell">
                             <a href="/datasets?grp=00000000-1111-2222-3333-444444444444&amp;subm=4" class="">0</a>
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_9  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
                           <div class="cell">
                             <!---->
                             <!---->
@@ -276,27 +276,27 @@ exports[`ViewGroupPage members tab should match snapshot (manager, including tab
                         </td>
                       </tr>
                       <tr class="el-table__row">
-                        <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                           <div class="cell">
                             Invitee
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
                           <div class="cell">
                             awaiting@response.com
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_7  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
                           <div class="cell"><span>
           Invited
         </span></div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_8 is-center ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                           <div class="cell">
                             <a href="/datasets?grp=00000000-1111-2222-3333-444444444444&amp;subm=5" class="">0</a>
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_9  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
                           <div class="cell">
                             <!---->
                             <button type="button" class="el-button grid-button el-button--default el-button--mini">
@@ -310,29 +310,29 @@ exports[`ViewGroupPage members tab should match snapshot (manager, including tab
                         </td>
                       </tr>
                       <tr class="el-table__row">
-                        <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                           <div class="cell">
                             Project member
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
                           <div class="cell">
                             person@embl.de
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_7  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
                           <div class="cell">
                             <a href="#" title="Change role">
                               Member
                             </a>
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_8 is-center ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                           <div class="cell">
                             <a href="/datasets?grp=00000000-1111-2222-3333-444444444444&amp;subm=6" class="">1</a>
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_9  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
                           <div class="cell">
                             <button type="button" class="el-button grid-button el-button--default el-button--mini">
                               <!---->

--- a/metaspace/webapp/src/modules/Project/ViewProjectPage.spec.ts
+++ b/metaspace/webapp/src/modules/Project/ViewProjectPage.spec.ts
@@ -5,7 +5,6 @@ import router from '../../router';
 import { initMockGraphqlClient, provide } from '../../../tests/utils/mockGraphqlClient';
 
 
-
 describe('ViewProjectPage', () => {
   const mockMembersForManagers = [
     {
@@ -158,6 +157,7 @@ describe('ViewProjectPage', () => {
 
     expect(router.currentRoute.params.projectIdOrSlug).toEqual(urlSlug);
     // Assert that the correct graphql calls were made. See the GraphQLFieldResolver type for details on the args here
+    expect(mockProjectFn).toHaveBeenCalledTimes(2);
     expect(mockProjectFn.mock.calls[0][1].projectId).toEqual(mockProject.id);
     expect(mockProjectFn.mock.calls[0][3].fieldName).toEqual('project');
     expect(mockProjectFn.mock.calls[1][1].urlSlug).toEqual(urlSlug);

--- a/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
+++ b/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
@@ -120,12 +120,12 @@
         query() {
           if (isUuid(this.$route.params.projectIdOrSlug)) {
             return gql`query ProjectProfileById($projectIdOrSlug: ID!) {
-              project(projectId: $projectIdOrSlug) { ...ViewProjectFragment }
+              project(projectId: $projectIdOrSlug) { ...ViewProjectFragment hasPendingRequest }
             }
             ${ViewProjectFragment}`;
           } else {
             return gql`query ProjectProfileBySlug($projectIdOrSlug: String!) {
-              project: projectByUrlSlug(urlSlug: $projectIdOrSlug) { ...ViewProjectFragment }
+              project: projectByUrlSlug(urlSlug: $projectIdOrSlug) { ...ViewProjectFragment hasPendingRequest }
             }
             ${ViewProjectFragment}`;
           }
@@ -133,6 +133,9 @@
         variables() {
           return {projectIdOrSlug: this.$route.params.projectIdOrSlug};
         },
+        // Can't be 'no-cache' because `refetchProject` is used for updating the cache, which in turn updates
+        // MetaspaceHeader's project.hasPendingRequest notification
+        fetchPolicy: 'network-only',
         loadingKey: 'projectLoading'
       },
       data: {

--- a/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
+++ b/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
@@ -48,7 +48,7 @@
         <el-tab-pane name="members" lazy>
           <span slot="label">
             {{'Members' | optionalSuffixInParens(countMembers)}}
-            <span v-if="hasMembershipRequest" class="notification" />
+            <notification-icon v-if="hasMembershipRequest" />
           </span>
           <div style="max-width: 950px">
             <project-members-list
@@ -87,6 +87,7 @@
   import gql from 'graphql-tag';
   import {encodeParams} from '../Filters';
   import ConfirmAsync from '../../components/ConfirmAsync';
+  import NotificationIcon from '../../components/NotificationIcon.vue';
   import reportError from '../../lib/reportError';
   import {currentUserRoleQuery, CurrentUserRoleResult} from '../../api/user';
   import isUuid from '../../lib/isUuid';
@@ -106,6 +107,7 @@
       DatasetList,
       ProjectMembersList,
       ProjectSettings,
+      NotificationIcon,
     },
     filters: {
       optionalSuffixInParens,
@@ -355,17 +357,6 @@
     flex-grow: 1;
     align-self: center;
     margin-right: 3px;
-  }
-
-  .notification:before {
-    content: '';
-    display: inline-block;
-    width: 10px;
-    height: 10px;
-    border-radius: 5px;
-    margin-left: 4px;
-    vertical-align: middle;
-    background-color: $--color-success;
   }
 
   .hidden-members-text {

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
@@ -163,27 +163,27 @@ exports[`ViewProjectPage members tab should match snapshot (manager, including t
                 <div class="el-table__header-wrapper">
                   <table cellspacing="0" cellpadding="0" border="0" class="el-table__header" style="width: 850px;">
                     <colgroup>
-                      <col name="el-table_2_column_5" width="200">
-                      <col name="el-table_2_column_6" width="200">
-                      <col name="el-table_2_column_7" width="160">
-                      <col name="el-table_2_column_8" width="90">
-                      <col name="el-table_2_column_9" width="200">
+                      <col name="el-table_1_column_1" width="200">
+                      <col name="el-table_1_column_2" width="200">
+                      <col name="el-table_1_column_3" width="160">
+                      <col name="el-table_1_column_4" width="90">
+                      <col name="el-table_1_column_5" width="200">
                     </colgroup>
                     <thead class="">
                       <tr class="">
-                        <th colspan="1" rowspan="1" class="el-table_2_column_5     is-leaf">
+                        <th colspan="1" rowspan="1" class="el-table_1_column_1     is-leaf">
                           <div class="cell">Name</div>
                         </th>
-                        <th colspan="1" rowspan="1" class="el-table_2_column_6     is-leaf">
+                        <th colspan="1" rowspan="1" class="el-table_1_column_2     is-leaf">
                           <div class="cell">Email</div>
                         </th>
-                        <th colspan="1" rowspan="1" class="el-table_2_column_7     is-leaf">
+                        <th colspan="1" rowspan="1" class="el-table_1_column_3     is-leaf">
                           <div class="cell">Role</div>
                         </th>
-                        <th colspan="1" rowspan="1" class="el-table_2_column_8  is-center   is-leaf">
+                        <th colspan="1" rowspan="1" class="el-table_1_column_4  is-center   is-leaf">
                           <div class="cell">Datasets</div>
                         </th>
-                        <th colspan="1" rowspan="1" class="el-table_2_column_9     is-leaf">
+                        <th colspan="1" rowspan="1" class="el-table_1_column_5     is-leaf">
                           <div class="cell"></div>
                         </th>
                       </tr>
@@ -193,37 +193,37 @@ exports[`ViewProjectPage members tab should match snapshot (manager, including t
                 <div class="el-table__body-wrapper is-scrolling-left">
                   <table cellspacing="0" cellpadding="0" border="0" class="el-table__body" style="width: 850px;">
                     <colgroup>
-                      <col name="el-table_2_column_5" width="200">
-                      <col name="el-table_2_column_6" width="200">
-                      <col name="el-table_2_column_7" width="160">
-                      <col name="el-table_2_column_8" width="90">
-                      <col name="el-table_2_column_9" width="200">
+                      <col name="el-table_1_column_1" width="200">
+                      <col name="el-table_1_column_2" width="200">
+                      <col name="el-table_1_column_3" width="160">
+                      <col name="el-table_1_column_4" width="90">
+                      <col name="el-table_1_column_5" width="200">
                     </colgroup>
                     <tbody>
                       <tr class="el-table__row">
-                        <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                           <div class="cell">
                             me
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
                           <div class="cell">
                             my-email@example.com
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_7  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
                           <div class="cell">
                             <a href="#" title="Change role">
                               Project manager
                             </a>
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_8 is-center ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                           <div class="cell">
                             <a href="/datasets?prj=00000000-1111-2222-3333-444444444444&amp;subm=3" class="">123</a>
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_9  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
                           <div class="cell">
                             <!---->
                             <!---->
@@ -233,29 +233,29 @@ exports[`ViewProjectPage members tab should match snapshot (manager, including t
                         </td>
                       </tr>
                       <tr class="el-table__row">
-                        <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                           <div class="cell">
                             Project member
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
                           <div class="cell">
                             person@embl.de
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_7  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
                           <div class="cell">
                             <a href="#" title="Change role">
                               Member
                             </a>
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_8 is-center ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                           <div class="cell">
                             <a href="/datasets?prj=00000000-1111-2222-3333-444444444444&amp;subm=6" class="">1</a>
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_9  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
                           <div class="cell">
                             <button type="button" class="el-button grid-button el-button--default el-button--mini">
                               <!---->
@@ -269,27 +269,27 @@ exports[`ViewProjectPage members tab should match snapshot (manager, including t
                         </td>
                       </tr>
                       <tr class="el-table__row">
-                        <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                           <div class="cell">
                             Person who asked to join
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
                           <div class="cell">
                             access@requestor.com
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_7  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
                           <div class="cell"><span>
           Requesting access
         </span></div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_8 is-center ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                           <div class="cell">
                             <a href="/datasets?prj=00000000-1111-2222-3333-444444444444&amp;subm=4" class="">0</a>
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_9  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
                           <div class="cell">
                             <!---->
                             <!---->
@@ -307,27 +307,27 @@ exports[`ViewProjectPage members tab should match snapshot (manager, including t
                         </td>
                       </tr>
                       <tr class="el-table__row">
-                        <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                           <div class="cell">
                             Invitee
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
                           <div class="cell">
                             awaiting@response.com
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_7  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
                           <div class="cell"><span>
           Invited
         </span></div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_8 is-center ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_4 is-center ">
                           <div class="cell">
                             <a href="/datasets?prj=00000000-1111-2222-3333-444444444444&amp;subm=5" class="">0</a>
                           </div>
                         </td>
-                        <td rowspan="1" colspan="1" class="el-table_2_column_9  ">
+                        <td rowspan="1" colspan="1" class="el-table_1_column_5  ">
                           <div class="cell">
                             <!---->
                             <button type="button" class="el-button grid-button el-button--default el-button--mini">

--- a/metaspace/webapp/src/modules/UserProfile/GroupsTable.vue
+++ b/metaspace/webapp/src/modules/UserProfile/GroupsTable.vue
@@ -12,6 +12,10 @@
         <el-table-column label="Group">
           <template slot-scope="scope">
             <router-link :to="scope.row.route">{{scope.row.name}}</router-link>
+            <notification-icon
+              v-if="scope.row.hasPendingRequest"
+              :tooltip="`${scope.row.name} has a pending membership request.`"
+              tooltipPlacement="right" />
           </template>
         </el-table-column>
         <el-table-column prop="roleName" label="Role" width="160" />
@@ -75,6 +79,7 @@
   } from '../../api/group';
   import reportError from '../../lib/reportError';
   import ConfirmAsync from '../../components/ConfirmAsync';
+  import NotificationIcon from '../../components/NotificationIcon.vue';
   import { encodeParams } from '../Filters';
   import { TransferDatasetsDialog } from '../GroupProfile';
 
@@ -88,7 +93,8 @@
 
   @Component({
     components: {
-      TransferDatasetsDialog
+      TransferDatasetsDialog,
+      NotificationIcon,
     }
   })
   export default class GroupsTable extends Vue {
@@ -104,10 +110,10 @@
       if (this.currentUser != null && this.currentUser.groups != null) {
         return this.currentUser.groups.map((item) => {
           const {group, numDatasets, role} = item;
-          const {id, name, urlSlug} = group;
+          const {id, name, urlSlug, hasPendingRequest} = group;
 
           return {
-            id, name, role, numDatasets,
+            id, name, role, numDatasets, hasPendingRequest,
             roleName: getRoleName(role),
             route: {
               name: 'group',

--- a/metaspace/webapp/src/modules/UserProfile/ProjectsTable.vue
+++ b/metaspace/webapp/src/modules/UserProfile/ProjectsTable.vue
@@ -11,6 +11,10 @@
         <el-table-column label="Project">
           <template slot-scope="scope">
             <router-link :to="scope.row.route">{{scope.row.name}}</router-link>
+            <notification-icon
+              v-if="scope.row.hasPendingRequest"
+              :tooltip="`${scope.row.name} has a pending membership request.`"
+              tooltipPlacement="right" />
           </template>
         </el-table-column>
         <el-table-column prop="roleName" label="Role" width="160" />
@@ -70,6 +74,7 @@
   import { acceptProjectInvitationMutation, getRoleName, leaveProjectMutation, ProjectRole } from '../../api/project';
   import reportError from '../../lib/reportError';
   import ConfirmAsync from '../../components/ConfirmAsync';
+  import NotificationIcon from '../../components/NotificationIcon.vue';
   import { encodeParams } from '../Filters';
   import { CreateProjectDialog } from '../Project';
 
@@ -84,7 +89,8 @@
 
   @Component({
     components: {
-      CreateProjectDialog
+      CreateProjectDialog,
+      NotificationIcon,
     }
   })
   export default class ProjectsTable extends Vue {
@@ -101,10 +107,10 @@
       if (this.currentUser != null && this.currentUser.projects != null) {
         return this.currentUser.projects.map((item) => {
           const {project, numDatasets, role} = item;
-          const {id, name, urlSlug} = project;
+          const {id, name, urlSlug, hasPendingRequest} = project;
 
           return {
-            id, name, role, numDatasets,
+            id, name, role, numDatasets, hasPendingRequest,
             roleName: getRoleName(role),
             route: {
               name: 'project',

--- a/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
@@ -138,6 +138,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                     <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                       <div class="cell">
                         <a href="/group/grp-a" class="">Group A</a>
+                        <mock-el-tooltip content="Group A has a pending membership request." placement="right"><span class="notification"></span></mock-el-tooltip>
                       </div>
                     </td>
                     <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
@@ -164,6 +165,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                     <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                       <div class="cell">
                         <a href="/group/BBB" class="">Group B</a>
+                        <!---->
                       </div>
                     </td>
                     <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
@@ -194,6 +196,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                     <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                       <div class="cell">
                         <a href="/group/CCC" class="">Group C</a>
+                        <mock-el-tooltip content="Group C has a pending membership request." placement="right"><span class="notification"></span></mock-el-tooltip>
                       </div>
                     </td>
                     <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
@@ -216,6 +219,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                     <td rowspan="1" colspan="1" class="el-table_1_column_1  ">
                       <div class="cell">
                         <a href="/group/DDD" class="">Group D</a>
+                        <!---->
                       </div>
                     </td>
                     <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
@@ -387,6 +391,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                     <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
                       <div class="cell">
                         <a href="/project/proj-a" class="">Project A</a>
+                        <mock-el-tooltip content="Project A has a pending membership request." placement="right"><span class="notification"></span></mock-el-tooltip>
                       </div>
                     </td>
                     <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
@@ -413,6 +418,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                     <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
                       <div class="cell">
                         <a href="/project/BB" class="">Project B</a>
+                        <!---->
                       </div>
                     </td>
                     <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
@@ -443,6 +449,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                     <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
                       <div class="cell">
                         <a href="/project/CC" class="">Project C</a>
+                        <mock-el-tooltip content="Project C has a pending membership request." placement="right"><span class="notification"></span></mock-el-tooltip>
                       </div>
                     </td>
                     <td rowspan="1" colspan="1" class="el-table_2_column_6  ">
@@ -465,6 +472,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                     <td rowspan="1" colspan="1" class="el-table_2_column_5  ">
                       <div class="cell">
                         <a href="/project/DD" class="">Project D</a>
+                        <!---->
                       </div>
                     </td>
                     <td rowspan="1" colspan="1" class="el-table_2_column_6  ">

--- a/metaspace/webapp/tests/utils/setupTestFramework.ts
+++ b/metaspace/webapp/tests/utils/setupTestFramework.ts
@@ -1,19 +1,21 @@
-import { config as testConfig } from '@vue/test-utils';
+import * as VueTestUtils from '@vue/test-utils';
 import Vue from 'vue';
 import ElementUI from 'element-ui';
 import registerMockComponent from './registerMockComponent';
 import VueRouter from 'vue-router';
 import registerMockDirective from './registerMockDirective';
+import {Wrapper} from '@vue/test-utils';
 
 window.fetch = jest.fn();
 
-testConfig.logModifiedComponents = false;
+VueTestUtils.config.logModifiedComponents = false;
 
 Vue.use(VueRouter);
 Vue.use(ElementUI);
 // Mock problematic ElementUI components
 registerMockComponent('el-dialog');
 registerMockComponent('el-popover');
+registerMockComponent('el-tooltip');
 registerMockComponent('el-autocomplete');
 registerMockComponent('el-select');
 registerMockComponent('el-option');
@@ -34,3 +36,27 @@ registerMockComponent('transition-group');
 
 // Ignore delay duration
 jest.mock('../../src/lib/delay', () => jest.fn(() => Promise.resolve()));
+
+// Track all components mounted by vue-test-utils and automatically clean them up after each test to prevent stale
+// components from updating due to e.g. route changes
+const mockWrappers: Wrapper<Vue>[] = [];
+jest.mock('@vue/test-utils', () => {
+  const wrapVueTestToolsFunction = (originalFunc: ((...args: any[]) => Wrapper<Vue>)) => {
+    return function(...args: any[]) {
+      const wrapper = originalFunc(...args);
+      mockWrappers.push(wrapper);
+      return wrapper;
+    }
+  };
+  const actual = require.requireActual('@vue/test-utils');
+  return Object.assign({}, actual, {
+    mount: wrapVueTestToolsFunction(actual.mount),
+    shallowMount: wrapVueTestToolsFunction(actual.shallowMount),
+  });
+});
+
+afterEach(() => {
+  while (mockWrappers.length > 0) {
+    mockWrappers.pop()!.destroy();
+  }
+});


### PR DESCRIPTION
When you are invited to a group/project, or you manage a group/project and there is a pending request, this add a trail of indicators, some with tooltips, to guide you to where you can accept:

#### Menu bar:
![image](https://user-images.githubusercontent.com/26366936/48553727-a2686580-e8dc-11e8-9ce8-1349c9558dcc.png)
![image](https://user-images.githubusercontent.com/26366936/48553742-b744f900-e8dc-11e8-9e7e-e24d982e6927.png)
#### My Account
![image](https://user-images.githubusercontent.com/26366936/48554987-25d78600-e8e0-11e8-9fea-c5937f295ee1.png)
#### Group Page
![image](https://user-images.githubusercontent.com/26366936/48553797-e491a700-e8dc-11e8-9eef-ddc9e811f63a.png)

It also sorts the group/project members list so that pending requests come first, then invited people, then admins/managers, and finally members.

I had to add some extra code to `setupTestFramework`, because I found that after tests ended the components they create would continue to exist and would sometimes send graphql queries during other tests. This is why there are some seemingly unrelated HTML class changes in the snapshots.