### PR TITLE
Handle conflicts during ElasticSearch indexing

### DIFF
--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -89,7 +89,7 @@
     "version": 1,
     "formatters": {
       "sm": {
-        "format": "%(asctime)s - %(levelname)s - %(name)s[%(thread)d] - %(filename)s:%(lineno)d - %(message)s"
+        "format": "%(asctime)s - %(levelname)s - %(name)s[%(threadName)d] - %(filename)s:%(lineno)d - %(message)s"
       }
     },
     "handlers": {

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -377,16 +377,17 @@ class ESExporter(object):
                 self._ingest.put_pipeline(
                     id=pipeline_id,
                     body={'processors': processors})
-                # Note: mind the time gap between the queries when called from different processes
-                self._es.update_by_query(
-                    index=self.index,
-                    body={'query': {'term': {'ds_id': ds_id}}},
-                    params={
-                        'pipeline': pipeline_id,
-                        'wait_for_completion': True,
-                        'request_timeout': 60,
-                    })
-                self._ingest.delete_pipeline(pipeline_id)
+                try:
+                    self._es.update_by_query(
+                        index=self.index,
+                        body={'query': {'term': {'ds_id': ds_id}}},
+                        params={
+                            'pipeline': pipeline_id,
+                            'wait_for_completion': True,
+                            'request_timeout': 60,
+                        })
+                finally:
+                    self._ingest.delete_pipeline(pipeline_id)
 
     @retry_on_conflict()
     def delete_ds(self, ds_id, mol_db=None):

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -1,13 +1,12 @@
-import random
 from functools import wraps
-
+from time import sleep
 from elasticsearch import Elasticsearch, NotFoundError, ElasticsearchException, ConflictError
 from elasticsearch.helpers import parallel_bulk
 from elasticsearch.client import IndicesClient, IngestClient
 import logging
 from collections import defaultdict, MutableMapping
 import pandas as pd
-from time import sleep
+import random
 
 from sm.engine.dataset_locker import DatasetLocker
 from sm.engine.util import SMConfig
@@ -82,6 +81,7 @@ LEFT JOIN (
 WHERE d.ds_id = %s'''
 
 DS_COLUMNS_TO_SKIP_IN_ANN = ('ds_acq_geometry',)
+
 
 def init_es_conn(es_config):
     hosts = [{"host": es_config['host'], "port": int(es_config['port'])}]

--- a/metaspace/engine/sm/engine/sm_daemons.py
+++ b/metaspace/engine/sm/engine/sm_daemons.py
@@ -273,9 +273,8 @@ class SMIndexUpdateDaemon(object):
     def _on_failure(self, msg):
         self.logger.error(f' SM update daemon: failure', exc_info=True)
 
-        if msg['action'] != 'update':
-            ds = Dataset.load(self._db, msg['ds_id'])
-            ds.set_status(self._db, self._manager.es, self._manager.status_queue, DatasetStatus.FAILED)
+        ds = Dataset.load(self._db, msg['ds_id'])
+        ds.set_status(self._db, self._manager.es, self._manager.status_queue, DatasetStatus.FAILED)
 
         self._manager.post_to_slack('hankey', f" [x] Failed to {msg['action']}: {json.dumps(msg)}")
 


### PR DESCRIPTION
Changes as discussed. I was only able to test it locally by increasing my `refresh_interval` and updating the same dataset multiple times in a row. Seemed to work:
```
2018-11-15 16:18:34,414 - INFO - engine[MainThread] - update_es_index.py:37 - Reindexing 9 out of 12
2018-11-15 16:18:34,629 - INFO - engine[MainThread] - es_export.py:304 - Indexing 849 documents: 2018-11-15_13h29m14s, HMDB-v4 2018-04-09
2018-11-15 16:18:35,910 - WARNING - engine[MainThread] - es_export.py:223 - ElasticSearch update conflict on attempt 1. Retrying after 2.6 seconds...
2018-11-15 16:18:38,709 - WARNING - engine[MainThread] - es_export.py:223 - ElasticSearch update conflict on attempt 2. Retrying after 2.8 seconds...
2018-11-15 16:18:41,727 - WARNING - engine[MainThread] - es_export.py:223 - ElasticSearch update conflict on attempt 3. Retrying after 4.9 seconds...
2018-11-15 16:18:47,207 - INFO - engine[MainThread] - update_es_index.py:37 - Reindexing 10 out of 12
2018-11-15 16:18:47,353 - INFO - engine[MainThread] - es_export.py:304 - Indexing 849 documents: 2018-11-15_13h29m14s, HMDB-v4 2018-04-09
```