### PR TITLE
Add toggle to projects page to switch between All Projects and My Projects

### DIFF
--- a/metaspace/graphql/src/modules/project/ProjectSourceRepository.ts
+++ b/metaspace/graphql/src/modules/project/ProjectSourceRepository.ts
@@ -17,7 +17,8 @@ export class ProjectSourceRepository {
 
     let qb = this.manager
       .createQueryBuilder(ProjectModel, 'project')
-      .select(columnMap);
+      .select(columnMap)
+      .orderBy('project.name');
 
     // Hide datasets the current user doesn't have access to
     if (user && user.role === 'admin') {
@@ -93,10 +94,10 @@ export class ProjectSourceRepository {
                             offset?: number, limit?: number): Promise<ProjectSource[]> {
     let queryBuilder = this.queryProjectsByTextSearch(user, query);
     if (offset != null) {
-      queryBuilder = queryBuilder.skip(offset);
+      queryBuilder = queryBuilder.offset(offset);
     }
     if (limit != null) {
-      queryBuilder = queryBuilder.take(limit);
+      queryBuilder = queryBuilder.limit(limit);
     }
     return await queryBuilder.getRawMany();
   }

--- a/metaspace/webapp/src/modules/Project/ProjectsListPage.spec.ts
+++ b/metaspace/webapp/src/modules/Project/ProjectsListPage.spec.ts
@@ -40,6 +40,7 @@ describe('ProjectsListPage', () => {
     });
     const wrapper = mount(ProjectsListPage, { router, provide, store, sync: false });
     await Vue.nextTick();
+    await Vue.nextTick();
 
     expect(wrapper).toMatchSnapshot();
     const projectIds = wrapper.findAll({name:'ProjectsListItem'}).wrappers.map(item => item.props().project.id);

--- a/metaspace/webapp/src/modules/Project/ProjectsListPage.vue
+++ b/metaspace/webapp/src/modules/Project/ProjectsListPage.vue
@@ -7,14 +7,15 @@
       @create="handleProjectCreated"
     />
     <div class="page-content">
-      <el-radio-group v-if="currentUser != null" v-model="tab">
-        <el-radio-button :label="ALL_PROJECTS" />
-        <el-radio-button :label="MY_PROJECTS" />
-      </el-radio-group>
-      <filter-panel level="projects" />
-      <el-row v-if="currentUser" type="flex" justify="end">
-        <el-button @click="handleOpenCreateProject">Create project</el-button>
-      </el-row>
+      <div class="header-row">
+        <el-radio-group v-if="currentUser != null" v-model="tab">
+          <el-radio-button :label="ALL_PROJECTS" />
+          <el-radio-button :label="MY_PROJECTS" />
+        </el-radio-group>
+        <filter-panel level="projects" />
+        <div style="flex-grow: 1" />
+        <el-button v-if="currentUser" @click="handleOpenCreateProject">Create project</el-button>
+      </div>
       <div class="clearfix"/>
       <div v-loading="loading !== 0" style="min-height: 100px;">
         <projects-list-item v-for="project in projects"
@@ -63,7 +64,7 @@
         query: projectsListQuery,
         loadingKey: 'loading',
         skip() {
-          return !(this.tab === this.ALL_PROJECTS && this.currentUser != null);
+          return this.tab !== this.ALL_PROJECTS;
         },
         variables() {
           return {
@@ -76,7 +77,7 @@
       allProjectsCount: {
         query: projectsCountQuery,
         skip() {
-          return !(this.tab === this.ALL_PROJECTS && this.currentUser != null);
+          return this.tab !== this.ALL_PROJECTS;
         },
         variables() {
           return {
@@ -126,14 +127,14 @@
       }
     }
     get projects() {
-      if (this.tab === this.ALL_PROJECTS || this.currentUser == null) {
+      if (this.tab === this.ALL_PROJECTS) {
         return this.allProjects;
       } else {
         return this.filteredMyProjects.slice((this.page - 1) * this.pageSize, this.page * this.pageSize);
       }
     }
     get projectsCount() {
-      if (this.tab === this.ALL_PROJECTS || this.currentUser == null) {
+      if (this.tab === this.ALL_PROJECTS) {
         return this.allProjectsCount;
       } else {
         return this.filteredMyProjects.length;
@@ -144,6 +145,13 @@
     @Watch('tab')
     resetPagination() {
       this.page = 1;
+    }
+
+    @Watch('currentUser')
+    resetTab() {
+      if (this.currentUser == null) {
+        this.tab = this.ALL_PROJECTS;
+      }
     }
 
     created() {
@@ -179,5 +187,12 @@
 
   .page-content {
     width: 800px;
+  }
+
+  .header-row {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: flex-start;
   }
 </style>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -74,16 +74,17 @@ exports[`ProjectsListPage should match snapshot 1`] = `
     </div>
   </mock-el-dialog>
   <div class="page-content">
-    <div role="radiogroup" class="el-radio-group">
-      <label role="radio" aria-checked="true" tabindex="0" class="el-radio-button is-active">
-        <input type="radio" tabindex="-1" class="el-radio-button__orig-radio" value="All projects"><span class="el-radio-button__inner">All projects</span></label>
-      <label role="radio" tabindex="-1" class="el-radio-button">
-        <input type="radio" tabindex="-1" class="el-radio-button__orig-radio" value="My projects"><span class="el-radio-button__inner">My projects</span></label>
-    </div>
-    <div class="filter-panel">
-      <!---->
-    </div>
-    <div class="el-row is-justify-end el-row--flex">
+    <div class="header-row">
+      <div role="radiogroup" class="el-radio-group">
+        <label role="radio" aria-checked="true" tabindex="0" class="el-radio-button is-active">
+          <input type="radio" tabindex="-1" class="el-radio-button__orig-radio" value="All projects"><span class="el-radio-button__inner">All projects</span></label>
+        <label role="radio" tabindex="-1" class="el-radio-button">
+          <input type="radio" tabindex="-1" class="el-radio-button__orig-radio" value="My projects"><span class="el-radio-button__inner">My projects</span></label>
+      </div>
+      <div class="filter-panel">
+        <!---->
+      </div>
+      <div></div>
       <button type="button" class="el-button el-button--default">
         <!---->
         <!----><span>Create project</span></button>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`ProjectsListPage should match snapshot 1`] = `
 <div class="page">
   <mock-el-dialog append-to-body="" title="Create project" class="dialog">
-    <div mock-v-loading="1">
+    <div mock-v-loading="0">
       <form class="el-form el-form--label-top" size="mini">
         <div>
           <div class="el-form-item name is-required">
@@ -74,6 +74,12 @@ exports[`ProjectsListPage should match snapshot 1`] = `
     </div>
   </mock-el-dialog>
   <div class="page-content">
+    <div role="radiogroup" class="el-radio-group">
+      <label role="radio" aria-checked="true" tabindex="0" class="el-radio-button is-active">
+        <input type="radio" tabindex="-1" class="el-radio-button__orig-radio" value="All projects"><span class="el-radio-button__inner">All projects</span></label>
+      <label role="radio" tabindex="-1" class="el-radio-button">
+        <input type="radio" tabindex="-1" class="el-radio-button__orig-radio" value="My projects"><span class="el-radio-button__inner">My projects</span></label>
+    </div>
     <div class="filter-panel">
       <!---->
     </div>
@@ -83,7 +89,7 @@ exports[`ProjectsListPage should match snapshot 1`] = `
         <!----><span>Create project</span></button>
     </div>
     <div class="clearfix"></div>
-    <div mock-v-loading="false">
+    <div style="min-height: 100px;" mock-v-loading="false">
       <div class="project-item">
         <a href="/project/proj-one" class="underlay"></a>
         <div class="item-body">


### PR DESCRIPTION
Fixes #121 

![image](https://user-images.githubusercontent.com/26366936/48620753-7531bb00-e9a1-11e8-80f8-c5b6801531c6.png)

The dataflow is a bit awkward because "My Projects" is queried and paginated client-side, and "All Projects" is queried & paginated server-side. It's not worth the time to adapt the graphql API to clean this up.

Other changes:
* Sorts projects by `num_members * 20 + num_datasets` so that more prominent projects rise to the top.
* Fixes a bug in pagination on the projects page. Basically, it didn't work at all before. It seems like TypeORM ignores the QueryBuilder methods `skip` and `take` for Postgres, so I changed to `offset` and `limit`.
* Moves the "Create Project" button into the same row as the search box.