### PR TITLE
Fix log format string

### DIFF
--- a/docker/sm-engine/conf/config.json
+++ b/docker/sm-engine/conf/config.json
@@ -92,7 +92,7 @@
     "version": 1,
     "formatters": {
       "sm": {
-        "format": "%(asctime)s - %(levelname)s - %(name)s - %(filename)s:%(lineno)d - %(message)s"
+        "format": "%(asctime)s - %(levelname)s - %(name)s[%(threadName)s] - %(filename)s:%(lineno)d - %(message)s"
       }
     },
     "handlers": {

--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -89,7 +89,7 @@
     "version": 1,
     "formatters": {
       "sm": {
-        "format": "%(asctime)s - %(levelname)s - %(name)s[%(threadName)d] - %(filename)s:%(lineno)d - %(message)s"
+        "format": "%(asctime)s - %(levelname)s - %(name)s[%(threadName)s] - %(filename)s:%(lineno)d - %(message)s"
       }
     },
     "handlers": {


### PR DESCRIPTION
I previously had `%(thread)d`, which worked because `thread` is a number. When I changed to `threadName` I forgot to change it to use `s` instead of `d`.