### PR TITLE
Update URLs linking to metaspace2020.eu

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Please check the [ansible](ansible) project for production installations on AWS,
 ## Uploading Dataset and Browsing Results
 Please visit the help page of our web application running on AWS:
 
-[http://metaspace2020.eu/#/help](http://metaspace2020.eu/#/help)
+[https://metaspace2020.eu/help](https://metaspace2020.eu/help)
 
 ## Acknowledgements
 

--- a/metaspace/engine/README.md
+++ b/metaspace/engine/README.md
@@ -15,7 +15,7 @@ Please check the [sm-engine-ansible](https://github.com/metaspace2020/sm-engine-
 ## Uploading Dataset and Browsing Results
 Please visit the help page of our web application running on AWS:
 
-[http://metaspace2020.eu/#/help](http://metaspace2020.eu/#/help)
+[https://metaspace2020.eu/help](https://metaspace2020.eu/help)
 
 ## Running sm-engine tests
 

--- a/metaspace/engine/sm/engine/sm_daemons.py
+++ b/metaspace/engine/sm/engine/sm_daemons.py
@@ -46,7 +46,7 @@ class SMDaemonManager(object):
             md_type_quoted = urllib.parse.quote(ds_meta['Data_Type'])
             base_url = self._sm_config['services']['web_app_url']
             ds_id_quoted = urllib.parse.quote(msg['ds_id'])
-            link = '{}/#/annotations?mdtype={}&ds={}'.format(base_url, md_type_quoted, ds_id_quoted)
+            link = '{}/annotations?mdtype={}&ds={}'.format(base_url, md_type_quoted, ds_id_quoted)
         except Exception as e:
             self.logger.error(e)
         return link

--- a/metaspace/python-client/example/compare-reference-engine-results.ipynb
+++ b/metaspace/python-client/example/compare-reference-engine-results.ipynb
@@ -98,7 +98,7 @@
     "collapsed": false
    },
    "source": [
-    "This notebook compares the results of a dataset annotated with the [reference pipeline](https://github.com/alexandrovteam/pySM) that accompanies [Palmer et al](http://www.nature.com/nmeth/journal/v14/n1/abs/nmeth.4072.html) submitted to the [METASPACE online engine](http://annotate.metaspace2020.eu/)"
+    "This notebook compares the results of a dataset annotated with the [reference pipeline](https://github.com/alexandrovteam/pySM) that accompanies [Palmer et al](https://www.nature.com/nmeth/journal/v14/n1/abs/nmeth.4072.html) submitted to the [METASPACE online engine](https://metaspace2020.eu/)"
    ]
   },
   {

--- a/metaspace/python-client/example/iso_img_retrieval.ipynb
+++ b/metaspace/python-client/example/iso_img_retrieval.ipynb
@@ -16,7 +16,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook illustrates how to pull ion images for annotations from the [METASPACE platform](annotate.metaspace2020.eu). It will obtain and display all the isotope images for a set of annotations"
+    "This notebook illustrates how to pull ion images for annotations from the [METASPACE platform](metaspace2020.eu). It will obtain and display all the isotope images for a set of annotations"
    ]
   },
   {

--- a/metaspace/python-client/example/metadata_access.ipynb
+++ b/metaspace/python-client/example/metadata_access.ipynb
@@ -15,7 +15,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook provides a minimal example of accessing metadata for datasets submitted to the [METASPACE annotation platform](annotate.metaspace2020.eu)"
+    "This notebook provides a minimal example of accessing metadata for datasets submitted to the [METASPACE annotation platform](metaspace2020.eu)"
    ]
   },
   {

--- a/metaspace/webapp/package.json
+++ b/metaspace/webapp/package.json
@@ -14,7 +14,7 @@
     "coverage": "cross-env NODE_ENV=test jest --coverage",
     "deref-schema": "node ./deref_schema.js src/assets",
     "generate-local-graphql-schema": "NODE_PATH=../graphql/node_modules node ../graphql/bin/generate-json-graphql-schema.js tests/utils/graphql-schema.json",
-    "fetch-prod-graphql-schema": "apollo schema:download tests/utils/graphql-schema.json --endpoint http://metaspace2020.eu/graphql"
+    "fetch-prod-graphql-schema": "apollo schema:download tests/utils/graphql-schema.json --endpoint https://metaspace2020.eu/graphql"
   },
   "dependencies": {
     "@types/js-cookie": "^2.1.0",

--- a/metaspace/webapp/src/about.md
+++ b/metaspace/webapp/src/about.md
@@ -7,8 +7,8 @@ as well as a spatial metabolite knowledgebase of the metabolites from hundreds o
 provided by the community.
 
 METASPACE platform is developed by software engineers, data scientists and mass spectrometrists
-from the [Alexandrov team at EMBL](http://www.embl.de/research/units/scb/alexandrov/).
-This work is a part of the [European project METASPACE](http://metaspace2020.eu).
+from the [Alexandrov team at EMBL](https://www.embl.de/research/units/scb/alexandrov/).
+This work is a part of the [European project METASPACE](https://metaspace2020.eu).
 
 ## Open as public space
 
@@ -18,8 +18,8 @@ and can be browsed or exported.
 
 ## How can I contribute?
 
-Please read [our publication in Nature Methods](http://www.nature.com/nmeth/journal/v14/n1/full/nmeth.4072.html),
-follow us on [Twitter](http://twitter.com/metaspace2020), spread the word, and think of us while doing good deeds :)
+Please read [our publication in Nature Methods](https://www.nature.com/nmeth/journal/v14/n1/full/nmeth.4072.html),
+follow us on [Twitter](https://twitter.com/metaspace2020), spread the word, and think of us while doing good deeds :)
 
 - **Have high-resolution imaging mass spectrometry data**? Please consider uploading them.
 - **Are you a data scientist**? Please feel free to the export the metabolite annotations to mine thousands of metabolites found in hundreds of community-provided datasets.
@@ -28,7 +28,7 @@ follow us on [Twitter](http://twitter.com/metaspace2020), spread the word, and t
 
 ## How shall I cite METASPACE in a publication?
 
-Please cite our publication [(Palmer et al., 2016, Nature Methods)](http://www.nature.com/nmeth/journal/v14/n1/full/nmeth.4072.html) and refer to [http://annotate.metaspace2020.eu](http://annotate.metaspace2020.eu).
+Please cite our publication [(Palmer et al., 2016, Nature Methods)](http://www.nature.com/nmeth/journal/v14/n1/full/nmeth.4072.html) and refer to [https://metaspace2020.eu](https://metaspace2020.eu).
 
 ## Please appreciate those who funded it
 
@@ -43,7 +43,7 @@ Please cite our publication [(Palmer et al., 2016, Nature Methods)](http://www.n
 
 ## How to stay in touch?
 
-Follow us on [Twitter](http://twitter.com/metaspace2020) or drop a line to [our email](mailto:contact@metaspace2020.eu), we will add you to our special list :)
+Follow us on [Twitter](https://twitter.com/metaspace2020) or drop a line to [our email](mailto:contact@metaspace2020.eu), we will add you to our special list :)
 
 For all other inquiries or questions, please [contact us over email](mailto:contact@metaspace2020.eu).
 

--- a/metaspace/webapp/src/modules/App/AboutPage.vue
+++ b/metaspace/webapp/src/modules/App/AboutPage.vue
@@ -41,7 +41,7 @@
           spatial metabolite knowledgebase of the metabolites from hundreds of public datasets provided by the
           community.</p>
         <p>The METASPACE platform is developed by software engineers, data scientists and mass spectrometrists from the <a
-          href="http://www.embl.de/research/units/scb/alexandrov/">Alexandrov team at EMBL</a>. This work is a part of the
+          href="https://www.embl.de/research/units/scb/alexandrov/">Alexandrov team at EMBL</a>. This work is a part of the
           <a href="http://project.metaspace2020.eu">European project METASPACE</a>.</p>
       </el-row>
       <el-row id="A public space">
@@ -52,8 +52,8 @@
       </el-row>
       <el-row id="getInvolved">
         <h2 id="how-can-i-contribute-">How can I contribute?</h2>
-        <p>Please read <a href="http://www.nature.com/nmeth/journal/v14/n1/full/nmeth.4072.html">our publication in Nature
-          Methods</a>, follow us on <a href="http://twitter.com/metaspace2020">Twitter</a>, spread the word, and think of
+        <p>Please read <a href="https://www.nature.com/nmeth/journal/v14/n1/full/nmeth.4072.html">our publication in Nature
+          Methods</a>, follow us on <a href="https://twitter.com/metaspace2020">Twitter</a>, spread the word, and think of
           us while doing good deeds :)</p>
         <ul>
           <li><strong>Have high-resolution imaging mass spectrometry data</strong>? Please consider uploading them.</li>
@@ -67,11 +67,11 @@
          <p>Please cite our publication <a
         href="http://www.nature.com/nmeth/journal/v14/n1/full/nmeth.4072.html">(Palmer et al., 2016, Nature Methods)</a>
         and
-        refer to <a href="http://metaspace2020.eu">http://metaspace2020.eu</a>.</p>
+        refer to <a href="https://metaspace2020.eu">https://metaspace2020.eu</a>.</p>
       </el-row>
       <el-row id="contact">
         <h2 id="how-to-stay-in-touch-">How to stay in touch?</h2>
-        <p>Follow us on <a href="http://twitter.com/metaspace2020">Twitter</a>
+        <p>Follow us on <a href="https://twitter.com/metaspace2020">Twitter</a>
           or subscribe to the <a href="#" @click.prevent="onShowMailingList">METASPACE mailing list</a>.
         </p>
         <p>Find out more about the METASPACE consortium at the <a href="http://project.metaspace2020.eu/">project website</a></p>

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
@@ -268,7 +268,7 @@
            row.polarity.toLowerCase(),
            row.uploadDateTime,
            row.fdrCounts ? `${row.fdrCounts.counts}` + ' ' + `${row.fdrCounts.dbName}` : '',
-           (row.opticalImage) ? 'http://' + window.location.host + row.opticalImage : 'No optical image'
+           (row.opticalImage) ? window.location.origin + row.opticalImage : 'No optical image'
          ]);
        }
 


### PR DESCRIPTION
Made these changes:
* HTTP -> HTTPS where appropriate
* annotate.metaspace2020.eu -> metaspace2020.eu
* metaspace2020.eu/#/ -> metaspace2020.eu/
* Updated dataset CSV export to include the current page's protocol in the optical image URL