### PR TITLE
Fixed a proper path return for isotope image path

### DIFF
--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -20,7 +20,7 @@ def _extract_data(res):
 
 def get_config(host, email=None, password=None, verify_certificate=True):
     return {
-        'host': '{}'.format(host),
+        'host': host,
         'graphql_url': '{}/graphql'.format(host),
         'moldb_url': '{}/mol_db/v1'.format(host),
         'signin_url': '{}/api_auth/signin'.format(host),
@@ -532,7 +532,7 @@ class SMDataset(object):
         def fetchImage(url):
             if not url:
                 return None
-            url = self._gqclient.url.rsplit("/",1)[0]+url
+            url = self._baseurl + url
             im = mpimg.imread(BytesIO(requests.get(url).content))
             mask = im[:, :, 3]
             data = im[:, :, 0]

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -34,6 +34,7 @@ def get_config(host, email=None, password=None, verify_certificate=True):
 class GraphQLClient(object):
     def __init__(self, config):
         self._config = config
+        self.host = self._config['host']
         self.session = requests.Session()
         self.session.verify = self._config['verify_certificate']
         res = self.session.post(self._config['signin_url'], params={
@@ -519,7 +520,7 @@ class SMDataset(object):
 
     @property
     def _baseurl(self):
-        return self._gqclient._config['host']
+        return self._gqclient.host
 
     def isotope_images(self, sf, adduct):
         records = self._gqclient.getAnnotations(

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -20,6 +20,7 @@ def _extract_data(res):
 
 def get_config(host, email=None, password=None, verify_certificate=True):
     return {
+        'host': '{}'.format(host),
         'graphql_url': '{}/graphql'.format(host),
         'moldb_url': '{}/mol_db/v1'.format(host),
         'signin_url': '{}/api_auth/signin'.format(host),
@@ -518,7 +519,7 @@ class SMDataset(object):
 
     @property
     def _baseurl(self):
-        return self._gqclient.url.rsplit("/", 1)[0]
+        return self._gqclient._config['host']
 
     def isotope_images(self, sf, adduct):
         records = self._gqclient.getAnnotations(


### PR DESCRIPTION
There was an obsolete call from `v0.11` release because we had defined
`DEFAULT_CONFIG = { ...
    'moldb_url': 'http://metaspace2020.eu/mol_db/v1' ...}`
But in principle this code line just returned the hostname , so I added it to `get_config`