### PR TITLE
Dataset page optimizations and link to group page

### DIFF
--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -32,9 +32,11 @@ type Dataset {
   status: JobStatus
   inputPath: String
   uploadDateTime: String
-  fdrCounts(inpFdrLvls: [Int!]!, checkLvl: Int!): FdrCounts
+  fdrCounts(inpFdrLvls: [Int!]! = [10], checkLvl: Int! = 10): FdrCounts
   opticalImage: String @deprecated(badName: "Renamed to rawOpticalImageUrl")
   rawOpticalImageUrl: String
+
+  thumbnailOpticalImageUrl: String
 }
 
 # Datasets' submitter and group are taken from ElasticSearch, which means they can be out of sync with the database.
@@ -201,7 +203,7 @@ type Query {
 
   thumbnailImage(datasetId: String!): String @deprecated(badName: "Renamed to thumbnailOpticalImageUrl")
 
-  thumbnailOpticalImageUrl(datasetId: String!): String
+  thumbnailOpticalImageUrl(datasetId: String!): String @deprecated(reason: "Use Dataset.thumbnailOpticalImageUrl instead")
 
   currentUserLastSubmittedDataset: Dataset
 }

--- a/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
@@ -7,6 +7,7 @@ import {Dataset} from '../../../binding';
 import {rawOpticalImage} from './Query';
 import getScopeRoleForEsDataset from '../util/getScopeRoleForEsDataset';
 import {logger} from '../../../utils';
+import {db} from '../../../utils/knexDb';
 
 const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
   id(ds) {
@@ -186,6 +187,18 @@ const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
   async rawOpticalImageUrl(ds, _, ctx) {
     const opticalImage = await rawOpticalImage(ds._source.ds_id, ctx);
     return opticalImage ? opticalImage.url : null;
+  },
+
+  async thumbnailOpticalImageUrl(ds, args, ctx) {
+    const row = await db.from('dataset')
+      .where('id', ds._source.ds_id)
+      .select('thumbnail')
+      .first();
+    if (row && row.thumbnail) {
+      return `/fs/optical_images/${row.thumbnail}`;
+    } else {
+      return null;
+    }
   }
 };
 

--- a/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
@@ -7,7 +7,16 @@ import {Dataset} from '../../../binding';
 import {rawOpticalImage} from './Query';
 import getScopeRoleForEsDataset from '../util/getScopeRoleForEsDataset';
 import {logger} from '../../../utils';
-import {db} from '../../../utils/knexDb';
+import {Context} from '../../../context';
+
+export const thumbnailOpticalImageUrl = async (ctx: Context, id: string) => {
+  const result = await ctx.connection.query('SELECT thumbnail FROM public.dataset WHERE id = $1', [id]);
+  if (result && result.length === 1 && result[0].thumbnail != null) {
+    return `/fs/optical_images/${result[0].thumbnail}`;
+  } else {
+    return null;
+  }
+};
 
 const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
   id(ds) {
@@ -190,15 +199,7 @@ const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
   },
 
   async thumbnailOpticalImageUrl(ds, args, ctx) {
-    const row = await db.from('dataset')
-      .where('id', ds._source.ds_id)
-      .select('thumbnail')
-      .first();
-    if (row && row.thumbnail) {
-      return `/fs/optical_images/${row.thumbnail}`;
-    } else {
-      return null;
-    }
+    return await thumbnailOpticalImageUrl(ctx, ds._source.ds_id);
   }
 };
 

--- a/metaspace/graphql/src/modules/dataset/controller/Query.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Query.ts
@@ -5,6 +5,7 @@ import {db} from '../../../utils/knexDb';
 import {Dataset as DatasetModel} from '../model';
 import {UserGroup as UserGroupModel, UserGroupRoleOptions} from '../../group/model';
 import {Context} from '../../../context';
+import {thumbnailOpticalImageUrl} from './Dataset';
 
 
 const resolveDatasetScopeRole = async (ctx: Context, dsId: string) => {
@@ -104,22 +105,12 @@ const QueryResolvers: FieldResolversFor<Query, void>  = {
 
   // TODO: deprecated, remove
   async thumbnailImage(source, {datasetId}, ctx) {
-    return QueryResolvers.thumbnailOpticalImageUrl!(source, {datasetId}, ctx, null as any);
+    return await thumbnailOpticalImageUrl(ctx, datasetId);
   },
 
   // TODO: deprecated, remove
-  async thumbnailOpticalImageUrl(source, {datasetId: dsId}, ctx) {
-    // TODO: consider moving to Dataset type
-    const ds = await esDatasetByID(dsId, ctx.user);  // check if user has access
-    if (ds) {
-      const row = await (db.from('dataset')
-        .where('id', dsId)
-        .first());
-      if (row && row.thumbnail) {
-        return `/fs/optical_images/${row.thumbnail}`;
-      }
-    }
-    return null;
+  async thumbnailOpticalImageUrl(source, {datasetId}, ctx) {
+    return await thumbnailOpticalImageUrl(ctx, datasetId);
   },
 
   async currentUserLastSubmittedDataset(source, args, ctx): Promise<DatasetSource | null> {

--- a/metaspace/graphql/src/modules/dataset/controller/Query.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Query.ts
@@ -107,6 +107,7 @@ const QueryResolvers: FieldResolversFor<Query, void>  = {
     return QueryResolvers.thumbnailOpticalImageUrl!(source, {datasetId}, ctx, null as any);
   },
 
+  // TODO: deprecated, remove
   async thumbnailOpticalImageUrl(source, {datasetId: dsId}, ctx) {
     // TODO: consider moving to Dataset type
     const ds = await esDatasetByID(dsId, ctx.user);  // check if user has access

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -77,7 +77,7 @@ export const datasetDetailItemFragment =
       levels
       counts
     }
-    rawOpticalImageUrl
+    thumbnailOpticalImageUrl
   }`;
 
 export const datasetDetailItemsQuery =

--- a/metaspace/webapp/src/modules/App/MetaspaceHeader.vue
+++ b/metaspace/webapp/src/modules/App/MetaspaceHeader.vue
@@ -357,6 +357,7 @@
    font-size: 16px;
    align-self: stretch;
    justify-content: center;
+   white-space: nowrap;
  }
  .limit-width {
    max-width: 250px;

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -66,7 +66,7 @@
           {{ formatSubmitter }}</span><!--
           Be careful not to add empty space before the comma
           --><span v-if="dataset.groupApproved && dataset.group">,
-          <el-dropdown @command="handleDropdownCommand" :showTimeout="50">
+          <el-dropdown @command="handleDropdownCommand" :showTimeout="50" placement="bottom">
             <span class="s-group ds-add-filter"
                   @click="addFilter('group')">
               {{dataset.group.shortName}}

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -305,14 +305,18 @@
        showMetadataDialog: false,
        disabled: false,
        ind: null,
-       deferRender: this.idx > 20,
+       deferRender: this.idx >= 20,
      };
    },
-   created() {
+   async created() {
      // Defer rendering of most elements until after the first render, so that the page becomes interactive sooner
-     setTimeout(() => {
-       this.deferRender = false;
-     }, Math.floor(this.idx/10) * 10);
+     const delayFrames = Math.floor(this.idx/10);
+     try {
+       for (let i = 0; i < delayFrames; i++) {
+         await new Promise(resolve => requestAnimationFrame(resolve));
+       }
+     } catch (err) { /* Browser/test doesn't support requestAnimationFrame? */}
+     this.deferRender = false;
    },
    apollo: {
      datasetVisibility: {

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -66,11 +66,16 @@
           {{ formatSubmitter }}</span><!--
           Be careful not to add empty space before the comma
           --><span v-if="dataset.groupApproved && dataset.group">,
-          <span class="s-group ds-add-filter"
-                title="Filter by this group"
-                @click="addFilter('group')">
-            {{dataset.group.shortName}}
-          </span>
+          <el-dropdown @command="handleDropdownCommand">
+            <span class="s-group ds-add-filter"
+                  @click="addFilter('group')">
+              {{dataset.group.shortName}}
+            </span>
+            <el-dropdown-menu slot="dropdown" v-if="!hideGroupMenu">
+              <el-dropdown-item command="filter_group">Filter by this group</el-dropdown-item>
+              <el-dropdown-item command="view_group">View group</el-dropdown-item>
+            </el-dropdown-menu>
+          </el-dropdown>
         </span>
       </div>
       <div class="ds-item-line" v-if="dataset.status == 'FINISHED' && this.dataset.fdrCounts">
@@ -157,9 +162,9 @@
 
  export default {
    name: 'dataset-item',
-   props: ['dataset', 'currentUser', 'idx'],
+   props: ['dataset', 'currentUser', 'idx', 'hideGroupMenu'],
    components: {
-     DatasetInfo
+     DatasetInfo,
    },
    filters: {
      plural
@@ -398,6 +403,19 @@
          reportError(err);
        } finally {
          this.disabled = false;
+       }
+     },
+
+     handleDropdownCommand(command) {
+       if (command.startsWith('filter_')) {
+         this.addFilter(command.substring('filter_'.length));
+       } else if (command === 'view_group') {
+         this.$router.push({
+           name: 'group',
+           params: {
+             groupIdOrSlug: this.dataset.group.id,
+           },
+         })
        }
      },
 

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -7,15 +7,15 @@
 
     <div class="opt-image" v-if="isOpticalImageSupported">
       <router-link :to="opticalImageAlignmentHref" v-if="canEditOpticalImage">
-        <div v-if="thumbnailCheck" class="edit-opt-image" title="Edit Optical Image">
-          <img class="opt-image-thumbnail" :src="opticalImageSmall" alt="Edit optical image"/>
+        <div v-if="dataset.thumbnailOpticalImageUrl != null" class="edit-opt-image" title="Edit Optical Image">
+          <img class="opt-image-thumbnail" :src="dataset.thumbnailOpticalImageUrl" alt="Edit optical image"/>
         </div>
         <div v-else class="no-opt-image" title="Add Optical Image">
           <img class="add-opt-image-thumbnail" src="../../../assets/no_opt_image.png" alt="Add optical image"/>
         </div>
       </router-link>
       <div v-else class="edit-opt-image-guest">
-        <img v-if="thumbnailCheck" :src="opticalImageSmall" alt="Optical image"/>
+        <img v-if="dataset.thumbnailOpticalImageUrl != null" :src="dataset.thumbnailOpticalImageUrl" alt="Optical image"/>
         <img v-else src="../../../assets/no_opt_image.png" alt="Optical image"/>
       </div>
     </div>
@@ -144,7 +144,6 @@
    datasetVisibilityQuery,
    deleteDatasetQuery,
    reprocessDatasetQuery,
-   thumbnailOptImageQuery,
  } from '../../../api/dataset';
  import {mdTypeSupportsOpticalImages} from '../../../util';
  import {encodeParams} from '../../Filters/index';
@@ -167,10 +166,6 @@
    },
 
    computed: {
-     thumbnailCheck() {
-       return this.opticalImageSmall!=null
-     },
-
      opticalImageAlignmentHref() {
          return {
              name: 'add-optical-image',
@@ -303,7 +298,6 @@
    data() {
      return {
        showMetadataDialog: false,
-       opticalImageSmall: null,
        disabled: false,
        ind: null,
        deferRender: this.idx > 20,
@@ -323,21 +317,6 @@
          return {id: this.dataset.id}
        }
      },
-     thumbnailImage: {
-       query: thumbnailOptImageQuery,
-       variables() {
-         return {
-           datasetId: this.dataset.id,
-         };
-       },
-       skip() {
-         return this.deferRender;
-       },
-       fetchPolicy: 'cache-first',
-       result(res) {
-         this.opticalImageSmall = res.data.thumbnailImage
-       }
-     }
    },
 
    methods: {

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -304,7 +304,6 @@
      return {
        showMetadataDialog: false,
        disabled: false,
-       ind: null,
        deferRender: this.idx >= 20,
      };
    },

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -66,7 +66,7 @@
           {{ formatSubmitter }}</span><!--
           Be careful not to add empty space before the comma
           --><span v-if="dataset.groupApproved && dataset.group">,
-          <el-dropdown @command="handleDropdownCommand">
+          <el-dropdown @command="handleDropdownCommand" :showTimeout="50">
             <span class="s-group ds-add-filter"
                   @click="addFilter('group')">
               {{dataset.group.shortName}}

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetList.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetList.vue
@@ -2,7 +2,9 @@
   <div class="dataset-list" :class="{'double-column': isDoubleColumn, 'allow-double-column': allowDoubleColumn}">
     <dataset-item v-for="(dataset, i) in datasets"
                   :dataset="dataset" :key="dataset.id"
-                  :class="[i%2 ? 'odd': '']"
+                  :class="i%2 ? 'odd': ''"
+                  :currentUser="currentUser"
+                  :idx="i"
                   @filterUpdate="filter => $emit('filterUpdate', filter)"
                   @datasetMutated="$emit('datasetMutated')">
     </dataset-item>
@@ -11,6 +13,7 @@
 
 <script>
   import DatasetItem from './DatasetItem.vue';
+  import {currentUserRoleQuery} from '../../../api/user';
 
   export default {
     name: 'dataset-list',
@@ -20,6 +23,12 @@
     },
     components: {
       DatasetItem,
+    },
+    apollo: {
+      currentUser: {
+        query: currentUserRoleQuery,
+        fetchPolicy: 'cache-first',
+      },
     },
     data() {
       // window.matchMedia is present on all our supported browsers, but not available in jsdom for tests

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetList.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetList.vue
@@ -5,6 +5,7 @@
                   :class="i%2 ? 'odd': ''"
                   :currentUser="currentUser"
                   :idx="i"
+                  :hideGroupMenu="hideGroupMenu"
                   @filterUpdate="filter => $emit('filterUpdate', filter)"
                   @datasetMutated="$emit('datasetMutated')">
     </dataset-item>
@@ -19,7 +20,8 @@
     name: 'dataset-list',
     props: {
       datasets: {type: Array, required: true},
-      allowDoubleColumn: {type: Boolean, default: false}
+      allowDoubleColumn: {type: Boolean, default: false},
+      hideGroupMenu: {type: Boolean, default: false}
     },
     components: {
       DatasetItem,

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -132,7 +132,7 @@ exports[`DatasetTable should match snapshot 1`] = `
         </mock-el-dialog>
         <div class="opt-image">
           <div class="edit-opt-image-guest">
-            <img src="thumbnailImage" alt="Optical image">
+            <img src="allDatasets.0.thumbnailOpticalImageUrl" alt="Optical image">
           </div>
         </div>
         <div class="ds-info">
@@ -155,231 +155,255 @@ exports[`DatasetTable should match snapshot 1`] = `
             Submitted <span class="s-bold">????-??-??</span> at ??:?? by
             <span title="Filter by submitter" class="ds-add-filter">
         allDatasets.0.submitter.name</span><span>,
-        <span title="Filter by this group" class="s-group ds-add-filter">
-          allDatasets.0.group.shortName
-        </span></span>
+        <mock-el-dropdown><div slot-key="default"><span class="s-group ds-add-filter">
+            allDatasets.0.group.shortName
+          </span> </div>
+          <div slot-key="dropdown">
+            <mock-el-dropdown-menu>
+              <mock-el-dropdown-item command="filter_group">Filter by this group</mock-el-dropdown-item>
+              <mock-el-dropdown-item command="view_group">View group</mock-el-dropdown-item>
+            </mock-el-dropdown-menu>
           </div>
-          <!---->
+          </mock-el-dropdown>
+          </span>
         </div>
-        <div class="ds-actions">
-          <!----><span><div title="Processing is under way" class="striped-progressbar processing"></div></span>
-          <!---->
-          <i class="el-icon-view"></i>
-          <a class="metadata-link">Show full metadata</a>
-          <!---->
-          <!---->
-          <!---->
-          <!---->
-        </div>
+        <!---->
       </div>
-      <div class="dataset-item odd">
-        <mock-el-dialog title="Provided metadata">
-          <div class="el-row">
-            <div role="tree" class="el-tree" id="metadata-tree">
-              <div role="treeitem" tabindex="0" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
-                <div class="el-tree-node__content" style="padding-left: 0px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
-                  <!---->
-                  <!----><span class="el-tree-node__label">MS analysis</span></div>
-                <div role="group" aria-expanded="true" class="el-tree-node__children">
-                  <div role="treeitem" tabindex="-1" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
-                    <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
+      <div class="ds-actions">
+        <!----><span><div title="Processing is under way" class="striped-progressbar processing"></div></span>
+        <!---->
+        <i class="el-icon-view"></i>
+        <a class="metadata-link">Show full metadata</a>
+        <!---->
+        <!---->
+        <!---->
+        <!---->
+      </div>
+    </div>
+    <div class="dataset-item odd">
+      <mock-el-dialog title="Provided metadata">
+        <div class="el-row">
+          <div role="tree" class="el-tree" id="metadata-tree">
+            <div role="treeitem" tabindex="0" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
+              <div class="el-tree-node__content" style="padding-left: 0px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
+                <!---->
+                <!----><span class="el-tree-node__label">MS analysis</span></div>
+              <div role="group" aria-expanded="true" class="el-tree-node__children">
+                <div role="treeitem" tabindex="-1" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
+                  <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
+                    <!---->
+                    <!----><span class="el-tree-node__label">Detector resolving power</span></div>
+                  <div role="group" aria-expanded="true" class="el-tree-node__children">
+                    <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+                      <div class="el-tree-node__content" style="padding-left: 36px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
+                        <!---->
+                        <!----><span class="el-tree-node__label">mz: 1234</span></div>
                       <!---->
-                      <!----><span class="el-tree-node__label">Detector resolving power</span></div>
-                    <div role="group" aria-expanded="true" class="el-tree-node__children">
-                      <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                        <div class="el-tree-node__content" style="padding-left: 36px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                          <!---->
-                          <!----><span class="el-tree-node__label">mz: 1234</span></div>
+                    </div>
+                    <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+                      <div class="el-tree-node__content" style="padding-left: 36px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
                         <!---->
-                      </div>
-                      <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                        <div class="el-tree-node__content" style="padding-left: 36px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                          <!---->
-                          <!----><span class="el-tree-node__label">Resolving power: 123456</span></div>
-                        <!---->
-                      </div>
+                        <!----><span class="el-tree-node__label">Resolving power: 123456</span></div>
+                      <!---->
                     </div>
                   </div>
                 </div>
               </div>
-              <div role="treeitem" tabindex="-1" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
-                <div class="el-tree-node__content" style="padding-left: 0px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
+            </div>
+            <div role="treeitem" tabindex="-1" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
+              <div class="el-tree-node__content" style="padding-left: 0px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
+                <!---->
+                <!----><span class="el-tree-node__label">Data Management</span></div>
+              <div role="group" aria-expanded="true" class="el-tree-node__children">
+                <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+                  <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
+                    <!---->
+                    <!----><span class="el-tree-node__label">Submitter: allDatasets.0.submitter.name</span></div>
                   <!---->
-                  <!----><span class="el-tree-node__label">Data Management</span></div>
-                <div role="group" aria-expanded="true" class="el-tree-node__children">
-                  <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                    <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                      <!---->
-                      <!----><span class="el-tree-node__label">Submitter: allDatasets.0.submitter.name</span></div>
+                </div>
+                <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+                  <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
                     <!---->
-                  </div>
-                  <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                    <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                      <!---->
-                      <!----><span class="el-tree-node__label">Principal Investigator: allDatasets.0.principalInvestigator.name</span></div>
+                    <!----><span class="el-tree-node__label">Principal Investigator: allDatasets.0.principalInvestigator.name</span></div>
+                  <!---->
+                </div>
+                <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+                  <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
                     <!---->
-                  </div>
-                  <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                    <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                      <!---->
-                      <!----><span class="el-tree-node__label">Group: allDatasets.0.group.name</span></div>
+                    <!----><span class="el-tree-node__label">Group: allDatasets.0.group.name</span></div>
+                  <!---->
+                </div>
+                <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+                  <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
                     <!---->
-                  </div>
-                  <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                    <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                      <!---->
-                      <!----><span class="el-tree-node__label">Projects: allDatasets.0.projects.0.name, allDatasets.0.projects.1.name</span></div>
-                    <!---->
-                  </div>
+                    <!----><span class="el-tree-node__label">Projects: allDatasets.0.projects.0.name, allDatasets.0.projects.1.name</span></div>
+                  <!---->
                 </div>
               </div>
-              <!---->
-              <div class="el-tree__drop-indicator" style="display: none;"></div>
             </div>
-          </div>
-        </mock-el-dialog>
-        <div class="opt-image">
-          <div class="edit-opt-image-guest">
-            <img src="thumbnailImage" alt="Optical image">
+            <!---->
+            <div class="el-tree__drop-indicator" style="display: none;"></div>
           </div>
         </div>
-        <div class="ds-info">
-          <div class="ds-item-line">
-            <b>allDatasets.0.name</b>
-          </div>
-          <div class="ds-item-line"><span title="Filter by species" class="ds-add-filter">
-        allDatasets.0.organism</span>,
-            <span title="Filter by organism part" class="ds-add-filter">
-        alldatasets.0.organismpart</span> <span title="Filter by condition" class="ds-add-filter">
-        (alldatasets.0.condition)</span></div>
-          <div class="ds-item-line"><span title="Filter by ionisation source" class="ds-add-filter">
-        allDatasets.0.ionisationSource</span> +
-            <span title="Filter by analyzer type" class="ds-add-filter">
-        allDatasets.0.analyzer.type</span>,
-            <span title="Filter by polarity" class="ds-add-filter">
-        positive mode</span>, RP 123k @ 1234
-          </div>
-          <div class="ds-item-line" style="font-size: 15px;">
-            Submitted <span class="s-bold">????-??-??</span> at ??:?? by
-            <span title="Filter by submitter" class="ds-add-filter">
-        allDatasets.0.submitter.name</span><span>,
-        <span title="Filter by this group" class="s-group ds-add-filter">
-          allDatasets.0.group.shortName
-        </span></span>
-          </div>
-          <!---->
-        </div>
-        <div class="ds-actions">
-          <!---->
-          <!----><span><div title="Waiting in the queue" class="striped-progressbar queued"></div></span>
-          <i class="el-icon-view"></i>
-          <a class="metadata-link">Show full metadata</a>
-          <!---->
-          <!---->
-          <!---->
-          <!---->
+      </mock-el-dialog>
+      <div class="opt-image">
+        <div class="edit-opt-image-guest">
+          <img src="allDatasets.0.thumbnailOpticalImageUrl" alt="Optical image">
         </div>
       </div>
-      <div class="dataset-item">
-        <mock-el-dialog title="Provided metadata">
-          <div class="el-row">
-            <div role="tree" class="el-tree" id="metadata-tree">
-              <div role="treeitem" tabindex="0" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
-                <div class="el-tree-node__content" style="padding-left: 0px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
-                  <!---->
-                  <!----><span class="el-tree-node__label">MS analysis</span></div>
-                <div role="group" aria-expanded="true" class="el-tree-node__children">
-                  <div role="treeitem" tabindex="-1" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
-                    <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
-                      <!---->
-                      <!----><span class="el-tree-node__label">Detector resolving power</span></div>
-                    <div role="group" aria-expanded="true" class="el-tree-node__children">
-                      <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                        <div class="el-tree-node__content" style="padding-left: 36px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                          <!---->
-                          <!----><span class="el-tree-node__label">mz: 1234</span></div>
-                        <!---->
-                      </div>
-                      <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                        <div class="el-tree-node__content" style="padding-left: 36px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                          <!---->
-                          <!----><span class="el-tree-node__label">Resolving power: 123456</span></div>
-                        <!---->
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div role="treeitem" tabindex="-1" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
-                <div class="el-tree-node__content" style="padding-left: 0px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
-                  <!---->
-                  <!----><span class="el-tree-node__label">Data Management</span></div>
-                <div role="group" aria-expanded="true" class="el-tree-node__children">
-                  <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                    <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                      <!---->
-                      <!----><span class="el-tree-node__label">Submitter: allDatasets.0.submitter.name</span></div>
-                    <!---->
-                  </div>
-                  <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                    <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                      <!---->
-                      <!----><span class="el-tree-node__label">Principal Investigator: allDatasets.0.principalInvestigator.name</span></div>
-                    <!---->
-                  </div>
-                  <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                    <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                      <!---->
-                      <!----><span class="el-tree-node__label">Group: allDatasets.0.group.name</span></div>
-                    <!---->
-                  </div>
-                  <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                    <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                      <!---->
-                      <!----><span class="el-tree-node__label">Projects: allDatasets.0.projects.0.name, allDatasets.0.projects.1.name</span></div>
-                    <!---->
-                  </div>
-                </div>
-              </div>
-              <!---->
-              <div class="el-tree__drop-indicator" style="display: none;"></div>
-            </div>
-          </div>
-        </mock-el-dialog>
-        <div class="opt-image">
-          <div class="edit-opt-image-guest">
-            <img src="thumbnailImage" alt="Optical image">
-          </div>
+      <div class="ds-info">
+        <div class="ds-item-line">
+          <b>allDatasets.0.name</b>
         </div>
-        <div class="ds-info">
-          <div class="ds-item-line">
-            <b>allDatasets.0.name</b>
-          </div>
-          <div class="ds-item-line"><span title="Filter by species" class="ds-add-filter">
+        <div class="ds-item-line"><span title="Filter by species" class="ds-add-filter">
         allDatasets.0.organism</span>,
-            <span title="Filter by organism part" class="ds-add-filter">
+          <span title="Filter by organism part" class="ds-add-filter">
         alldatasets.0.organismpart</span> <span title="Filter by condition" class="ds-add-filter">
         (alldatasets.0.condition)</span></div>
-          <div class="ds-item-line"><span title="Filter by ionisation source" class="ds-add-filter">
+        <div class="ds-item-line"><span title="Filter by ionisation source" class="ds-add-filter">
         allDatasets.0.ionisationSource</span> +
-            <span title="Filter by analyzer type" class="ds-add-filter">
+          <span title="Filter by analyzer type" class="ds-add-filter">
         allDatasets.0.analyzer.type</span>,
-            <span title="Filter by polarity" class="ds-add-filter">
+          <span title="Filter by polarity" class="ds-add-filter">
         positive mode</span>, RP 123k @ 1234
-          </div>
-          <div class="ds-item-line" style="font-size: 15px;">
-            Submitted <span class="s-bold">????-??-??</span> at ??:?? by
-            <span title="Filter by submitter" class="ds-add-filter">
+        </div>
+        <div class="ds-item-line" style="font-size: 15px;">
+          Submitted <span class="s-bold">????-??-??</span> at ??:?? by
+          <span title="Filter by submitter" class="ds-add-filter">
         allDatasets.0.submitter.name</span><span>,
-        <span title="Filter by this group" class="s-group ds-add-filter">
-          allDatasets.0.group.shortName
-        </span></span>
+        <mock-el-dropdown><div slot-key="default"><span class="s-group ds-add-filter">
+            allDatasets.0.group.shortName
+          </span> </div>
+        <div slot-key="dropdown">
+          <mock-el-dropdown-menu>
+            <mock-el-dropdown-item command="filter_group">Filter by this group</mock-el-dropdown-item>
+            <mock-el-dropdown-item command="view_group">View group</mock-el-dropdown-item>
+          </mock-el-dropdown-menu>
+        </div>
+        </mock-el-dropdown>
+        </span>
+      </div>
+      <!---->
+    </div>
+    <div class="ds-actions">
+      <!---->
+      <!----><span><div title="Waiting in the queue" class="striped-progressbar queued"></div></span>
+      <i class="el-icon-view"></i>
+      <a class="metadata-link">Show full metadata</a>
+      <!---->
+      <!---->
+      <!---->
+      <!---->
+    </div>
+  </div>
+  <div class="dataset-item">
+    <mock-el-dialog title="Provided metadata">
+      <div class="el-row">
+        <div role="tree" class="el-tree" id="metadata-tree">
+          <div role="treeitem" tabindex="0" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
+            <div class="el-tree-node__content" style="padding-left: 0px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
+              <!---->
+              <!----><span class="el-tree-node__label">MS analysis</span></div>
+            <div role="group" aria-expanded="true" class="el-tree-node__children">
+              <div role="treeitem" tabindex="-1" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
+                <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
+                  <!---->
+                  <!----><span class="el-tree-node__label">Detector resolving power</span></div>
+                <div role="group" aria-expanded="true" class="el-tree-node__children">
+                  <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+                    <div class="el-tree-node__content" style="padding-left: 36px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
+                      <!---->
+                      <!----><span class="el-tree-node__label">mz: 1234</span></div>
+                    <!---->
+                  </div>
+                  <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+                    <div class="el-tree-node__content" style="padding-left: 36px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
+                      <!---->
+                      <!----><span class="el-tree-node__label">Resolving power: 123456</span></div>
+                    <!---->
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-          <div class="ds-item-line"><span><a href="/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">1, 2, 20 annotations</a>
+          <div role="treeitem" tabindex="-1" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
+            <div class="el-tree-node__content" style="padding-left: 0px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
+              <!---->
+              <!----><span class="el-tree-node__label">Data Management</span></div>
+            <div role="group" aria-expanded="true" class="el-tree-node__children">
+              <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+                <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
+                  <!---->
+                  <!----><span class="el-tree-node__label">Submitter: allDatasets.0.submitter.name</span></div>
+                <!---->
+              </div>
+              <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+                <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
+                  <!---->
+                  <!----><span class="el-tree-node__label">Principal Investigator: allDatasets.0.principalInvestigator.name</span></div>
+                <!---->
+              </div>
+              <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+                <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
+                  <!---->
+                  <!----><span class="el-tree-node__label">Group: allDatasets.0.group.name</span></div>
+                <!---->
+              </div>
+              <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+                <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
+                  <!---->
+                  <!----><span class="el-tree-node__label">Projects: allDatasets.0.projects.0.name, allDatasets.0.projects.1.name</span></div>
+                <!---->
+              </div>
+            </div>
+          </div>
+          <!---->
+          <div class="el-tree__drop-indicator" style="display: none;"></div>
+        </div>
+      </div>
+    </mock-el-dialog>
+    <div class="opt-image">
+      <div class="edit-opt-image-guest">
+        <img src="allDatasets.0.thumbnailOpticalImageUrl" alt="Optical image">
+      </div>
+    </div>
+    <div class="ds-info">
+      <div class="ds-item-line">
+        <b>allDatasets.0.name</b>
+      </div>
+      <div class="ds-item-line"><span title="Filter by species" class="ds-add-filter">
+        allDatasets.0.organism</span>,
+        <span title="Filter by organism part" class="ds-add-filter">
+        alldatasets.0.organismpart</span> <span title="Filter by condition" class="ds-add-filter">
+        (alldatasets.0.condition)</span></div>
+      <div class="ds-item-line"><span title="Filter by ionisation source" class="ds-add-filter">
+        allDatasets.0.ionisationSource</span> +
+        <span title="Filter by analyzer type" class="ds-add-filter">
+        allDatasets.0.analyzer.type</span>,
+        <span title="Filter by polarity" class="ds-add-filter">
+        positive mode</span>, RP 123k @ 1234
+      </div>
+      <div class="ds-item-line" style="font-size: 15px;">
+        Submitted <span class="s-bold">????-??-??</span> at ??:?? by
+        <span title="Filter by submitter" class="ds-add-filter">
+        allDatasets.0.submitter.name</span><span>,
+        <mock-el-dropdown><div slot-key="default"><span class="s-group ds-add-filter">
+            allDatasets.0.group.shortName
+          </span> </div>
+      <div slot-key="dropdown">
+        <mock-el-dropdown-menu>
+          <mock-el-dropdown-item command="filter_group">Filter by this group</mock-el-dropdown-item>
+          <mock-el-dropdown-item command="view_group">View group</mock-el-dropdown-item>
+        </mock-el-dropdown-menu>
+      </div>
+      </mock-el-dropdown>
+      </span>
+    </div>
+    <div class="ds-item-line"><span><a href="/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">1, 2, 20 annotations</a>
         @ FDR 0.05, 0.1, 0.5% (HMDB-v2.5)
       </span></div>
-        </div>
-        <div class="ds-actions"><span><i class="el-icon-picture"></i> <mock-el-popover trigger="hover" placement="top"><div slot-key="default"><div class="db-link-list">
+  </div>
+  <div class="ds-actions"><span><i class="el-icon-picture"></i> <mock-el-popover trigger="hover" placement="top"><div slot-key="default"><div class="db-link-list">
           Select a database:
           <div><a href="/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
               HMDB-v2.5
@@ -388,17 +412,17 @@ exports[`DatasetTable should match snapshot 1`] = `
             </a></div><div><a href="/annotations?db=CHEBI&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
               CHEBI
             </a></div></div> </div><div slot-key="reference"><a>Browse annotations</a></div></mock-el-popover> <br></span>
-          <!---->
-          <!---->
-          <i class="el-icon-view"></i>
-          <a class="metadata-link">Show full metadata</a>
-          <!---->
-          <!---->
-          <!---->
-          <!---->
-        </div>
-      </div>
-    </div>
+    <!---->
+    <!---->
+    <i class="el-icon-view"></i>
+    <a class="metadata-link">Show full metadata</a>
+    <!---->
+    <!---->
+    <!---->
+    <!---->
   </div>
+</div>
+</div>
+</div>
 </div>
 `;

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -155,7 +155,7 @@ exports[`DatasetTable should match snapshot 1`] = `
             Submitted <span class="s-bold">????-??-??</span> at ??:?? by
             <span title="Filter by submitter" class="ds-add-filter">
         allDatasets.0.submitter.name</span><span>,
-        <mock-el-dropdown showtimeout="50"><div slot-key="default"><span class="s-group ds-add-filter">
+        <mock-el-dropdown showtimeout="50" placement="bottom"><div slot-key="default"><span class="s-group ds-add-filter">
             allDatasets.0.group.shortName
           </span> </div>
           <div slot-key="dropdown">
@@ -271,7 +271,7 @@ exports[`DatasetTable should match snapshot 1`] = `
           Submitted <span class="s-bold">????-??-??</span> at ??:?? by
           <span title="Filter by submitter" class="ds-add-filter">
         allDatasets.0.submitter.name</span><span>,
-        <mock-el-dropdown showtimeout="50"><div slot-key="default"><span class="s-group ds-add-filter">
+        <mock-el-dropdown showtimeout="50" placement="bottom"><div slot-key="default"><span class="s-group ds-add-filter">
             allDatasets.0.group.shortName
           </span> </div>
         <div slot-key="dropdown">
@@ -387,7 +387,7 @@ exports[`DatasetTable should match snapshot 1`] = `
         Submitted <span class="s-bold">????-??-??</span> at ??:?? by
         <span title="Filter by submitter" class="ds-add-filter">
         allDatasets.0.submitter.name</span><span>,
-        <mock-el-dropdown showtimeout="50"><div slot-key="default"><span class="s-group ds-add-filter">
+        <mock-el-dropdown showtimeout="50" placement="bottom"><div slot-key="default"><span class="s-group ds-add-filter">
             allDatasets.0.group.shortName
           </span> </div>
       <div slot-key="dropdown">

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -155,7 +155,7 @@ exports[`DatasetTable should match snapshot 1`] = `
             Submitted <span class="s-bold">????-??-??</span> at ??:?? by
             <span title="Filter by submitter" class="ds-add-filter">
         allDatasets.0.submitter.name</span><span>,
-        <mock-el-dropdown><div slot-key="default"><span class="s-group ds-add-filter">
+        <mock-el-dropdown showtimeout="50"><div slot-key="default"><span class="s-group ds-add-filter">
             allDatasets.0.group.shortName
           </span> </div>
           <div slot-key="dropdown">
@@ -271,7 +271,7 @@ exports[`DatasetTable should match snapshot 1`] = `
           Submitted <span class="s-bold">????-??-??</span> at ??:?? by
           <span title="Filter by submitter" class="ds-add-filter">
         allDatasets.0.submitter.name</span><span>,
-        <mock-el-dropdown><div slot-key="default"><span class="s-group ds-add-filter">
+        <mock-el-dropdown showtimeout="50"><div slot-key="default"><span class="s-group ds-add-filter">
             allDatasets.0.group.shortName
           </span> </div>
         <div slot-key="dropdown">
@@ -387,7 +387,7 @@ exports[`DatasetTable should match snapshot 1`] = `
         Submitted <span class="s-bold">????-??-??</span> at ??:?? by
         <span title="Filter by submitter" class="ds-add-filter">
         allDatasets.0.submitter.name</span><span>,
-        <mock-el-dropdown><div slot-key="default"><span class="s-group ds-add-filter">
+        <mock-el-dropdown showtimeout="50"><div slot-key="default"><span class="s-group ds-add-filter">
             allDatasets.0.group.shortName
           </span> </div>
       <div slot-key="dropdown">

--- a/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.vue
@@ -47,7 +47,7 @@
       </div>
       <el-tabs v-model="tab">
         <el-tab-pane name="datasets" :label="'Datasets' | optionalSuffixInParens(countDatasets)" lazy>
-          <dataset-list :datasets="groupDatasets.slice(0, maxVisibleDatasets)" @filterUpdate="handleFilterUpdate" />
+          <dataset-list :datasets="groupDatasets.slice(0, maxVisibleDatasets)" @filterUpdate="handleFilterUpdate" hideGroupMenu />
 
           <div class="dataset-list-footer">
             <router-link v-if="countDatasets > maxVisibleDatasets" :to="datasetsListLink">See all datasets</router-link>

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupPage.spec.ts.snap
@@ -36,9 +36,9 @@ exports[`ViewGroupPage datasets tab should match snapshot (non-member) 1`] = `
       <div class="el-tabs__content">
         <div role="tabpanel" id="pane-datasets" aria-labelledby="tab-datasets" class="el-tab-pane">
           <div class="dataset-list">
-            <datasetitem-stub dataset="[object Object]" class=""></datasetitem-stub>
-            <datasetitem-stub dataset="[object Object]" class="odd"></datasetitem-stub>
-            <datasetitem-stub dataset="[object Object]" class=""></datasetitem-stub>
+            <datasetitem-stub dataset="[object Object]" currentuser="[object Object]" idx="0" hidegroupmenu="true" class=""></datasetitem-stub>
+            <datasetitem-stub dataset="[object Object]" currentuser="[object Object]" idx="1" hidegroupmenu="true" class="odd"></datasetitem-stub>
+            <datasetitem-stub dataset="[object Object]" currentuser="[object Object]" idx="2" hidegroupmenu="true" class=""></datasetitem-stub>
           </div>
           <div class="dataset-list-footer">
             <a href="/datasets?grp=00000000-1111-2222-3333-444444444444" class="">See all datasets</a>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
@@ -34,9 +34,9 @@ exports[`ViewProjectPage datasets tab should match snapshot (non-member) 1`] = `
       <div class="el-tabs__content">
         <div role="tabpanel" id="pane-datasets" aria-labelledby="tab-datasets" class="el-tab-pane">
           <div class="dataset-list">
-            <datasetitem-stub dataset="[object Object]" class=""></datasetitem-stub>
-            <datasetitem-stub dataset="[object Object]" class="odd"></datasetitem-stub>
-            <datasetitem-stub dataset="[object Object]" class=""></datasetitem-stub>
+            <datasetitem-stub dataset="[object Object]" currentuser="[object Object]" idx="0" class=""></datasetitem-stub>
+            <datasetitem-stub dataset="[object Object]" currentuser="[object Object]" idx="1" class="odd"></datasetitem-stub>
+            <datasetitem-stub dataset="[object Object]" currentuser="[object Object]" idx="2" class=""></datasetitem-stub>
           </div>
           <div class="dataset-list-footer">
             <a href="/datasets?prj=00000000-1111-2222-3333-444444444444" class="">See all datasets</a>

--- a/metaspace/webapp/tests/utils/setupTestFramework.ts
+++ b/metaspace/webapp/tests/utils/setupTestFramework.ts
@@ -20,6 +20,9 @@ registerMockComponent('el-autocomplete');
 registerMockComponent('el-select');
 registerMockComponent('el-option');
 registerMockComponent('el-messagebox');
+registerMockComponent('el-dropdown');
+registerMockComponent('el-dropdown-menu');
+registerMockComponent('el-dropdown-item');
 
 // Mock problematic directives
 registerMockDirective('loading');


### PR DESCRIPTION
Resolves #120

#### Datasets page changes

* Link to group page from dataset items:
    ![image](https://user-images.githubusercontent.com/26366936/49373524-beeb0700-f6fe-11e8-9ab9-bff137bca2ac.png)
    * This menu appears on after hovering over the group name
    * This menu is disabled on the group page, because it doesn't make sense there
* Move GraphQL `thumbnailOpticalImageUrl` into the `Dataset` type so that DatasetItems don't have to do a separate query for it. (Reduces number of GraphQL queries by 100 & increases page rendering speed by ~100ms)
* Move `currentUser` query from `DatasetItem` into parent `DatasetList` component (Removes 100 queries that would cost ~100ms even though Apollo deduplicates them into all into just 1 query)
* Start deferring rendering of datasets once more than 20 appear on the screen. This makes the page show datasets and become interactive about 500ms sooner. 
    * A negative side effect is that the page height jumps a few times while the page is loading
    * People with high-res screens (greater than 1400px high) will see past the initial 20 visible items, which looks a little bit worse because the page moves multiple times after loading
    * I had to use `requestAnimationFrame` to ensure that the datasets were evenly spread out. Otherwise Vue was clumping the 8 deferred batches of datasets to render into 1-3 janky updates instead of 8 smooth updates. This unfortunately adds about 100ms to the total time (but greatly improves interactivity while it is loading)


#### Other changes

* Add `white-space: nowrap` to the "My Account" menu items in the header, so that the notification icon doesn't wrap.
* Add default values for the `inpFdrLvls` and `checkLvl` args in the GraphQL side, because we actually only use a specific set of constants for this value and it's a pain to find out what they should be if they're needed in a nested query.