### PR TITLE
Complete refactoring of using TypeORM EntityManager instead of Connection

### DIFF
--- a/metaspace/graphql/server.js
+++ b/metaspace/graphql/server.js
@@ -61,11 +61,12 @@ async function createHttpServerAsync(config) {
 
   app.use(bodyParser.json());
   configureSession(app);
-  await configureAuth(app, connection);
+  await configureAuth(app, connection.manager);
+
 
   const apollo = new ApolloServer({
     schema: executableSchema,
-    context: ({req, res}) => getContext(req.user && req.user.user, connection, req, res),
+    context: ({req, res}) => getContext(req.user && req.user.user, connection.manager, req, res),
     playground: {
       settings: {
         'editor.theme': 'light',

--- a/metaspace/graphql/src/context.ts
+++ b/metaspace/graphql/src/context.ts
@@ -1,5 +1,5 @@
 import {Request, Response} from 'express';
-import {Connection, EntityManager} from 'typeorm';
+import {EntityManager} from 'typeorm';
 import {ProjectRole} from '../../webapp/src/api/project';
 
 export type UserProjectRoles = {[projectId: string]: ProjectRole | undefined}
@@ -16,9 +16,7 @@ export interface ContextUser {
 export interface Context {
   req: Request;
   res: Response;
-  // TODO: Replace connection with just EntityManager and rename it, as EntityManager is almost the same, but
-  // it can be swapped out by tests so that everything runs in a transaction.
-  connection: Connection | EntityManager;
+  entityManager: EntityManager;
   user: ContextUser | null;
   isAdmin: boolean;
   getUserIdOrFail: () => string; // Throws "Unauthenticated" error if not logged in

--- a/metaspace/graphql/src/getContext.ts
+++ b/metaspace/graphql/src/getContext.ts
@@ -1,4 +1,4 @@
-import {Connection, EntityManager} from 'typeorm';
+import {EntityManager} from 'typeorm';
 import {Context, UserProjectRoles} from './context';
 import {UserProjectRoleOptions as UPRO} from './modules/project/model';
 import {UserError} from 'graphql-errors';
@@ -7,14 +7,14 @@ import {getUserProjectRoles} from './utils/db';
 import {Request, Response} from 'express';
 
 
-const getContext = (jwtUser: JwtUser | null, connection: Connection | EntityManager,
+const getContext = (jwtUser: JwtUser | null, entityManager: EntityManager,
                 req: Request, res: Response): Context => {
   const user = jwtUser != null && jwtUser.id != null ? jwtUser : null;
 
   let currentUserProjectRoles: Promise<UserProjectRoles> | null = null;
   const getProjectRoles = async () => {
     if (currentUserProjectRoles == null && user != null && user.id != null) {
-      currentUserProjectRoles = getUserProjectRoles(connection, user.id)
+      currentUserProjectRoles = getUserProjectRoles(entityManager, user.id)
     } else if (currentUserProjectRoles == null) {
       currentUserProjectRoles = Promise.resolve({});
     }
@@ -30,7 +30,7 @@ const getContext = (jwtUser: JwtUser | null, connection: Connection | EntityMana
   };
 
   return {
-    req, res, connection,
+    req, res, entityManager,
     user: user == null || user.id == null ? null : {
       id: user.id,
       role: user.role as ('user' | 'admin'),
@@ -51,7 +51,7 @@ const getContext = (jwtUser: JwtUser | null, connection: Connection | EntityMana
 };
 export default getContext;
 
-export const getContextForTest = (jwtUser: JwtUser | null, connection: Connection | EntityManager): Context => {
+export const getContextForTest = (jwtUser: JwtUser | null, entityManager: EntityManager): Context => {
   // TODO: Add mocks for req & res if/when needed
-  return getContext(jwtUser, connection, null as any, null as any);
+  return getContext(jwtUser, entityManager, null as any, null as any);
 };

--- a/metaspace/graphql/src/modules/auth/controller.ts
+++ b/metaspace/graphql/src/modules/auth/controller.ts
@@ -4,7 +4,7 @@ import * as Passport from 'passport';
 import {Strategy as LocalStrategy} from 'passport-local';
 import {Strategy as GoogleStrategy} from 'passport-google-oauth20';
 import * as JwtSimple from 'jwt-simple';
-import {Connection} from 'typeorm';
+import {EntityManager} from 'typeorm';
 
 import config from '../../utils/config';
 import {User} from '../user/model';
@@ -297,9 +297,9 @@ const configureResetPassword = (router: IRouter<any>) => {
   });
 };
 
-export const configureAuth = async (app: Express, connection: Connection) => {
+export const configureAuth = async (app: Express, entityManager: EntityManager) => {
   const router = Router();
-  await initOperation(connection);
+  await initOperation(entityManager);
   configurePassport(router);
   configureJwt(router);
   configureLocalAuth(router);

--- a/metaspace/graphql/src/modules/auth/operation.ts
+++ b/metaspace/graphql/src/modules/auth/operation.ts
@@ -1,6 +1,6 @@
 import * as bcrypt from 'bcrypt';
 import * as uuid from 'uuid';
-import {Connection, EntityManager, Repository} from 'typeorm';
+import {EntityManager, Repository} from 'typeorm';
 import * as moment from 'moment';
 import {Moment} from 'moment';
 
@@ -20,14 +20,14 @@ export interface UserCredentialsInput {
 
 const NUM_ROUNDS = 12;
 
-let connection: Connection | EntityManager;
+let entityManager: EntityManager;
 let credRepo: Repository<Credentials>;
 let userRepo: Repository<User>;
 
-export const initOperation = async (typeormConn?: Connection | EntityManager) => {
-  connection = typeormConn || await utils.createConnection();
-  credRepo = connection.getRepository(Credentials);
-  userRepo = connection.getRepository(User);
+export const initOperation = async (typeormConn?: EntityManager) => {
+  entityManager = typeormConn || (await utils.createConnection()).manager;
+  credRepo = entityManager.getRepository(Credentials);
+  userRepo = entityManager.getRepository(User);
 };
 
 // FIXME: some mechanism should be added so that a user's other sessions are revoked when they change their password, etc.
@@ -50,7 +50,7 @@ export const findUserById = async (id: string|undefined, credentials: boolean=tr
 };
 
 export const findUserByEmail = async (value: string, field: string='email') => {
-  return utils.findUserByEmail(connection, value, field);
+  return utils.findUserByEmail(entityManager, value, field);
 };
 
 export const findUserByGoogleId = async (googleId: string) => {
@@ -256,8 +256,8 @@ export const resetPassword = async (email: string, password: string, token: stri
 };
 
 export const createInactiveUser = async (email: string): Promise<UserModel> => {
-  const invUserCred = await connection.getRepository(CredentialsModel).save({ emailVerified: false });
-  return await connection.getRepository(UserModel).save({
+  const invUserCred = await entityManager.getRepository(CredentialsModel).save({ emailVerified: false });
+  return await entityManager.getRepository(UserModel).save({
     notVerifiedEmail: email,
     credentials: invUserCred
   }) as UserModel;

--- a/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
@@ -10,7 +10,7 @@ import {logger} from '../../../utils';
 import {Context} from '../../../context';
 
 export const thumbnailOpticalImageUrl = async (ctx: Context, id: string) => {
-  const result = await ctx.connection.query('SELECT thumbnail FROM public.dataset WHERE id = $1', [id]);
+  const result = await ctx.entityManager.query('SELECT thumbnail FROM public.dataset WHERE id = $1', [id]);
   if (result && result.length === 1 && result[0].thumbnail != null) {
     return `/fs/optical_images/${result[0].thumbnail}`;
   } else {
@@ -104,7 +104,7 @@ const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
       return [];
     }
 
-    const projects = await ctx.connection.getCustomRepository(ProjectSourceRepository)
+    const projects = await ctx.entityManager.getCustomRepository(ProjectSourceRepository)
       .findProjectsByDatasetId(ctx.user, ds._source.ds_id);
     return projects.map(p => ({
       id: p.id,
@@ -114,8 +114,8 @@ const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
     }));
   },
 
-  async principalInvestigator(ds, _, {connection, isAdmin, user}) {
-    const dataset = await connection.getRepository(DatasetModel).findOne({ id: ds._source.ds_id });
+  async principalInvestigator(ds, _, {entityManager, isAdmin, user}) {
+    const dataset = await entityManager.getRepository(DatasetModel).findOne({ id: ds._source.ds_id });
     if (dataset == null) {
       logger.warn(`Elasticsearch DS does not exist in DB: ${ds._source.ds_id}`);
       return null;

--- a/metaspace/graphql/src/modules/dataset/controller/Mutation.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Mutation.ts
@@ -2,7 +2,7 @@ import * as jsondiffpatch from 'jsondiffpatch';
 import config from '../../../utils/config';
 import * as Ajv from 'ajv';
 import {UserError} from 'graphql-errors';
-import {Connection, EntityManager} from 'typeorm';
+import {EntityManager} from 'typeorm';
 import * as moment from 'moment';
 import * as _ from 'lodash';
 
@@ -112,8 +112,8 @@ export function processingSettingsChanged(ds: EngineDS, update: DatasetUpdateInp
   return {newDB: newDB, procSettingsUpd: procSettingsUpd, metaDiff: metaDiff}
 }
 
-const isMemberOf = async (connection: Connection | EntityManager, userId: string, groupId: string) => {
-  const userGroup = await connection.getRepository(UserGroupModel).findOne({
+const isMemberOf = async (entityManager: EntityManager, userId: string, groupId: string) => {
+  const userGroup = await entityManager.getRepository(UserGroupModel).findOne({
     userId,
     groupId
   });
@@ -133,11 +133,11 @@ interface SaveDSArgs {
   principalInvestigator?: {name: string, email: string};
 }
 
-const saveDS = async (connection: Connection | EntityManager, args: SaveDSArgs, requireInsert = false) => {
+const saveDS = async (entityManager: EntityManager, args: SaveDSArgs, requireInsert = false) => {
   const {dsId, submitterId, groupId, projectIds, principalInvestigator} = args;
   const groupUpdate = groupId === undefined ? {}
     : groupId === null ? { groupId: null, groupApproved: false }
-      : { groupId, groupApproved: await isMemberOf(connection, submitterId, groupId) };
+      : { groupId, groupApproved: await isMemberOf(entityManager, submitterId, groupId) };
   const piUpdate = principalInvestigator === undefined ? {}
     : principalInvestigator === null ? { piName: null, piEmail: null }
     : { piName: principalInvestigator.name, piEmail: principalInvestigator.email };
@@ -150,15 +150,15 @@ const saveDS = async (connection: Connection | EntityManager, args: SaveDSArgs, 
 
   if (requireInsert) {
     // When creating new datasets, use INSERT so that SQL prevents the same ID from being used twice
-    await connection.getRepository(DatasetModel).insert(dsUpdate);
+    await entityManager.getRepository(DatasetModel).insert(dsUpdate);
   } else {
-    await connection.getRepository(DatasetModel).save(dsUpdate);
+    await entityManager.getRepository(DatasetModel).save(dsUpdate);
   }
 
   if (projectIds != null) {
-    const datasetProjectRepo = connection.getRepository(DatasetProjectModel);
+    const datasetProjectRepo = entityManager.getRepository(DatasetProjectModel);
     const existingDatasetProjects = await datasetProjectRepo.find({ datasetId: dsId });
-    const userProjectRoles = await getUserProjectRoles(connection, submitterId);
+    const userProjectRoles = await getUserProjectRoles(entityManager, submitterId);
     const savePromises = projectIds
       .map((projectId) => ({
         projectId,
@@ -198,7 +198,7 @@ type CreateDatasetArgs = {
 };
 const createDataset = async (args: CreateDatasetArgs, ctx: Context) => {
   const {input, priority, force, skipValidation} = args;
-  const {user, connection, isAdmin, getUserIdOrFail} = ctx;
+  const {user, entityManager, isAdmin, getUserIdOrFail} = ctx;
   const dsId = args.id || newDatasetId();
   const dsIdWasSpecified = !!args.id;
   const userId = getUserIdOrFail();
@@ -206,7 +206,7 @@ const createDataset = async (args: CreateDatasetArgs, ctx: Context) => {
   logger.info(`Creating dataset '${dsId}' by '${userId}' user ...`);
   let ds;
   if (dsIdWasSpecified) {
-    ds = await getDatasetForEditing(connection, user, dsId);
+    ds = await getDatasetForEditing(entityManager, user, dsId);
   } else {
     assertCanCreateDataset(user);
   }
@@ -227,7 +227,7 @@ const createDataset = async (args: CreateDatasetArgs, ctx: Context) => {
     projectIds: projectIds as string[],
     principalInvestigator
   };
-  await saveDS(connection, saveDSArgs, !dsIdWasSpecified);
+  await saveDS(entityManager, saveDSArgs, !dsIdWasSpecified);
 
   const url = `/v1/datasets/${dsId}/add`;
   await smAPIRequest(url, {
@@ -265,11 +265,11 @@ const MutationResolvers: FieldResolversFor<Mutation, void>  = {
     return await createDataset(args, ctx);
   },
 
-  updateDataset: async (source, args, {user, connection, isAdmin}) => {
+  updateDataset: async (source, args, {user, entityManager, isAdmin}) => {
     const {id: dsId, input: update, reprocess, skipValidation, delFirst, force, priority} = args;
 
     logger.info(`User '${user && user.id}' updating '${dsId}' dataset...`);
-    const ds = await getDatasetForEditing(connection, user, dsId);
+    const ds = await getDatasetForEditing(entityManager, user, dsId);
 
     let metadata;
     if (update.metadataJson) {
@@ -294,7 +294,7 @@ const MutationResolvers: FieldResolversFor<Mutation, void>  = {
 
     let smAPIResp;
     if (reprocess) {
-      await saveDS(connection, saveDSArgs);
+      await saveDS(entityManager, saveDSArgs);
       smAPIResp = await smAPIRequest(`/v1/datasets/${dsId}/add`, {
         doc: {...engineDS, ...update, ...(metadata ? {metadata} : {})},
         del_first: procSettingsUpd || delFirst,  // delete old results if processing settings changed
@@ -311,7 +311,7 @@ const MutationResolvers: FieldResolversFor<Mutation, void>  = {
         }));
       }
       else {
-        await saveDS(connection, saveDSArgs);
+        await saveDS(entityManager, saveDSArgs);
         smAPIResp = await smAPIRequest(`/v1/datasets/${dsId}/update`, {
           doc: {
             ..._.omit(update, 'metadataJson'),
@@ -327,21 +327,21 @@ const MutationResolvers: FieldResolversFor<Mutation, void>  = {
     return JSON.stringify(smAPIResp);
   },
 
-  deleteDataset: async (_, args, {user, connection}) => {
+  deleteDataset: async (_, args, {user, entityManager}) => {
     const {id: dsId, force} = args;
     if (user == null) {
       throw new UserError('Unauthorized');
     }
-    const resp = await deleteDataset(connection, user, dsId, {force});
+    const resp = await deleteDataset(entityManager, user, dsId, {force});
     return JSON.stringify(resp);
   },
 
-  addOpticalImage: async (_, {input}, {user, connection, getUserIdOrFail}) => {
+  addOpticalImage: async (_, {input}, {user, entityManager, getUserIdOrFail}) => {
     const {datasetId: dsId, transform} = input;
     let {imageUrl} = input;
 
     logger.info(`User '${getUserIdOrFail()}' adding optical image to '${dsId}' dataset...`);
-    await getDatasetForEditing(connection, user, dsId);
+    await getDatasetForEditing(entityManager, user, dsId);
     // TODO support image storage running on a separate host
     const url = `http://localhost:${config.img_storage_port}${imageUrl}`;
     const resp = await smAPIRequest(`/v1/datasets/${dsId}/add-optical-image`, {
@@ -352,11 +352,11 @@ const MutationResolvers: FieldResolversFor<Mutation, void>  = {
     return JSON.stringify(resp);
   },
 
-  deleteOpticalImage: async (_, args, {user, connection, getUserIdOrFail}) => {
+  deleteOpticalImage: async (_, args, {user, entityManager, getUserIdOrFail}) => {
     const {datasetId: dsId} = args;
 
     logger.info(`User '${getUserIdOrFail()}' deleting optical image from '${dsId}' dataset...`);
-    await getDatasetForEditing(connection, user, dsId);
+    await getDatasetForEditing(entityManager, user, dsId);
     const resp = await smAPIRequest(`/v1/datasets/${dsId}/del-optical-image`, {});
 
     logger.info(`Optical image was deleted from '${dsId}' dataset`);

--- a/metaspace/graphql/src/modules/dataset/controller/Query.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Query.ts
@@ -12,11 +12,11 @@ const resolveDatasetScopeRole = async (ctx: Context, dsId: string) => {
   let scopeRole = SRO.OTHER;
   if (ctx.user) {
     if (dsId) {
-      const ds = await ctx.connection.getRepository(DatasetModel).findOne({
+      const ds = await ctx.entityManager.getRepository(DatasetModel).findOne({
         where: { id: dsId }
       });
       if (ds) {
-        const userGroup = await ctx.connection.getRepository(UserGroupModel).findOne({
+        const userGroup = await ctx.entityManager.getRepository(UserGroupModel).findOne({
           where: { userId: ctx.user.id, groupId: ds.groupId }
         });
         if (userGroup) {

--- a/metaspace/graphql/src/modules/dataset/operation/deleteDataset.ts
+++ b/metaspace/graphql/src/modules/dataset/operation/deleteDataset.ts
@@ -1,20 +1,20 @@
-import {Connection, EntityManager} from 'typeorm';
+import {EntityManager} from 'typeorm';
 import {ContextUser} from '../../../context';
 import {logger} from '../../../../utils';
 import {getDatasetForEditing} from './getDatasetForEditing';
 import {Dataset as DatasetModel, DatasetProject as DatasetProjectModel} from '../model';
 import {DeleteDatasetArgs, smAPIDeleteDataset} from '../../../utils/smAPI';
 
-export const deleteDataset = async (connection: Connection | EntityManager, user: ContextUser, dsId: string,
+export const deleteDataset = async (entityManager: EntityManager, user: ContextUser, dsId: string,
                                     args?: DeleteDatasetArgs) => {
   logger.info(`User '${user.id}' deleting '${dsId}' dataset...`);
   if (user.role !== 'admin') {
     // Skip this for admins so that datasets that are missing their graphql.dataset record can still be deleted
-    await getDatasetForEditing(connection, user, dsId);
+    await getDatasetForEditing(entityManager, user, dsId);
   }
 
-  await connection.getRepository(DatasetProjectModel).delete({ datasetId: dsId });
-  await connection.getRepository(DatasetModel).delete(dsId);
+  await entityManager.getRepository(DatasetProjectModel).delete({ datasetId: dsId });
+  await entityManager.getRepository(DatasetModel).delete(dsId);
   const resp = await smAPIDeleteDataset(dsId, args);
 
   logger.info(`Dataset '${dsId}' was deleted`);

--- a/metaspace/graphql/src/modules/dataset/operation/getDatasetForEditing.ts
+++ b/metaspace/graphql/src/modules/dataset/operation/getDatasetForEditing.ts
@@ -1,16 +1,16 @@
-import {Connection, EntityManager} from 'typeorm';
+import {EntityManager} from 'typeorm';
 import {ContextUser} from '../../../context';
 import {UserError} from 'graphql-errors';
 import {Dataset as DatasetModel} from '../model';
 
-export const getDatasetForEditing = async (connection: Connection | EntityManager, user: ContextUser | null, dsId: string) => {
+export const getDatasetForEditing = async (entityManager: EntityManager, user: ContextUser | null, dsId: string) => {
   if (!user)
     throw new UserError('Access denied');
 
   if (!dsId)
     throw new UserError(`DS id not provided`);
 
-  const ds = await connection.getRepository(DatasetModel).findOne({
+  const ds = await entityManager.getRepository(DatasetModel).findOne({
     id: dsId,
   });
   if (!ds)

--- a/metaspace/graphql/src/modules/group/util/resolveGroupScopeRole.ts
+++ b/metaspace/graphql/src/modules/group/util/resolveGroupScopeRole.ts
@@ -5,7 +5,7 @@ import {UserGroup as UserGroupModel, UserGroupRoleOptions} from '../model';
 export const resolveGroupScopeRole = async (ctx: Context, groupId?: string): Promise<ScopeRole> => {
   let scopeRole = ScopeRoleOptions.OTHER;
   if (ctx.user != null && groupId) {
-    const userGroup = await ctx.connection.getRepository(UserGroupModel).findOne({
+    const userGroup = await ctx.entityManager.getRepository(UserGroupModel).findOne({
       where: { userId: ctx.user.id, groupId },
     });
     if (userGroup) {

--- a/metaspace/graphql/src/modules/project/controller/Project.ts
+++ b/metaspace/graphql/src/modules/project/controller/Project.ts
@@ -28,7 +28,7 @@ const getProjectScopeRole = (currentUserRole: UserProjectRole | null): ScopeRole
 const ProjectResolvers: FieldResolversFor<Project, ProjectSource> = {
   async hasPendingRequest(project, args, ctx: Context): Promise<boolean | null> {
     if (project.currentUserRole === UPRO.MANAGER) {
-      const requests = await ctx.connection
+      const requests = await ctx.entityManager
         .getRepository(UserProjectModel)
         .count({
           where: { projectId: project.id, role: UPRO.PENDING }
@@ -43,7 +43,7 @@ const ProjectResolvers: FieldResolversFor<Project, ProjectSource> = {
       ? { projectId: project.id }
       : { projectId: project.id, role: UPRO.MANAGER };
 
-    const userProjectModels = await ctx.connection
+    const userProjectModels = await ctx.entityManager
       .getRepository(UserProjectModel)
       .createQueryBuilder('user_project')
       .where(filter)
@@ -65,18 +65,18 @@ const ProjectResolvers: FieldResolversFor<Project, ProjectSource> = {
   },
 
   async numMembers(project, args, ctx: Context): Promise<number> {
-    return await ctx.connection
+    return await ctx.entityManager
       .getRepository(UserProjectModel)
       .count({ where: { projectId: project.id, role: In([UPRO.MEMBER, UPRO.MANAGER]) } });
   },
 
   async numDatasets(project, args, ctx: Context): Promise<number> {
     if (canViewProjectMembersAndDatasets(project.currentUserRole, ctx.isAdmin)) {
-      return await ctx.connection
+      return await ctx.entityManager
         .getRepository(DatasetProjectModel)
         .count({ where: { projectId: project.id, approved: true } });
     } else {
-      return await ctx.connection
+      return await ctx.entityManager
         .getRepository(DatasetProjectModel)
         .createQueryBuilder('dataset_project')
         .innerJoinAndSelect('dataset_project.dataset', 'dataset')
@@ -89,7 +89,7 @@ const ProjectResolvers: FieldResolversFor<Project, ProjectSource> = {
   },
 
   async latestUploadDT(project, args, ctx: Context): Promise<Date> {
-    let query = ctx.connection
+    let query = ctx.entityManager
       .getRepository(DatasetProjectModel)
       .createQueryBuilder('dataset_project')
       .innerJoin('dataset_project.dataset', 'dataset')

--- a/metaspace/graphql/src/modules/project/controller/Query.ts
+++ b/metaspace/graphql/src/modules/project/controller/Query.ts
@@ -4,19 +4,19 @@ import {ProjectSourceRepository} from '../ProjectSourceRepository';
 
 const QueryResolvers: FieldResolversFor<Query, void> = {
   async project(source, { projectId }, ctx): Promise<ProjectSource | null> {
-    return await ctx.connection.getCustomRepository(ProjectSourceRepository)
+    return await ctx.entityManager.getCustomRepository(ProjectSourceRepository)
       .findProjectById(ctx.user, projectId);
   },
   async projectByUrlSlug(source, { urlSlug }, ctx): Promise<ProjectSource | null> {
-    return await ctx.connection.getCustomRepository(ProjectSourceRepository)
+    return await ctx.entityManager.getCustomRepository(ProjectSourceRepository)
       .findProjectByUrlSlug(ctx.user, urlSlug);
   },
   async allProjects(source, { query, offset, limit }, ctx): Promise<ProjectSource[]> {
-    return await ctx.connection.getCustomRepository(ProjectSourceRepository)
+    return await ctx.entityManager.getCustomRepository(ProjectSourceRepository)
       .findProjectsByQuery(ctx.user, query, offset, limit);
   },
   async projectsCount(source, { query }, ctx): Promise<number> {
-    return await ctx.connection.getCustomRepository(ProjectSourceRepository)
+    return await ctx.entityManager.getCustomRepository(ProjectSourceRepository)
       .countProjectsByQuery(ctx.user, query);
   },
 };

--- a/metaspace/graphql/src/modules/project/controller/UserProject.ts
+++ b/metaspace/graphql/src/modules/project/controller/UserProject.ts
@@ -7,7 +7,7 @@ import {Dataset as DatasetModel} from '../../dataset/model';
 
 const UserProjectResolvers: FieldResolversFor<UserProject, UserProjectSource> = {
   async project(userProject, args, ctx: Context): Promise<ProjectSource> {
-    const project = await ctx.connection.getCustomRepository(ProjectSourceRepository)
+    const project = await ctx.entityManager.getCustomRepository(ProjectSourceRepository)
       .findProjectById(ctx.user, userProject.projectId);
 
     if (project != null) {
@@ -16,13 +16,13 @@ const UserProjectResolvers: FieldResolversFor<UserProject, UserProjectSource> = 
       throw new UserError('Project not found');
     }
   },
-  async numDatasets(userProject, args, { connection }: Context): Promise<number> {
+  async numDatasets(userProject, args, { entityManager }: Context): Promise<number> {
     // NOTE: This number includes private datasets. It is only secure because we *currently* only resolve
     // `UserProjectSource`s when you are in the same project as the user, and thus allowed to see the private datasets
     // that are also in that project.
     // If this assumption changes, we'll have to consider whether showing a number that includes private datasets is a privacy breach.
     const { userId, projectId } = userProject;
-    return await connection.getRepository(DatasetModel)
+    return await entityManager.getRepository(DatasetModel)
       .createQueryBuilder('dataset')
       .innerJoin('dataset.datasetProjects', 'datasetProject')
       .innerJoin('(SELECT id, status FROM "public"."dataset")', 'engine_dataset', 'dataset.id = engine_dataset.id')

--- a/metaspace/graphql/src/modules/project/operation/updateProjectDatasets.ts
+++ b/metaspace/graphql/src/modules/project/operation/updateProjectDatasets.ts
@@ -6,8 +6,8 @@ import {smAPIUpdateDataset} from '../../../utils/smAPI';
 
 
 export default async function (ctx: Context, projectId: string, datasetIds: string[], approved: Boolean | null) {
-  const datasetProjectRepository = ctx.connection.getRepository(DatasetProjectModel);
-  const datasets = await ctx.connection.getRepository(DatasetModel)
+  const datasetProjectRepository = ctx.entityManager.getRepository(DatasetProjectModel);
+  const datasets = await ctx.entityManager.getRepository(DatasetModel)
     .find({
       where: { id: In(datasetIds) },
       relations: ['datasetProjects'],

--- a/metaspace/graphql/src/modules/project/operation/updateUserProjectRole.ts
+++ b/metaspace/graphql/src/modules/project/operation/updateUserProjectRole.ts
@@ -9,12 +9,12 @@ import {ProjectSourceRepository} from '../ProjectSourceRepository';
 
 export default async (ctx: Context, userId: string, projectId: string, newRole: UserProjectRole | null) => {
   const currentUserId = ctx.getUserIdOrFail();
-  const userProjectRepository = ctx.connection.getRepository(UserProjectModel);
-  const datasetProjectRepository = ctx.connection.getRepository(DatasetProjectModel);
-  const user = await ctx.connection.getRepository(UserModel).findOne(userId);
+  const userProjectRepository = ctx.entityManager.getRepository(UserProjectModel);
+  const datasetProjectRepository = ctx.entityManager.getRepository(DatasetProjectModel);
+  const user = await ctx.entityManager.getRepository(UserModel).findOne(userId);
   if (user == null) throw new UserError('User not found');
 
-  const project = await ctx.connection.getCustomRepository(ProjectSourceRepository)
+  const project = await ctx.entityManager.getCustomRepository(ProjectSourceRepository)
     .findProjectById(ctx.user, projectId);
   if (project == null) throw new UserError('Project not found');
   const projectMembers = await userProjectRepository.find({ where: { projectId } });

--- a/metaspace/graphql/src/utils/db.ts
+++ b/metaspace/graphql/src/utils/db.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata';
 import * as _ from 'lodash';
 import {
   createConnection as createTypeORMConnection,
-  ConnectionOptions, Connection, EntityManager,
+  ConnectionOptions, EntityManager,
 } from 'typeorm';
 
 import config from './config';
@@ -41,16 +41,16 @@ export const createConnection = async () => {
   });
 };
 
-export const findUserByEmail = async (connection: Connection | EntityManager, value: string, field: string='email') => {
-  return await connection.getRepository(UserModel)
+export const findUserByEmail = async (entityManager: EntityManager, value: string, field: string='email') => {
+  return await entityManager.getRepository(UserModel)
     .createQueryBuilder('user')
     .leftJoinAndSelect('user.credentials', 'credentials')
     .where(`LOWER(${field}) = :email`, { email: value.toLowerCase() })
     .getOne() || null;
 };
 
-export const getUserProjectRoles = async (connection: Connection | EntityManager, userId: string) => {
-  const userProjects = await connection.getRepository(UserProjectModel)
+export const getUserProjectRoles = async (entityManager: EntityManager, userId: string) => {
+  const userProjects = await entityManager.getRepository(UserProjectModel)
     .find({ where: { userId } });
   return _.fromPairs(userProjects.map(up => [up.projectId, up.role]));
 };


### PR DESCRIPTION
This is a mostly automated refactor to implement a `// TODO` item from v1.0.

I'm skipping review as I don't think it's worth it - if I overlooked something, it would only come out through testing.