### PR TITLE
Fix reset password

### DIFF
--- a/metaspace/graphql/src/modules/auth/controller.ts
+++ b/metaspace/graphql/src/modules/auth/controller.ts
@@ -16,6 +16,7 @@ import {
   initOperation,
   resetPassword,
   sendResetPasswordToken,
+  validateResetPasswordToken,
   verifyEmail,
   verifyPassword,
 } from './operation';
@@ -265,8 +266,7 @@ const configureResetPassword = (router: IRouter<any>) => {
   router.post('/validatepasswordresettoken', async (req, res, next) => {
     try {
       const { email, token } = req.body;
-      const user = await findUserByEmail(email);
-      if (user && user.credentials.resetPasswordToken === token) {
+      if (await validateResetPasswordToken(email, token)) {
         res.send(true);
       } else {
         res.sendStatus(400);

--- a/metaspace/graphql/src/modules/auth/email.ts
+++ b/metaspace/graphql/src/modules/auth/email.ts
@@ -28,6 +28,19 @@ METASPACE Team`;
   logger.info(`Email already verified. Sent log in email to ${email}`);
 };
 
+export const sendCreateAccountEmail = (email: string, link: string) => {
+  const subject = 'METASPACE log in',
+    text =
+      `Dear METASPACE user,
+
+You do not have an account with this email address. Please create an account here: ${link}.
+
+Best wishes,
+METASPACE Team`;
+  sendEmail(email, subject, text);
+  logger.info(`No account. Sent create account email to ${email}`);
+};
+
 export const sendResetPasswordEmail = (email: string, link: string) => {
   const subject = 'METASPACE password reset',
     text =

--- a/metaspace/graphql/src/modules/auth/operation.ts
+++ b/metaspace/graphql/src/modules/auth/operation.ts
@@ -214,7 +214,8 @@ export const verifyEmail = async (email: string, token: string): Promise<User|nu
 export const sendResetPasswordToken = async (email: string): Promise<void> => {
   const user = await findUserByEmail(email) || await findUserByEmail(email, 'not_verified_email');
 
-  if (!user || (!user.email && !user.name)) {
+  // Inactive users can reset their password only if they have a name, otherwise they have to create an account
+  if (user == null || (user.email == null && (user.name == null || user.name === ''))) {
     sendCreateAccountEmail(email, `${config.web_public_url}/account/create-account`);
   } else {
     logger.info(`Creating password reset token for ${user.email == null ? 'inactive ' : ''}user ${user.id}`);

--- a/metaspace/graphql/src/modules/auth/operation.ts
+++ b/metaspace/graphql/src/modules/auth/operation.ts
@@ -10,6 +10,7 @@ import {logger} from '../../utils';
 import * as utils from '../../utils';
 import {Credentials as CredentialsModel, Credentials} from './model';
 import {User as UserModel, User} from '../user/model';
+import {sendCreateAccountEmail} from './email';
 
 export interface UserCredentialsInput {
   email: string;
@@ -211,44 +212,63 @@ export const verifyEmail = async (email: string, token: string): Promise<User|nu
 };
 
 export const sendResetPasswordToken = async (email: string): Promise<void> => {
-  const user = await findUserByEmail(email);
-  if (!user) {
-    throw new Error(`User with ${email} email does not exist`);
-  }
+  const user = await findUserByEmail(email) || await findUserByEmail(email, 'not_verified_email');
 
-  const cred = user.credentials;
-  let resetPasswordToken;
-  if (cred.resetPasswordToken == null || tokenExpired(cred.resetPasswordTokenExpires)) {
-    resetPasswordToken = uuid.v4();
-    logger.debug(`Token '${cred.resetPasswordToken}' expired for ${email}. A new one generated: ${resetPasswordToken}`);
-    const updCred = credRepo.create({
-      ...cred,
-      resetPasswordToken,
-      resetPasswordTokenExpires: createExpiry()
-    });
-    await credRepo.update(updCred.id, updCred);
+  if (!user || (!user.email && !user.name)) {
+    sendCreateAccountEmail(email, `${config.web_public_url}/account/create-account`);
+  } else {
+    logger.info(`Creating password reset token for ${user.email == null ? 'inactive ' : ''}user ${user.id}`);
+    const cred = user.credentials;
+    let resetPasswordToken;
+    if (cred.resetPasswordToken == null || tokenExpired(cred.resetPasswordTokenExpires)) {
+      resetPasswordToken = uuid.v4();
+      logger.debug(`Token '${cred.resetPasswordToken}' expired for ${email}. A new one generated: ${resetPasswordToken}`);
+      const updCred = credRepo.create({
+        ...cred,
+        resetPasswordToken,
+        resetPasswordTokenExpires: createExpiry()
+      });
+      await credRepo.update(updCred.id, updCred);
+    } else {
+      resetPasswordToken = cred.resetPasswordToken;
+    }
+    const link = `${config.web_public_url}/account/reset-password?email=${encodeURIComponent(email)}&token=${encodeURIComponent(resetPasswordToken)}`;
+    emailService.sendResetPasswordEmail(email, link);
   }
-  else {
-    resetPasswordToken = cred.resetPasswordToken;
-  }
-  const link = `${config.web_public_url}/account/reset-password?email=${encodeURIComponent(email)}&token=${encodeURIComponent(resetPasswordToken)}`;
-  emailService.sendResetPasswordEmail(email, link);
+};
+
+export const validateResetPasswordToken = async (email: string, token: string): Promise<boolean> => {
+  const user = await findUserByEmail(email) || await findUserByEmail(email, 'not_verified_email');
+  return user != null
+    && user.credentials.resetPasswordToken === token
+    && !tokenExpired(user.credentials.resetPasswordTokenExpires);
 };
 
 export const resetPassword = async (email: string, password: string, token: string): Promise<User | undefined> => {
-  const user = await findUserByEmail(email);
+  const user = await findUserByEmail(email) || await findUserByEmail(email, 'not_verified_email');
   if (user) {
     if (user.credentials.resetPasswordToken !== token || tokenExpired(user.credentials.resetPasswordTokenExpires)) {
       logger.debug(`Token '${user.credentials.resetPasswordToken}' is wrong or expired for ${email}`);
     }
     else {
-      const updCred = credRepo.create({
-        ...user.credentials,
+      if (user.email == null) {
+        await credRepo.update(user.credentials.id, {
+          emailVerified: true,
+          emailVerificationToken: null,
+          emailVerificationTokenExpires: null,
+        });
+        await userRepo.update(user.id, {
+          email: user.notVerifiedEmail,
+          notVerifiedEmail: null
+        });
+
+        logger.info(`Validated email address during password reset for ${email}`);
+      }
+      await credRepo.update(user.credentials.id, {
         hash: await hashPassword(password),
         resetPasswordToken: null,
         resetPasswordTokenExpires: null
       });
-      await credRepo.update(updCred.id, updCred);
       logger.info(`Successful password reset for ${email} email`);
       return user;
     }

--- a/metaspace/webapp/src/modules/Account/components/ForgotPasswordDialog.vue
+++ b/metaspace/webapp/src/modules/Account/components/ForgotPasswordDialog.vue
@@ -31,6 +31,7 @@
   import { Form } from 'element-ui';
   import InterDialogLink from './InterDialogLink';
   import { sendPasswordResetToken } from '../../../api/auth';
+  import reportError from '../../../lib/reportError';
 
   interface Model {
     email: string;
@@ -59,6 +60,7 @@
         await sendPasswordResetToken(this.model.email);
         this.hasSucceeded = true;
       } catch (err) {
+        reportError(err);
       } finally {
         this.isSubmitting = false;
       }


### PR DESCRIPTION
The issue is that Reset Password was silently failing for users that don't exist or have not been activated since the migration. GraphQL was only checking for users with a matching verified email address, and the web app wasn't handling server errors correctly.

This change does several things:
* Makes the Reset Password flow work for inactive users (as long as they already have a name). Once they've set their password, their email is automatically validated.
* Makes the Reset Password flow send an email directing the user to the Create Account page if the email is not recognized
* Adds error handling to the Reset Password dialog
* Adds more tests & groups the existing tests by function (hide whitespace changes - most of the file's changes are just indentation)

Resolves #170 