### PR TITLE
Queue exit message support

### DIFF
--- a/ansible/aws/cluster_auto_start_daemon.py
+++ b/ansible/aws/cluster_auto_start_daemon.py
@@ -177,12 +177,13 @@ class ClusterDaemon(object):
         return True
 
     def cluster_stop(self):
-        self.logger.info('No jobs running. Queue is empty. Queue exit message sent')
-        self.queue.send_queue_exit_message()
-        self.logger.info('Stopping the cluster...')
-        self._local(['ansible-playbook', '-i', self.stage, '-f', '1', 'aws_stop.yml', '-e', 'components=master,slave'],
-                    'Cluster is stopped successfully', 'Failed to stop the cluster')
-        self._post_to_slack('checkered_flag', "[v] Cluster stopped")
+        if self.queue_empty():
+            self.queue.send_queue_exit_message()
+            self.logger.info('No jobs running. Queue is empty. Queue exit message sent')
+            self.logger.info('Stopping the cluster...')
+            self._local(['ansible-playbook', '-i', self.stage, '-f', '1', 'aws_stop.yml', '-e', 'components=master,slave'],
+                        'Cluster is stopped successfully', 'Failed to stop the cluster')
+            self._post_to_slack('checkered_flag', "[v] Cluster stopped")
 
     def cluster_setup(self):
         self.logger.info('Setting up the cluster...')

--- a/ansible/aws/cluster_auto_start_daemon.py
+++ b/ansible/aws/cluster_auto_start_daemon.py
@@ -51,7 +51,8 @@ class AnnotationQueue(object):
                              routing_key=self.qname,
                              body=json.dumps({'action': 'exit'}),
                              properties=pika.BasicProperties(
-                                 priority=3  # max priority
+                                 priority=3,  # max priority
+                                 expiration=60000,  # 60 sec ttl
                              ))
         except AMQPError as e:
             self.logger.error(f'Failed to publish exit message: {e}')

--- a/ansible/aws/cluster_auto_start_daemon.py
+++ b/ansible/aws/cluster_auto_start_daemon.py
@@ -55,7 +55,7 @@ class AnnotationQueue(object):
                                  priority=3  # max priority
                              ))
         except AMQPError as e:
-            self.logger.error(f'Failed to publish exis message: {e}')
+            self.logger.error(f'Failed to publish exit message: {e}')
         finally:
             if self.conn:
                 self.conn.close()

--- a/ansible/aws/cluster_auto_start_daemon.py
+++ b/ansible/aws/cluster_auto_start_daemon.py
@@ -51,7 +51,6 @@ class AnnotationQueue(object):
                              routing_key=self.qname,
                              body=json.dumps({'action': 'exit'}),
                              properties=pika.BasicProperties(
-                                 delivery_mode=2,  # make message persistent
                                  priority=3  # max priority
                              ))
         except AMQPError as e:

--- a/metaspace/engine/sm/engine/queue.py
+++ b/metaspace/engine/sm/engine/queue.py
@@ -394,6 +394,10 @@ class QueueConsumer(Thread):
                                  method.delivery_tag, properties.app_id, body)
                 msg = json.loads(body)
 
+                if msg['action'] == 'exit':
+                    self.stop()
+                    return
+
                 self._callback(msg)
             except BaseException as e:
                 self.logger.error(' [x] Failed: {}'.format(body), exc_info=False)

--- a/metaspace/engine/sm/engine/queue.py
+++ b/metaspace/engine/sm/engine/queue.py
@@ -394,7 +394,7 @@ class QueueConsumer(Thread):
                                  method.delivery_tag, properties.app_id, body)
                 msg = json.loads(body)
 
-                if msg['action'] == 'exit':
+                if msg.get('action', None) == 'exit':
                     self.stop()
                     return
 

--- a/metaspace/engine/sm/engine/sm_daemons.py
+++ b/metaspace/engine/sm/engine/sm_daemons.py
@@ -201,7 +201,7 @@ class SMAnnotateDaemon(object):
 
         self._manager.post_to_slack('hankey', ' [x] Annotation failed: {}'.format(json.dumps(msg)))
 
-        if msg.get('email'):
+        if 'email' in msg:
             self._manager.send_failed_email(msg)
 
     def _callback(self, msg):
@@ -230,6 +230,8 @@ class SMAnnotateDaemon(object):
         self._annot_queue_consumer.start()
 
     def stop(self):
+        """  Must be called from main thread
+        """
         if not self._stopped:
             self._annot_queue_consumer.stop()
             self._annot_queue_consumer.join()


### PR DESCRIPTION
* It seems like the only way to prevent new annotation jobs from starting while cluster is being stopped