### PR TITLE
Annotations page bug fixes & tweaks

### DIFF
--- a/metaspace/webapp/src/api/annotation.ts
+++ b/metaspace/webapp/src/api/annotation.ts
@@ -69,6 +69,7 @@ gql`query Export($orderBy: AnnotationOrderBy, $sortingOrder: SortingOrder,
         id
         name
         group { id name }
+        groupApproved
       }
       possibleCompounds {
         name

--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
@@ -485,7 +485,7 @@
          const {sumFormula, adduct, msmScore, mz,
                 rhoSpatial, rhoSpectral, rhoChaos, fdrLevel} = row;
          return formatCsvRow([
-           row.dataset.groupApproved && row.dataset.group ? row.dataset.group.shortName : '',
+           row.dataset.groupApproved && row.dataset.group ? row.dataset.group.name : '',
            row.dataset.name,
            row.dataset.id,
            sumFormula, "M" + adduct, mz,

--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
@@ -11,7 +11,7 @@
               width="100%"
               stripe
               tabindex="1"
-              :default-sort="getDefaultSort"
+              :default-sort="tableSort"
               :row-class-name="getRowClass"
               @keyup.native="onKeyUp"
               @keydown.native="onKeyDown"
@@ -238,7 +238,21 @@
        return this.$store.getters.settings.table.order.dir;
      },
 
-     getDefaultSort() {
+     queryVariables() {
+       const {annotationFilter, datasetFilter, ftsQuery} = this.gqlFilter;
+
+       return {
+         filter: annotationFilter,
+         dFilter: datasetFilter,
+         query: ftsQuery,
+         orderBy: this.orderBy,
+         sortingOrder: this.sortingOrder,
+         offset: (this.currentPage - 1) * this.recordsPerPage,
+         limit: this.recordsPerPage
+       };
+     },
+
+     tableSort() {
        let by = this.orderBy,
            order = this.sortingOrder.toLowerCase(),
            prop = 'msmScore';
@@ -248,6 +262,8 @@
          prop = 'msmScore';
        else if (by == 'ORDER_BY_FDR_MSM')
          prop = 'fdrLevel';
+       else if (by == 'ORDER_BY_FORMULA')
+         prop = 'sumFormula';
        return {prop, order};
      },
 
@@ -286,7 +302,7 @@
        query: annotationListQuery,
        fetchPolicy: 'cache-first',
        variables() {
-         return this.queryVariables();
+         return this.queryVariables;
        },
        update: data => data.allAnnotations,
        debounce: 200,
@@ -339,19 +355,6 @@
          this.$refs.table.setCurrentRow(data[rowIndex]);
        }
      },
-     queryVariables() {
-       const {annotationFilter, datasetFilter, ftsQuery} = this.gqlFilter;
-
-       return {
-         filter: annotationFilter,
-         dFilter: datasetFilter,
-         query: ftsQuery,
-         orderBy: this.orderBy,
-         sortingOrder: this.sortingOrder,
-         offset: (this.currentPage - 1) * this.recordsPerPage,
-         limit: this.recordsPerPage
-       };
-     },
 
      hidden (columnLabel) {
        return this.hideColumns.indexOf(columnLabel) >= 0;
@@ -373,11 +376,14 @@
      formatDatasetName: (row, col) => row.dataset.name,
 
      onSortChange (event) {
+       this.clearCurrentRow();
+
        if (!event.order) {
+         const {prop, order} = this.tableSort;
+         // Skip the "unsorted" state by just inverting the last seen sort order
+         this.$refs.table.sort(prop, order === 'ascending' ? 'descending' : 'ascending');
          return;
        }
-
-       this.clearCurrentRow();
 
        let orderBy = this.orderBy;
        if (event.prop == 'msmScore')
@@ -515,11 +521,11 @@
          FileSaver.saveAs(blob, "metaspace_annotations.csv");
        }
 
-       let v = this.queryVariables(),
-           chunks = [],
-           offset = 0;
-
-       v.limit = chunkSize;
+       const v = {
+         ...this.queryVariables,
+         limit: chunkSize,
+       };
+       let offset = 0;
 
        function runExport() {
          const variables = Object.assign(v, {offset});

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
@@ -15,6 +15,7 @@
  import { Location } from 'vue-router';
  import { currentUserRoleQuery, CurrentUserRoleResult} from '../../api/user';
  import { safeJsonParse } from '../../util';
+ import {omit, pick} from 'lodash-es';
 
  type ImagePosition = {
    zoom: number
@@ -106,7 +107,7 @@
    msAcqGeometry: any
    peakChartData: any
    opticalImageUrl?: string
-   showOpticalImage: boolean = true
+
    datasetVisibility: DatasetVisibilityResult | null = null
    currentUser: CurrentUserRoleResult | null = null
 
@@ -114,6 +115,10 @@
      const currentMdType: string = this.$store.getters.filter.metadataType;
      const componentKey: string = currentMdType in metadataDependentComponents[category] ? currentMdType : 'default';
      return metadataDependentComponents[category][componentKey];
+   }
+
+   get showOpticalImage(): boolean {
+     return !this.$route.query.hideopt;
    }
 
    get activeSections(): string[] {
@@ -150,11 +155,16 @@
        adduct: this.annotation.adduct,
        fdrLevel: this.annotation.fdrLevel,
        database: this.$store.getters.filter.database,
-       simpleQuery: ''
+       simpleQuery: '',
      };
      const path = '/annotations';
-     const q = encodeParams(filter, path, this.$store.state.filterLists);
-     return {query: q, path};
+     return {
+       path,
+       query: {
+         ...encodeParams(filter, path, this.$store.state.filterLists),
+         ...pick(this.$route.query, 'sections', 'sort', 'hideopt'),
+       },
+     };
    }
 
    get imageLoaderSettings(): ImageLoaderSettings {
@@ -242,7 +252,18 @@
 
    toggleOpticalImage(event: any): void {
      event.stopPropagation();
-     this.showOpticalImage = !this.showOpticalImage
+     if(this.showOpticalImage) {
+       this.$router.replace({
+         query: {
+           ...this.$route.query,
+           hideopt: '1',
+         }
+       });
+     } else {
+       this.$router.replace({
+         query: omit(this.$route.query, 'hideopt'),
+       });
+     }
    }
 
    loadVisibility() {

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
@@ -162,7 +162,7 @@
        path,
        query: {
          ...encodeParams(filter, path, this.$store.state.filterLists),
-         ...pick(this.$route.query, 'sections', 'sort', 'hideopt'),
+         ...pick(this.$route.query, 'sections', 'sort', 'hideopt', 'cmap'),
        },
      };
    }

--- a/metaspace/webapp/src/modules/Filters/url.ts
+++ b/metaspace/webapp/src/modules/Filters/url.ts
@@ -41,10 +41,12 @@ const PATH_TO_LEVEL: Record<string, Level> = {
   '/projects': 'projects',
 };
 
-export const DEFAULT_ORDER = {
+export const DEFAULT_TABLE_ORDER = {
   by: 'ORDER_BY_MSM',
   dir: 'DESCENDING'
 };
+
+export const DEFAULT_COLORMAP = 'Viridis';
 
 export function encodeParams(filter: any, path?: string, filterLists?: MetadataLists): Dictionary<string> {
   const level = path != null ? PATH_TO_LEVEL[path.toLowerCase()] : null;
@@ -167,12 +169,12 @@ export function decodeSettings(location: Location): any {
   let settings = {
     table: {
       currentPage: 1,
-      order: DEFAULT_ORDER,
+      order: DEFAULT_TABLE_ORDER,
     },
 
     annotationView: {
       activeSections: ['images'],
-      colormap: 'Viridis'
+      colormap: DEFAULT_COLORMAP
     },
 
     datasets: {

--- a/metaspace/webapp/src/modules/Filters/url.ts
+++ b/metaspace/webapp/src/modules/Filters/url.ts
@@ -46,6 +46,8 @@ export const DEFAULT_TABLE_ORDER = {
   dir: 'DESCENDING'
 };
 
+export const DEFAULT_ANNOTATION_VIEW_SECTIONS = ['images'];
+
 export const DEFAULT_COLORMAP = 'Viridis';
 
 export function encodeParams(filter: any, path?: string, filterLists?: MetadataLists): Dictionary<string> {
@@ -173,7 +175,7 @@ export function decodeSettings(location: Location): any {
     },
 
     annotationView: {
-      activeSections: ['images'],
+      activeSections: DEFAULT_ANNOTATION_VIEW_SECTIONS,
       colormap: DEFAULT_COLORMAP
     },
 

--- a/metaspace/webapp/src/modules/Filters/url.ts
+++ b/metaspace/webapp/src/modules/Filters/url.ts
@@ -41,6 +41,11 @@ const PATH_TO_LEVEL: Record<string, Level> = {
   '/projects': 'projects',
 };
 
+export const DEFAULT_ORDER = {
+  by: 'ORDER_BY_MSM',
+  dir: 'DESCENDING'
+};
+
 export function encodeParams(filter: any, path?: string, filterLists?: MetadataLists): Dictionary<string> {
   const level = path != null ? PATH_TO_LEVEL[path.toLowerCase()] : null;
   const defaultFilter = level != null ? getDefaultFilter(level, filterLists) : null;
@@ -148,9 +153,10 @@ interface SortSettings {
   dir: string
 }
 
-export function encodeSortOrder(settings: SortSettings): string {
-  let sort = settings.dir == 'ASCENDING' ? '' : '-';
-  return sort + settings.by.replace('ORDER_BY_', '').toLowerCase();
+export function encodeSortOrder(settings: SortSettings): string | null {
+  const dir = settings.dir == 'ASCENDING' ? '' : '-';
+  const sort = dir + settings.by.replace('ORDER_BY_', '').toLowerCase();
+  return sort === '-msm' ? null : sort;
 }
 
 export function decodeSettings(location: Location): any {
@@ -161,10 +167,7 @@ export function decodeSettings(location: Location): any {
   let settings = {
     table: {
       currentPage: 1,
-      order: {
-        by: 'ORDER_BY_MSM',
-        dir: 'DESCENDING'
-      }
+      order: DEFAULT_ORDER,
     },
 
     annotationView: {

--- a/metaspace/webapp/src/store/mutations.js
+++ b/metaspace/webapp/src/store/mutations.js
@@ -11,7 +11,7 @@ import {
   getFilterInitialValue,
   stripFilteringParams,
 } from '../modules/Filters';
-import {DEFAULT_COLORMAP, DEFAULT_TABLE_ORDER} from '../modules/Filters/url';
+import {DEFAULT_ANNOTATION_VIEW_SECTIONS, DEFAULT_COLORMAP, DEFAULT_TABLE_ORDER} from '../modules/Filters/url';
 
 
 function updatedLocation(state, filter) {
@@ -125,10 +125,13 @@ export default {
   },
 
   updateAnnotationViewSections(state, activeSections) {
-    let query = Object.assign({}, state.route.query, {
-      sections: encodeSections(activeSections)
+    const sections = encodeSections(activeSections);
+    const defaultSections = encodeSections(DEFAULT_ANNOTATION_VIEW_SECTIONS);
+    router.replace({
+      query: sections !== defaultSections
+        ? { ...state.route.query, sections }
+        : omit(state.route.query, 'sections'),
     });
-    router.replace({query});
   },
 
   setColormap(state, cmap) {

--- a/metaspace/webapp/src/store/mutations.js
+++ b/metaspace/webapp/src/store/mutations.js
@@ -1,4 +1,4 @@
-import {isEqual, pull, without, omit} from 'lodash-es';
+import {isEqual, omit, pull, without} from 'lodash-es';
 import router from '../router';
 import compare from '../lib/compare';
 
@@ -11,7 +11,7 @@ import {
   getFilterInitialValue,
   stripFilteringParams,
 } from '../modules/Filters';
-import {DEFAULT_ORDER} from '../modules/Filters/url';
+import {DEFAULT_COLORMAP, DEFAULT_TABLE_ORDER} from '../modules/Filters/url';
 
 
 function updatedLocation(state, filter) {
@@ -131,21 +131,25 @@ export default {
     router.replace({query});
   },
 
-  setColormap(state, colormap) {
-    let query = Object.assign({}, state.route.query, {
-      cmap: colormap
+  setColormap(state, cmap) {
+    router.replace({
+      query: cmap !== DEFAULT_COLORMAP
+        ? {...state.route.query, cmap}
+        : omit(state.route.query, 'cmap'),
     });
-    router.replace({query});
   },
 
   setCurrentPage(state, page) {
-    let query = Object.assign({}, state.route.query, {page});
-    router.replace({query});
+    router.replace({
+      query: page !== 1
+        ? { ...state.route.query, page }
+        : omit(state.route.query, 'page'),
+    });
   },
 
   setSortOrder(state, sortOrder) {
     const sort = encodeSortOrder(sortOrder);
-    const defaultSort = encodeSortOrder(DEFAULT_ORDER);
+    const defaultSort = encodeSortOrder(DEFAULT_TABLE_ORDER);
     router.replace({
       query: sort !== defaultSort
         ? { ...state.route.query, sort }

--- a/metaspace/webapp/src/store/mutations.js
+++ b/metaspace/webapp/src/store/mutations.js
@@ -1,13 +1,17 @@
-import {isEqual, pull, without} from 'lodash-es';
+import {isEqual, pull, without, omit} from 'lodash-es';
 import router from '../router';
 import compare from '../lib/compare';
 
 import {
   decodeParams,
-  encodeParams, encodeSections, encodeSortOrder, FILTER_SPECIFICATIONS,
+  encodeParams,
+  encodeSections,
+  encodeSortOrder,
+  FILTER_SPECIFICATIONS,
+  getFilterInitialValue,
   stripFilteringParams,
 } from '../modules/Filters';
-import {getFilterInitialValue} from '../modules/Filters';
+import {DEFAULT_ORDER} from '../modules/Filters/url';
 
 
 function updatedLocation(state, filter) {
@@ -140,10 +144,13 @@ export default {
   },
 
   setSortOrder(state, sortOrder) {
-    let query = Object.assign({}, state.route.query, {
-      sort: encodeSortOrder(sortOrder)
+    const sort = encodeSortOrder(sortOrder);
+    const defaultSort = encodeSortOrder(DEFAULT_ORDER);
+    router.replace({
+      query: sort !== defaultSort
+        ? { ...state.route.query, sort }
+        : omit(state.route.query, 'sort'),
     });
-    router.replace({query});
   },
 
   setDatasetTab(state, tab) {

--- a/metaspace/webapp/yarn.lock
+++ b/metaspace/webapp/yarn.lock
@@ -9991,10 +9991,6 @@ mat4-recompose@^1.0.3:
   dependencies:
     gl-mat4 "^1.0.1"
 
-material-colors@^1.0.0:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
-
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -14646,7 +14642,7 @@ tiny-sdf@^1.0.2:
   resolved "https://registry.yarnpkg.com/tiny-sdf/-/tiny-sdf-1.0.2.tgz#28e76985c44c4e584c4b67d8ecdd9b33a1cac28c"
   integrity sha1-KOdphcRMTlhMS2fY7N2bM6HKwow=
 
-tinycolor2@^1.1.2, tinycolor2@^1.3.0:
+tinycolor2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
   integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
@@ -15473,14 +15469,6 @@ vue-clickaway@^2.1.0:
   integrity sha1-OS3nZHUfMc0geH6Ps6bjGYJfjU8=
   dependencies:
     loose-envify "^1.2.0"
-
-vue-color@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/vue-color/-/vue-color-2.6.0.tgz#a4ef85b871cef4d47bf662c3b54321d2bb96f349"
-  dependencies:
-    lodash.throttle "^4.0.0"
-    material-colors "^1.0.0"
-    tinycolor2 "^1.1.2"
 
 vue-hot-reload-api@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
* Fix "Group" column in annotations page CSV export (fixes #189)
* Changes to the annotations page URLs: (fixes #191)
    * Add the visibility status of the optical image to the URL
    * Include the current sort order, opened sections, colormap and visibility of the optical image in the annotation permalink
    * Hide all querystring parameters (`page`, `sections`, `cmap`, etc.) if they are reset to their default values
* Prevent the annotations grid from going into the "unsorted" state, as it doesn't do anything and is confusing
* Fix bug causing the sort order to be lost if the page is refreshed when sorting by `sumFormula`