### PR TITLE
Staging fixes

### DIFF
--- a/metaspace/graphql/src/modules/auth/operation.ts
+++ b/metaspace/graphql/src/modules/auth/operation.ts
@@ -141,6 +141,9 @@ export const createUserCredentials = async (userCred: UserCredentialsInput): Pro
       else {
         existingUserNotVerified.credentials.hash = await hashPassword(userCred.password) || null;
         await credRepo.save(existingUserNotVerified.credentials);
+        await userRepo.update(existingUserNotVerified.id, {
+          name: userCred.name,
+        });
         logger.info(`${userCred.email} user credentials updated, password added`);
         await sendEmailVerificationToken(existingUserNotVerified.credentials,
           existingUserNotVerified.notVerifiedEmail!);

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -66,7 +66,6 @@
           {{ formatSubmitter }}</span><!--
           Be careful not to add empty space before the comma
           --><span v-if="dataset.groupApproved && dataset.group">,
-
           <el-dropdown @command="handleDropdownCommand"
                        :showTimeout="50"
                        placement="bottom"

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -66,12 +66,15 @@
           {{ formatSubmitter }}</span><!--
           Be careful not to add empty space before the comma
           --><span v-if="dataset.groupApproved && dataset.group">,
-          <el-dropdown @command="handleDropdownCommand" :showTimeout="50" placement="bottom">
-            <span class="s-group ds-add-filter"
-                  @click="addFilter('group')">
+
+          <el-dropdown @command="handleDropdownCommand"
+                       :showTimeout="50"
+                       placement="bottom"
+                       :trigger="hideGroupMenu ? 'never' : 'hover'">
+            <span class="s-group ds-add-filter" @click="addFilter('group')">
               {{dataset.group.shortName}}
             </span>
-            <el-dropdown-menu slot="dropdown" v-if="!hideGroupMenu">
+            <el-dropdown-menu slot="dropdown">
               <el-dropdown-item command="filter_group">Filter by this group</el-dropdown-item>
               <el-dropdown-item command="view_group">View group</el-dropdown-item>
             </el-dropdown-menu>

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -155,7 +155,7 @@ exports[`DatasetTable should match snapshot 1`] = `
             Submitted <span class="s-bold">????-??-??</span> at ??:?? by
             <span title="Filter by submitter" class="ds-add-filter">
         allDatasets.0.submitter.name</span><span>,
-        <mock-el-dropdown showtimeout="50" placement="bottom"><div slot-key="default"><span class="s-group ds-add-filter">
+        <mock-el-dropdown showtimeout="50" placement="bottom" trigger="hover"><div slot-key="default"><span class="s-group ds-add-filter">
             allDatasets.0.group.shortName
           </span> </div>
           <div slot-key="dropdown">
@@ -271,7 +271,7 @@ exports[`DatasetTable should match snapshot 1`] = `
           Submitted <span class="s-bold">????-??-??</span> at ??:?? by
           <span title="Filter by submitter" class="ds-add-filter">
         allDatasets.0.submitter.name</span><span>,
-        <mock-el-dropdown showtimeout="50" placement="bottom"><div slot-key="default"><span class="s-group ds-add-filter">
+        <mock-el-dropdown showtimeout="50" placement="bottom" trigger="hover"><div slot-key="default"><span class="s-group ds-add-filter">
             allDatasets.0.group.shortName
           </span> </div>
         <div slot-key="dropdown">
@@ -387,7 +387,7 @@ exports[`DatasetTable should match snapshot 1`] = `
         Submitted <span class="s-bold">????-??-??</span> at ??:?? by
         <span title="Filter by submitter" class="ds-add-filter">
         allDatasets.0.submitter.name</span><span>,
-        <mock-el-dropdown showtimeout="50" placement="bottom"><div slot-key="default"><span class="s-group ds-add-filter">
+        <mock-el-dropdown showtimeout="50" placement="bottom" trigger="hover"><div slot-key="default"><span class="s-group ds-add-filter">
             allDatasets.0.group.shortName
           </span> </div>
       <div slot-key="dropdown">


### PR DESCRIPTION
Fixes two bugs:

* When an inactive user is created by inviting them to a group, their name wasn't being saved as they went through the Create Account process, causing them to have no name after registration.

* Going to the groups page was causing console errors due to `<el-dropdown>` requiring that there is always something in the `dropdown` slot. When `hideGroupMenu == true` this page shouldn't actually show the dropdown menu. I worked around this by making the `<el-dropdown>` only trigger on a non-existent event type (`never`) when `hideGroupMenu == true`, so that it can never activate.