### PR TITLE
Colocalization backend

### DIFF
--- a/docker/sm-engine/requirements.txt
+++ b/docker/sm-engine/requirements.txt
@@ -28,3 +28,4 @@ psycopg2==2.7.1
 cherrypy<9
 pyimzML==1.2.4
 redis
+scikit-learn==0.20.2

--- a/metaspace/engine/requirements.txt
+++ b/metaspace/engine/requirements.txt
@@ -26,3 +26,4 @@ psycopg2==2.7.1
 cherrypy<9
 pyimzML==1.2.4
 redis
+scikit-learn==0.20.2

--- a/metaspace/engine/scripts/run_colocalization.py
+++ b/metaspace/engine/scripts/run_colocalization.py
@@ -3,7 +3,7 @@ import logging
 
 from sm.engine.util import init_loggers, SMConfig
 from sm.engine.db import DB
-from sm.engine.colocalization_job import ColocalizationJob
+from sm.engine.colocalization import Colocalization
 
 def run_coloc_jobs(ds_id, sql_where):
     assert ds_id or sql_where
@@ -25,7 +25,7 @@ def run_coloc_jobs(ds_id, sql_where):
     for i, ds_id in enumerate(ds_ids):
         try:
             logger.info(f'Running colocalization on {i+1} out of {len(ds_ids)}')
-            coloc = ColocalizationJob(db)
+            coloc = Colocalization(db)
             coloc.run_coloc_job_for_existing_ds(ds_id)
         except Exception:
             logger.error(f'Failed to run colocalization on {ds_id}', exc_info=True)

--- a/metaspace/engine/scripts/run_colocalization.py
+++ b/metaspace/engine/scripts/run_colocalization.py
@@ -1,0 +1,46 @@
+import argparse
+import logging
+
+from sm.engine.util import init_loggers, SMConfig
+from sm.engine.db import DB
+from sm.engine.colocalization_job import ColocalizationJob
+
+def run_coloc_jobs(ds_id, sql_where):
+    assert ds_id or sql_where
+    assert not (ds_id and sql_where)
+
+    conf = SMConfig.get_conf()
+
+    db = DB(conf['db'])
+
+    if sql_where:
+        ds_ids = [id for (id, ) in db.select(f'SELECT DISTINCT dataset.id FROM dataset WHERE {sql_where}')]
+    else:
+        ds_ids = ds_id.split(',')
+
+    if not ds_ids:
+        logger.warning('No datasets match filter')
+        return
+
+    for i, ds_id in enumerate(ds_ids):
+        try:
+            logger.info(f'Running colocalization on {i+1} out of {len(ds_ids)}')
+            coloc = ColocalizationJob(db)
+            coloc.run_coloc_job_for_existing_ds(ds_id)
+        except Exception:
+            logger.error(f'Failed to run colocalization on {ds_id}', exc_info=True)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Run colocalization jobs')
+    parser.add_argument('--config', default='conf/config.json', help='SM config path')
+    parser.add_argument('--ds-id', dest='ds_id', default=None, help='DS id (or comma-separated list of ids)')
+    parser.add_argument('--sql-where', dest='sql_where', default=None,
+                        help='SQL WHERE clause for picking rows from the dataset table, e.g. "status = \'FINISHED\'"')
+    args = parser.parse_args()
+
+    SMConfig.set_path(args.config)
+    init_loggers(SMConfig.get_conf()['logs'])
+    logger = logging.getLogger('engine')
+
+    run_coloc_jobs(args.ds_id, args.sql_where)

--- a/metaspace/engine/sm/engine/colocalization.py
+++ b/metaspace/engine/sm/engine/colocalization.py
@@ -11,18 +11,212 @@ from sklearn.cluster import spectral_clustering
 from scipy.stats import spearmanr, pearsonr
 
 from sm.engine.dataset import Dataset
+from sm.engine.ion_mapping import get_ion_id_mapping
 from sm.engine.mol_db import MolecularDB
 from sm.engine.util import SMConfig
 from sm.engine.png_generator import ImageStoreServiceWrapper
 
-logger = logging.getLogger('engine')
+COLOC_JOB_DEL = ('DELETE FROM graphql.coloc_job ' 
+                 'WHERE ds_id = %s AND mol_db = %s')
+
+COLOC_JOB_INS = ('INSERT INTO graphql.coloc_job (ds_id, mol_db, fdr, algorithm, start, finish, error, sample_ion_ids) ' 
+                 'VALUES (%s, %s, %s, %s, %s, %s, %s, %s) ' 
+                 'RETURNING id')
+
+COLOC_ANN_INS = ('INSERT INTO graphql.coloc_annotation(coloc_job_id, ion_id, coloc_ion_ids, coloc_coeffs) ' 
+                 'VALUES (%s, %s, %s, %s)')
 
 ANNOTATIONS_SEL = ('SELECT iso_image_ids[1], sf, adduct, fdr '
                    'FROM iso_image_metrics m '
                    'JOIN job j ON j.id = m.job_id '
                    'WHERE j.ds_id = %s AND j.db_id = %s')
 
-DATASET_CONFIG_SEL = "SELECT mol_dbs, config #>> '{isotope_generation,charge,polarity}' FROM dataset WHERE id = %s"
+DATASET_CONFIG_SEL = ("SELECT mol_dbs, config #>> '{isotope_generation,charge,polarity}' "
+                      "FROM dataset "
+                      "WHERE id = %s")
+
+logger = logging.getLogger('engine')
+
+
+class ColocalizationJob(object):
+    def __init__(self, ds_id, mol_db, fdr, algorithm_name=None, start=None, finish=None,
+                 error=None, ion_ids=None, sample_ion_ids=None, coloc_annotations=None):
+        """
+        Args
+        ----------
+        ds_id: str
+        mol_db: str
+        fdr: float
+        algorithm_name: str
+        start: datetime
+        finish: datetime
+        error: str
+        ion_ids: list[int]
+        sample_ion_ids: list[int]
+            ids of ions that show distinctive localizations
+        coloc_annotations: list[tuple[int, list[int], list[float]]]
+            list of (base_ion_id, list(other_ion_ids), list(other_ion_scores))
+        """
+        assert error or all((algorithm_name, ion_ids is not None, sample_ion_ids is not None,
+                             coloc_annotations is not None))
+
+        self.ds_id = ds_id
+        self.mol_db = mol_db
+        self.fdr = fdr
+        self.algorithm_name = algorithm_name or 'error'
+        self.start = start or datetime.now()
+        self.finish = finish or datetime.now()
+        self.error = error
+        self.ion_ids = ion_ids
+        self.sample_ion_ids = sample_ion_ids
+        self.coloc_annotations = coloc_annotations
+
+
+def _preprocess_images(imgs):
+    """ Clips the top 1% (if more than 1% of pixels are populated),
+    scales all pixels to the range 0...1,
+    and ensures that no image is completely zero.
+    """
+    max_clipped, max_unclipped = np.percentile(imgs, [99, 100], axis=1, keepdims=True)
+    scale = np.select([max_clipped != 0, max_unclipped != 0], [max_clipped, max_unclipped], 1)
+    imgs = np.clip(imgs / scale, 0, 1)
+    imgs[(max_unclipped == 0)[:, 0], :] = 0.01
+    return imgs
+
+
+def _labels_to_clusters(labels, scores):
+    """ Converts from [0,1,0,1,2] form (mapping sample idx to cluster idx)
+    to [[0,2],[1,3],[4]] form (mapping cluster idx to sample idx's).
+    Each cluster is sorted based on items' distance from the cluster's mean
+    """
+    assert labels.shape[0] == scores.shape[0] == scores.shape[1]
+
+    in_same_cluster_mask = labels[:, np.newaxis] == labels[np.newaxis, :]
+    typicalness = np.average(scores * scores, axis=1, weights=in_same_cluster_mask)
+    clusters = [np.argwhere(labels == cid).ravel() for cid in np.unique(labels) if cid != -1]
+    return [sorted(cluster, key=lambda i: -typicalness[i]) for cluster in clusters]
+
+
+def _label_clusters(scores):
+    min_clusters = 2
+    max_clusters = 20
+    n_samples = scores.shape[0]
+    if n_samples <= min_clusters:
+        return [[i] for i in range(n_samples)]
+
+    results = []
+    last_error = None
+    for n_clusters in range(min_clusters, min(n_samples, max_clusters)):
+        try:
+            labels = spectral_clustering(affinity=scores, n_clusters=n_clusters, random_state=1, n_init=100)
+            cluster_score = np.mean([scores[a, b] for a, b in enumerate(labels)])
+            results.append((n_clusters, cluster_score, labels))
+        except Exception as err:
+            last_error = err
+
+    if not results:
+        raise last_error
+    elif last_error:
+        logger.warning('Warning: clustering failed on some cluster sizes', last_error)
+
+    # Find the best cluster, subtracting n/1000 to add a slight preference to having fewer clusters
+    best_cluster_idx = np.argmax([cs - n / 1000 for n, cs, l in results])
+    best_n, best_cluster_score, best_labels = results[best_cluster_idx]
+    logger.debug(f'best with {best_n} clusters (scores: {[(r[0], r[1]) for r in results]})')
+    return best_labels
+
+
+def _get_best_colocs(scores, labels, max_samples, min_score):
+    coloc_idxs = []
+    for i, cluster_id in enumerate(labels):
+        pairing_scores = scores[i, :].copy()
+        pairing_scores[labels == cluster_id] = 1 # Give preference to items in the same cluster
+        pairing_scores[pairing_scores < min_score] = 0 # Discard scores below threshold
+        pairing_scores[i] = 0 # Ignore self-correlation
+
+        num_in_cluster = np.count_nonzero(labels == cluster_id)
+        num_above_min_score = np.count_nonzero(pairing_scores)
+        num_to_keep = np.clip(num_above_min_score, num_in_cluster, max_samples)
+
+        coloc_idxs.append(list(np.argsort(pairing_scores)[::-1][:num_to_keep]))
+
+    return coloc_idxs
+
+
+def _format_coloc_annotations(ion_ids, scores, colocs):
+    for i, js in enumerate(colocs):
+        sorted_js = sorted(js, key=lambda j: -scores[i, j])
+        base_ion_id = ion_ids[i].item()
+        other_ion_ids = [ion_ids[j].item() for j in sorted_js]
+        other_ion_scores = [scores[i, j].item() for j in sorted_js]
+
+        yield base_ion_id, other_ion_ids, other_ion_scores
+
+
+def analyze_colocalization(ds_id, mol_db, annotations):
+    """ Calculate co-localization of ion images for all algorithms and yield results
+
+    Args
+    ----------
+    ds_id: str
+    mol_db: str
+    annotations: list[tuple[np.ndarray, int, float]]
+        list of tuples of (raw_image, ion_id, fdr)
+    """
+    start = datetime.now()
+
+    filtered_annotations = [a for a in annotations if a[0] is not None]
+    if len(filtered_annotations) < 1:
+        logger.info('Not enough annotations to perform colocalization')
+        return
+
+    logger.debug('Preprocessing images')
+    images = _preprocess_images(np.array([a[0] for a in filtered_annotations], ndmin=2, dtype=np.float32))
+    ion_ids = np.array([a[1] for a in filtered_annotations])
+    fdrs = np.array([a[2] for a in filtered_annotations])
+
+    pca_images = PCA(min(20, *images.shape)).fit_transform(images)
+    cos_scores = pairwise_kernels(images, metric='cosine')
+    pca_cos_scores = pairwise_kernels(pca_images, metric='cosine')
+    pca_pear_scores = pairwise_kernels(pca_images, metric=lambda a, b: pearsonr(a, b)[0])
+    pca_sper_scores = spearmanr(pca_images.transpose())[0]  # TODO: Discard low p-value entries?
+
+    for fdr in [0.05, 0.1, 0.2, 0.5]:
+        fdr_mask = np.array(fdrs) <= fdr + 0.001
+        masked_ion_ids = np.array(ion_ids)[fdr_mask].tolist()
+
+        if len(masked_ion_ids) > 1:
+
+            # NOTE: Keep labels/clusters between algorithms so that if any algorithm fails to cluster,
+            # it can use the labels/clusters from a previous successful run.
+            # Usually cosine succeeds at clustering and PCA data fails clustering.
+            labels = [0] * len(fdr_mask)
+            clusters = []
+
+            def run_alg(algorithm, scores, cluster):
+                nonlocal labels, clusters
+                masked_scores = scores[fdr_mask, :][:, fdr_mask]
+                if cluster:
+                    logger.debug(f'Clustering {algorithm} at {fdr} FDR with {len(masked_ion_ids)} annotations')
+                    try:
+                        labels = _label_clusters(masked_scores)
+                        clusters = _labels_to_clusters(labels, masked_scores)
+                    except Exception as err:
+                        logger.warning(f'Failed to cluster {algorithm}: {err}')
+
+                colocs = _get_best_colocs(masked_scores, labels, 50, 0.3)
+
+                sample_ion_ids = [masked_ion_ids[c[0]] for c in clusters] # This could be done better
+                coloc_annotations = list(_format_coloc_annotations(ion_ids, scores, colocs))
+                return ColocalizationJob(ds_id, mol_db, fdr, algorithm, start, datetime.now(),
+                                         ion_ids=masked_ion_ids, sample_ion_ids=sample_ion_ids,
+                                         coloc_annotations=coloc_annotations)
+
+            yield run_alg('cosine', cos_scores, True)
+            yield run_alg('pca_cosine', pca_cos_scores, False)
+            yield run_alg('pca_pearson', pca_pear_scores, False)
+            yield run_alg('pca_spearman', pca_sper_scores, False)
+
 
 class Colocalization(object):
 
@@ -31,206 +225,24 @@ class Colocalization(object):
         self._sm_config = SMConfig.get_conf()
         self._img_store = ImageStoreServiceWrapper(self._sm_config['services']['img_service_url'])
 
-    def _preprocess_images(self, imgs):
-        """Clips the top 1% (if more than 1% of pixels are populated),
-           scales all pixels to the range 0...1,
-           and ensures that no image is completely zero."""
-        max_clipped, max_unclipped = np.percentile(imgs, [99, 100], axis=1, keepdims=True)
-        scale = np.select([max_clipped != 0, max_unclipped != 0], [max_clipped, max_unclipped], 1)
-        imgs = np.clip(imgs / scale, 0, 1)
-        imgs[(max_unclipped == 0)[:, 0], :] = 0.01
-        return imgs
+    def _save_job_to_db(self, job):
 
-    def _labels_to_clusters(self, labels, scores):
-        """
-        Converts from [0,1,0,1,2] form (mapping sample idx to cluster idx)
-        to [[0,2],[1,3],[4]] form (mapping cluster idx to sample idx's).
-        Each cluster is sorted based on items' distance from the cluster's mean
-        """
-        assert labels.shape[0] == scores.shape[0] == scores.shape[1]
+        job_id, = self._db.insert_return(COLOC_JOB_INS,
+            [[job.ds_id, job.mol_db, job.fdr, job.algorithm_name, job.start, job.finish, job.error, job.sample_ion_ids]])
 
-        in_same_cluster_mask = labels[:, np.newaxis] == labels[np.newaxis, :]
-        typicalness = np.average(scores * scores, axis=1, weights=in_same_cluster_mask)
-        clusters = [np.argwhere(labels == cid).ravel() for cid in np.unique(labels) if cid != -1]
-        return [sorted(cluster, key=lambda i: -typicalness[i]) for cluster in clusters]
+        annotations = [(job_id, *ann) for ann in job.coloc_annotations]
+        self._db.insert(COLOC_ANN_INS, annotations)
 
-    def _label_clusters(self, scores):
-        min_clusters = 2
-        max_clusters = 20
-        n_samples = scores.shape[0]
-        if n_samples <= min_clusters:
-            return [[i] for i in range(n_samples)]
-
-        results = []
-        last_error = None
-        for n_clusters in range(min_clusters, min(n_samples, max_clusters)):
-            try:
-                labels = spectral_clustering(affinity=scores, n_clusters=n_clusters, random_state=1, n_init=100)
-                cluster_score = np.mean([scores[a, b] for a, b in enumerate(labels)])
-                results.append((n_clusters, cluster_score, labels))
-            except Exception as err:
-                last_error = err
-
-        if not results:
-            raise last_error
-        elif last_error:
-            logger.warning('Warning: clustering failed on some cluster sizes', last_error)
-
-        # Find the best cluster, subtracting n/1000 to add a slight preference to having fewer clusters
-        best_cluster_idx = np.argmax([cs - n / 1000 for n, cs, l in results])
-        best_n, best_cluster_score, best_labels = results[best_cluster_idx]
-        logger.debug(f'best with {best_n} clusters (scores: {[(r[0], r[1]) for r in results]})')
-        return best_labels
-
-    def _get_ion_id_mapping(self, mols, polarity):
-        """Get a mapping of ions to ion ids, adding missing ions to the database if necessary
-        Args
-        ------------
-        mols : list[tuple[str, str]]
-            (formula, adduct) tuples
-        polarity : str
-            'Positive' or 'Negative'
-        Returns
-        ------------
-        dict[tuple[str, str], int]
-
-        """
-        if polarity in ('Positive', '+'):
-            charge = 1
-            charge_sign = '+'
-        elif polarity in ('Negative', '-'):
-            charge = -1
-            charge_sign = '-'
-        else:
-            raise TypeError("polarity must be 'Positive', 'Negative', '+' or '-'")
-
-        ions = [formula + adduct + charge_sign for formula, adduct in mols]
-        ion_to_mol = dict(zip(ions, mols))
-        ion_to_id = dict(self._db.select("SELECT ion, id FROM graphql.ion WHERE ion = ANY(%s)", [ions]))
-        missing_ions = sorted(set(ions).difference(ion_to_id.keys()))
-
-        if missing_ions:
-            rows = [(ion, *ion_to_mol[ion], charge) for ion in missing_ions]
-            ids = self._db.insert_return('INSERT INTO graphql.ion (ion, formula, adduct, charge) VALUES (%s, %s, %s, %s) RETURNING id',
-                                   rows)
-            ion_to_id.update((row[0], id) for id, row in zip(ids, rows))
-
-        return dict((ion_to_mol[ion], ion_to_id[ion]) for ion in ions)
-
-    def _save_job_to_db(self, ds_id, fdr, mol_db, algorithm_name, start, finish, error, ion_ids, scores, clusters, colocs):
-        assert len(ion_ids) == scores.shape[0] == scores.shape[1] == len(colocs)
-        # Extract data for DB
-        sample_ion_ids = [ion_ids[c[0]] for c in clusters]
-        grouped_ion_ids = dict()
-        grouped_scores = dict()
-        for i, js in enumerate(colocs):
-            sorted_js = sorted(js, key = lambda j: -scores[i, j])
-            grouped_ion_ids[ion_ids[i]] = [ion_ids[j] for j in sorted_js]
-            grouped_scores[ion_ids[i]] = [np.asscalar(scores[i, j]) for j in sorted_js]
-
-        # Insert into DB
-        job_id, = self._db.insert_return(
-            "INSERT INTO graphql.coloc_job (ds_id, fdr, mol_db, algorithm, start, finish, error, sample_ion_ids) "
-            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) RETURNING id",
-            [[ds_id, fdr, mol_db, algorithm_name, start, finish, error, sample_ion_ids]])
-
-        self._db.insert(
-            "INSERT INTO graphql.coloc_annotation(coloc_job_id, ion_id, coloc_ion_ids, coloc_coeffs) VALUES (%s, %s, %s, %s)",
-            [(job_id, ion_id, grouped_ion_ids[ion_id], grouped_scores[ion_id])
-             for i, ion_id in enumerate(ion_ids)])
-
-        # Clear old jobs from DB
-        self._db.alter(
-            "DELETE FROM graphql.coloc_job WHERE ds_id = %s AND fdr = %s AND mol_db = %s AND algorithm = %s AND id != %s",
-            [ds_id, fdr, mol_db, algorithm_name, job_id])
-
-    def _get_best_colocs(self, scores, labels, max_samples, min_score):
-        coloc_idxs = []
-        for i, cluster_id in enumerate(labels):
-            pairing_scores = scores[i, :].copy()
-            pairing_scores[labels == cluster_id] = 1 # Give preference to items in the same cluster
-            pairing_scores[pairing_scores < min_score] = 0 # Discard scores below threshold
-            pairing_scores[i] = 0 # Ignore self-correlation
-
-            num_in_cluster = np.count_nonzero(labels == cluster_id)
-            num_above_min_score = np.count_nonzero(pairing_scores)
-            num_to_keep = np.clip(num_above_min_score, num_in_cluster, max_samples)
-
-            coloc_idxs.append(list(np.argsort(pairing_scores)[::-1][:num_to_keep]))
-
-        return coloc_idxs
-
-    def run_coloc_job(self, ds_id, mol_db, annotations):
-        """ Calculate co-localization of ion images for a search job and save the results to DB
-
-        Args
-        ----------
-        ds_id: str
-        mol_db: str
-        annotations: list[tuple[np.ndarray, int, float]]
-            list of tuples of (raw_image, ion_id, fdr)
-        """
-        start = datetime.now()
-
-        # Clear old errors
-        self._db.alter("DELETE FROM graphql.coloc_job WHERE ds_id = %s AND mol_db = %s AND algorithm = 'error'", [ds_id, mol_db])
-
+    def _analyze_and_save(self, ds_id, mol_db, annotations):
         try:
-            logger.debug('Preprocessing images')
-            filtered_annotations = [a for a in annotations if a[0] is not None]
-            if not filtered_annotations:
+            # Clear old jobs from DB
+            self._db.alter(COLOC_JOB_DEL, [ds_id, mol_db])
 
-
-            images = self._preprocess_images(np.array([a[0] for a in filtered_annotations], ndmin=2, dtype=np.float32))
-            ion_ids = np.array([a[1] for a in filtered_annotations])
-            fdrs = np.array([a[2] for a in filtered_annotations])
-            pca_images = PCA(min(20, images.shape[1])).fit_transform(images)
-
-            logger.debug('Running cosine comparison')
-            cos_scores = pairwise_kernels(images, metric='cosine')
-            logger.debug('Running pca-cosine comparison')
-            pca_cos_scores = pairwise_kernels(pca_images, metric='cosine')
-            logger.debug('Running pca-pearson comparison')
-            pca_pear_scores = pairwise_kernels(pca_images, metric=lambda a, b: pearsonr(a, b)[0])
-            logger.debug('Running pca-spearman comparison')
-            pca_sper_scores = spearmanr(pca_images.transpose())[0]  # TODO: Discard low p-value entries?
-
-            for fdr in [0.05, 0.1, 0.2, 0.5]:
-                fdr_mask = np.array(fdrs) <= fdr + 0.001
-                masked_ion_ids = np.array(ion_ids)[fdr_mask].tolist()
-
-                if len(masked_ion_ids) > 1:
-
-                    # NOTE: Keep labels/clusters between algorithms so that if any algorithm fails to cluster,
-                    # it can use the labels/clusters from a previous successful run.
-                    # Usually cosine succeeds at clustering and PCA data fails clustering.
-                    labels = [0] * len(fdr_mask)
-                    clusters = []
-
-                    def run_alg(algorithm, scores, cluster):
-                        nonlocal labels, clusters
-                        masked_scores = scores[fdr_mask, :][:, fdr_mask]
-                        if cluster:
-                            logger.debug(f'Clustering {algorithm} at {fdr} FDR with {len(masked_ion_ids)} annotations')
-                            try:
-                                labels = self._label_clusters(masked_scores)
-                                clusters = self._labels_to_clusters(labels, masked_scores)
-                            except Exception as err:
-                                logger.warning(f'Failed to cluster {algorithm}: {err}')
-
-                        colocs = self._get_best_colocs(masked_scores, labels, 50, 0.3)
-                        logger.debug(f'Saving {algorithm} at {fdr} FDR')
-                        self._save_job_to_db(ds_id, fdr, mol_db, algorithm, start, datetime.now(), None,
-                                             masked_ion_ids, masked_scores, clusters, colocs)
-
-                    run_alg('cosine', cos_scores, True)
-                    run_alg('pca_cosine', pca_cos_scores, False)
-                    run_alg('pca_pearson', pca_pear_scores, False)
-                    run_alg('pca_spearman', pca_sper_scores, False)
-
+            for job in analyze_colocalization(ds_id, mol_db, annotations):
+                self._save_job_to_db(job)
         except Exception:
             logger.warning('Colocalization job failed', exc_info=True)
-            self._save_job_to_db(ds_id, 0, mol_db, 'error', start, datetime.now(), format_exc(), [], np.array([[]]), [], [])
+            self._save_job_to_db(ColocalizationJob(ds_id, mol_db, 0, error=format_exc()))
             raise
 
     def _get_existing_ds_annotations(self, ds_id, mol_db_name, image_storage_type, polarity):
@@ -244,7 +256,7 @@ class Colocalization(object):
         mol_db = MolecularDB(name=mol_db_name)
         annotation_rows = self._db.select(ANNOTATIONS_SEL, [ds_id, mol_db.id])
         sf_adducts = [(formula, adduct) for image, formula, adduct, fdr in annotation_rows]
-        ion_id_mapping = self._get_ion_id_mapping(sf_adducts, polarity)
+        ion_id_mapping = get_ion_id_mapping(sf_adducts, polarity)
         ion_ids = [ion_id_mapping[sf_adduct] for sf_adduct in sf_adducts]
         fdrs = [fdr for image, formula, adduct, fdr in annotation_rows]
 
@@ -255,15 +267,22 @@ class Colocalization(object):
         return list(zip(ion_images, ion_ids, fdrs))
 
     def run_coloc_job_for_existing_ds(self, ds_id):
+        """ Analyze colocalization for a previously annotated dataset, querying the dataset's annotations from the db,
+        and downloading the exported ion images
+        Args
+        ====
+        ds_id: str
+        """
+
         image_storage_type = Dataset(ds_id).get_ion_img_storage_type(self._db)
         mol_dbs, polarity = self._db.select_one(DATASET_CONFIG_SEL, [ds_id])
 
         for mol_db_name in mol_dbs:
             annotations = self._get_existing_ds_annotations(ds_id, mol_db_name, image_storage_type, polarity)
-            self.run_coloc_job(ds_id, mol_db_name, annotations)
+            self._analyze_and_save(ds_id, mol_db_name, annotations)
 
     def run_coloc_job_for_new_ds(self, ds, mol_db_name, ion_metrics_df, ion_iso_images, alpha_channel):
-        """
+        """ Analyze colocalization as part of an annotation job, using dataframes from the annotation job as a datasource
         Args
         ====
         ds: Dataset
@@ -276,15 +295,16 @@ class Colocalization(object):
         logger.info('Running colocalization job')
         polarity = ds.config['isotope_generation']['charge']['polarity']
         mols = list(ion_metrics_df[['formula','adduct']].itertuples(index=False, name=None))
-        ion_id_mapping = self._get_ion_id_mapping(mols, polarity)
+        ion_id_mapping = get_ion_id_mapping(self._db, mols, polarity)
 
         def extract_image(imgs):
-            if imgs[0]:
+            if imgs[0] is not None:
                 return (imgs[0].toarray() * alpha_channel).ravel()
             return None
+
         image_map = ion_iso_images.mapValues(extract_image).collectAsMap()
         annotations = [(image_map.get(i), ion_id_mapping[(item.formula, item.adduct)], item.fdr)
                        for i, item in ion_metrics_df.iterrows()]
 
-        self.run_coloc_job(ds.id, mol_db_name, annotations)
+        self._analyze_and_save(ds.id, mol_db_name, annotations)
 

--- a/metaspace/engine/sm/engine/colocalization.py
+++ b/metaspace/engine/sm/engine/colocalization.py
@@ -330,9 +330,14 @@ class Colocalization(object):
                        for i, item in ion_metrics_df.iterrows()
                        if image_map.get(i) is not None]
 
-        images = np.array([a[0] for a in annotations], ndmin=2, dtype=np.float32)
-        ion_ids = np.array([a[1] for a in annotations])
-        fdrs = np.array([a[2] for a in annotations])
+        if annotations:
+            images = np.array([a[0] for a in annotations], dtype=np.float32)
+            ion_ids = np.array([a[1] for a in annotations], dtype=np.int64)
+            fdrs = np.array([a[2] for a in annotations], dtype=np.float32)
+        else:
+            images = np.zeros((0, 0), dtype=np.float32)
+            ion_ids = np.zeros((0,), dtype=np.int64)
+            fdrs = np.zeros((0,), dtype=np.float32)
 
         return images, ion_ids, fdrs
 

--- a/metaspace/engine/sm/engine/colocalization.py
+++ b/metaspace/engine/sm/engine/colocalization.py
@@ -130,13 +130,11 @@ def _get_best_colocs(scores, labels, max_samples, min_score):
     coloc_idxs = []
     for i, cluster_id in enumerate(labels):
         pairing_scores = scores[i, :].copy()
-        pairing_scores[labels == cluster_id] = 1 # Give preference to items in the same cluster
         pairing_scores[pairing_scores < min_score] = 0 # Discard scores below threshold
         pairing_scores[i] = 0 # Ignore self-correlation
 
-        num_in_cluster = np.count_nonzero(labels == cluster_id)
         num_above_min_score = np.count_nonzero(pairing_scores)
-        num_to_keep = np.clip(num_above_min_score, num_in_cluster, max_samples)
+        num_to_keep = np.minimum(num_above_min_score, max_samples)
 
         coloc_idxs.append(list(np.argsort(pairing_scores)[::-1][:num_to_keep]))
 
@@ -204,7 +202,7 @@ def analyze_colocalization(ds_id, mol_db, annotations):
                     except Exception as err:
                         logger.warning(f'Failed to cluster {algorithm}: {err}')
 
-                colocs = _get_best_colocs(masked_scores, labels, 50, 0.3)
+                colocs = _get_best_colocs(masked_scores, labels, 100, 0.3)
 
                 sample_ion_ids = [masked_ion_ids[c[0]] for c in clusters] # This could be done better
                 coloc_annotations = list(_format_coloc_annotations(ion_ids, scores, colocs))

--- a/metaspace/engine/sm/engine/colocalization.py
+++ b/metaspace/engine/sm/engine/colocalization.py
@@ -256,7 +256,7 @@ class Colocalization(object):
         mol_db = MolecularDB(name=mol_db_name)
         annotation_rows = self._db.select(ANNOTATIONS_SEL, [ds_id, mol_db.id])
         sf_adducts = [(formula, adduct) for image, formula, adduct, fdr in annotation_rows]
-        ion_id_mapping = get_ion_id_mapping(sf_adducts, polarity)
+        ion_id_mapping = get_ion_id_mapping(self._db, sf_adducts, polarity)
         ion_ids = [ion_id_mapping[sf_adduct] for sf_adduct in sf_adducts]
         fdrs = [fdr for image, formula, adduct, fdr in annotation_rows]
 

--- a/metaspace/engine/sm/engine/colocalization_job.py
+++ b/metaspace/engine/sm/engine/colocalization_job.py
@@ -1,0 +1,278 @@
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from traceback import format_exc
+import numpy as np
+import pandas as pd
+import pyspark.rdd
+from sklearn.decomposition import PCA
+from sklearn.metrics.pairwise import pairwise_kernels
+from sklearn.cluster import spectral_clustering
+from scipy.stats import spearmanr, pearsonr
+
+from sm.engine.dataset import Dataset
+from sm.engine.mol_db import MolecularDB
+from sm.engine.util import SMConfig
+from sm.engine.png_generator import ImageStoreServiceWrapper
+
+logger = logging.getLogger('engine')
+
+ANNOTATIONS_SEL = ('SELECT iso_image_ids[1], sf, adduct, fdr '
+                   'FROM iso_image_metrics m '
+                   'JOIN job j ON j.id = m.job_id '
+                   'WHERE j.ds_id = %s AND j.db_id = %s')
+
+DATASET_CONFIG_SEL = "SELECT mol_dbs, config #>> '{isotope_generation,charge,polarity}' FROM dataset WHERE id = %s"
+
+class ColocalizationJob(object):
+
+    def __init__(self, db):
+        self._db = db
+        self._sm_config = SMConfig.get_conf()
+        self._img_store = ImageStoreServiceWrapper(self._sm_config['services']['img_service_url'])
+
+    def _preprocess_images(self, imgs):
+        """Clips the top 1% (if more than 1% of pixels are populated),
+           scales all pixels to the range 0...1,
+           and ensures that no image is completely zero."""
+        max_clipped, max_unclipped = np.percentile(imgs, [99, 100], axis=1, keepdims=True)
+        scale = np.select([max_clipped != 0, max_unclipped != 0], [max_clipped, max_unclipped], 1)
+        imgs = np.clip(imgs / scale, 0, 1)
+        imgs[(max_unclipped == 0)[:, 0], :] = 0.01
+        return imgs
+
+    def _labels_to_clusters(self, labels, scores):
+        """
+        Converts from [0,1,0,1,2] form (mapping sample idx to cluster idx)
+        to [[0,2],[1,3],[4]] form (mapping cluster idx to sample idx's).
+        Each cluster is sorted based on items' distance from the cluster's mean
+        """
+        assert labels.shape[0] == scores.shape[0] == scores.shape[1]
+
+        in_same_cluster_mask = labels[:, np.newaxis] == labels[np.newaxis, :]
+        typicalness = np.average(scores * scores, axis=1, weights=in_same_cluster_mask)
+        clusters = [np.argwhere(labels == cid).ravel() for cid in np.unique(labels) if cid != -1]
+        return [sorted(cluster, key=lambda i: -typicalness[i]) for cluster in clusters]
+
+    def _label_clusters(self, scores):
+        min_clusters = 2
+        max_clusters = 20
+        n_samples = scores.shape[0]
+        if n_samples <= min_clusters:
+            return [[i] for i in range(n_samples)]
+
+        results = []
+        last_error = None
+        for n_clusters in range(min_clusters, min(n_samples, max_clusters)):
+            try:
+                labels = spectral_clustering(affinity=scores, n_clusters=n_clusters, random_state=1, n_init=100)
+                cluster_score = np.mean([scores[a, b] for a, b in enumerate(labels)])
+                results.append((n_clusters, cluster_score, labels))
+            except Exception as err:
+                last_error = err
+
+        if not results:
+            raise last_error
+        elif last_error:
+            logger.warning('Warning: clustering failed on some cluster sizes', last_error)
+
+        # Find the best cluster, subtracting n/1000 to add a slight preference to having fewer clusters
+        best_cluster_idx = np.argmax([cs - n / 1000 for n, cs, l in results])
+        best_n, best_cluster_score, best_labels = results[best_cluster_idx]
+        logger.debug(f'best with {best_n} clusters (scores: {[(r[0], r[1]) for r in results]})')
+        return best_labels
+
+    def _get_ion_id_mapping(self, mols, polarity):
+        """Get a mapping of ions to ion ids, adding missing ions to the database if necessary
+        Args
+        ------------
+        mols : list[tuple[str, str]]
+            (formula, adduct) tuples
+        polarity : str
+            'Positive' or 'Negative'
+        Returns
+        ------------
+        dict[tuple[str, str], int]
+
+        """
+        if polarity in ('Positive', '+'):
+            charge = 1
+            charge_sign = '+'
+        elif polarity in ('Negative', '-'):
+            charge = -1
+            charge_sign = '-'
+        else:
+            raise TypeError("polarity must be 'Positive', 'Negative', '+' or '-'")
+
+        ions = [formula + adduct + charge_sign for formula, adduct in mols]
+        ion_to_mol = dict(zip(ions, mols))
+        ion_to_id = dict(self._db.select("SELECT ion, id FROM graphql.ion WHERE ion = ANY(%s)", [ions]))
+        missing_ions = sorted(set(ions).difference(ion_to_id.keys()))
+
+        if missing_ions:
+            rows = [(ion, *ion_to_mol[ion], charge) for ion in missing_ions]
+            ids = self._db.insert_return('INSERT INTO graphql.ion (ion, formula, adduct, charge) VALUES (%s, %s, %s, %s) RETURNING id',
+                                   rows)
+            ion_to_id.update((row[0], id) for id, row in zip(ids, rows))
+
+        return dict((ion_to_mol[ion], ion_to_id[ion]) for ion in ions)
+
+    def _save_job_to_db(self, ds_id, fdr, mol_db, algorithm_name, start, finish, error, ion_ids, scores, clusters, colocs):
+        assert len(ion_ids) == scores.shape[0] == scores.shape[1] == len(colocs)
+        # Extract data for DB
+        sample_ion_ids = [ion_ids[c[0]] for c in clusters]
+        grouped_ion_ids = dict()
+        grouped_scores = dict()
+        for i, js in enumerate(colocs):
+            sorted_js = sorted(js, key = lambda j: -scores[i, j])
+            grouped_ion_ids[ion_ids[i]] = [ion_ids[j] for j in sorted_js]
+            grouped_scores[ion_ids[i]] = [np.asscalar(scores[i, j]) for j in sorted_js]
+
+        # Insert into DB
+        job_id, = self._db.insert_return(
+            "INSERT INTO graphql.coloc_job (ds_id, fdr, mol_db, algorithm, start, finish, error, sample_ion_ids) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) RETURNING id",
+            [[ds_id, fdr, mol_db, algorithm_name, start, finish, error, sample_ion_ids]])
+
+        self._db.insert(
+            "INSERT INTO graphql.coloc_annotation(coloc_job_id, ion_id, coloc_ion_ids, coloc_coeffs) VALUES (%s, %s, %s, %s)",
+            [(job_id, ion_id, grouped_ion_ids[ion_id], grouped_scores[ion_id])
+             for i, ion_id in enumerate(ion_ids)])
+
+        # Clear old jobs from DB
+        self._db.alter(
+            "DELETE FROM graphql.coloc_job WHERE ds_id = %s AND fdr = %s AND mol_db = %s AND algorithm = %s AND id != %s",
+            [ds_id, fdr, mol_db, algorithm_name, job_id])
+
+    def _get_best_colocs(self, scores, labels, max_samples, min_score):
+        coloc_idxs = []
+        for i, cluster_id in enumerate(labels):
+            pairing_scores = scores[i, :].copy()
+            pairing_scores[labels == cluster_id] = 1 # Give preference to items in the same cluster
+            pairing_scores[pairing_scores < min_score] = 0 # Discard scores below threshold
+            pairing_scores[i] = 0 # Ignore self-correlation
+
+            num_in_cluster = np.count_nonzero(labels == cluster_id)
+            num_above_min_score = np.count_nonzero(pairing_scores)
+            num_to_keep = np.clip(num_above_min_score, num_in_cluster, max_samples)
+
+            coloc_idxs.append(list(np.argsort(pairing_scores)[::-1][:num_to_keep]))
+
+        return coloc_idxs
+
+    def run_coloc_job(self, ds_id, mol_db, annotations):
+        """ Calculate co-localization of ion images for a search job and save the results to DB
+
+        Args
+        ----------
+        ds_id: str
+        mol_db: str
+        annotations: list[tuple[np.ndarray, int, float]]
+            list of tuples of (raw_image, ion_id, fdr)
+        """
+        start = datetime.now()
+
+        # Clear old errors
+        self._db.alter("DELETE FROM graphql.coloc_job WHERE ds_id = %s AND mol_db = %s AND algorithm = 'error'", [ds_id, mol_db])
+
+        try:
+            logger.debug('Preprocessing images')
+            images = self._preprocess_images([a[0] for a in annotations])
+            ion_ids = np.array([a[1] for a in annotations])
+            fdrs = np.array([a[2] for a in annotations])
+            pca_images = PCA(min(20, images.shape[1])).fit_transform(images)
+
+            logger.debug('Running cosine comparison')
+            cos_scores = pairwise_kernels(images, metric='cosine')
+            logger.debug('Running pca-cosine comparison')
+            pca_cos_scores = pairwise_kernels(pca_images, metric='cosine')
+            logger.debug('Running pca-pearson comparison')
+            pca_pear_scores = pairwise_kernels(pca_images, metric=lambda a, b: pearsonr(a, b)[0])
+            logger.debug('Running pca-spearman comparison')
+            pca_sper_scores = spearmanr(pca_images.transpose())[0]  # TODO: Discard low p-value entries?
+
+            for fdr in [0.05, 0.1, 0.2, 0.5]:
+                fdr_mask = np.array(fdrs) <= fdr + 0.001
+                masked_ion_ids = np.array(ion_ids)[fdr_mask].tolist()
+
+                if len(masked_ion_ids) > 1:
+
+                    # NOTE: Keep labels/clusters between algorithms so that if any algorithm fails to cluster,
+                    # it can use the labels/clusters from a previous successful run.
+                    # Usually cosine succeeds at clustering and PCA data fails clustering.
+                    labels = [0] * len(fdr_mask)
+                    clusters = []
+
+                    def run_alg(algorithm, scores, cluster):
+                        nonlocal labels, clusters
+                        masked_scores = scores[fdr_mask, :][:, fdr_mask]
+                        if cluster:
+                            logger.debug(f'Clustering {algorithm} at {fdr} FDR with {len(masked_ion_ids)} annotations')
+                            try:
+                                labels = self._label_clusters(masked_scores)
+                                clusters = self._labels_to_clusters(labels, masked_scores)
+                            except Exception as err:
+                                logger.warning(f'Failed to cluster {algorithm}: {err}')
+
+                        colocs = self._get_best_colocs(masked_scores, labels, 50, 0.3)
+                        logger.debug(f'Saving {algorithm} at {fdr} FDR')
+                        self._save_job_to_db(ds_id, fdr, mol_db, algorithm, start, datetime.now(), None,
+                                             masked_ion_ids, masked_scores, clusters, colocs)
+
+                    run_alg('cosine', cos_scores, True)
+                    run_alg('pca_cosine', pca_cos_scores, False)
+                    run_alg('pca_pearson', pca_pear_scores, False)
+                    run_alg('pca_spearman', pca_sper_scores, False)
+
+        except Exception:
+            logger.warning('Colocalization job failed', exc_info=True)
+            self._save_job_to_db(ds_id, 0, mol_db, 'error', start, datetime.now(), format_exc(), [], np.array([[]]), [], [])
+            raise
+
+    def _get_existing_ds_annotations(self, ds_id, mol_db_name, image_storage_type, polarity):
+        def get_ion_image(id):
+            im = self._img_store.get_image_by_id(image_storage_type, 'iso_image', id)
+            data = np.asarray(im)
+            return np.where(data[:, :, 3] != 0, data[:, :, 0], 0).ravel()
+
+        mol_db = MolecularDB(name=mol_db_name)
+        annotation_rows = self._db.select(ANNOTATIONS_SEL, [ds_id, mol_db.id])
+        sf_adducts = [(formula, adduct) for image, formula, adduct, fdr in annotation_rows]
+        ion_id_mapping = self._get_ion_id_mapping(sf_adducts, polarity)
+        ion_ids = [ion_id_mapping[sf_adduct] for sf_adduct in sf_adducts]
+        fdrs = [fdr for image, formula, adduct, fdr in annotation_rows]
+
+        with ThreadPoolExecutor() as ex:
+            logger.debug(f'Getting {len(annotation_rows)} images for "{ds_id}" {mol_db_name}')
+            ion_images = ex.map(get_ion_image, [row[0] for row in annotation_rows])
+            logger.debug(f'Finished getting images for "{ds_id}" {mol_db_name}')
+        return list(zip(ion_images, ion_ids, fdrs))
+
+    def run_coloc_job_for_existing_ds(self, ds_id):
+
+        image_storage_type = Dataset(ds_id).get_ion_img_storage_type(self._db)
+        mol_dbs, polarity = self._db.select_one(DATASET_CONFIG_SEL, [ds_id])
+
+        for mol_db_name in mol_dbs:
+            annotations = self._get_existing_ds_annotations(ds_id, mol_db_name, image_storage_type, polarity)
+            self.run_coloc_job(ds_id, mol_db_name, annotations)
+
+    def run_coloc_job_for_new_ds(self, ds, mol_db_name, ion_metrics_df, ion_iso_images, alpha_channel):
+        """
+        Args
+        ====
+        ds: Dataset
+        mol_db_name: str
+        ion_metrics_df: pd.DataFrame
+        ion_iso_images: pyspark.rdd.RDD
+        alpha_channel: np.ndarray
+        """
+        logger.info('Running colocalization job')
+        polarity = ds.config['isotope_generation']['charge']['polarity']
+        mols = list(ion_metrics_df[['formula','adduct']].itertuples(index=False, name=None))
+        ion_id_mapping = self._get_ion_id_mapping(mols, polarity)
+        image_map = ion_iso_images.mapValues(lambda imgs: (imgs[0].toarray() * alpha_channel).ravel()).collectAsMap()
+        annotations = [(image_map[i], ion_id_mapping[(item.formula, item.adduct)], item.fdr)
+                       for i, item in ion_metrics_df.iterrows()]
+        self.run_coloc_job(ds.id, mol_db_name, annotations)
+

--- a/metaspace/engine/sm/engine/ion_mapping.py
+++ b/metaspace/engine/sm/engine/ion_mapping.py
@@ -1,0 +1,41 @@
+ION_INS = ('INSERT INTO graphql.ion (ion, formula, adduct, charge) ' 
+           'VALUES (%s, %s, %s, %s) ' 
+           'RETURNING id')
+ION_SEL = ('SELECT ion, id ' 
+           'FROM graphql.ion ' 
+           'WHERE ion = ANY(%s)')
+
+
+def get_ion_id_mapping(db, mols, polarity):
+    """Get a mapping of ions to ion ids, adding missing ions to the database if necessary
+    Args
+    ------------
+    mols : list[tuple[str, str]]
+        (formula, adduct) tuples
+    polarity : str
+        'Positive', 'Negative', '+' or '-'
+    Returns
+    ------------
+    dict[tuple[str, str], int]
+        (formula, adduct) => ion_id
+    """
+    if polarity in ('Positive', '+'):
+        charge = 1
+        charge_sign = '+'
+    elif polarity in ('Negative', '-'):
+        charge = -1
+        charge_sign = '-'
+    else:
+        raise TypeError("polarity must be 'Positive', 'Negative', '+' or '-'")
+
+    ions = [formula + adduct + charge_sign for formula, adduct in mols]
+    ion_to_mol = dict(zip(ions, mols))
+    ion_to_id = dict(db.select(ION_SEL, [ions]))
+    missing_ions = sorted(set(ions).difference(ion_to_id.keys()))
+
+    if missing_ions:
+        rows = [(ion, *ion_to_mol[ion], charge) for ion in missing_ions]
+        ids = db.insert_return(ION_INS, rows)
+        ion_to_id.update((row[0], id) for id, row in zip(ids, rows))
+
+    return dict((ion_to_mol[ion], ion_to_id[ion]) for ion in ions)

--- a/metaspace/engine/sm/engine/png_generator.py
+++ b/metaspace/engine/sm/engine/png_generator.py
@@ -13,7 +13,7 @@ class ImageStoreServiceWrapper(object):
     def __init__(self, img_service_url):
         self._img_service_url = img_service_url
         self._session = requests.Session()
-        self._session.mount(self._img_service_url, HTTPAdapter(max_retries=5))
+        self._session.mount(self._img_service_url, HTTPAdapter(max_retries=5, pool_maxsize=100))
 
     def _format_url(self, storage_type, img_type, method='', img_id=''):
         assert storage_type, 'Wrong storage_type: %s' % storage_type

--- a/metaspace/engine/sm/engine/search_job.py
+++ b/metaspace/engine/sm/engine/search_job.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from pyspark import SparkContext, SparkConf
 import logging
 
+from sm.engine.colocalization_job import ColocalizationJob
 from sm.engine.isocalc_wrapper import IsocalcWrapper
 from sm.engine.msm_basic.msm_basic_search import MSMBasicSearch
 from sm.engine.dataset import DatasetStatus
@@ -124,6 +125,9 @@ class SearchJob(object):
             mask = self._ds_reader.get_2d_sample_area_mask()
             img_store_type = self._ds.get_ion_img_storage_type(self._db)
             search_results.store(ion_metrics_df, ion_iso_images, mask, self._db, self._img_store, img_store_type)
+
+            coloc = ColocalizationJob(self._db)
+            coloc.run_coloc_job_for_new_ds(self._ds, mol_db.name, ion_metrics_df, ion_iso_images, mask)
         except Exception as e:
             self._db.alter(JOB_UPD_STATUS_FINISH, params=(JobStatus.FAILED,
                                                           datetime.now().strftime('%Y-%m-%d %H:%M:%S'),

--- a/metaspace/engine/sm/engine/search_job.py
+++ b/metaspace/engine/sm/engine/search_job.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pyspark import SparkContext, SparkConf
 import logging
 
-from sm.engine.colocalization_job import ColocalizationJob
+from sm.engine.colocalization import Colocalization
 from sm.engine.isocalc_wrapper import IsocalcWrapper
 from sm.engine.msm_basic.msm_basic_search import MSMBasicSearch
 from sm.engine.dataset import DatasetStatus
@@ -126,7 +126,7 @@ class SearchJob(object):
             img_store_type = self._ds.get_ion_img_storage_type(self._db)
             search_results.store(ion_metrics_df, ion_iso_images, mask, self._db, self._img_store, img_store_type)
 
-            coloc = ColocalizationJob(self._db)
+            coloc = Colocalization(self._db)
             coloc.run_coloc_job_for_new_ds(self._ds, mol_db.name, ion_metrics_df, ion_iso_images, mask)
         except Exception as e:
             self._db.alter(JOB_UPD_STATUS_FINISH, params=(JobStatus.FAILED,

--- a/metaspace/engine/tests/test_colocalization.py
+++ b/metaspace/engine/tests/test_colocalization.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+import numpy as np
+import pandas as pd
+from scipy.sparse import coo_matrix
+
+from sm.engine.colocalization import analyze_colocalization, Colocalization
+from sm.engine.dataset import Dataset
+from sm.engine.db import DB
+from sm.engine.tests.util import sm_config, test_db, metadata, ds_config, pyspark_context
+
+def test_valid_colocalization_jobs_generated():
+    annotations = []
+
+    for i in range(20):
+        ion_image = np.linspace(0, 50, 50, False) % (i + 1)
+        fdr = [0.05, 0.1, 0.2, 0.5][i % 4]
+        annotations.append((ion_image, i * 4, fdr))
+
+    jobs = list(analyze_colocalization('ds_id', 'HMDB_v4', annotations))
+
+    assert len(jobs) > 1
+    assert not any(job.error for job in jobs)
+    sample_job = [job for job in jobs if job.fdr == 0.2 and job.algorithm_name == 'cosine'][0]
+    assert len(sample_job.sample_ion_ids) > 0
+    assert len(sample_job.coloc_annotations) == 15
+    assert len(sample_job.coloc_annotations[0][1]) > 0 # First annotation was colocalized with at least one other
+
+
+def _make_sparse_ion_imgs(seed):
+    pixels = np.linspace(0, 25, 25, False).reshape((5, 5)) % (seed or 1)
+    return [coo_matrix(pixels)]
+
+
+def test_new_ds_saves_to_db(test_db, metadata, ds_config, pyspark_context):
+    db = DB(sm_config['db'])
+    ds = Dataset('ds_id', 'ds_name', 'input_path', datetime.now(), metadata, mol_dbs=['HDMB'])
+    ion_metrics_df = pd.DataFrame({'formula': ['H2O', 'H2O', 'CO2', 'CO2', 'H2SO4', 'H2SO4'],
+                                   'adduct': ['+H', '+K', '+H', '+K', '+H', '+K'],
+                                   'fdr': [0.05, 0.1, 0.05, 0.1, 0.05, 0.1]})
+    num_ions = len(ion_metrics_df)
+
+    test_images = [_make_sparse_ion_imgs(i) for i in range(num_ions)]
+    ion_iso_images = pyspark_context.parallelize(zip(range(num_ions), test_images), num_ions)
+    alpha_channel = np.linspace(0, 25, 25, False).reshape((5, 5)) % 2
+
+    Colocalization(db).run_coloc_job_for_new_ds(ds, 'HMDB', ion_metrics_df, ion_iso_images, alpha_channel)
+
+    jobs = db.select('SELECT id, error, sample_ion_ids FROM graphql.coloc_job')
+    annotations = db.select('SELECT coloc_ion_ids, coloc_coeffs FROM graphql.coloc_annotation')
+    ions = db.select('SELECT id FROM graphql.ion')
+
+    assert len(jobs) > 0
+    assert not any(job[1] for job in jobs)
+    assert jobs[0][2]
+    assert len(annotations) > 10
+    assert all(len(ann[0]) == len(ann[1]) for ann in annotations)
+    assert len(ions) == num_ions

--- a/metaspace/engine/tests/test_colocalization.py
+++ b/metaspace/engine/tests/test_colocalization.py
@@ -11,12 +11,11 @@ from sm.engine.tests.util import sm_config, test_db, metadata, ds_config, pyspar
 def test_valid_colocalization_jobs_generated():
     annotations = []
 
-    for i in range(20):
-        ion_image = np.linspace(0, 50, 50, False) % (i + 1)
-        fdr = [0.05, 0.1, 0.2, 0.5][i % 4]
-        annotations.append((ion_image, i * 4, fdr))
+    ion_images = np.array([np.linspace(0, 50, 50, False) % (i + 1) for i in range(20)])
+    ion_ids = np.array(range(20)) * 4
+    fdrs = np.array([[0.05, 0.1, 0.2, 0.5][i % 4] for i in range(20)])
 
-    jobs = list(analyze_colocalization('ds_id', 'HMDB_v4', annotations))
+    jobs = list(analyze_colocalization('ds_id', 'HMDB_v4', ion_images, ion_ids, fdrs))
 
     assert len(jobs) > 1
     assert not any(job.error for job in jobs)

--- a/metaspace/graphql/src/modules/annotation/model.ts
+++ b/metaspace/graphql/src/modules/annotation/model.ts
@@ -1,0 +1,97 @@
+import {
+  Entity,
+  PrimaryColumn,
+  Column, ManyToOne, JoinColumn, OneToMany, JoinTable, Index, PrimaryGeneratedColumn,
+} from 'typeorm';
+import {MomentValueTransformer} from '../../utils/MomentValueTransformer';
+import {Moment} from 'moment';
+
+@Entity('coloc_job')
+export class ColocJob {
+
+  @PrimaryColumn({ type: 'uuid', default: () => 'uuid_generate_v1mc()' })
+  id: string;
+
+  @Column({ type: 'text', name: 'ds_id' })
+  datasetId: string;
+
+  @Column({ type: 'text', name: 'mol_db', nullable: true })
+  molDb: string | null;
+
+  @Column({ type: 'numeric', precision: 2, scale: 2 })
+  fdr: number;
+
+  @Column({ type: 'text' })
+  algorithm: string;
+
+  @Column({ type: 'timestamp without time zone', default: () => "(now() at time zone 'utc')",
+    transformer: new MomentValueTransformer() })
+  start: Moment;
+
+  @Column({ type: 'timestamp without time zone', default: () => "(now() at time zone 'utc')",
+    transformer: new MomentValueTransformer() })
+  finish: Moment;
+
+  @Column({ type: 'text', nullable: true })
+  error: string | null;
+
+  @Column({ type: 'int', array: true, name: 'sample_ion_ids' })
+  sampleIonIds: number[];
+
+  @OneToMany(type => ColocAnnotation, colocAnnotation => colocAnnotation.colocJob)
+  @JoinTable({ name: 'dataset_project' })
+  colocAnnotations: ColocAnnotation[];
+}
+
+@Entity('coloc_annotation')
+export class ColocAnnotation {
+
+  @PrimaryColumn({ type: 'uuid', name: 'coloc_job_id' })
+  colocJobId: string;
+
+  /** Index of the annotation's sfAdduct in the parent ColocJob's orderedMols array */
+  @PrimaryColumn({ type: 'int', name: 'ion_id' })
+  ionId: number;
+
+  @Column({ type: 'int', array: true, name: 'coloc_ion_ids' })
+  colocIonIds: number[];
+
+  @Column({ type: 'float4', array: true, name: 'coloc_coeffs' })
+  colocCoeffs: number[];
+
+  @ManyToOne(type => ColocJob, {onDelete: 'CASCADE'})
+  @JoinColumn({ name: 'coloc_job_id' })
+  colocJob: ColocJob;
+}
+
+@Entity('ion')
+export class Ion {
+  @PrimaryGeneratedColumn({ type: 'int' })
+  id: number;
+
+  /** All components of the ion in one string, with charge as a '+'/'-' suffix e.g. "C21H41O6P-HO+HO3P-H2O-CO2+Na+" */
+  @Index({ unique: true })
+  @Column({ type: 'text' })
+  ion: string;
+
+  /** The formula of the molecule prior to any modifications, e.g. "C21H41O6P".
+   *  Internally this has been called "sumFormula" or "sf", but this term is incorrect.
+   *  It should be referred to as "formula" or "molecular formula". */
+  @Column({ type: 'text' })
+  formula: string;
+
+  // /** Array of molecules lost, including the '-' prefix, e.g. ['-H2O','-CO2'] */
+  // @Column({ type: 'text', name: 'neutral_losses' })
+  // neutralLosses: string[];
+
+  // /** Array of derivatizations, using '-' and '+' prefixes to indicate atoms lost/gained, e.g. ['-HO+HO3P'] */
+  // @Column({ type: 'text' })
+  // derivatizations: string[];
+
+  @Column({ type: 'text' })
+  adduct: string;
+
+  /** 1 or -1 */
+  @Column({ type: 'smallint' })
+  charge: number;
+}

--- a/metaspace/graphql/src/utils/typeOrmConfig.ts
+++ b/metaspace/graphql/src/utils/typeOrmConfig.ts
@@ -5,6 +5,7 @@ import {User} from '../modules/user/model';
 import {Dataset, DatasetProject} from '../modules/dataset/model';
 import {Group, UserGroup} from '../modules/group/model';
 import {Project, UserProject} from '../modules/project/model';
+import {ColocAnnotation, ColocJob, Ion} from '../modules/annotation/model';
 
 export const DbSchemaName = 'graphql';
 
@@ -24,6 +25,9 @@ const typeOrmConfig: ConnectionOptions = {
     UserGroup,
     Project,
     UserProject,
+    ColocJob,
+    ColocAnnotation,
+    Ion,
   ],
   synchronize: true,
   logging: ['error', 'warn', 'info', 'log'],


### PR DESCRIPTION
First piece of #163 

Includes the DB schema and annotation pipeline changes needed for colocalization.

There are 3 entry points to run colocalization:
* via `analyze_colocalization` for a completely self-contained interface, so that algorithms can be run/tested without needing the database, etc.
* via `Colocalization.run_coloc_job_for_existing_ds` (/`scripts/run_colocalization.py`) to add colocalization data to existing datasets, taking the data from the DB and downloading ion images
* via `Colocalization.run_coloc_job_for_new_ds` to take the data from the Spark/Pandas dataframes produced by the annotation pipeline
