### PR TITLE
Update ansible script to install from requirements.txt

### DIFF
--- a/ansible/roles/sm_engine/tasks/main.yml
+++ b/ansible/roles/sm_engine/tasks/main.yml
@@ -4,7 +4,7 @@
   args:
     chdir: "{{ sm_home }}"
     executable: /bin/bash
-  shell: "{{ sm_activate_venv }} && pip install -e ."
+  shell: "{{ sm_activate_venv }} && pip install -e . && pip install --upgrade -r requirements.txt"
 
 - name: Pull SM config from the remote host
   fetch: src={{ sm_home }}/conf/config.json.template dest=/tmp/config.json.template


### PR DESCRIPTION
After deploying to staging, sm-update-daemon and sm-cluster-autostart were failing to start due to a missing `redis` package. I'm not sure if `--upgrade` is correct, but that's how it is used in Docker/CircleCI