### PR TITLE
Fix rare colocalization error, reduce memory consumption

### DIFF
--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -127,5 +127,8 @@
   "ds_config_defaults": {
     "adducts": {{ sm_default_adducts | to_json }},
     "moldb_names": ["HMDB-v4"]
+  },
+  "colocalization": {
+    "enabled": true
   }
 }

--- a/metaspace/engine/conf/test_config.json
+++ b/metaspace/engine/conf/test_config.json
@@ -115,5 +115,8 @@
       "-": ["-H", "+Cl" ]
     },
     "moldb_names": ["HMDB-v4"]
+  },
+  "colocalization": {
+    "enabled": true
   }
 }

--- a/metaspace/engine/sm/engine/colocalization.py
+++ b/metaspace/engine/sm/engine/colocalization.py
@@ -77,6 +77,23 @@ class ColocalizationJob(object):
         self.coloc_annotations = coloc_annotations or []
 
 
+class FreeableRef(object):
+    def __init__(self, ref):
+        self._ref = ref
+        self._freed = False
+
+    def free(self):
+        self._ref = None
+        self._freed = True
+
+    @property
+    def ref(self):
+        if self._freed:
+            raise Exception('FreeableRef is already freed')
+        else:
+            return self._ref
+
+
 def _preprocess_images_inplace(imgs):
     """ Clips the top 1% (if more than 1% of pixels are populated),
     scales all pixels to the range 0...1,
@@ -183,24 +200,26 @@ def analyze_colocalization(ds_id, mol_db, images, ion_ids, fdrs):
     ----------
     ds_id: str
     mol_db: str
-    images: np.ndarray
+    images: FreeableRef[np.ndarray]
         2D array where each row contains the pixels from one image
-        WARNING: This np.ndarray is modified in-place to save memory
+        WARNING: This FreeableRef is released during use to save memory
     ion_ids: np.ndarray
         1D array where each item is the ion_id for the corresponding row in images
     fdrs: np.ndarray
         1D array where each item is the fdr for the corresponding row in images
     """
-    assert images.shape[1] >= 3
-    assert images.shape[0] == ion_ids.shape[0] == fdrs.shape[0], (images.shape, ion_ids.shape, fdrs.shape)
+    assert images.ref.shape[1] >= 3
+    assert images.ref.shape[0] == ion_ids.shape[0] == fdrs.shape[0], (images.ref.shape, ion_ids.shape, fdrs.shape)
     start = datetime.now()
 
-    logger.debug(f'Preprocessing images (shape: {images.shape}, dtype: {images.dtype})')
-    _preprocess_images_inplace(images)
+    logger.debug(f'Preprocessing images (shape: {images.ref.shape}, dtype: {images.ref.dtype})')
+    _preprocess_images_inplace(images.ref)
 
     logger.debug('Calculating colocalization metrics')
-    pca_images = PCA(min(20, *images.shape)).fit_transform(images)
-    cos_scores = pairwise_kernels(images, metric='cosine')
+    pca_images = PCA(min(20, *images.ref.shape)).fit_transform(images.ref)
+    cos_scores = pairwise_kernels(images.ref, metric='cosine')
+    images.free()
+
     pca_cos_scores = pairwise_kernels(pca_images, metric='cosine')
     pca_pear_scores = np.float32(np.corrcoef(pca_images))
     pca_sper_scores = np.float32(spearmanr(pca_images, axis=1)[0])  # TODO: Discard low p-value entries?
@@ -297,7 +316,7 @@ class Colocalization(object):
             ion_images = list(ex.map(get_ion_image, [row[0] for row in annotation_rows]))
             logger.debug(f'Finished getting images for "{ds_id}" {mol_db_name}')
 
-        images = np.array([img for img in ion_images if img is not None], ndmin=2, dtype=np.float32)
+        images = FreeableRef(np.array([img for img in ion_images if img is not None], ndmin=2, dtype=np.float32))
         ion_ids = np.array([ion_id for i, ion_id in enumerate(ion_ids) if ion_images[i] is not None], dtype=np.int64)
         fdrs = np.array([fdr for i, fdr in enumerate(fdrs) if ion_images[i] is not None], dtype=np.float32)
 
@@ -336,7 +355,7 @@ class Colocalization(object):
                        for i, item in ion_metrics_df.iterrows()
                        if image_map.get(i) is not None]
 
-        images = np.array([a[0] for a in annotations], ndmin=2, dtype=np.float32)
+        images = FreeableRef(np.array([a[0] for a in annotations], ndmin=2, dtype=np.float32))
         ion_ids = np.array([a[1] for a in annotations], dtype=np.int64)
         fdrs = np.array([a[2] for a in annotations], dtype=np.float32)
 

--- a/metaspace/engine/sm/engine/colocalization.py
+++ b/metaspace/engine/sm/engine/colocalization.py
@@ -333,7 +333,7 @@ class Colocalization(object):
         image_storage_type = Dataset(ds_id).get_ion_img_storage_type(self._db)
         mol_dbs, polarity = self._db.select_one(DATASET_CONFIG_SEL, [ds_id])
 
-        for mol_db_name in mol_dbs[1:2]:
+        for mol_db_name in mol_dbs:
             logger.info(f'Running colocalization job for {ds_id} on {mol_db_name}')
             images, ion_ids, fdrs = self._get_existing_ds_annotations(ds_id, mol_db_name, image_storage_type, polarity)
             self._analyze_and_save(ds_id, mol_db_name, images, ion_ids, fdrs)

--- a/metaspace/engine/tests/test_colocalization.py
+++ b/metaspace/engine/tests/test_colocalization.py
@@ -3,15 +3,16 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import coo_matrix
 
-from sm.engine.colocalization import analyze_colocalization, Colocalization
+from sm.engine.colocalization import analyze_colocalization, Colocalization, FreeableRef
 from sm.engine.dataset import Dataset
 from sm.engine.db import DB
 from sm.engine.tests.util import sm_config, test_db, metadata, ds_config, pyspark_context
 
+
 def test_valid_colocalization_jobs_generated():
     annotations = []
 
-    ion_images = np.array([np.linspace(0, 50, 50, False) % (i + 1) for i in range(20)])
+    ion_images = FreeableRef(np.array([np.linspace(0, 50, 50, False) % (i + 1) for i in range(20)]))
     ion_ids = np.array(range(20)) * 4
     fdrs = np.array([[0.05, 0.1, 0.2, 0.5][i % 4] for i in range(20)])
 


### PR DESCRIPTION
* Fixes an error that occurs when running against a dataset that has multiple jobs for the same mol_db. Previously it would select all annotations across all jobs, but with duplicate jobs this resulted in duplicate ions being selected. This happened against 4 datasets on Staging:
    * 2017-05-11_13h42m35s HMDB-v2.5
    * 2017-02-02_17h24m26s SwissLipids
    * 2017-05-02_15h37m42s SwissLipids
    * 2017-05-02_15h28m51s ChEBI

* Add config setting to disable colocalization as part of the annotation pipeline

* Reduce worst-case memory consumption by 2-3.6GB. On the dataset with 12k annotations (2018-10-09_03h48m12s), the "score" ndarrays have 12k*12k elements (=576MB each if 4 bytes per element). This PR saves up to:
    * 2GB by freeing `images` after it is no longer needed
    * 2 * 576MB by converting `pca_pear_scores` and `pca_sper_scores` from float64 to float32
    * Another 576MB by not creating a duplicate for `masked_scores` when the mask includes all annotations (i.e. for FDR 0.5)

The motivation for this is that when running against all of Staging the peak memory usage was 13.2 GiB. The spark master uses c4.xlarge instances, which only have 7.5GiB of RAM. While this won't completely stop swapping, it should reduce it substantially. Also, it makes the process less resource-intensive during development.