### PR TITLE
Tidy dataset lists & dataset page header

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/DatasetsPage.vue
+++ b/metaspace/webapp/src/modules/Datasets/DatasetsPage.vue
@@ -27,7 +27,6 @@
 
   /* 1 dataset per row by default*/
   #dataset-page-contents {
-    display: inline-block;
     width: 820px;
 
     @media (min-width: 1650px) {

--- a/metaspace/webapp/src/modules/Datasets/DatasetsPage.vue
+++ b/metaspace/webapp/src/modules/Datasets/DatasetsPage.vue
@@ -28,6 +28,8 @@
   /* 1 dataset per row by default*/
   #dataset-page-contents {
     width: 820px;
+    margin-left: 5px;
+    margin-right: 5px;
 
     @media (min-width: 1650px) {
       /* 2 datasets per row on wide screens */

--- a/metaspace/webapp/src/modules/Datasets/DatasetsPage.vue
+++ b/metaspace/webapp/src/modules/Datasets/DatasetsPage.vue
@@ -28,8 +28,7 @@
   /* 1 dataset per row by default*/
   #dataset-page-contents {
     width: 820px;
-    margin-left: 5px;
-    margin-right: 5px;
+    margin: 0 5px;
 
     @media (min-width: 1650px) {
       /* 2 datasets per row on wide screens */

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -516,9 +516,11 @@
 
  .dataset-item {
    position: relative;
+   box-sizing: border-box;
    border-radius: 5px;
-   width: calc(100% - 6px);
+   flex: 1 1 100%;
    min-height: 120px;
+   min-width: 600px;
    max-width: 950px;
    margin: 3px;
    padding: 0px;

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetList.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetList.vue
@@ -9,6 +9,10 @@
                   @filterUpdate="filter => $emit('filterUpdate', filter)"
                   @datasetMutated="$emit('datasetMutated')">
     </dataset-item>
+    <div v-if="datasets == null || datasets.length === 0"
+         class="datasets-list-empty">
+      No datasets found
+    </div>
   </div>
 </template>
 
@@ -61,9 +65,11 @@
 </script>
 
 <style scoped lang="scss">
+  @import "~element-ui/packages/theme-chalk/src/common/var";
+
   .allow-double-column {
     >.dataset-item {
-      max-width: 800px;
+      flex-basis: calc(50% - 10px);
     }
   }
 
@@ -72,11 +78,21 @@
     flex-direction: row;
     flex-wrap: wrap;
     align-items: stretch;
+    margin: -3px;
 
     &:not(.double-column) {
       .odd {
         background-color: #e6f1ff;
       }
     }
+  }
+
+  .datasets-list-empty {
+    display: flex;
+    height: 200px;
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    color: $--color-text-secondary;
   }
 </style>

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
@@ -9,7 +9,7 @@
           <el-radio-button label="Summary"></el-radio-button>
         </el-radio-group>
 
-        <el-checkbox-group v-model="categories" :min=1 style="padding: 5px 20px;">
+        <el-checkbox-group v-model="categories" :min=1 class="dataset-status-checkboxes">
           <el-checkbox class="cb-started" label="started">Processing {{ count('started') }}</el-checkbox>
           <el-checkbox class="cb-queued" label="queued">Queued {{ count('queued') }}</el-checkbox>
           <el-checkbox label="finished">Finished {{ count('finished') }}</el-checkbox>
@@ -300,6 +300,13 @@
  #dataset-page {
    display: flex;
    justify-content: center;
+ }
+
+ .dataset-status-checkboxes {
+   padding: 5px 20px;
+   display: flex;
+   flex-direction: row;
+   align-items: center;
  }
 
  .cb-started .el-checkbox__input.is-checked .el-checkbox__inner {

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
@@ -3,7 +3,7 @@
     <filter-panel level="dataset"></filter-panel>
 
     <div>
-      <el-form :inline="true" style="display: inline-flex">
+      <el-form :inline="true" id="dataset-list-header">
         <el-radio-group value="List" @input="onChangeTab" size="small">
           <el-radio-button label="List"></el-radio-button>
           <el-radio-button label="Summary"></el-radio-button>
@@ -15,31 +15,15 @@
           <el-checkbox label="finished">Finished {{ count('finished') }}</el-checkbox>
           <el-checkbox v-if="canSeeFailed" class="cb-failed" label="failed">Failed {{ count('failed') }}</el-checkbox>
         </el-checkbox-group>
+        <div style="flex-grow: 1;" />
+
+        <el-button v-if="nonEmpty" :disabled="isExporting" @click="startExport" size="small">
+          Export to CSV
+        </el-button>
       </el-form>
     </div>
 
-    <div>
-      <div id="dataset-list-header">
-        <div v-if="noFilters" style="font: 24px 'Roboto', sans-serif; padding: 5px;">
-          <span v-if="noFilters">
-            Recent uploads
-          </span>
-        </div>
-
-        <div v-else style="font: 18px 'Roboto', sans-serif; padding: 5px;">
-          <span v-if="nonEmpty">
-            Search results in reverse chronological order
-          </span>
-          <span v-else>No datasets found</span>
-        </div>
-
-        <el-button v-if="nonEmpty" :disabled="isExporting" @click="startExport" class="export-btn">
-          Export to CSV
-        </el-button>
-      </div>
-
-      <dataset-list :datasets="datasets" allowDoubleColumn />
-    </div>
+    <dataset-list :datasets="datasets" allowDoubleColumn />
   </div>
 </template>
 
@@ -318,23 +302,6 @@
    justify-content: center;
  }
 
- /* 1 dataset per row by default*/
- #dataset-page-contents {
-   display: inline-block;
-   width: 820px;
-
-   @media (min-width: 1650px) {
-     /* 2 datasets per row on wide screens */
-     width: 1620px;
-   }
- }
-
- .export-btn {
-   margin-top: 7px;
-   width: 135px;
-   height: 36px;
- }
-
  .cb-started .el-checkbox__input.is-checked .el-checkbox__inner {
    background: #5eed5e;
  }
@@ -349,6 +316,7 @@
 
  #dataset-list-header {
    display: flex;
-   align-items: baseline;
+   flex-wrap: wrap;
+   margin-bottom: 10px;
  }
 </style>

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -31,7 +31,7 @@ exports[`DatasetTable should match snapshot 1`] = `
     </mock-el-select>
   </div>
   <div>
-    <form class="el-form el-form--inline" style="display: inline-flex;">
+    <form class="el-form el-form--inline" id="dataset-list-header">
       <div role="radiogroup" class="el-radio-group">
         <label role="radio" aria-checked="true" tabindex="0" class="el-radio-button el-radio-button--small is-active">
           <input type="radio" tabindex="-1" class="el-radio-button__orig-radio" value="List"><span class="el-radio-button__inner">List</span></label>
@@ -50,137 +50,16 @@ exports[`DatasetTable should match snapshot 1`] = `
           </span><span class="el-checkbox__label">Finished (1)<!----></span></label>
         <!---->
       </div>
-    </form>
-  </div>
-  <div>
-    <div id="dataset-list-header">
-      <div style="font: sans-serif 24px 24px; padding: 5px;"><span>
-          Recent uploads
-        </span></div>
-      <button type="button" class="el-button export-btn el-button--default">
+      <div></div>
+      <button type="button" class="el-button el-button--default el-button--small">
         <!---->
         <!----><span>
         Export to CSV
       </span></button>
-    </div>
-    <div class="dataset-list allow-double-column">
-      <div class="dataset-item">
-        <mock-el-dialog title="Provided metadata">
-          <div class="el-row">
-            <div role="tree" class="el-tree" id="metadata-tree">
-              <div role="treeitem" tabindex="0" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
-                <div class="el-tree-node__content" style="padding-left: 0px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
-                  <!---->
-                  <!----><span class="el-tree-node__label">MS analysis</span></div>
-                <div role="group" aria-expanded="true" class="el-tree-node__children">
-                  <div role="treeitem" tabindex="-1" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
-                    <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
-                      <!---->
-                      <!----><span class="el-tree-node__label">Detector resolving power</span></div>
-                    <div role="group" aria-expanded="true" class="el-tree-node__children">
-                      <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                        <div class="el-tree-node__content" style="padding-left: 36px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                          <!---->
-                          <!----><span class="el-tree-node__label">mz: 1234</span></div>
-                        <!---->
-                      </div>
-                      <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                        <div class="el-tree-node__content" style="padding-left: 36px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                          <!---->
-                          <!----><span class="el-tree-node__label">Resolving power: 123456</span></div>
-                        <!---->
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div role="treeitem" tabindex="-1" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
-                <div class="el-tree-node__content" style="padding-left: 0px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
-                  <!---->
-                  <!----><span class="el-tree-node__label">Data Management</span></div>
-                <div role="group" aria-expanded="true" class="el-tree-node__children">
-                  <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                    <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                      <!---->
-                      <!----><span class="el-tree-node__label">Submitter: allDatasets.0.submitter.name</span></div>
-                    <!---->
-                  </div>
-                  <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                    <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                      <!---->
-                      <!----><span class="el-tree-node__label">Principal Investigator: allDatasets.0.principalInvestigator.name</span></div>
-                    <!---->
-                  </div>
-                  <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                    <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                      <!---->
-                      <!----><span class="el-tree-node__label">Group: allDatasets.0.group.name</span></div>
-                    <!---->
-                  </div>
-                  <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
-                    <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
-                      <!---->
-                      <!----><span class="el-tree-node__label">Projects: allDatasets.0.projects.0.name, allDatasets.0.projects.1.name</span></div>
-                    <!---->
-                  </div>
-                </div>
-              </div>
-              <!---->
-              <div class="el-tree__drop-indicator" style="display: none;"></div>
-            </div>
-          </div>
-        </mock-el-dialog>
-        <div class="opt-image">
-          <div class="edit-opt-image-guest">
-            <img src="allDatasets.0.thumbnailOpticalImageUrl" alt="Optical image">
-          </div>
-        </div>
-        <div class="ds-info">
-          <div class="ds-item-line">
-            <b>allDatasets.0.name</b>
-          </div>
-          <div class="ds-item-line"><span title="Filter by species" class="ds-add-filter">
-        allDatasets.0.organism</span>,
-            <span title="Filter by organism part" class="ds-add-filter">
-        alldatasets.0.organismpart</span> <span title="Filter by condition" class="ds-add-filter">
-        (alldatasets.0.condition)</span></div>
-          <div class="ds-item-line"><span title="Filter by ionisation source" class="ds-add-filter">
-        allDatasets.0.ionisationSource</span> +
-            <span title="Filter by analyzer type" class="ds-add-filter">
-        allDatasets.0.analyzer.type</span>,
-            <span title="Filter by polarity" class="ds-add-filter">
-        positive mode</span>, RP 123k @ 1234
-          </div>
-          <div class="ds-item-line" style="font-size: 15px;">
-            Submitted <span class="s-bold">????-??-??</span> at ??:?? by
-            <span title="Filter by submitter" class="ds-add-filter">
-        allDatasets.0.submitter.name</span><span>,
-        <mock-el-dropdown showtimeout="50" placement="bottom" trigger="hover"><div slot-key="default"><span class="s-group ds-add-filter">
-            allDatasets.0.group.shortName
-          </span> </div>
-          <div slot-key="dropdown">
-            <mock-el-dropdown-menu>
-              <mock-el-dropdown-item command="filter_group">Filter by this group</mock-el-dropdown-item>
-              <mock-el-dropdown-item command="view_group">View group</mock-el-dropdown-item>
-            </mock-el-dropdown-menu>
-          </div>
-          </mock-el-dropdown>
-          </span>
-        </div>
-        <!---->
-      </div>
-      <div class="ds-actions">
-        <!----><span><div title="Processing is under way" class="striped-progressbar processing"></div></span>
-        <!---->
-        <i class="el-icon-view"></i>
-        <a class="metadata-link">Show full metadata</a>
-        <!---->
-        <!---->
-        <!---->
-        <!---->
-      </div>
-    </div>
-    <div class="dataset-item odd">
+    </form>
+  </div>
+  <div class="dataset-list allow-double-column">
+    <div class="dataset-item">
       <mock-el-dialog title="Provided metadata">
         <div class="el-row">
           <div role="tree" class="el-tree" id="metadata-tree">
@@ -286,8 +165,8 @@ exports[`DatasetTable should match snapshot 1`] = `
       <!---->
     </div>
     <div class="ds-actions">
+      <!----><span><div title="Processing is under way" class="striped-progressbar processing"></div></span>
       <!---->
-      <!----><span><div title="Waiting in the queue" class="striped-progressbar queued"></div></span>
       <i class="el-icon-view"></i>
       <a class="metadata-link">Show full metadata</a>
       <!---->
@@ -296,7 +175,7 @@ exports[`DatasetTable should match snapshot 1`] = `
       <!---->
     </div>
   </div>
-  <div class="dataset-item">
+  <div class="dataset-item odd">
     <mock-el-dialog title="Provided metadata">
       <div class="el-row">
         <div role="tree" class="el-tree" id="metadata-tree">
@@ -399,21 +278,11 @@ exports[`DatasetTable should match snapshot 1`] = `
       </mock-el-dropdown>
       </span>
     </div>
-    <div class="ds-item-line"><span><a href="/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">1, 2, 20 annotations</a>
-        @ FDR 0.05, 0.1, 0.5% (HMDB-v2.5)
-      </span></div>
+    <!---->
   </div>
-  <div class="ds-actions"><span><i class="el-icon-picture"></i> <mock-el-popover trigger="hover" placement="top"><div slot-key="default"><div class="db-link-list">
-          Select a database:
-          <div><a href="/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
-              HMDB-v2.5
-            </a></div><div><a href="/annotations?db=HMDB-v4&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
-              HMDB-v4
-            </a></div><div><a href="/annotations?db=CHEBI&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
-              CHEBI
-            </a></div></div> </div><div slot-key="reference"><a>Browse annotations</a></div></mock-el-popover> <br></span>
+  <div class="ds-actions">
     <!---->
-    <!---->
+    <!----><span><div title="Waiting in the queue" class="striped-progressbar queued"></div></span>
     <i class="el-icon-view"></i>
     <a class="metadata-link">Show full metadata</a>
     <!---->
@@ -422,7 +291,133 @@ exports[`DatasetTable should match snapshot 1`] = `
     <!---->
   </div>
 </div>
+<div class="dataset-item">
+  <mock-el-dialog title="Provided metadata">
+    <div class="el-row">
+      <div role="tree" class="el-tree" id="metadata-tree">
+        <div role="treeitem" tabindex="0" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
+          <div class="el-tree-node__content" style="padding-left: 0px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
+            <!---->
+            <!----><span class="el-tree-node__label">MS analysis</span></div>
+          <div role="group" aria-expanded="true" class="el-tree-node__children">
+            <div role="treeitem" tabindex="-1" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
+              <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
+                <!---->
+                <!----><span class="el-tree-node__label">Detector resolving power</span></div>
+              <div role="group" aria-expanded="true" class="el-tree-node__children">
+                <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+                  <div class="el-tree-node__content" style="padding-left: 36px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
+                    <!---->
+                    <!----><span class="el-tree-node__label">mz: 1234</span></div>
+                  <!---->
+                </div>
+                <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+                  <div class="el-tree-node__content" style="padding-left: 36px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
+                    <!---->
+                    <!----><span class="el-tree-node__label">Resolving power: 123456</span></div>
+                  <!---->
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div role="treeitem" tabindex="-1" aria-expanded="true" draggable="false" class="el-tree-node is-expanded is-focusable">
+          <div class="el-tree-node__content" style="padding-left: 0px;"><span class="el-tree-node__expand-icon el-icon-caret-right expanded"></span>
+            <!---->
+            <!----><span class="el-tree-node__label">Data Management</span></div>
+          <div role="group" aria-expanded="true" class="el-tree-node__children">
+            <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+              <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
+                <!---->
+                <!----><span class="el-tree-node__label">Submitter: allDatasets.0.submitter.name</span></div>
+              <!---->
+            </div>
+            <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+              <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
+                <!---->
+                <!----><span class="el-tree-node__label">Principal Investigator: allDatasets.0.principalInvestigator.name</span></div>
+              <!---->
+            </div>
+            <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+              <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
+                <!---->
+                <!----><span class="el-tree-node__label">Group: allDatasets.0.group.name</span></div>
+              <!---->
+            </div>
+            <div role="treeitem" tabindex="-1" draggable="false" class="el-tree-node is-focusable">
+              <div class="el-tree-node__content" style="padding-left: 18px;"><span class="el-tree-node__expand-icon el-icon-caret-right is-leaf"></span>
+                <!---->
+                <!----><span class="el-tree-node__label">Projects: allDatasets.0.projects.0.name, allDatasets.0.projects.1.name</span></div>
+              <!---->
+            </div>
+          </div>
+        </div>
+        <!---->
+        <div class="el-tree__drop-indicator" style="display: none;"></div>
+      </div>
+    </div>
+  </mock-el-dialog>
+  <div class="opt-image">
+    <div class="edit-opt-image-guest">
+      <img src="allDatasets.0.thumbnailOpticalImageUrl" alt="Optical image">
+    </div>
+  </div>
+  <div class="ds-info">
+    <div class="ds-item-line">
+      <b>allDatasets.0.name</b>
+    </div>
+    <div class="ds-item-line"><span title="Filter by species" class="ds-add-filter">
+        allDatasets.0.organism</span>,
+      <span title="Filter by organism part" class="ds-add-filter">
+        alldatasets.0.organismpart</span> <span title="Filter by condition" class="ds-add-filter">
+        (alldatasets.0.condition)</span></div>
+    <div class="ds-item-line"><span title="Filter by ionisation source" class="ds-add-filter">
+        allDatasets.0.ionisationSource</span> +
+      <span title="Filter by analyzer type" class="ds-add-filter">
+        allDatasets.0.analyzer.type</span>,
+      <span title="Filter by polarity" class="ds-add-filter">
+        positive mode</span>, RP 123k @ 1234
+    </div>
+    <div class="ds-item-line" style="font-size: 15px;">
+      Submitted <span class="s-bold">????-??-??</span> at ??:?? by
+      <span title="Filter by submitter" class="ds-add-filter">
+        allDatasets.0.submitter.name</span><span>,
+        <mock-el-dropdown showtimeout="50" placement="bottom" trigger="hover"><div slot-key="default"><span class="s-group ds-add-filter">
+            allDatasets.0.group.shortName
+          </span> </div>
+    <div slot-key="dropdown">
+      <mock-el-dropdown-menu>
+        <mock-el-dropdown-item command="filter_group">Filter by this group</mock-el-dropdown-item>
+        <mock-el-dropdown-item command="view_group">View group</mock-el-dropdown-item>
+      </mock-el-dropdown-menu>
+    </div>
+    </mock-el-dropdown>
+    </span>
+  </div>
+  <div class="ds-item-line"><span><a href="/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">1, 2, 20 annotations</a>
+        @ FDR 0.05, 0.1, 0.5% (HMDB-v2.5)
+      </span></div>
 </div>
+<div class="ds-actions"><span><i class="el-icon-picture"></i> <mock-el-popover trigger="hover" placement="top"><div slot-key="default"><div class="db-link-list">
+          Select a database:
+          <div><a href="/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
+              HMDB-v2.5
+            </a></div><div><a href="/annotations?db=HMDB-v4&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
+              HMDB-v4
+            </a></div><div><a href="/annotations?db=CHEBI&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
+              CHEBI
+            </a></div></div> </div><div slot-key="reference"><a>Browse annotations</a></div></mock-el-popover> <br></span>
+  <!---->
+  <!---->
+  <i class="el-icon-view"></i>
+  <a class="metadata-link">Show full metadata</a>
+  <!---->
+  <!---->
+  <!---->
+  <!---->
+</div>
+</div>
+<!---->
 </div>
 </div>
 `;

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -38,7 +38,7 @@ exports[`DatasetTable should match snapshot 1`] = `
         <label role="radio" tabindex="-1" class="el-radio-button el-radio-button--small">
           <input type="radio" tabindex="-1" class="el-radio-button__orig-radio" value="Summary"><span class="el-radio-button__inner">Summary</span></label>
       </div>
-      <div role="group" aria-label="checkbox-group" class="el-checkbox-group" style="padding: 5px 20px;">
+      <div role="group" aria-label="checkbox-group" class="el-checkbox-group dataset-status-checkboxes">
         <label role="checkbox" aria-checked="true" class="el-checkbox cb-started is-checked"><span aria-checked="mixed" class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span>
           <input type="checkbox" aria-hidden="true" class="el-checkbox__original" value="started">
           </span><span class="el-checkbox__label">Processing (1)<!----></span></label>

--- a/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.vue
@@ -354,6 +354,8 @@
   }
   .page-content {
     width: 950px;
+    margin-left: 5px;
+    margin-right: 5px;
   }
 
   .header-row {

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupPage.spec.ts.snap
@@ -39,6 +39,7 @@ exports[`ViewGroupPage datasets tab should match snapshot (non-member) 1`] = `
             <datasetitem-stub dataset="[object Object]" currentuser="[object Object]" idx="0" hidegroupmenu="true" class=""></datasetitem-stub>
             <datasetitem-stub dataset="[object Object]" currentuser="[object Object]" idx="1" hidegroupmenu="true" class="odd"></datasetitem-stub>
             <datasetitem-stub dataset="[object Object]" currentuser="[object Object]" idx="2" hidegroupmenu="true" class=""></datasetitem-stub>
+            <!---->
           </div>
           <div class="dataset-list-footer">
             <a href="/datasets?grp=00000000-1111-2222-3333-444444444444" class="">See all datasets</a>

--- a/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
+++ b/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
@@ -334,6 +334,8 @@
   }
   .page-content {
     width: 950px;
+    margin-left: 5px;
+    margin-right: 5px;
   }
 
   .header-row {

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
@@ -37,6 +37,7 @@ exports[`ViewProjectPage datasets tab should match snapshot (non-member) 1`] = `
             <datasetitem-stub dataset="[object Object]" currentuser="[object Object]" idx="0" class=""></datasetitem-stub>
             <datasetitem-stub dataset="[object Object]" currentuser="[object Object]" idx="1" class="odd"></datasetitem-stub>
             <datasetitem-stub dataset="[object Object]" currentuser="[object Object]" idx="2" class=""></datasetitem-stub>
+            <!---->
           </div>
           <div class="dataset-list-footer">
             <a href="/datasets?prj=00000000-1111-2222-3333-444444444444" class="">See all datasets</a>


### PR DESCRIPTION
* Removed the "Search results in reverse chronological order" text
* Moved the "Export CSV" button into the line above
* Adjusted the dataset item width so that the list takes the full width available to it
* Centered & greyed out the "No datasets found" message
* Moved the "No datasets found" message into DatasetsList so that it also appears on the Group/Project pages


## Before
![image](https://user-images.githubusercontent.com/26366936/53109727-c8d01980-3539-11e9-87e1-d029e0abe70f.png)

## After
![image](https://user-images.githubusercontent.com/26366936/53109476-40517900-3539-11e9-9c1a-64f47512a13e.png)

## Before
![image](https://user-images.githubusercontent.com/26366936/53109760-d5ed0880-3539-11e9-9892-5af7da4c41c2.png)

## After
![image](https://user-images.githubusercontent.com/26366936/53109435-29128b80-3539-11e9-93ca-10321f59bf5d.png)

## Before
![image](https://user-images.githubusercontent.com/26366936/53109705-bc4bc100-3539-11e9-8069-3d5d489e9ff9.png)

## After
![image](https://user-images.githubusercontent.com/26366936/53109660-a3dba680-3539-11e9-91f2-17acae73dab5.png)


## Before
![image](https://user-images.githubusercontent.com/26366936/53109788-ebfac900-3539-11e9-80e7-3737be5a4cea.png)
(Note that the line above the datasets has a 3px overhang on each side)

## After
![image](https://user-images.githubusercontent.com/26366936/53109598-7d1d7000-3539-11e9-986c-3b6d42401165.png)
