### PR TITLE
Add ansible config for coloc algorithms

### DIFF
--- a/ansible/aws/templates/all.yml.template
+++ b/ansible/aws/templates/all.yml.template
@@ -163,6 +163,10 @@ sm_graphql_cookie_secret: COOKIE_SECRET
 sm_graphql_features:
   graphqlMocks: false
   impersonation: false
+sm_graphql_metadata_lookups:
+  colocalizationAlgos:
+    - ['cosine', 'Cosine distance']
+  defaultColocalizationAlgo: 'cosine'
 
 sm_webapp_hostname: "{{ web_host }}"  # specify manually in production
 sm_webapp_home: "{{ metaspace_home }}/metaspace/webapp"

--- a/metaspace/graphql/config/config.js.template
+++ b/metaspace/graphql/config/config.js.template
@@ -59,4 +59,6 @@ config.aws = {
 
 config.features = {{ sm_graphql_features | to_json }};
 
+config.metadataLookups = {{ sm_graphql_metadata_lookups | default({}) | to_json }};
+
 module.exports = config;

--- a/metaspace/graphql/config/default.js
+++ b/metaspace/graphql/config/default.js
@@ -99,12 +99,12 @@ module.exports = {
   },
 
   metadataLookups: {
-    colocalizationAlgos: {
-      cosine: 'Cosine distance',
-      pca_cosine: 'PCA + Cosine distance',
-      pca_pearson: 'PCA + Pearson correlation',
-      pca_spearman: 'PCA + Spearman correlation',
-    },
+    colocalizationAlgos: [
+      ['cosine', 'Cosine distance'],
+      ['pca_cosine', 'PCA + Cosine distance'],
+      ['pca_pearson', 'PCA + Pearson correlation'],
+      ['pca_spearman', 'PCA + Spearman correlation'],
+    ],
     defaultColocalizationAlgo: 'cosine',
   },
 };

--- a/metaspace/graphql/resolvers.js
+++ b/metaspace/graphql/resolvers.js
@@ -114,7 +114,7 @@ const Resolvers = {
     },
 
     async colocalizationAlgos() {
-      return Object.entries(config.metadataLookups.colocalizationAlgos)
+      return config.metadataLookups.colocalizationAlgos
         .map(([id, name]) => ({id, name}));
     },
   },

--- a/metaspace/graphql/src/utils/config.ts
+++ b/metaspace/graphql/src/utils/config.ts
@@ -76,7 +76,7 @@ export interface Config {
     aws_region: string;
   };
   metadataLookups: {
-    colocalizationAlgos: Record<string, string>;
+    colocalizationAlgos: [string, string][]; // code, name
     defaultColocalizationAlgo: string;
   };
 }


### PR DESCRIPTION
Also changed `colocalizationAlgos` structure from object to array, because the `config` package merges objects in the configuration layers. It doesn't attempt to merge arrays, instead just taking the value from the most specific config file.