### PR TITLE
Increase spark driver maxResultSize 

### DIFF
--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -42,6 +42,7 @@
     "master": "{{ spark_master_host | default('local[*]') }}",
     "spark.executor.memory": "2g",
     "spark.driver.memory": "4g",
+    "spark.driver.maxResultSize": "3g",
     "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
     "spark.kryoserializer.buffer.max": "128m",
     "spark.python.worker.memory": "512m",


### PR DESCRIPTION
Because colocalization collect()s up to approx. 2GiB of ion images, which is higher than Spark's default limit of 1gb. It can be slightly more than 2GiB due to rounding, so I chose 3g.