### PR TITLE
Thumbnails for datasets based on ion images

### DIFF
--- a/ansible/aws/templates/all.yml.template
+++ b/ansible/aws/templates/all.yml.template
@@ -190,6 +190,7 @@ sm_webapp_enable_uploads: true
 sm_webapp_metadata_types: ["ims"]  # set ["ims", "lcms"] to accept both IMS and LC-MS datasets
 sm_webapp_features:
   coloc: false
+  ion_thumbs: false
 
 sm_activate_venv: source {{ miniconda_prefix }}/bin/activate {{ miniconda_env.name }}
 
@@ -286,6 +287,10 @@ nginx_servers:
         params:
           - proxy_pass http://isotope_image_server/fs/raw_optical_images/;
           - client_max_body_size 50M;
+      - path: /fs/ion_thumbnails/
+        params:
+          - proxy_pass http://isotope_image_server/fs/ion_thumbnails/;
+          - limit_except GET {deny all;}
       - path: /graphql
         params:
           - proxy_pass http://graphql_server/graphql;

--- a/docker/nginx/config/sites-enabled/default
+++ b/docker/nginx/config/sites-enabled/default
@@ -37,6 +37,10 @@ server {
         proxy_pass http://sm-graphql:4201/fs/raw_optical_images/;
         client_max_body_size 50M;
     }
+    location /fs/ion_thumbnails/ {
+        proxy_pass http://sm-graphql:4201/fs/ion_thumbnails/;
+        client_max_body_size 50M;
+    }
     location /graphql {
         proxy_pass http://sm-graphql:3010/graphql;
         include proxy-params.conf;

--- a/metaspace/engine/migrations/r1_4_20190228_ion_thumbs.sql
+++ b/metaspace/engine/migrations/r1_4_20190228_ion_thumbs.sql
@@ -1,0 +1,3 @@
+-- NOTE: This script should only take a couple seconds to run. If update-daemon is running, it may
+-- hang waiting for update-daemon to release locks on the table.
+ALTER TABLE dataset ADD IF NOT EXISTS ion_thumbnail text;

--- a/metaspace/engine/scripts/create_schema.sql
+++ b/metaspace/engine/scripts/create_schema.sql
@@ -25,6 +25,7 @@ CREATE TABLE dataset (
 	acq_geometry	json,
 	ion_img_storage_type text not null default('fs'),
   thumbnail     text,
+  ion_thumbnail text,
 	CONSTRAINT dataset_id_pk PRIMARY KEY(id)
 );
 CREATE INDEX ind_dataset_name ON dataset (name);

--- a/metaspace/engine/scripts/run_colocalization.py
+++ b/metaspace/engine/scripts/run_colocalization.py
@@ -1,22 +1,105 @@
 import argparse
 import logging
+from itertools import groupby
 
+from sm.engine.mol_db import MolDBServiceWrapper
 from sm.engine.util import init_loggers, SMConfig
 from sm.engine.db import DB
 from sm.engine.colocalization import Colocalization
 
-def run_coloc_jobs(ds_id, sql_where):
-    assert ds_id or sql_where
+
+CORRUPT_COLOC_JOBS_SEL = """
+WITH mol_db_lookup AS (SELECT unnest(%s::int[]) AS id, unnest(%s::text[]) AS name), 
+    algorithm_lookup AS (SELECT unnest(%s::text[]) algorithm),
+    fdr_lookup AS (SELECT unnest(%s::numeric[]) AS fdr), 
+    job_fdr_counts AS (
+      SELECT job_id, fdr.fdr, COUNT(*) AS num_annotations
+      FROM iso_image_metrics iim
+      JOIN fdr_lookup fdr ON iim.fdr <= fdr.fdr - 0.01
+      GROUP BY job_id, fdr.fdr
+      HAVING COUNT(*) > 2
+    ), coloc_job_fdr_counts AS (
+      SELECT cj.ds_id, cj.mol_db, cj.fdr, cj.algorithm, COUNT(*) AS num_annotations
+      FROM graphql.coloc_job cj
+      JOIN graphql.coloc_annotation ca ON cj.id = ca.coloc_job_id
+      GROUP BY cj.id, cj.mol_db, cj.fdr, cj.algorithm
+    )
+SELECT DISTINCT j.ds_id, (CASE WHEN cj IS NULL THEN 'missing' ELSE 'corrupt' END) as reason
+FROM dataset ds
+JOIN job j ON ds.id = j.ds_id
+JOIN job_fdr_counts jfc ON j.id = jfc.job_id
+JOIN mol_db_lookup mdb ON j.db_id = mdb.id
+CROSS JOIN algorithm_lookup alg
+LEFT JOIN coloc_job_fdr_counts cj ON ds.id = cj.ds_id AND cj.mol_db = mdb.name 
+                                  AND cj.fdr = jfc.fdr AND cj.algorithm = alg.algorithm
+WHERE ds.status = 'FINISHED'
+  AND j.status = 'FINISHED'
+  AND (cj IS NULL OR cj.num_annotations < jfc.num_annotations)
+ORDER BY j.ds_id DESC;
+"""
+
+MISSING_COLOC_JOBS_SEL = """
+WITH mol_db_lookup AS (SELECT unnest(%s::int[]) AS id, unnest(%s::text[]) AS name), 
+    algorithm_lookup AS (SELECT unnest(%s::text[]) algorithm),
+    fdr_lookup AS (SELECT unnest(%s::numeric[]) AS fdr), 
+    job_fdr_counts AS (
+      SELECT job_id, fdr.fdr, COUNT(*) AS num_annotations
+      FROM iso_image_metrics iim
+      JOIN fdr_lookup fdr ON iim.fdr <= fdr.fdr - 0.01
+      GROUP BY job_id, fdr.fdr
+      HAVING COUNT(*) > 2
+    ), coloc_job_fdr_counts AS (
+      SELECT cj.ds_id, cj.mol_db, cj.fdr, cj.algorithm
+      FROM graphql.coloc_job cj
+      GROUP BY cj.id, cj.mol_db, cj.fdr, cj.algorithm
+    )
+SELECT DISTINCT j.ds_id
+FROM dataset ds
+JOIN job j ON ds.id = j.ds_id
+JOIN job_fdr_counts jfc ON j.id = jfc.job_id
+JOIN mol_db_lookup mdb ON j.db_id = mdb.id
+CROSS JOIN algorithm_lookup alg
+LEFT JOIN coloc_job_fdr_counts cj ON ds.id = cj.ds_id AND cj.mol_db = mdb.name 
+                                  AND cj.fdr = jfc.fdr AND cj.algorithm = alg.algorithm
+WHERE ds.status = 'FINISHED'
+  AND j.status = 'FINISHED'
+  AND cj IS NULL
+ORDER BY j.ds_id DESC;
+"""
+
+
+def run_coloc_jobs(ds_id, sql_where, fix_missing, fix_corrupt):
+    assert len([data_source for data_source in [ds_id, sql_where, fix_missing, fix_corrupt] if data_source]) == 1, \
+           "Exactly one data source (ds_id, sql_where or repair) must be specified"
     assert not (ds_id and sql_where)
 
     conf = SMConfig.get_conf()
 
     db = DB(conf['db'])
 
-    if sql_where:
+    if ds_id:
+        ds_ids = ds_id.split(',')
+    elif sql_where:
         ds_ids = [id for (id, ) in db.select(f'SELECT DISTINCT dataset.id FROM dataset WHERE {sql_where}')]
     else:
-        ds_ids = ds_id.split(',')
+        mol_db_service = MolDBServiceWrapper(conf['services']['mol_db'])
+        mol_dbs = [(db['id'], db['name']) for db in mol_db_service.fetch_all_dbs()]
+        mol_db_ids, mol_db_names = map(list, zip(*mol_dbs))
+        algorithms = ['cosine', 'pca_cosine', 'pca_pearson', 'pca_spearman']
+        fdrs = [0.05, 0.1, 0.2, 0.5]
+
+        if fix_missing:
+            logger.info('Checking for missing colocalization jobs...')
+            results = db.select(MISSING_COLOC_JOBS_SEL, [list(mol_db_ids), list(mol_db_names), algorithms, fdrs])
+            ds_ids = [ds_id for ds_id, in results]
+            logger.info(f'Found {len(ds_ids)} missing colocalization sets')
+        else:
+            logger.info('Checking all colocalization jobs. This is super slow: ~5 minutes per 1000 datasets...')
+            results = db.select(MISSING_COLOC_JOBS_SEL, [list(mol_db_ids), list(mol_db_names), algorithms, fdrs])
+            ds_ids, reasons = map(list, zip(*results))
+            reason_counts = ', '.join([f'{len(list(group))} {reason}' for reason, group in groupby(sorted(reasons))])
+            logger.info(f'Found {reason_counts} colocalization sets')
+
 
     if not ds_ids:
         logger.warning('No datasets match filter')
@@ -37,10 +120,15 @@ if __name__ == '__main__':
     parser.add_argument('--ds-id', dest='ds_id', default=None, help='DS id (or comma-separated list of ids)')
     parser.add_argument('--sql-where', dest='sql_where', default=None,
                         help='SQL WHERE clause for picking rows from the dataset table, e.g. "status = \'FINISHED\'"')
+    parser.add_argument('--fix-missing', action='store_true',
+                        help='Run colocalization on all datasets that are missing colocalization data')
+    parser.add_argument('--fix-corrupt', action='store_true',
+                        help='Run colocalization on all datasets that are missing colocalization data, '
+                             'or have incomplete colocalization data (SLOW)')
     args = parser.parse_args()
 
     SMConfig.set_path(args.config)
     init_loggers(SMConfig.get_conf()['logs'])
     logger = logging.getLogger('engine')
 
-    run_coloc_jobs(args.ds_id, args.sql_where)
+    run_coloc_jobs(args.ds_id, args.sql_where, args.fix_missing, args.fix_corrupt)

--- a/metaspace/engine/scripts/update_ion_thumbnails.py
+++ b/metaspace/engine/scripts/update_ion_thumbnails.py
@@ -42,7 +42,7 @@ if __name__ == '__main__':
                         help='Algorithm for thumbnail generation. Options: ' + str(list(ALGORITHMS.keys())))
     args = parser.parse_args()
 
-    if not (args.ds_id or args.sql_where) or (args.ds_id and args.sql_where):
+    if not (bool(args.ds_id) ^ bool(args.sql_where)):
         parser.print_usage()
         print('error: must specify either --ds-id or --sql-where')
         exit(1)

--- a/metaspace/engine/scripts/update_ion_thumbnails.py
+++ b/metaspace/engine/scripts/update_ion_thumbnails.py
@@ -1,0 +1,54 @@
+import argparse
+import logging
+
+from sm.engine.ion_thumbnail import DEFAULT_ALGORITHM, ALGORITHMS, generate_ion_thumbnail
+from sm.engine.png_generator import ImageStoreServiceWrapper
+from sm.engine.util import init_loggers, SMConfig
+from sm.engine.db import DB
+
+
+def run(ds_id, sql_where, algorithm):
+
+    conf = SMConfig.get_conf()
+
+    db = DB(conf['db'])
+    img_store = ImageStoreServiceWrapper(conf['services']['img_service_url'])
+
+    if sql_where:
+        ds_ids = [id for (id, ) in db.select(f'SELECT DISTINCT dataset.id FROM dataset WHERE {sql_where}')]
+    else:
+        ds_ids = ds_id.split(',')
+
+    if not ds_ids:
+        logger.warning('No datasets match filter')
+        return
+
+    for i, ds_id in enumerate(ds_ids):
+        try:
+            logger.info(f'[{i+1} / {len(ds_ids)}] Generating ion thumbnail for {ds_id}')
+            generate_ion_thumbnail(db, img_store, ds_id, algorithm=algorithm)
+        except Exception:
+            logger.error(f'Failed on {ds_id}', exc_info=True)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Run colocalization jobs')
+    parser.add_argument('--config', default='conf/config.json', help='SM config path')
+    parser.add_argument('--ds-id', dest='ds_id', default=None, help='DS id (or comma-separated list of ids)')
+    parser.add_argument('--sql-where', dest='sql_where', default=None,
+                        help='SQL WHERE clause for picking rows from the dataset table, '
+                             'e.g. "status = \'FINISHED\' and ion_thumbnail is null"')
+    parser.add_argument('--algorithm', dest='algorithm', default=DEFAULT_ALGORITHM,
+                        help='Algorithm for thumbnail generation. Options: ' + str(list(ALGORITHMS.keys())))
+    args = parser.parse_args()
+
+    if not (args.ds_id or args.sql_where) or (args.ds_id and args.sql_where):
+        parser.print_usage()
+        print('error: must specify either --ds-id or --sql-where')
+        exit(1)
+
+    SMConfig.set_path(args.config)
+    init_loggers(SMConfig.get_conf()['logs'])
+    logger = logging.getLogger('engine')
+
+    run(args.ds_id, args.sql_where, args.algorithm)

--- a/metaspace/engine/sm/engine/colocalization.py
+++ b/metaspace/engine/sm/engine/colocalization.py
@@ -94,23 +94,6 @@ class FreeableRef(object):
             return self._ref
 
 
-def _preprocess_images_inplace(imgs):
-    """ Clips the top 1% (if more than 1% of pixels are populated),
-    scales all pixels to the range 0...1,
-    and ensures that no image is completely zero.
-    Modifies imgs in-place to minimize memory usage
-    """
-    max_clipped = np.percentile(imgs, 99, axis=1, keepdims=True)
-    max_unclipped = np.max(imgs, axis=1, keepdims=True)
-    # Use the 99th percentile for each image as a scaling factor, but fall back to the image's maximum or 1.0 if needed
-    # to ensure that there are no divide-by-zero issues
-    scale = np.select([max_clipped != 0, max_unclipped != 0], [max_clipped, max_unclipped], 1)
-    imgs /= scale
-    np.clip(imgs, 0, 1, out=imgs)
-    # On rows that are all zero, set a small non-zero value to prevent future NaNs
-    imgs[(max_unclipped == 0)[:, 0], :] = 0.01
-
-
 def _labels_to_clusters(labels, scores):
     """ Converts from [0,1,0,1,2] form (mapping sample idx to cluster idx)
     to [[0,2],[1,3],[4]] form (mapping cluster idx to sample idx's).
@@ -212,8 +195,9 @@ def analyze_colocalization(ds_id, mol_db, images, ion_ids, fdrs):
     assert images.ref.shape[0] == ion_ids.shape[0] == fdrs.shape[0], (images.ref.shape, ion_ids.shape, fdrs.shape)
     start = datetime.now()
 
-    logger.debug(f'Preprocessing images (shape: {images.ref.shape}, dtype: {images.ref.dtype})')
-    _preprocess_images_inplace(images.ref)
+    if len(ion_ids) < 2:
+        logger.info('Not enough annotations to perform colocalization')
+        return
 
     logger.debug('Calculating colocalization metrics')
     pca_images = PCA(min(20, *images.ref.shape)).fit_transform(images.ref)
@@ -295,32 +279,25 @@ class Colocalization(object):
             raise
 
     def _get_existing_ds_annotations(self, ds_id, mol_db_name, image_storage_type, polarity):
-        def get_ion_image(id):
-            if id is not None:
-                im = self._img_store.get_image_by_id(image_storage_type, 'iso_image', id)
-                data = np.asarray(im)
-                image = np.where(data[:, :, 3] != 0, data[:, :, 0], 0)
-                return _downscale_image_if_required(image, num_annotations).ravel()
-            return None
-
         mol_db = MolecularDB(name=mol_db_name)
         annotation_rows = self._db.select(ANNOTATIONS_SEL, [ds_id, mol_db.id])
         num_annotations = len(annotation_rows)
-        sf_adducts = [(formula, adduct) for image, formula, adduct, fdr in annotation_rows]
-        ion_id_mapping = get_ion_id_mapping(self._db, sf_adducts, polarity)
-        ion_ids = [ion_id_mapping[sf_adduct] for sf_adduct in sf_adducts]
-        fdrs = [fdr for image, formula, adduct, fdr in annotation_rows]
+        if num_annotations != 0:
+            sf_adducts = [(formula, adduct) for image, formula, adduct, fdr in annotation_rows]
+            ion_id_mapping = get_ion_id_mapping(self._db, sf_adducts, polarity)
+            ion_ids = np.array([ion_id_mapping[sf_adduct] for sf_adduct in sf_adducts])
+            fdrs = np.array([fdr for image, formula, adduct, fdr in annotation_rows])
 
-        with ThreadPoolExecutor() as ex:
             logger.debug(f'Getting {num_annotations} images for "{ds_id}" {mol_db_name}')
-            ion_images = list(ex.map(get_ion_image, [row[0] for row in annotation_rows]))
-            logger.debug(f'Finished getting images for "{ds_id}" {mol_db_name}')
+            image_ids = [row[0] for row in annotation_rows]
+            images, mask, (h, w) = self._img_store.get_ion_images_for_analysis(image_storage_type, image_ids)
+            logger.debug(f'Finished getting images for "{ds_id}" {mol_db_name}. Image size: {h}x{w}')
+        else:
+            images = np.zeros((0, 0), dtype=np.float32)
+            ion_ids = np.zeros((0,), dtype=np.int64)
+            fdrs = np.zeros((0,), dtype=np.float32)
 
-        images = FreeableRef(np.array([img for img in ion_images if img is not None], ndmin=2, dtype=np.float32))
-        ion_ids = np.array([ion_id for i, ion_id in enumerate(ion_ids) if ion_images[i] is not None], dtype=np.int64)
-        fdrs = np.array([fdr for i, fdr in enumerate(fdrs) if ion_images[i] is not None], dtype=np.float32)
-
-        return images, ion_ids, fdrs
+        return FreeableRef(images), ion_ids, fdrs
 
     def run_coloc_job_for_existing_ds(self, ds_id):
         """ Analyze colocalization for a previously annotated dataset, querying the dataset's annotations from the db,

--- a/metaspace/engine/sm/engine/ion_thumbnail.py
+++ b/metaspace/engine/sm/engine/ion_thumbnail.py
@@ -1,0 +1,196 @@
+import logging
+from io import BytesIO
+from itertools import combinations
+
+import numpy as np
+import png
+from scipy.spatial.distance import cdist
+from sklearn.cluster import KMeans
+
+from sm.engine.dataset import Dataset
+
+ISO_IMAGE_SEL = ("SELECT iso_image_ids[1] "
+                 "FROM iso_image_metrics m "
+                 "JOIN job j on j.id = m.job_id "
+                 "WHERE ds_id = %s "
+                 "ORDER BY fdr, msm "
+                 "LIMIT 500")
+
+THUMB_SEL = "SELECT ion_thumbnail FROM dataset WHERE id = %s"
+
+THUMB_UPD = "UPDATE dataset SET ion_thumbnail = %s WHERE id = %s"
+
+ALGORITHMS = {
+    'smart-image-medoid': lambda *args: _make_thumbnail_from_minimally_overlapping_image_clusters(*args, use_centroids=False),
+    'smart-image-centroid': lambda *args: _make_thumbnail_from_minimally_overlapping_image_clusters(*args, use_centroids=True),
+    'image-medoid': lambda *args: _make_thumbnail_from_image_clusters(*args, use_centroids=False),
+    'image-centroid': lambda *args: _make_thumbnail_from_image_clusters(*args, use_centroids=True),
+    'pixel-mean-intensity': lambda *args: _make_thumbnail_from_pixel_clusters(*args, use_distance_from_centroid=False),
+    'pixel-distance': lambda *args: _make_thumbnail_from_pixel_clusters(*args, use_distance_from_centroid=True),
+}
+DEFAULT_ALGORITHM = 'image-centroid'
+
+logger = logging.getLogger('engine')
+
+
+def _get_good_images(images, mask):
+    """ Try to discard images with very many or very few populated pixels """
+    fill_factor = np.count_nonzero(images > 0.25, axis=1) / np.count_nonzero(mask)
+    good_fill = (fill_factor > 0.2) * (fill_factor < 0.8)
+    if np.count_nonzero(good_fill) < 20:
+        good_fill = np.nonzero(fill_factor > 0)
+    if np.count_nonzero(good_fill) < 20:
+        good_fill = np.ones(len(images), dtype=np.bool)
+    return images[good_fill]
+
+
+def _pick_least_overlapping_image_set(images, mask, num_to_pick):
+    pixel_count = np.count_nonzero(mask)
+
+    def get_overlap(idxs):
+        num_nonoverlapping = np.count_nonzero(np.sum([images[i] > 0.25 for i in idxs], axis=0) == 1) / pixel_count
+        sum_population = np.count_nonzero(np.sum([images[i] > 0.25 for i in idxs], axis=0)) / pixel_count
+        min_population = np.min([np.sum(images[i] > 0.25) for i in idxs]) / pixel_count
+        return num_nonoverlapping * (1 - np.abs(0.8 - sum_population)) * min_population
+
+    possible_choices = list(combinations(range(len(images)), num_to_pick))
+    best_choice_idx = np.argmax([get_overlap(idxs) for idxs in possible_choices])
+    return images[possible_choices[best_choice_idx], :]
+
+
+def _sort_by_centralness(images, h, w):
+    cone_h = np.abs(np.linspace(0, 2, h) - 1)[:, np.newaxis]
+    cone_w = np.abs(np.linspace(0, 2, w) - 1)[np.newaxis, :]
+    cone = (cone_h * cone_w).ravel()
+    centralness = np.sum(images * cone[np.newaxis, :], axis=1) / np.sum(images + 0.01, axis=1)
+    return images[np.argsort(centralness)]
+
+
+def _make_thumbnail_from_minimally_overlapping_image_clusters(images, mask, h, w, use_centroids):
+    if len(images) > 3:
+        good_images = _get_good_images(images, mask)
+        kmeans = KMeans(min(10, len(images)))
+        kmeans.fit(good_images)
+        all_centroids = kmeans.cluster_centers_
+        centroids = _pick_least_overlapping_image_set(all_centroids, mask, 3)
+        # centroids, labels = kmeans2(good_images, good_images[:3])
+        medoids_idxs = [np.argmin(cdist(good_images, centroid[np.newaxis, :])) for centroid in centroids]
+        medoids = np.array([good_images[idx] for idx in medoids_idxs])
+    else:
+        # Pad with zeros
+        medoids = centroids = np.array([*np.zeros((3-len(images), h*w)), *images])
+
+    # centroids are smoother and slightly nicer looking, medoids are more eye-catching but look worse in large lists
+    samples = centroids if use_centroids else medoids
+    # Sort by total intensity for consistency
+    # samples = [samples[i] for i in np.argsort(np.sum(samples, axis=1))]
+    samples = _sort_by_centralness(samples, h, w)[::-1]
+    return np.dstack([*(sample.reshape(h, w) for sample in samples), mask])
+
+
+def _make_thumbnail_from_image_clusters(images, mask, h, w, use_centroids):
+    if len(images) > 3:
+        good_images = _get_good_images(images, mask)
+        kmeans = KMeans(3)
+        kmeans.fit(good_images)
+        centroids = kmeans.cluster_centers_
+        medoids_idxs = [np.argmin(cdist(good_images, centroid[np.newaxis, :])) for centroid in centroids]
+        medoids = np.array([good_images[idx] for idx in medoids_idxs])
+    else:
+        # Pad with zeros
+        medoids = centroids = np.array([*np.zeros((3-len(images), h*w)), *images])
+
+    # centroids are smoother and slightly nicer looking, medoids are more eye-catching but look worse in large lists
+    samples = centroids if use_centroids else medoids
+    # Sort by total intensity for consistency
+    samples = _sort_by_centralness(samples, h, w)[::-1]
+    return np.dstack([*(sample.reshape(h, w) for sample in samples), mask])
+
+
+def _make_thumbnail_from_pixel_clusters(images, mask, h, w, use_distance_from_centroid=False):
+    """ Alternate implementation. Results are sharper, but noisier """
+    # 6-color
+    # COLORS = np.array([[1, 0, 1, 0], [1, 0, 0, 0], [1, 1, 0, 0], [0, 1, 0, 0], [0, 1, 1, 0], [0, 0, 1, 0]],
+    #                   dtype=np.float32)
+    COLORS = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]], dtype=np.float32)
+    num_clusters = len(COLORS)
+
+    pixels = images.transpose()[np.flatnonzero(mask)] # Only include unmasked pixels
+    kmeans = KMeans(num_clusters)
+    kmeans.fit(pixels)
+    centroids = kmeans.cluster_centers_
+    labels = kmeans.labels_
+    labels_mask = labels[np.newaxis, :] == np.arange(num_clusters)[:, np.newaxis]
+    if use_distance_from_centroid:
+        # Get pixel intensity from inverse distance from centroid
+        pixel_centroids = centroids[labels]
+        pixel_distance_from_centroid = np.sum((pixels - pixel_centroids) ** 2, axis=1) ** 0.5
+        cluster_radii = np.average(pixel_distance_from_centroid[np.newaxis, :] * labels_mask, weights=labels_mask, axis=1)
+        pixel_cluster_radii = cluster_radii[labels]
+        pixel_intensity = (1 - pixel_distance_from_centroid / pixel_cluster_radii)
+    else:
+        pixel_intensity = np.mean(pixels, axis=1)
+
+    # Sort colors by total intensity for consistency, and normalize each label
+    label_intensity = np.average(pixel_intensity[np.newaxis, :] * labels_mask, weights=labels_mask, axis=1)
+    sorted_colors = COLORS[np.argsort(label_intensity)]
+
+    pixel_vals = (sorted_colors[labels] * pixel_intensity[:, np.newaxis])
+    pixel_vals[:, :3] /= np.max(pixel_vals, axis=0)[:3]
+
+    unmasked_pixel_vals = np.zeros((w*h, 4), dtype=np.float32)
+    unmasked_pixel_vals[np.flatnonzero(mask)] = pixel_vals
+    unmasked_pixel_vals[:, 3] = mask.ravel()
+    return unmasked_pixel_vals.reshape((h, w, 4))
+
+
+def _generate_ion_thumbnail_image(db, img_store, ds_id, algorithm):
+    annotation_rows = db.select(ISO_IMAGE_SEL, [ds_id])
+    if not annotation_rows:
+        logger.warning('Could not create ion thumbnail - no annotations found')
+        return None
+
+    image_ids = [image_id for image_id, in annotation_rows]
+    image_storage_type = Dataset(ds_id).get_ion_img_storage_type(db)
+
+    # Hotspot percentile is lowered as a lazy way to brighten images
+    images, mask, (h, w) = img_store.get_ion_images_for_analysis(image_storage_type, image_ids,
+                                                                 max_size=(200,200), hotspot_percentile=90)
+
+    logger.debug(f'Generating ion thumbnail: {algorithm}({len(images)} x {h} x {w}) ')
+    thumbnail = ALGORITHMS[algorithm](images, mask, h, w)
+
+    return np.uint8(np.clip(thumbnail * 255, 0, 255)).reshape((h, w, 4))
+
+
+def _save_ion_thumbnail_image(img_store, thumbnail):
+    h, w, depth = thumbnail.shape
+    fp = BytesIO()
+    png_writer = png.Writer(width=w, height=h, alpha=True, compression=9)
+    png_writer.write(fp, thumbnail.reshape(h, w * depth).tolist())
+    fp.seek(0)
+    return img_store.post_image('fs', 'ion_thumbnail', fp)
+
+
+def generate_ion_thumbnail(db, img_store, ds_id, only_if_needed=False, algorithm=DEFAULT_ALGORITHM):
+    try:
+        existing_thumb_id, = db.select_one(THUMB_SEL, [ds_id])
+
+        if existing_thumb_id and only_if_needed:
+            return
+
+        thumbnail = _generate_ion_thumbnail_image(db, img_store, ds_id, algorithm)
+
+        if thumbnail is None:
+            return
+
+        image_id = _save_ion_thumbnail_image(img_store, thumbnail)
+        db.alter(THUMB_UPD, [image_id, ds_id])
+
+        if existing_thumb_id:
+            img_store.delete_image_by_id('fs', 'ion_thumbnail', existing_thumb_id)
+
+    except Exception:
+        logger.error('Error generating ion thumbnail image', exc_info=True)
+        return
+

--- a/metaspace/engine/sm/engine/ion_thumbnail.py
+++ b/metaspace/engine/sm/engine/ion_thumbnail.py
@@ -151,10 +151,9 @@ def _generate_ion_thumbnail_image(db, img_store, ds_id, algorithm):
         return None
 
     image_ids = [image_id for image_id, in annotation_rows]
-    image_storage_type = Dataset(ds_id).get_ion_img_storage_type(db)
 
     # Hotspot percentile is lowered as a lazy way to brighten images
-    images, mask, (h, w) = img_store.get_ion_images_for_analysis(image_storage_type, image_ids,
+    images, mask, (h, w) = img_store.get_ion_images_for_analysis('fs', image_ids,
                                                                  max_size=(200,200), hotspot_percentile=90)
 
     logger.debug(f'Generating ion thumbnail: {algorithm}({len(images)} x {h} x {w}) ')

--- a/metaspace/engine/sm/engine/ion_thumbnail.py
+++ b/metaspace/engine/sm/engine/ion_thumbnail.py
@@ -189,5 +189,4 @@ def generate_ion_thumbnail(db, img_store, ds_id, only_if_needed=False, algorithm
 
     except Exception:
         logger.error('Error generating ion thumbnail image', exc_info=True)
-        return
 

--- a/metaspace/engine/sm/engine/ion_thumbnail.py
+++ b/metaspace/engine/sm/engine/ion_thumbnail.py
@@ -7,8 +7,6 @@ import png
 from scipy.spatial.distance import cdist
 from sklearn.cluster import KMeans
 
-from sm.engine.dataset import Dataset
-
 ISO_IMAGE_SEL = ("SELECT iso_image_ids[1] "
                  "FROM iso_image_metrics m "
                  "JOIN job j on j.id = m.job_id "

--- a/metaspace/engine/sm/engine/png_generator.py
+++ b/metaspace/engine/sm/engine/png_generator.py
@@ -124,14 +124,6 @@ class ImageStoreServiceWrapper(object):
 
         return value, mask, (h, w)
 
-    def get_images_by_ids(self, storage_type, img_type, img_ids):
-        def get_ion_image(id):
-            if id is not None:
-                return self.get_image_by_id(storage_type, img_type, id)
-            return None
-        with ThreadPoolExecutor() as ex:
-            return list(ex.map(get_ion_image, img_ids))
-
     def delete_image_by_id(self, storage_type, img_type, img_id):
         url = self._format_url(storage_type=storage_type, img_type=img_type, method='delete', img_id=img_id)
         self.delete_image(url)

--- a/metaspace/engine/sm/engine/png_generator.py
+++ b/metaspace/engine/sm/engine/png_generator.py
@@ -2,10 +2,13 @@ import logging
 from io import BytesIO
 from PIL import Image
 from os import path
+from concurrent.futures import ThreadPoolExecutor
 import png
 import requests
 import numpy as np
+from matplotlib.colors import Normalize
 from requests.adapters import HTTPAdapter
+from scipy.ndimage import zoom
 
 
 class ImageStoreServiceWrapper(object):
@@ -49,6 +52,85 @@ class ImageStoreServiceWrapper(object):
     def get_image_by_id(self, storage_type, img_type, img_id):
         url = self._format_url(storage_type=storage_type, img_type=img_type, img_id=img_id)
         return Image.open(self._session.get(url, stream=True).raw)
+
+    def get_ion_images_for_analysis(self, storage_type, img_ids, hotspot_percentile=99,
+                                    max_size=None, max_mem_mb=2048):
+        """ Retrieves ion images, does hot-spot removal and resizing, and returns them as a numpy array.
+        Args
+        ----
+        storage_type: str
+        img_ids: list[str]
+        hotspot_percentile: float
+        max_size: Union[None, tuple[int, int]]
+            If images are greater than this size, they will be downsampled to fit in this size
+        max_mem_mb: Union[None, float]
+            If the output numpy array would require more than this amount of memory, images will be downsampled to fit
+
+        Returns
+        -------
+        tuple[np.ndarray, np.ndarray, tuple[int, int]]
+            (value, mask, (h, w))
+            value - A float32 numpy array with shape (len(img_ids), h * w) where each row is one image
+            mask - A float32 numpy array with shape (h, w) containing the ion image mask. May contain values that are
+                   between 0 and 1 if downsampling caused both filled and empty pixels to be merged
+            h, w - shape of each image in value such that value[i].reshape(h, w) reconstructs the image
+        """
+        assert all(img_ids)
+
+        zoom_factor = 1
+        h, w = None, None
+        value, mask = None, None
+
+        def setup_shared_vals(img):
+            nonlocal zoom_factor, h, w, value, mask
+
+            img_h, img_w = img.height, img.width
+            if max_size:
+                size_zoom = min(max_size[0] / img_h, max_size[1] / img_w)
+                zoom_factor = min(zoom_factor, size_zoom)
+            if max_mem_mb:
+                expected_mem = img_h * img_w * len(img_ids) * 4 / 1024 / 1024
+                zoom_factor = min(zoom_factor, max_mem_mb / expected_mem)
+
+            raw_mask = np.float32(np.array(img)[:, :, 3] != 0)
+            if abs(zoom_factor - 1) < 0.001:
+                zoom_factor = 1
+                mask = raw_mask
+            else:
+                mask = zoom(raw_mask, zoom_factor, prefilter=False)
+
+            h, w = mask.shape
+            value = np.empty((len(img_ids), h * w), dtype=np.float32)
+
+        def process_img(img_id, idx, do_setup=False):
+            img = self.get_image_by_id(storage_type, 'iso_image', img_id)
+            if do_setup:
+                setup_shared_vals(img)
+
+            img_arr = np.asarray(img, dtype=np.float32)[:, :, 0]
+            hotspot_threshold = np.percentile(img_arr, hotspot_percentile)
+            normalized_img = Normalize()(np.clip(img_arr, 0, hotspot_threshold))
+            if zoom_factor != 1:
+                zoomed_img = zoom(normalized_img, zoom_factor, prefilter=False)
+            else:
+                zoomed_img = normalized_img
+
+            value[idx, :] = zoomed_img.ravel()
+
+        process_img(img_ids[0], 0, do_setup=True)
+        with ThreadPoolExecutor() as ex:
+            for result in ex.map(process_img, img_ids[1:], range(1, len(img_ids))):
+                pass
+
+        return value, mask, (h, w)
+
+    def get_images_by_ids(self, storage_type, img_type, img_ids):
+        def get_ion_image(id):
+            if id is not None:
+                return self.get_image_by_id(storage_type, img_type, id)
+            return None
+        with ThreadPoolExecutor() as ex:
+            return list(ex.map(get_ion_image, img_ids))
 
     def delete_image_by_id(self, storage_type, img_type, img_id):
         url = self._format_url(storage_type=storage_type, img_type=img_type, method='delete', img_id=img_id)

--- a/metaspace/engine/sm/engine/sm_daemons.py
+++ b/metaspace/engine/sm/engine/sm_daemons.py
@@ -6,6 +6,7 @@ import logging
 import boto3
 
 from sm.engine.daemon_action import DaemonAction, DaemonActionStage
+from sm.engine.ion_thumbnail import generate_ion_thumbnail
 from sm.rest.dataset_manager import IMG_URLS_BY_ID_SEL
 from sm.engine.errors import UnknownDSID
 from sm.engine.isocalc_wrapper import IsocalcWrapper
@@ -66,6 +67,10 @@ class SMDaemonManager(object):
             self._db.alter('DELETE FROM job WHERE ds_id=%s', params=(ds.id,))
         ds.save(self._db, self.es)
         search_job_factory(img_store=self._img_store).run(ds)
+        generate_ion_thumbnail(db=self._db,
+                               img_store=self._img_store,
+                               ds_id=ds.id,
+                               only_if_needed=not del_first)
 
     def _finished_job_moldbs(self, ds_id):
         for job_id, mol_db_id in self._db.select('SELECT id, db_id FROM job WHERE ds_id = %s', params=(ds_id,)):

--- a/metaspace/engine/tests/test_colocalization.py
+++ b/metaspace/engine/tests/test_colocalization.py
@@ -10,9 +10,7 @@ from sm.engine.tests.util import sm_config, test_db, metadata, ds_config, pyspar
 
 
 def test_valid_colocalization_jobs_generated():
-    annotations = []
-
-    ion_images = FreeableRef(np.array([np.linspace(0, 50, 50, False) % (i + 1) for i in range(20)]))
+    ion_images = FreeableRef(np.array([np.linspace(0, 50, 50, False) % (i + 2) for i in range(20)]))
     ion_ids = np.array(range(20)) * 4
     fdrs = np.array([[0.05, 0.1, 0.2, 0.5][i % 4] for i in range(20)])
 

--- a/metaspace/engine/tests/test_ion_thumbnails.py
+++ b/metaspace/engine/tests/test_ion_thumbnails.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from sm.engine.ion_thumbnail import generate_ion_thumbnail, ALGORITHMS
+from sm.engine.dataset import Dataset, DatasetStatus
+from sm.engine.db import DB
+from sm.engine.png_generator import ImageStoreServiceWrapper
+from sm.engine.tests.util import sm_config, test_db
+
+OLD_IMG_ID = 'old-ion-thumb-id'
+IMG_ID = 'new-ion-thumb-id'
+DS_ID = '2000-01-01_00h00m'
+
+
+def _make_fake_ds(db, ds_id):
+    upload_dt = datetime.now()
+    db.insert(Dataset.DS_INSERT, [{
+        'id': ds_id,
+        'name': 'name',
+        'input_path': 'path',
+        'upload_dt': upload_dt,
+        'metadata': '{}',
+        'config': '{}',
+        'status': DatasetStatus.FINISHED,
+        'is_public': True,
+        'mol_dbs': ['HMDB-v4'],
+        'adducts': ['+H', '+Na', '+K'],
+        'ion_img_storage': 'fs'
+    }])
+    job_id, = db.insert_return("INSERT INTO job (db_id, ds_id) VALUES (%s, %s) RETURNING id", [(0, ds_id)])
+    db.insert(("INSERT INTO iso_image_metrics (job_id, db_id, sf, adduct, iso_image_ids) "
+               "VALUES (%s, %s, %s, %s, %s)"),
+              rows=[(job_id, 0, f'H{i+1}O', '+H', [str(i), str(1000 + i)]) for i in range(200)])
+
+
+def _mock_get_ion_images_for_analysis(storage_type, img_ids, **kwargs):
+    images = np.unpackbits(np.arange(len(img_ids), dtype=np.uint8)).reshape((len(img_ids), 8))
+    mask = np.ones((4,2))
+    return images, mask, (4,2)
+
+
+@pytest.mark.parametrize('algorithm', [alg for alg in ALGORITHMS.keys()])
+def test_creates_ion_thumbnail(test_db, algorithm):
+    db = DB(sm_config['db'])
+    img_store_mock = MagicMock(spec=ImageStoreServiceWrapper)
+    img_store_mock.post_image.return_value = IMG_ID
+    img_store_mock.get_ion_images_for_analysis.side_effect = _mock_get_ion_images_for_analysis
+    _make_fake_ds(db, DS_ID)
+
+    generate_ion_thumbnail(db, img_store_mock, DS_ID, algorithm=algorithm)
+
+    new_ion_thumbnail, = db.select_one("SELECT ion_thumbnail FROM dataset WHERE id = %s", [DS_ID])
+    assert new_ion_thumbnail == IMG_ID
+    assert img_store_mock.post_image.called

--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -37,6 +37,7 @@ type Dataset {
   rawOpticalImageUrl: String
 
   thumbnailOpticalImageUrl: String
+  ionThumbnailUrl: String
 }
 
 # Datasets' submitter and group are taken from ElasticSearch, which means they can be out of sync with the database.

--- a/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
@@ -17,6 +17,14 @@ export const thumbnailOpticalImageUrl = async (ctx: Context, id: string) => {
     return null;
   }
 };
+export const ionThumbnailUrl = async (ctx: Context, id: string) => {
+  const result = await ctx.entityManager.query('SELECT ion_thumbnail FROM public.dataset WHERE id = $1', [id]);
+  if (result && result.length === 1 && result[0].ion_thumbnail != null) {
+    return `/fs/ion_thumbnails/${result[0].ion_thumbnail}`;
+  } else {
+    return null;
+  }
+};
 
 const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
   id(ds) {
@@ -200,6 +208,10 @@ const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
 
   async thumbnailOpticalImageUrl(ds, args, ctx) {
     return await thumbnailOpticalImageUrl(ctx, ds._source.ds_id);
+  },
+
+  async ionThumbnailUrl(ds, args, ctx) {
+    return await ionThumbnailUrl(ctx, ds._source.ds_id);
   }
 };
 

--- a/metaspace/graphql/src/modules/dataset/model.ts
+++ b/metaspace/graphql/src/modules/dataset/model.ts
@@ -75,6 +75,7 @@ export interface EngineDataset {
   acq_geometry: object | null;
   ion_img_storage_type: string;
   thumbnail: string | null;
+  ion_thumbnail: string | null;
   mol_dbs: string[];
   adducts: string[];
 }

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -78,6 +78,7 @@ export const datasetDetailItemFragment =
       counts
     }
     thumbnailOpticalImageUrl
+    ionThumbnailUrl
   }`;
 
 export const datasetDetailItemsQuery =

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -5,19 +5,8 @@
       <dataset-info :metadata="metadata" :currentUser="currentUser" />
     </el-dialog>
 
-    <div class="opt-image" v-if="isOpticalImageSupported">
-      <router-link :to="opticalImageAlignmentHref" v-if="canEditOpticalImage">
-        <div v-if="dataset.thumbnailOpticalImageUrl != null" class="edit-opt-image" title="Edit Optical Image">
-          <img class="opt-image-thumbnail" :src="dataset.thumbnailOpticalImageUrl" alt="Edit optical image"/>
-        </div>
-        <div v-else class="no-opt-image" title="Add Optical Image">
-          <img class="add-opt-image-thumbnail" src="../../../assets/no_opt_image.png" alt="Add optical image"/>
-        </div>
-      </router-link>
-      <div v-else class="edit-opt-image-guest">
-        <img v-if="dataset.thumbnailOpticalImageUrl != null" :src="dataset.thumbnailOpticalImageUrl" alt="Optical image"/>
-        <img v-else src="../../../assets/no_opt_image.png" alt="Optical image"/>
-      </div>
+    <div v-if="isOpticalImageSupported"class="opt-image--container">
+      <dataset-thumbnail :dataset="dataset" :editable="canEditOpticalImage" />
     </div>
 
     <div class="ds-info">
@@ -146,6 +135,7 @@
 
 <script>
  import DatasetInfo from '../../../components/DatasetInfo.vue';
+ import DatasetThumbnail from './DatasetThumbnail.vue';
  import {capitalize} from 'lodash-es';
  import {
    datasetVisibilityQuery,
@@ -167,6 +157,7 @@
    props: ['dataset', 'currentUser', 'idx', 'hideGroupMenu'],
    components: {
      DatasetInfo,
+     DatasetThumbnail,
    },
    filters: {
      plural
@@ -444,74 +435,11 @@
  }
 </script>
 
-<style>
-  .no-opt-image {
-    position: relative;
-    display: block;
-    width: 100px;
-    height: 100px;
-    outline: 1px dotted rgba(0, 0, 0, 0.6);
-    z-index: 0;
-  }
-
-  .no-opt-image:hover::before {
-    font-family: 'element-icons' !important;
-    font-style: normal;
-    font-weight: bold;
-    font-size: 1.5em;
-    color: #2c3e50;
-    position: absolute;
-    content: '\E62B';
-    display: block;
-    width: 30px;
-    height: 30px;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-  }
-
-
-  .no-opt-image:hover{
-    cursor: pointer;
-  }
-
-  .edit-opt-image, .edit-opt-image-guest {
-    position: relative;
-    display: block;
-    width: 100px;
-    height: 100px;
-    z-index: 0;
-  }
-
-  .edit-opt-image:hover::before {
-    font-family: 'element-icons' !important;
-    font-style: normal;
-    font-size: 1.5em;
-    color: #2c3e50;
-    position: absolute;
-    content: '\E61C';
-    display: block;
-    width: 30px;
-    height: 30px;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    background-size: contain;
-  }
-
-  .edit-opt-image:hover {
-    cursor: pointer;
-  }
-
-  .opt-image-thumbnail:hover, .add-opt-image-thumbnail:hover{
-    opacity: .2;
-  }
-
-  .opt-image img {
-    width: 100px;
-    height: 100px;
-    object-fit: cover;
-    object-position: 0 0;
+<style lang="scss">
+  .opt-image--container {
+    padding: 10px 0 10px 10px;
+    margin: 0px;
+    flex: none;
   }
 
  .dataset-item {
@@ -526,12 +454,6 @@
    display: flex;
    flex-direction: row;
    justify-content: space-between;
- }
-
- .opt-image {
-   padding: 10px 0 10px 10px;
-   margin: 0px;
-   flex: none;
  }
 
  .ds-info{

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetThumbnail.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetThumbnail.vue
@@ -1,0 +1,120 @@
+<template>
+  <router-link v-if="editable" :to="opticalImageAlignmentHref">
+    <div v-if="mode === 'opt'" class="thumb thumb__opt thumb__editable" title="Edit Optical Image">
+      <img class="thumb--img" :src="dataset.thumbnailOpticalImageUrl" alt="Edit optical image"/>
+    </div>
+    <div v-else-if="mode === 'ion'" class="thumb thumb__ion thumb__editable" title="Add Optical Image">
+      <img class="thumb--img" :src="dataset.ionThumbnailUrl" alt="Add optical image"/>
+    </div>
+    <div v-else class="thumb thumb__empty thumb__editable" title="Add Optical Image">
+      <img class="thumb--img" src="../../../assets/no_opt_image.png" alt="Add optical image"/>
+    </div>
+  </router-link>
+  <div v-else-if="mode === 'opt'" class="thumb thumb__opt">
+    <img class="thumb--img" :src="dataset.thumbnailOpticalImageUrl" alt="Optical image"/>
+  </div>
+  <div v-else-if="mode === 'ion'" class="thumb thumb__ion">
+    <img class="thumb--img" :src="dataset.ionThumbnailUrl" alt="Optical image"/>
+  </div>
+  <div v-else class="thumb thumb__empty">
+    <img class="thumb--img" src="../../../assets/no_opt_image.png" alt="Optical image"/>
+  </div>
+</template>
+
+<script>
+  import config from '../../../clientConfig.json';
+  export default {
+    props: ['dataset', 'editable'],
+    computed: {
+      opticalImageAlignmentHref() {
+        return {
+          name: 'add-optical-image',
+          params: {dataset_id: this.dataset.id}
+        };
+      },
+
+      mode() {
+        if (this.dataset.thumbnailOpticalImageUrl) {
+          return 'opt';
+        } else if (config.features.ion_thumbs && this.dataset.ionThumbnailUrl) {
+          return 'ion';
+        } else {
+          return 'empty';
+        }
+      },
+
+      imageUrl() {
+        return {
+          opt: this.dataset.thumbnailOpticalImageUrl,
+          ion: this.dataset.ionThumbnailUrl,
+          empty: null, // URL must be in the vue template for webpack to resolve it correctly
+        }[this.mode];
+      },
+
+      imageClass() {
+        return this.dataset.thumbnailOpticalImageUrl != null ? 'thumb-thumbnail' : 'ion-image-thumbnail';
+      }
+    }
+  }
+</script>
+
+<style lang="scss" scoped>
+  
+  .thumb {
+    position: relative;
+    display: block;
+    width: 100px;
+    height: 100px;
+    z-index: 0;
+  }
+
+  .thumb__editable {
+    cursor: pointer;
+    &:hover .thumb--img {
+      opacity: .2;
+    }
+    &:hover::before {
+      font-family: 'element-icons' !important;
+      font-style: normal;
+      font-size: 1.5em;
+      color: #2c3e50;
+      position: absolute;
+      display: block;
+      width: 30px;
+      height: 30px;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+    }
+
+    &.thumb__ion:hover::before, &.thumb__empty:hover::before {
+      font-weight: bold;
+      content: '\E62B';
+    }
+
+    &.thumb__opt:hover::before {
+      content: '\E61C';
+    }
+  }
+
+  .thumb--img {
+    width: 100px;
+    height: 100px;
+    object-fit: cover;
+    object-position: 0 0;
+  }
+
+  .thumb__ion .thumb--img {
+    object-fit: contain;
+    object-position: center;
+    /* Default image-rendering uses bilinear filtering, which makes the stretched ion image blurry.
+    Chrome only supports pixelated, Firefox only supports crisp-edges, IE11 supports nothing */
+    image-rendering: crisp-edges;
+    image-rendering: pixelated;
+  }
+
+  .thumb__empty {
+    outline: 1px dotted rgba(0, 0, 0, 0.6);
+  }
+
+</style>

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -130,9 +130,9 @@ exports[`DatasetTable should match snapshot 1`] = `
             </div>
           </div>
         </mock-el-dialog>
-        <div class="opt-image">
-          <div class="edit-opt-image-guest">
-            <img src="allDatasets.0.thumbnailOpticalImageUrl" alt="Optical image">
+        <div class="opt-image--container">
+          <div class="thumb thumb__opt">
+            <img src="allDatasets.0.thumbnailOpticalImageUrl" alt="Optical image" class="thumb--img">
           </div>
         </div>
         <div class="ds-info">
@@ -246,9 +246,9 @@ exports[`DatasetTable should match snapshot 1`] = `
           </div>
         </div>
       </mock-el-dialog>
-      <div class="opt-image">
-        <div class="edit-opt-image-guest">
-          <img src="allDatasets.0.thumbnailOpticalImageUrl" alt="Optical image">
+      <div class="opt-image--container">
+        <div class="thumb thumb__opt">
+          <img src="allDatasets.0.thumbnailOpticalImageUrl" alt="Optical image" class="thumb--img">
         </div>
       </div>
       <div class="ds-info">
@@ -362,9 +362,9 @@ exports[`DatasetTable should match snapshot 1`] = `
         </div>
       </div>
     </mock-el-dialog>
-    <div class="opt-image">
-      <div class="edit-opt-image-guest">
-        <img src="allDatasets.0.thumbnailOpticalImageUrl" alt="Optical image">
+    <div class="opt-image--container">
+      <div class="thumb thumb__opt">
+        <img src="allDatasets.0.thumbnailOpticalImageUrl" alt="Optical image" class="thumb--img">
       </div>
     </div>
     <div class="ds-info">


### PR DESCRIPTION
Resolves #239 

* Added `ion_thumbnails` image type to graphql's image server & the nginx configuration
* Added `ion_thumbs` webapp feature flag
* Added process at the end of the annotation pipeline to generate a thumbnail for the dataset. This thumbnail is based on annotations from all mol dbs that had been annotated at the time it is run. It should stay relatively consistent as it's only updated if a `del_first` annotation job is run.
* Added script for bulk-generating the thumbnails. This script also lets you choose non-default algorithms, so if there's desire we can test them out on Staging:
    * `smart-image-*`: Uses KMeans on the images to find 10 clusters and out of the 10 medoids/centroids it picks the set of 3 that have the least amount of overlap, a roughly even amount of color per channel and as close to 80% non-black pixels as possible
    * `image-` Uses KMeans on the images to find 3 clusters, and uses the medoids/centroids
    * `pixel-` Uses KMeans on the pixels to label them as clusters. Their color (R/G/B) is based on which cluster they're in, and their intensity is either based on their distance from the cluster's centroid(`pixel-distance`), or the mean intensity of that pixel across all ion images (`pixel-mean-intensity`)

Refactoring:
* Added `ImageStoreServiceWrapper.get_ion_images_for_analysis` as an easy and efficient way to get many ion images into a numpy array for processing
    * This has an improvement in memory efficiency over how `colocalization` used to do it: it preallocates the output array and copies ion images in as they arrive so that it can release them early, instead of collecting them all before making the output array.
    * I found that `ImageStoreServiceWrapper.get_image_by_id` always returns 8-bit images. This may be due to the version of Pillow that we use...
* Updated `colocalization` to use `ImageStoreServiceWrapper.get_ion_images_for_analysis`
* Added two additional queries to the `run_colocalization` script so that it's easy to rerun broken/missing jobs if something goes wrong
* Refactored UI code for dataset thumbnails as the CSS was a bit of a mess. Added code to fall back to the `ion_thumbnail` if no optical image is present and the `ion_thumbs` feature flag is set.

The generated thumbnails can be up to 200x200 pixels as a PNG with transparency. This seemed to average 20kB per thumbnail, or 2MB for the whole datasets page. The reason I went for 200x200 instead of 100x100 is because retina displays render images with 2-3x the pixel density. I will probably revisit this in the future as 2MB of images on a page is a bit excessive.

This PR includes a database migration script to add a new column to `public.dataset` that should be run before deployment.