### PR TITLE
Add dataloader to optimize DB queries, add Group.adminNames field

### DIFF
--- a/metaspace/graphql/package.json
+++ b/metaspace/graphql/package.json
@@ -40,6 +40,7 @@
     "config": "^1.26.1",
     "connect-redis": "^3.3.3",
     "cors": "^2.8.1",
+    "dataloader": "^1.4.0",
     "elasticsearch": "^12.1.0",
     "express": "^4.14.0",
     "express-jwt": "^5.3.1",

--- a/metaspace/graphql/package.json
+++ b/metaspace/graphql/package.json
@@ -88,6 +88,7 @@
     "knex-cleaner": "^1.1.4",
     "mocha": "^2.5.3",
     "nodemon": "^1.11.0",
+    "random-js": "^2.0.0-rc2",
     "request-promise": "^4.2.1",
     "sinon": "^2.2.0",
     "sinon-chai": "^2.10.0",

--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -54,6 +54,7 @@ type DatasetGroup {
   shortName: String!
   urlSlug: String @deprecated(reason: "Field removed as it cannot be accessed both consistently and efficiently")
   members: [UserGroup!] @deprecated(reason: "Field removed as it cannot be accessed both consistently and efficiently")
+  adminNames: [String!]
 }
 type DatasetProject {
   id: ID!

--- a/metaspace/graphql/src/context.ts
+++ b/metaspace/graphql/src/context.ts
@@ -38,6 +38,6 @@ export interface Context {
    *                        this should be an object. For entities with single-field primary keys, this should be a
    *                        string or number.
    */
-  cachedGetEntityById: <T>(Model: ObjectType<T> & {}, id: string | number | object) => Promise<T | null>
+  cachedGetEntityById: <T>(Model: ObjectType<T> & {}, id: string | number | Partial<T>) => Promise<T | null>
 }
 

--- a/metaspace/graphql/src/context.ts
+++ b/metaspace/graphql/src/context.ts
@@ -1,5 +1,5 @@
 import {Request, Response} from 'express';
-import {EntityManager} from 'typeorm';
+import {EntityManager, ObjectType} from 'typeorm';
 import {UserProjectRole} from './binding';
 
 export type UserProjectRoles = {[projectId: string]: UserProjectRole | undefined}
@@ -31,5 +31,13 @@ export interface Context {
    * @param func            Function to memoize
    */
   contextCacheGet: <V>(functionName: string, args: ContextCacheKeyArg[], func: (...args: ContextCacheKeyArg[]) => V) => V;
+  /**
+   * Fast equivalent of `entityManager.getRepository(Model).findOne(id)` using DataLoader to cache & batch results.
+   * @param Model           Any TypeORM Entity
+   * @param id              The primary key field value to look up. For an entity with a composite primary key,
+   *                        this should be an object. For entities with single-field primary keys, this should be a
+   *                        string or number.
+   */
+  cachedGetEntityById: <T>(Model: ObjectType<T> & {}, id: string | number | object) => Promise<T | null>
 }
 

--- a/metaspace/graphql/src/getContext.spec.ts
+++ b/metaspace/graphql/src/getContext.spec.ts
@@ -1,0 +1,129 @@
+import * as _ from 'lodash';
+import {
+  onAfterAll,
+  onAfterEach,
+  onBeforeAll,
+  onBeforeEach,
+  setupTestUsers, testEntityManager,
+  testUser,
+} from './tests/graphqlTestEnvironment';
+import {Dataset, DatasetProject} from './modules/dataset/model';
+import {Project, UserProject} from './modules/project/model';
+import {createTestUser} from './tests/testDataCreation';
+import {getContextForTest} from './getContext';
+import {MersenneTwister19937, pick} from 'random-js';
+
+
+describe('getContext', () => {
+  let userId: string;
+  beforeAll(onBeforeAll);
+  afterAll(onAfterAll);
+  beforeEach(async () => {
+    await onBeforeEach();
+    await setupTestUsers();
+    userId = testUser.id;
+  });
+  afterEach(onAfterEach);
+  describe('cachedGetEntityById', () => {
+    const testIds = [1,2,3].map(n => `00000000-1234-0000-0000-00000000000${n}`);
+    const [id1, id2, id3] = testIds;
+    const testIdPairs = [[id1, id1], [id1, id2], [id1, id3], [id2, id1], [id2, id2]];
+    const testDatasetProjectIds = testIdPairs.map(([idA, idB]) => ({datasetId: idA, projectId: idB}));
+    const testUserProjectIds = testIdPairs.map(([idA, idB]) => ({userId: idA, projectId: idB}));
+    const missingId = '11111111-2222-3333-4444-555555555555';
+
+    beforeEach(async () => {
+      // testIds are shared between different tables intentionally to ensure that cachedGetEntityById is correctly
+      // isolating between entity types. A mix of both single-primary-key and composite-primary-key tables is included.
+      await testEntityManager.insert(Dataset, testIds.map(id => ({id, userId, piName: id})));
+      await testEntityManager.insert(Project, testIds.map(id => ({id, name: id})));
+      await Promise.all(testIds.map(id => createTestUser({id: id, name: id})));
+      await testEntityManager.insert(DatasetProject, testDatasetProjectIds.map(id => ({...id, approved: true})));
+      await testEntityManager.insert(UserProject, testUserProjectIds.map(id => ({...id, role: 'MEMBER' as 'MEMBER'})));
+    });
+
+    // [EntityType, id, expected value]
+    const testQueries = [
+      ...testIds.map(id => [Dataset, id, expect.objectContaining({id, piName: id})]),
+      ...testIds.map(id => [Project, id, expect.objectContaining({id, name: id})]),
+      ...testDatasetProjectIds.map(id => [DatasetProject, id, expect.objectContaining(id)]),
+      ...testUserProjectIds.map(id => [UserProject, id, expect.objectContaining(id)]),
+      [Dataset, missingId, null],
+      [Project, missingId, null],
+      [DatasetProject, {datasetId: missingId, projectId: id1}, null],
+      [DatasetProject, {datasetId: id1, projectId: missingId}, null],
+      [UserProject, {userId: missingId, projectId: id1}, null],
+      [UserProject, {userId: id1, projectId: missingId}, null],
+    ];
+
+    _.range(5).forEach((seed) => {
+      it(`should fetch correct results for random overlapping batches of queries (seed: ${seed})`, async () => {
+        const context = getContextForTest(null, testEntityManager);
+        const rand = MersenneTwister19937.seed(seed);
+        const batch1 = _.range(10).map(() => pick(rand, testQueries));
+        const batch2 = _.range(10).map(() => pick(rand, testQueries));
+
+        const results1 = await Promise.all(batch1.map(([entity, id]) => context.cachedGetEntityById(entity, id)));
+        const results2 = await Promise.all(batch2.map(([entity, id]) => context.cachedGetEntityById(entity, id)));
+
+        expect(results1).toEqual(batch1.map(([,,expected]) => expected));
+        expect(results2).toEqual(batch2.map(([,,expected]) => expected));
+      });
+    });
+
+    it(`should share results between simultaneous queries within the same context`, async () => {
+      const context = getContextForTest(null, testEntityManager);
+
+      const [results1, results2] = await Promise.all([
+        Promise.all(testQueries.map(([entity, id]) => context.cachedGetEntityById(entity, id))),
+        Promise.all(testQueries.map(([entity, id]) => context.cachedGetEntityById(entity, id))),
+      ]);
+
+      results1.forEach((result, i) => {
+        expect(result).toBe(results2[i])
+      });
+    });
+
+    it(`should not share results for simultaneous queries between different contexts`, async () => {
+      const context1 = getContextForTest(null, testEntityManager);
+      const context2 = getContextForTest(null, testEntityManager);
+
+
+      const [results1, results2] = await Promise.all([
+        Promise.all(testQueries.map(([entity, id]) => context1.cachedGetEntityById(entity, id))),
+        Promise.all(testQueries.map(([entity, id]) => context2.cachedGetEntityById(entity, id))),
+      ]);
+
+      results1.forEach((result, i) => {
+        if (result != null) {
+          expect(result).not.toBe(results2[i]);
+        }
+      });
+    });
+
+    it(`should share results between subsequent queries within the same context`, async () => {
+      const context = getContextForTest(null, testEntityManager);
+
+      const results1 = await Promise.all(testQueries.map(([entity, id]) => context.cachedGetEntityById(entity, id)));
+      const results2 = await Promise.all(testQueries.map(([entity, id]) => context.cachedGetEntityById(entity, id)));
+
+      results1.forEach((result, i) => {
+        expect(result).toBe(results2[i])
+      });
+    });
+
+    it(`should not share results between subsequent queries between different contexts`, async () => {
+      const context1 = getContextForTest(null, testEntityManager);
+      const context2 = getContextForTest(null, testEntityManager);
+
+      const results1 = await Promise.all(testQueries.map(([entity, id]) => context1.cachedGetEntityById(entity, id)));
+      const results2 = await Promise.all(testQueries.map(([entity, id]) => context2.cachedGetEntityById(entity, id)));
+
+      results1.forEach((result, i) => {
+        if (result != null) {
+          expect(result).not.toBe(results2[i]);
+        }
+      });
+    });
+  })
+});

--- a/metaspace/graphql/src/getContext.ts
+++ b/metaspace/graphql/src/getContext.ts
@@ -65,7 +65,7 @@ const getContext = (jwtUser: JwtUser | null, entityManager: EntityManager,
         const results = await entityManager.getRepository(Model).findByIds(entityIds);
         const keyedResults = _.keyBy(results, obj => keyFunc(modelMetadata.getEntityIdMixedMap(obj)) as string);
         return entityIds.map(id => keyedResults[keyFunc(id) as any] || null);
-      }, {cacheKeyFn: validatingKeyFunc});
+      }, {cacheKeyFn: validatingKeyFunc, maxBatchSize: 100});
     });
     return await dataloader.load(entityId);
   };

--- a/metaspace/graphql/src/modules/dataset/controller/Query.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Query.ts
@@ -7,18 +7,13 @@ import {UserGroup as UserGroupModel, UserGroupRoleOptions} from '../../group/mod
 import {Context} from '../../../context';
 import {thumbnailOpticalImageUrl} from './Dataset';
 
-
 const resolveDatasetScopeRole = async (ctx: Context, dsId: string) => {
   let scopeRole = SRO.OTHER;
   if (ctx.user) {
     if (dsId) {
-      const ds = await ctx.entityManager.getRepository(DatasetModel).findOne({
-        where: { id: dsId }
-      });
+      const ds = await ctx.cachedGetEntityById(DatasetModel, dsId);
       if (ds) {
-        const userGroup = await ctx.entityManager.getRepository(UserGroupModel).findOne({
-          where: { userId: ctx.user.id, groupId: ds.groupId }
-        });
+        const userGroup = await ctx.cachedGetEntityById(UserGroupModel, { userId: ctx.user.id, groupId: ds.groupId });
         if (userGroup) {
           if (userGroup.role === UserGroupRoleOptions.GROUP_ADMIN)
             scopeRole = SRO.GROUP_MANAGER;

--- a/metaspace/graphql/src/modules/group/util/getGroupAdminNames.ts
+++ b/metaspace/graphql/src/modules/group/util/getGroupAdminNames.ts
@@ -1,0 +1,24 @@
+import {Context} from '../../../context';
+import * as DataLoader from 'dataloader';
+import {UserGroup as UserGroupModel, UserGroupRoleOptions} from '../model';
+import * as _ from 'lodash';
+
+const getGroupAdminNames = async (ctx: Context, groupId: string) => {
+  const dataloader = ctx.contextCacheGet('getGroupAdminNamesDataLoader', [], () => {
+    return new DataLoader(async (groupIds: string[]): Promise<(string[] | null)[]> => {
+      const results = await ctx.entityManager.createQueryBuilder(UserGroupModel, 'userGroup')
+        .leftJoin('userGroup.user', 'user')
+        .where('userGroup.groupId = ANY(:groupIds)', {groupIds})
+        .andWhere('userGroup.role = :role', {role: UserGroupRoleOptions.GROUP_ADMIN})
+        .groupBy('userGroup.groupId')
+        .select('userGroup.groupId', 'groupId')
+        .addSelect('array_agg(user.name)', 'names')
+        .getRawMany();
+      const keyedResults = _.keyBy(results, 'groupId');
+      return groupIds.map(id => keyedResults[id] != null ? keyedResults[id].names : null);
+    });
+  });
+  return dataloader.load(groupId);
+};
+
+export default getGroupAdminNames;

--- a/metaspace/graphql/src/modules/project/ProjectSourceRepository.spec.ts
+++ b/metaspace/graphql/src/modules/project/ProjectSourceRepository.spec.ts
@@ -46,7 +46,7 @@ describe('modules/project/ProjectSourceRepository', () => {
       });
 
       const result = await testEntityManager.getCustomRepository(ProjectSourceRepository)
-        .findProjectsByDatasetId(userContext.user, dataset.id);
+        .findProjectsByDatasetId(userContext, dataset.id);
 
       expect(result).toEqual([
         expect.objectContaining({id: project.id})
@@ -62,7 +62,7 @@ describe('modules/project/ProjectSourceRepository', () => {
       await testEntityManager.save(UserProjectModel, {userId, project: project1, role: UPRO.MEMBER});
 
       const result = await testEntityManager.getCustomRepository(ProjectSourceRepository)
-        .findProjectsByDatasetId(userContext.user, dataset.id);
+        .findProjectsByDatasetId(userContext, dataset.id);
 
       expect(result).toEqual([
         expect.objectContaining({id: project1.id})

--- a/metaspace/graphql/yarn.lock
+++ b/metaspace/graphql/yarn.lock
@@ -6270,6 +6270,11 @@ random-bytes@~1.0.0:
   resolved "https://registry.yarnpkg.com/random-bytes/-/random-bytes-1.0.0.tgz#4f68a1dc0ae58bd3fb95848c30324db75d64360b"
   integrity sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=
 
+random-js@^2.0.0-rc2:
+  version "2.0.0-rc2"
+  resolved "https://registry.yarnpkg.com/random-js/-/random-js-2.0.0-rc2.tgz#95745b6b08c48078199ce3e35a1a4bf7a68d001f"
+  integrity sha512-e82LHxdh/4ZbW0iARGh/IsDLXthwoX2ZPxVzZxV+szAdHH6ui8zTjkmU/yQ+toBxyA+nFpxZZlsObjFR/9QzQg==
+
 randomatic@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.0.0.tgz#d35490030eb4f7578de292ce6dfb04a91a128923"

--- a/metaspace/graphql/yarn.lock
+++ b/metaspace/graphql/yarn.lock
@@ -1860,6 +1860,11 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.0.0"
     whatwg-url "^6.4.0"
 
+dataloader@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
+  integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
+
 debug@2, debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
I started doing this as part of #247 and decided to split its GraphQL and Webapp components

When loading the Datasets page as a logged in user, graphql was doing 4 queries for every dataset (i.e. usually 400 queries):
* Querying `public.dataset` for the thumbnail
* Querying `graphql.dataset` for the principal investigator
* Querying `graphql.dataset` again to find its group ID
* Querying `graphql.user_group` to check the user's role in the dataset's group

I've added [dataloader](https://github.com/facebook/dataloader) to allow these to be batched up. The total number of queries for this page went from ~424 to ~32. I also wrote a helper function `ctx.cachedGetEntityById` for getting TypeORM entities by ID through dataloader, as it was getting quite messy writing a custom dataloader at every place a "get by id" operation was used.

Finally, to support #247, I've added a `Group.adminNames` field that returns an array of the group's admin names. This is needed because `Dataset.group` is now a cut-down "DatasetGroup" object that doesn't have `members`, etc. because of issues with apollo's client side cache (#127)
