### PR TITLE
Fix circleci issue - update base image for sm-webapp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
 
   test-graphql:
     docker:
-      - image: intsco/sm-webapp:0.9
+      - image: intsco/sm-webapp:0.10
 
       - image: postgres:9.5-alpine
         environment:
@@ -42,7 +42,7 @@ jobs:
 
   generate-graphql-schema:
     docker:
-      - image: intsco/sm-webapp:0.9
+      - image: intsco/sm-webapp:0.10
 
       - image: postgres:9.5-alpine
         environment:
@@ -56,12 +56,6 @@ jobs:
       - restore_cache:
           keys:
             - graphql-yarn-cache-{{checksum "yarn.lock"}}
-      - run:
-          name: Install build environment for bcrypt npm package
-          command: |
-            # This is required because alpine images use musl instead of glibc, and bcrypt doesn't publish prebuild musl packages
-            # More info: https://github.com/kelektiv/node.bcrypt.js/wiki/Installation-Instructions#alpine-linux-based-images
-            apk --no-cache add --virtual builds-deps build-base python
       - run:
           name: Install npm packages
           command: |
@@ -91,7 +85,7 @@ jobs:
 
   test-webapp:
     docker:
-      - image: intsco/sm-webapp:0.9
+      - image: intsco/sm-webapp:0.10
 
     working_directory: ~/metaspace/metaspace/webapp
     steps:
@@ -135,7 +129,7 @@ jobs:
 
   test-webapp-e2e:
     docker:
-      - image: intsco/sm-webapp:0.9
+      - image: intsco/sm-webapp:0.10
 
       - image: postgres:9.5-alpine
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
 
   test-graphql:
     docker:
-      - image: intsco/sm-webapp:0.10
+      - image: metaspace2020/sm-webapp:0.10
 
       - image: postgres:9.5-alpine
         environment:
@@ -42,7 +42,7 @@ jobs:
 
   generate-graphql-schema:
     docker:
-      - image: intsco/sm-webapp:0.10
+      - image: metaspace2020/sm-webapp:0.10
 
       - image: postgres:9.5-alpine
         environment:
@@ -85,7 +85,7 @@ jobs:
 
   test-webapp:
     docker:
-      - image: intsco/sm-webapp:0.10
+      - image: metaspace2020/sm-webapp:0.10
 
     working_directory: ~/metaspace/metaspace/webapp
     steps:
@@ -129,7 +129,7 @@ jobs:
 
   test-webapp-e2e:
     docker:
-      - image: intsco/sm-webapp:0.10
+      - image: metaspace2020/sm-webapp:0.10
 
       - image: postgres:9.5-alpine
         environment:
@@ -197,7 +197,7 @@ jobs:
 
   test-engine:
     docker:
-      - image: intsco/sm-engine:1.2.1
+      - image: metaspace2020/sm-engine:1.2.1
 
       - image: redis:5.0.3
 
@@ -241,7 +241,7 @@ jobs:
 
   test-engine-sci:
     docker:
-      - image: intsco/sm-engine:1.2.1
+      - image: metaspace2020/sm-engine:1.2.1
 
       - image: redis:5.0.3
 

--- a/metaspace/webapp/ci/Dockerfile
+++ b/metaspace/webapp/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9.1-alpine
+FROM node:8.15.1-alpine
 
 ENV NPM_CONFIG_LOGLEVEL=warn
 RUN npm install -g elasticdump forever
@@ -6,4 +6,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositori
     echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories &&\
     echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 
-RUN apk update && apk add --no-cache postgresql firefox git curl wget bash dbus ttf-freefont tar gzip
+# build-base and python are required because alpine images use musl instead of glibc,
+# and graphql's bcrypt dependency doesn't publish prebuilt musl packages
+# More info: https://github.com/kelektiv/node.bcrypt.js/wiki/Installation-Instructions#alpine-linux-based-images
+RUN apk update && apk add --no-cache postgresql firefox git curl wget bash dbus ttf-freefont tar gzip build-base python


### PR DESCRIPTION
~@intsco Please use the updated dockerfile in this PR to publish `intsco/sm-webapp:0.10`~

This fixes the [recent CircleCI issues](https://circleci.com/gh/metaspace2020/metaspace/2938?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link). They are caused by something in alpine's `build-base` package being updated in a way that's its dependencies conflict with the packages in our base image.

Node 8.15.1 is ABI-compatible with 8.9.1, so this shouldn't break anything. I've tested locally against the `generate-graphql-schema` circleci job, but I can't test any others because circleci local doesn't handle workflows.