### PR TITLE
Remove Spark-based colocalization codepath

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
 
   test-graphql:
     docker:
-      - image: intsco/sm-webapp:0.9
+      - image: metaspace2020/sm-webapp:0.10
 
       - image: postgres:9.5-alpine
         environment:
@@ -42,7 +42,7 @@ jobs:
 
   generate-graphql-schema:
     docker:
-      - image: intsco/sm-webapp:0.9
+      - image: metaspace2020/sm-webapp:0.10
 
       - image: postgres:9.5-alpine
         environment:
@@ -56,12 +56,6 @@ jobs:
       - restore_cache:
           keys:
             - graphql-yarn-cache-{{checksum "yarn.lock"}}
-      - run:
-          name: Install build environment for bcrypt npm package
-          command: |
-            # This is required because alpine images use musl instead of glibc, and bcrypt doesn't publish prebuild musl packages
-            # More info: https://github.com/kelektiv/node.bcrypt.js/wiki/Installation-Instructions#alpine-linux-based-images
-            apk --no-cache add --virtual builds-deps build-base python
       - run:
           name: Install npm packages
           command: |
@@ -91,7 +85,7 @@ jobs:
 
   test-webapp:
     docker:
-      - image: intsco/sm-webapp:0.9
+      - image: metaspace2020/sm-webapp:0.10
 
     working_directory: ~/metaspace/metaspace/webapp
     steps:
@@ -135,7 +129,7 @@ jobs:
 
   test-webapp-e2e:
     docker:
-      - image: intsco/sm-webapp:0.9
+      - image: metaspace2020/sm-webapp:0.10
 
       - image: postgres:9.5-alpine
         environment:
@@ -203,7 +197,7 @@ jobs:
 
   test-engine:
     docker:
-      - image: intsco/sm-engine:1.2.1
+      - image: metaspace2020/sm-engine:1.2.1
 
       - image: redis:5.0.3
 
@@ -247,7 +241,7 @@ jobs:
 
   test-engine-sci:
     docker:
-      - image: intsco/sm-engine:1.2.1
+      - image: metaspace2020/sm-engine:1.2.1
 
       - image: redis:5.0.3
 

--- a/metaspace/engine/scripts/run_colocalization.py
+++ b/metaspace/engine/scripts/run_colocalization.py
@@ -1,22 +1,102 @@
 import argparse
 import logging
 
+from sm.engine.mol_db import MolDBServiceWrapper
 from sm.engine.util import init_loggers, SMConfig
 from sm.engine.db import DB
 from sm.engine.colocalization import Colocalization
 
-def run_coloc_jobs(ds_id, sql_where):
-    assert ds_id or sql_where
+
+CORRUPT_COLOC_JOBS_SEL = """
+WITH mol_db_lookup AS (SELECT unnest(%s::int[]) AS id, unnest(%s::text[]) AS name), 
+    fdr_lookup AS (SELECT unnest(%s::numeric[]) AS fdr), 
+    algorithm_lookup AS (SELECT unnest(%s::text[]) algorithm),
+    job_fdr_counts_temp AS (SELECT job_id, fdr, COUNT(*) num_annotations FROM iso_image_metrics GROUP BY job_id, fdr),
+    job_fdr_counts AS (
+      SELECT iim.job_id, fdr.fdr, SUM(num_annotations) AS num_annotations
+      FROM job_fdr_counts_temp iim
+      JOIN fdr_lookup fdr ON iim.fdr <= fdr.fdr + 0.01
+      GROUP BY job_id, fdr.fdr
+      HAVING SUM(num_annotations) > 2
+    ), coloc_job_fdr_counts AS (
+      SELECT cj.ds_id, cj.mol_db, cj.fdr, cj.algorithm, COUNT(*) AS num_annotations
+      FROM graphql.coloc_job cj
+      JOIN graphql.coloc_annotation ca ON cj.id = ca.coloc_job_id
+      GROUP BY cj.ds_id, cj.mol_db, cj.fdr, cj.algorithm
+    )
+SELECT DISTINCT j.ds_id
+FROM dataset ds
+JOIN job j ON ds.id = j.ds_id
+JOIN job_fdr_counts jfc ON j.id = jfc.job_id
+JOIN mol_db_lookup mdb ON j.db_id = mdb.id
+CROSS JOIN algorithm_lookup alg
+JOIN coloc_job_fdr_counts cj ON ds.id = cj.ds_id AND cj.mol_db = mdb.name
+                                  AND cj.fdr = jfc.fdr AND cj.algorithm = alg.algorithm
+WHERE ds.status = 'FINISHED'
+  AND j.status = 'FINISHED'
+  AND cj.num_annotations < jfc.num_annotations
+ORDER BY j.ds_id DESC;
+"""
+
+MISSING_COLOC_JOBS_SEL = """
+WITH mol_db_lookup AS (SELECT unnest(%s::int[]) AS id, unnest(%s::text[]) AS name), 
+    fdr_lookup AS (SELECT unnest(%s::numeric[]) AS fdr), 
+    job_fdr_counts_temp AS (SELECT job_id, fdr, COUNT(*) num_annotations FROM iso_image_metrics GROUP BY job_id, fdr),
+    job_fdr_counts AS (
+      SELECT iim.job_id, fdr.fdr, SUM(num_annotations) AS num_annotations
+      FROM job_fdr_counts_temp iim
+      JOIN fdr_lookup fdr ON iim.fdr <= fdr.fdr + 0.01
+      GROUP BY job_id, fdr.fdr
+      HAVING SUM(num_annotations) > 2
+    ), coloc_job_fdr_counts AS (
+      SELECT cj.ds_id, cj.mol_db, cj.fdr, array_agg(cj.algorithm) AS algorithms
+      FROM graphql.coloc_job cj
+      GROUP BY cj.ds_id, cj.mol_db, cj.fdr
+    )
+SELECT DISTINCT j.ds_id
+FROM dataset ds
+JOIN job j ON ds.id = j.ds_id
+JOIN job_fdr_counts jfc ON j.id = jfc.job_id
+JOIN mol_db_lookup mdb ON j.db_id = mdb.id
+LEFT JOIN coloc_job_fdr_counts cj ON ds.id = cj.ds_id AND cj.mol_db = mdb.name AND cj.fdr = jfc.fdr
+WHERE ds.status = 'FINISHED'
+  AND j.status = 'FINISHED'
+  AND (cj IS NULL OR NOT cj.algorithms @> %s::text[])
+ORDER BY j.ds_id DESC;
+"""
+
+
+def run_coloc_jobs(ds_id, sql_where, fix_missing, fix_corrupt, skip_existing):
+    assert len([data_source for data_source in [ds_id, sql_where, fix_missing, fix_corrupt] if data_source]) == 1, \
+           "Exactly one data source (ds_id, sql_where, fix_missing, fix_corrupt) must be specified"
     assert not (ds_id and sql_where)
 
     conf = SMConfig.get_conf()
 
     db = DB(conf['db'])
 
-    if sql_where:
+    if ds_id:
+        ds_ids = ds_id.split(',')
+    elif sql_where:
         ds_ids = [id for (id, ) in db.select(f'SELECT DISTINCT dataset.id FROM dataset WHERE {sql_where}')]
     else:
-        ds_ids = ds_id.split(',')
+        mol_db_service = MolDBServiceWrapper(conf['services']['mol_db'])
+        mol_dbs = [(db['id'], db['name']) for db in mol_db_service.fetch_all_dbs()]
+        mol_db_ids, mol_db_names = map(list, zip(*mol_dbs))
+        fdrs = [0.05, 0.1, 0.2, 0.5]
+        algorithms = ['cosine', 'pca_cosine', 'pca_pearson', 'pca_spearman']
+
+        if fix_missing:
+            logger.info('Checking for missing colocalization jobs...')
+            results = db.select(MISSING_COLOC_JOBS_SEL, [list(mol_db_ids), list(mol_db_names), fdrs, algorithms])
+            ds_ids = [ds_id for ds_id, in results]
+            logger.info(f'Found {len(ds_ids)} missing colocalization sets')
+        else:
+            logger.info('Checking all colocalization jobs. This is super slow: ~5 minutes per 1000 datasets...')
+            results = db.select(CORRUPT_COLOC_JOBS_SEL, [list(mol_db_ids), list(mol_db_names), fdrs, algorithms])
+            ds_ids = [ds_id for ds_id, in results]
+            logger.info(f'Found {len(ds_ids)} corrupt colocalization sets')
+
 
     if not ds_ids:
         logger.warning('No datasets match filter')
@@ -26,7 +106,7 @@ def run_coloc_jobs(ds_id, sql_where):
         try:
             logger.info(f'Running colocalization on {i+1} out of {len(ds_ids)}')
             coloc = Colocalization(db)
-            coloc.run_coloc_job_for_existing_ds(ds_id)
+            coloc.run_coloc_job(ds_id, reprocess=not skip_existing)
         except Exception:
             logger.error(f'Failed to run colocalization on {ds_id}', exc_info=True)
 
@@ -37,10 +117,20 @@ if __name__ == '__main__':
     parser.add_argument('--ds-id', dest='ds_id', default=None, help='DS id (or comma-separated list of ids)')
     parser.add_argument('--sql-where', dest='sql_where', default=None,
                         help='SQL WHERE clause for picking rows from the dataset table, e.g. "status = \'FINISHED\'"')
+    parser.add_argument('--fix-missing', action='store_true',
+                        help='Run colocalization on all datasets that are missing colocalization data')
+    parser.add_argument('--fix-corrupt', action='store_true',
+                        help='Run colocalization on all datasets that have incomplete colocalization data (SLOW)')
+    parser.add_argument('--skip-existing', action='store_true',
+                        help='Re-run colocalization jobs even if they have already successfully run')
     args = parser.parse_args()
 
     SMConfig.set_path(args.config)
     init_loggers(SMConfig.get_conf()['logs'])
     logger = logging.getLogger('engine')
 
-    run_coloc_jobs(args.ds_id, args.sql_where)
+    run_coloc_jobs(ds_id=args.ds_id,
+                   sql_where=args.sql_where,
+                   fix_missing=args.fix_missing,
+                   fix_corrupt=args.fix_corrupt,
+                   skip_existing=args.skip_existing)

--- a/metaspace/engine/sm/engine/colocalization.py
+++ b/metaspace/engine/sm/engine/colocalization.py
@@ -11,7 +11,7 @@ from scipy.ndimage import zoom
 
 from sm.engine.dataset import Dataset
 from sm.engine.ion_mapping import get_ion_id_mapping
-from sm.engine.mol_db import MolDBServiceWrapper
+from sm.engine.mol_db import MolecularDB
 from sm.engine.util import SMConfig
 from sm.engine.png_generator import ImageStoreServiceWrapper
 
@@ -251,11 +251,10 @@ def analyze_colocalization(ds_id, mol_db, images, ion_ids, fdrs):
 
 class Colocalization(object):
 
-    def __init__(self, db, img_store=None, mol_db_svc=None):
+    def __init__(self, db, img_store=None):
         self._db = db
         self._sm_config = SMConfig.get_conf()
         self._img_store = img_store or ImageStoreServiceWrapper(self._sm_config['services']['img_service_url'])
-        self._mol_db_svc = mol_db_svc or MolDBServiceWrapper(self._sm_config['services']['mol_db'])
 
     def _save_job_to_db(self, job):
         job_id, = self._db.insert_return(COLOC_JOB_INS,
@@ -282,8 +281,8 @@ class Colocalization(object):
             raise
 
     def _get_existing_ds_annotations(self, ds_id, mol_db_name, image_storage_type, polarity):
-        mol_db = self._mol_db_svc.find_db_by_name_version(mol_db_name)[0]
-        annotation_rows = self._db.select(ANNOTATIONS_SEL, [ds_id, mol_db['id']])
+        mol_db = MolecularDB(name=mol_db_name)
+        annotation_rows = self._db.select(ANNOTATIONS_SEL, [ds_id, mol_db.id])
         num_annotations = len(annotation_rows)
         if num_annotations != 0:
             sf_adducts = [(formula, adduct) for image, formula, adduct, fdr in annotation_rows]

--- a/metaspace/engine/sm/engine/png_generator.py
+++ b/metaspace/engine/sm/engine/png_generator.py
@@ -2,10 +2,12 @@ import logging
 from io import BytesIO
 from PIL import Image
 from os import path
+from concurrent.futures import ThreadPoolExecutor
 import png
 import requests
 import numpy as np
 from requests.adapters import HTTPAdapter
+from scipy.ndimage import zoom
 
 
 class ImageStoreServiceWrapper(object):
@@ -49,6 +51,86 @@ class ImageStoreServiceWrapper(object):
     def get_image_by_id(self, storage_type, img_type, img_id):
         url = self._format_url(storage_type=storage_type, img_type=img_type, img_id=img_id)
         return Image.open(self._session.get(url, stream=True).raw)
+
+    def get_ion_images_for_analysis(self, storage_type, img_ids, hotspot_percentile=99,
+                                    max_size=None, max_mem_mb=2048):
+        """ Retrieves ion images, does hot-spot removal and resizing, and returns them as a numpy array.
+        Args
+        ----
+        storage_type: str
+        img_ids: list[str]
+        hotspot_percentile: float
+        max_size: Union[None, tuple[int, int]]
+            If images are greater than this size, they will be downsampled to fit in this size
+        max_mem_mb: Union[None, float]
+            If the output numpy array would require more than this amount of memory, images will be downsampled to fit
+
+        Returns
+        -------
+        tuple[np.ndarray, np.ndarray, tuple[int, int]]
+            (value, mask, (h, w))
+            value - A float32 numpy array with shape (len(img_ids), h * w) where each row is one image
+            mask - A float32 numpy array with shape (h, w) containing the ion image mask. May contain values that are
+                   between 0 and 1 if downsampling caused both filled and empty pixels to be merged
+            h, w - shape of each image in value such that value[i].reshape(h, w) reconstructs the image
+        """
+        assert all(img_ids)
+
+        zoom_factor = 1
+        h, w = None, None
+        value, mask = None, None
+
+        def setup_shared_vals(img):
+            nonlocal zoom_factor, h, w, value, mask
+
+            img_h, img_w = img.height, img.width
+            if max_size:
+                size_zoom = min(max_size[0] / img_h, max_size[1] / img_w)
+                zoom_factor = min(zoom_factor, size_zoom)
+            if max_mem_mb:
+                expected_mem = img_h * img_w * len(img_ids) * 4 / 1024 / 1024
+                zoom_factor = min(zoom_factor, max_mem_mb / expected_mem)
+
+            raw_mask = np.float32(np.array(img)[:, :, 3] != 0)
+            if abs(zoom_factor - 1) < 0.001:
+                zoom_factor = 1
+                mask = raw_mask
+            else:
+                mask = zoom(raw_mask, zoom_factor, prefilter=False)
+
+            h, w = mask.shape
+            value = np.empty((len(img_ids), h * w), dtype=np.float32)
+
+        def process_img(img_id, idx, do_setup=False):
+            img = self.get_image_by_id(storage_type, 'iso_image', img_id)
+            if do_setup:
+                setup_shared_vals(img)
+
+            img_arr = np.asarray(img, dtype=np.float32)[:, :, 0]
+
+            # Try to use the hotspot percentile, but fall back to the image's maximum or 1.0 if needed
+            # to ensure that there are no divide-by-zero issues
+            hotspot_threshold = np.percentile(img_arr, hotspot_percentile) or np.max(img_arr) or 1.
+            np.clip(img_arr, None, hotspot_threshold, out=img_arr)
+
+            if zoom_factor != 1:
+                zoomed_img = zoom(img_arr, zoom_factor)
+            else:
+                zoomed_img = img_arr
+
+            # Note: due to prefiltering & smoothing, zoom can change the min/max of the image, so hotspot_threshold
+            # cannot be reused here for scaling
+            np.clip(zoomed_img, 0, None, out=zoomed_img)
+            zoomed_img /= np.max(zoomed_img) or 1
+
+            value[idx, :] = zoomed_img.ravel()
+
+        process_img(img_ids[0], 0, do_setup=True)
+        with ThreadPoolExecutor() as ex:
+            for result in ex.map(process_img, img_ids[1:], range(1, len(img_ids))):
+                pass
+
+        return value, mask, (h, w)
 
     def delete_image_by_id(self, storage_type, img_type, img_id):
         url = self._format_url(storage_type=storage_type, img_type=img_type, method='delete', img_id=img_id)

--- a/metaspace/engine/sm/engine/search_job.py
+++ b/metaspace/engine/sm/engine/search_job.py
@@ -125,9 +125,6 @@ class SearchJob(object):
             mask = self._ds_reader.get_2d_sample_area_mask()
             img_store_type = self._ds.get_ion_img_storage_type(self._db)
             search_results.store(ion_metrics_df, ion_iso_images, mask, self._db, self._img_store, img_store_type)
-
-            coloc = Colocalization(self._db)
-            coloc.run_coloc_job_for_new_ds(self._ds, mol_db.name, ion_metrics_df, ion_iso_images, mask)
         except Exception as e:
             self._db.alter(JOB_UPD_STATUS_FINISH, params=(JobStatus.FAILED,
                                                           datetime.now().strftime('%Y-%m-%d %H:%M:%S'),

--- a/metaspace/engine/sm/engine/sm_daemons.py
+++ b/metaspace/engine/sm/engine/sm_daemons.py
@@ -5,6 +5,7 @@ from requests import post
 import logging
 import boto3
 
+from sm.engine.colocalization import Colocalization
 from sm.engine.daemon_action import DaemonAction, DaemonActionStage
 from sm.rest.dataset_manager import IMG_URLS_BY_ID_SEL
 from sm.engine.errors import UnknownDSID
@@ -66,6 +67,7 @@ class SMDaemonManager(object):
             self._db.alter('DELETE FROM job WHERE ds_id=%s', params=(ds.id,))
         ds.save(self._db, self.es)
         search_job_factory(img_store=self._img_store).run(ds)
+        Colocalization(self._db).run_coloc_job(ds.id)
 
     def _finished_job_moldbs(self, ds_id):
         for job_id, mol_db_id in self._db.select('SELECT id, db_id FROM job WHERE ds_id = %s', params=(ds_id,)):

--- a/metaspace/engine/tests/test_colocalization.py
+++ b/metaspace/engine/tests/test_colocalization.py
@@ -1,17 +1,19 @@
 from datetime import datetime
+from unittest.mock import MagicMock, patch
+
 import numpy as np
 import pandas as pd
-from scipy.sparse import coo_matrix
+from PIL import Image
 
 from sm.engine.colocalization import analyze_colocalization, Colocalization, FreeableRef
 from sm.engine.dataset import Dataset
 from sm.engine.db import DB
+from sm.engine.mol_db import MolDBServiceWrapper
+from sm.engine.png_generator import ImageStoreServiceWrapper
 from sm.engine.tests.util import sm_config, test_db, metadata, ds_config, pyspark_context
 
 
 def test_valid_colocalization_jobs_generated():
-    annotations = []
-
     ion_images = FreeableRef(np.array([np.linspace(0, 50, 50, False) % (i + 1) for i in range(20)]))
     ion_ids = np.array(range(20)) * 4
     fdrs = np.array([[0.05, 0.1, 0.2, 0.5][i % 4] for i in range(20)])
@@ -28,22 +30,40 @@ def test_valid_colocalization_jobs_generated():
 
 def _make_sparse_ion_imgs(seed):
     pixels = np.linspace(0, 25, 25, False).reshape((5, 5)) % (seed or 1)
-    return [coo_matrix(pixels)]
+    mask = (np.linspace(0, 25, 25, False).reshape((5, 5)) % 4 == 1) * 255
+    rgba = np.uint8(np.dstack([pixels, pixels, pixels, mask]))
+
+    return Image.fromarray(rgba)
 
 
-def test_new_ds_saves_to_db(test_db, metadata, ds_config, pyspark_context):
+class MockMolecularDB(object):
+    def __init__(self, **kwargs):
+        self.id = 123
+
+
+@patch('sm.engine.mol_db.MolecularDB', new=MockMolecularDB)
+def test_new_ds_saves_to_db(test_db, metadata, ds_config):
     db = DB(sm_config['db'])
     ds = Dataset('ds_id', 'ds_name', 'input_path', datetime.now(), metadata, mol_dbs=['HDMB'])
+    ds.save(db)
+
     ion_metrics_df = pd.DataFrame({'formula': ['H2O', 'H2O', 'CO2', 'CO2', 'H2SO4', 'H2SO4'],
                                    'adduct': ['+H', '+K', '+H', '+K', '+H', '+K'],
-                                   'fdr': [0.05, 0.1, 0.05, 0.1, 0.05, 0.1]})
-    num_ions = len(ion_metrics_df)
+                                   'fdr': [0.05, 0.1, 0.05, 0.1, 0.05, 0.1],
+                                   'image_id': list(map(str, range(6)))})
+    job_id, = db.insert_return("INSERT INTO job (db_id, ds_id, status) "
+                               "VALUES (1, %s, 'FINISHED') "
+                               "RETURNING id", [[ds.id]])
+    db.insert('INSERT INTO iso_image_metrics(job_id, db_id, sf, adduct, fdr, iso_image_ids) '
+              'VALUES (%s, 1, %s, %s, %s, %s)',
+              [(job_id, r.formula, r.adduct, r.fdr, [r.image_id]) for i, r in ion_metrics_df.iterrows()])
+    test_images = dict([(r.image_id, _make_sparse_ion_imgs(i)) for i, r in ion_metrics_df.iterrows()])
+    img_svc_mock = MagicMock(spec=ImageStoreServiceWrapper)
+    img_svc_mock.get_image_by_id.side_effect = lambda s_type, i_type, id: test_images[id]
+    mol_db_svc_mock = MagicMock(spec=MolDBServiceWrapper)
+    mol_db_svc_mock.find_db_by_name_version.return_value = [{'id': 1}]
 
-    test_images = [_make_sparse_ion_imgs(i) for i in range(num_ions)]
-    ion_iso_images = pyspark_context.parallelize(zip(range(num_ions), test_images), num_ions)
-    alpha_channel = np.linspace(0, 25, 25, False).reshape((5, 5)) % 2
-
-    Colocalization(db).run_coloc_job_for_new_ds(ds, 'HMDB', ion_metrics_df, ion_iso_images, alpha_channel)
+    Colocalization(db, img_store=img_svc_mock, mol_db_svc=mol_db_svc_mock).run_coloc_job(ds.id)
 
     jobs = db.select('SELECT id, error, sample_ion_ids FROM graphql.coloc_job')
     annotations = db.select('SELECT coloc_ion_ids, coloc_coeffs FROM graphql.coloc_annotation')
@@ -54,4 +74,4 @@ def test_new_ds_saves_to_db(test_db, metadata, ds_config, pyspark_context):
     assert jobs[0][2]
     assert len(annotations) > 10
     assert all(len(ann[0]) == len(ann[1]) for ann in annotations)
-    assert len(ions) == num_ions
+    assert len(ions) == len(ion_metrics_df)

--- a/metaspace/engine/tests/test_colocalization.py
+++ b/metaspace/engine/tests/test_colocalization.py
@@ -14,7 +14,7 @@ from sm.engine.tests.util import sm_config, test_db, metadata, ds_config, pyspar
 
 
 def test_valid_colocalization_jobs_generated():
-    ion_images = FreeableRef(np.array([np.linspace(0, 50, 50, False) % (i + 1) for i in range(20)]))
+    ion_images = FreeableRef(np.array([np.linspace(0, 50, 50, False) % (i + 2) for i in range(20)]))
     ion_ids = np.array(range(20)) * 4
     fdrs = np.array([[0.05, 0.1, 0.2, 0.5][i % 4] for i in range(20)])
 

--- a/metaspace/engine/tests/test_sm_daemon_manager.py
+++ b/metaspace/engine/tests/test_sm_daemon_manager.py
@@ -10,6 +10,8 @@ from sm.engine.dataset import DatasetStatus, Dataset
 from sm.engine.png_generator import ImageStoreServiceWrapper
 from sm.engine.tests.util import sm_config, test_db, fill_db, sm_index, es_dsl_search, metadata, ds_config
 
+mol_db_mock = {'id': 1, 'name': 'HMDB-v4', 'version':'2001-01-01'}
+
 
 def create_ds(ds_id='2000-01-01', ds_name='ds_name', input_path='input_path', upload_dt=None,
               metadata=None, status=DatasetStatus.QUEUED, mol_dbs=None, adducts=None):
@@ -42,6 +44,7 @@ class TestSMDaemonDatasetManager:
         def run(self, *args, **kwargs):
             pass
 
+    @patch('sm.engine.mol_db.MolDBServiceWrapper.find_db_by_name_version', return_value=[mol_db_mock])
     def test_annotate_ds(self, test_db, metadata, ds_config):
         es_mock = MagicMock(spec=ESExporter)
         db = DB(sm_config['db'])
@@ -70,14 +73,14 @@ class TestSMDaemonDatasetManager:
         ds = create_ds(ds_id=ds_id, metadata=metadata)
 
         with patch('sm.engine.sm_daemons.MolecularDB') as MolecularDB:
-            mol_db_mock = MolecularDB.return_value
-            mol_db_mock.name = 'HMDB-v4'
+            molecular_db_mock = MolecularDB.return_value
+            molecular_db_mock.name = 'HMDB-v4'
 
             manager.index(ds)
 
             es_mock.delete_ds.assert_called_with(ds_id, delete_dataset=False)
             call_args = es_mock.index_ds.call_args[1].values()
-            assert ds_id in call_args and mol_db_mock in call_args
+            assert ds_id in call_args and molecular_db_mock in call_args
 
     def test_delete_ds(self, fill_db):
         db = DB(sm_config['db'])

--- a/metaspace/engine/tests/test_sm_daemons.py
+++ b/metaspace/engine/tests/test_sm_daemons.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import pytest
 from fabric.api import local
 from fabric.context_managers import warn_only
+import numpy as np
 import pandas as pd
 
 from sm.engine.daemon_action import DaemonAction
@@ -54,6 +55,9 @@ def init_mol_db_service_wrapper_mock(MolDBServiceWrapperMock):
     mol_db_wrapper_mock.fetch_db_sfs.return_value = ['C12H24O']
     mol_db_wrapper_mock.fetch_molecules.return_value = [{'sf': 'C12H24O', 'mol_id': 'HMDB0001',
                                                          'mol_name': 'molecule name'}]
+
+
+get_ion_images_for_analysis_mock_return = np.linspace(0,25,18).reshape((3,6)), np.linspace(0,1,6).reshape((2,3)), (2,3)
 
 
 def init_queue_pub(qname='annotate'):
@@ -103,10 +107,13 @@ def run_daemons(db, es):
 
 @patch('sm.engine.mol_db.MolDBServiceWrapper')
 @patch('sm.engine.search_results.SearchResults.post_images_to_image_store')
+@patch('sm.engine.colocalization.ImageStoreServiceWrapper.get_ion_images_for_analysis',
+       return_value=get_ion_images_for_analysis_mock_return)
 @patch('sm.engine.msm_basic.msm_basic_search.MSMBasicSearch.filter_sf_metrics')
 @patch('sm.engine.msm_basic.msm_basic_search.MSMBasicSearch.calc_metrics')
 def test_sm_daemons(calc_metrics_mock,
                     filter_sf_metrics_mock,
+                    get_ion_images_for_analysis_mock,
                     post_images_to_annot_service_mock,
                     MolDBServiceWrapperMock,
                     # fixtures


### PR DESCRIPTION
Several other changes included:

* Move `Colocalization` call out of `SearchJob` as it is no longer dependent on the data inside `SearchJob`
* Rewrite part of the colocalization test to use the non-Spark code path (previously I hadn't tested the non-spark path because it was only run manually via the script file)
    * Add `img_svc` and `mol_db_svc` as dependency-injected services so that the test can mock them. Also, switch from using `MolecularDB` to `MolDBServiceWrapper` as the former isn't easy to patch.
* Add parameter to skip colocalization on mol DBs that have already been successfully processed
* Backport the `get_ion_images_for_analysis` optimization code & `run_colocalization` script changes
* Add `--skip-existing` flag to `run_colocalization` script
* Backport the CircleCI docker image fix