### PR TITLE
Return to previous page after login

### DIFF
--- a/metaspace/graphql/src/modules/auth/controller.ts
+++ b/metaspace/graphql/src/modules/auth/controller.ts
@@ -179,7 +179,7 @@ const configureGoogleAuth = (router: IRouter<any>) => {
     }));
 
     router.get('/google/callback', Passport.authenticate('google', {
-      successRedirect: '/datasets',
+      successRedirect: '/account/sign-in-success',
       failureRedirect: '/account/sign-in',
     }));
   }

--- a/metaspace/webapp/src/modules/Account/components/CreateAccountDialog.vue
+++ b/metaspace/webapp/src/modules/Account/components/CreateAccountDialog.vue
@@ -66,7 +66,7 @@
           <div class="divider" />
         </div>
         <div class="right-side">
-          <a class="google-button" href="/api_auth/google">
+          <a class="google-button" href="/api_auth/google" @click="setSignInReturnUrl">
             <google-button>Sign up with Google</google-button>
           </a>
           <ul style="padding: 0 20px;">
@@ -91,6 +91,7 @@
   import { createAccountByEmail } from '../../../api/auth';
   import reportError from '../../../lib/reportError';
   import emailRegex from '../../../lib/emailRegex';
+  import {setSignInReturnUrl} from '../signInReturnUrl';
 
   interface Model {
     firstName: string;
@@ -145,6 +146,10 @@
       } finally {
         this.isSubmitting = false;
       }
+    }
+
+    setSignInReturnUrl() {
+      setSignInReturnUrl(this.$route);
     }
 
     onClose() {

--- a/metaspace/webapp/src/modules/Account/components/SignInDialog.vue
+++ b/metaspace/webapp/src/modules/Account/components/SignInDialog.vue
@@ -31,7 +31,7 @@
         <div class="divider" />
       </div>
       <div class="right-side">
-        <a class="google-button" href="/api_auth/google">
+        <a class="google-button" href="/api_auth/google" @click="setSignInReturnUrl">
           <google-button>Sign in with Google</google-button>
         </a>
       </div>
@@ -65,6 +65,7 @@
   import { signInByEmail } from '../../../api/auth';
   import { refreshLoginStatus } from '../../../graphqlClient';
   import reportError from '../../../lib/reportError';
+  import {setSignInReturnUrl} from '../signInReturnUrl';
 
   interface Model {
     email: string;
@@ -119,6 +120,10 @@
       } finally {
         this.isSubmitting = false;
       }
+    }
+
+    setSignInReturnUrl() {
+      setSignInReturnUrl(this.$route);
     }
 
     onClose() {

--- a/metaspace/webapp/src/modules/Account/signInReturnUrl.ts
+++ b/metaspace/webapp/src/modules/Account/signInReturnUrl.ts
@@ -1,0 +1,30 @@
+import {Route} from 'vue-router';
+import * as cookie from 'js-cookie';
+import {pick} from 'lodash-es';
+import {safeJsonParse} from '../../util';
+
+const STORAGE_KEY = 'signInRedirect';
+const DEFAULT_ROUTE = {path:'/datasets'};
+
+
+export const setSignInReturnUrl = (route: Route) => {
+  const val = JSON.stringify(pick(route, ['name','path','hash','query','params']));
+  if (typeof window.localStorage != 'undefined') {
+    window.localStorage.setItem(STORAGE_KEY, val);
+  } else {
+    cookie.set(STORAGE_KEY, val);
+  }
+};
+
+export const redirectAfterSignIn = () => {
+  let redirect;
+  if ('localStorage' in window) {
+    redirect = safeJsonParse(window.localStorage.getItem(STORAGE_KEY));
+    window.localStorage.removeItem(STORAGE_KEY);
+  }
+  if (redirect == null) {
+    redirect = safeJsonParse(cookie.get(STORAGE_KEY));
+  }
+  cookie.remove(STORAGE_KEY);
+  return redirect || DEFAULT_ROUTE;
+};

--- a/metaspace/webapp/src/router.ts
+++ b/metaspace/webapp/src/router.ts
@@ -3,6 +3,7 @@ import VueRouter from 'vue-router';
 import AboutPage from './modules/App/AboutPage.vue';
 import DatasetsPage from './modules/Datasets/DatasetsPage.vue';
 import {DialogPage, ResetPasswordPage} from './modules/Account';
+import {redirectAfterSignIn} from './modules/Account/signInReturnUrl';
 
 Vue.use(VueRouter);
 
@@ -55,6 +56,7 @@ const router = new VueRouter({
     { path: '/admin/groups', component: async () => await import('./modules/Admin/GroupsListPage.vue') },
 
     { path: '/account/sign-in', component: DialogPage, props: {dialog: 'signIn'} },
+    { path: '/account/sign-in-success', redirect: redirectAfterSignIn },
     { path: '/account/create-account', component: DialogPage, props: {dialog: 'createAccount'} },
     { path: '/account/forgot-password', component: DialogPage, props: {dialog: 'forgotPassword'} },
     { path: '/account/reset-password', component: ResetPasswordPage },

--- a/metaspace/webapp/src/util.ts
+++ b/metaspace/webapp/src/util.ts
@@ -99,7 +99,7 @@ function getOS() {
   return os;
 }
 
-function safeJsonParse(json: string) {
+function safeJsonParse(json: string | null | undefined) {
   if (json) {
     try {
       return JSON.parse(json);


### PR DESCRIPTION
It's currently quite annoying when you search for a dataset or try to open a group, realize you're not signed in, sign in and find that you've been kicked back to an unfiltered Datasets page. This fixes that by redirecting you to the page you signed in from after a successful sign in.

I was surprised that this functionality isn't built into Passport in any way, as its a very common pattern. Most people recommend storing the referrer URL in the server-side session, but I decided to handle saving/restoring the route on the client side to [avoid any potential security issues](https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.md#dangerous-url-redirect-example-2).