### PR TITLE
Off-sample front-end integration

### DIFF
--- a/ansible/aws/templates/all.yml.template
+++ b/ansible/aws/templates/all.yml.template
@@ -191,8 +191,11 @@ sm_webapp_enable_uploads: true
 # "specialised metadata" subfolder
 sm_webapp_metadata_types: ["ims"]  # set ["ims", "lcms"] to accept both IMS and LC-MS datasets
 sm_webapp_features:
-  coloc: false
+  coloc: true
   ion_thumbs: false
+  off_sample: true
+  off_sample_col: false
+  new_feature_popups: true
 
 sm_activate_venv: source {{ miniconda_prefix }}/bin/activate {{ miniconda_env.name }}
 

--- a/metaspace/engine/scripts/run_off_sample.py
+++ b/metaspace/engine/scripts/run_off_sample.py
@@ -20,7 +20,7 @@ ORDER BY j.ds_id DESC;
 """
 
 
-def run_off_sample(ds_id, sql_where, fix_missing):
+def run_off_sample(ds_id, sql_where, fix_missing, overwrite_existing):
     assert len([data_source for data_source in [ds_id, sql_where, fix_missing] if data_source]) == 1, \
            "Exactly one data source (ds_id, sql_where, fix_missing) must be specified"
     assert not (ds_id and sql_where)
@@ -46,7 +46,7 @@ def run_off_sample(ds_id, sql_where, fix_missing):
     for i, ds_id in enumerate(ds_ids):
         try:
             logger.info(f'Running off-sample on {i+1} out of {len(ds_ids)}')
-            classify_dataset_ion_images(db, Dataset(id=ds_id))
+            classify_dataset_ion_images(db, Dataset(id=ds_id), overwrite_existing)
 
             # Reindex dataset
             ds_name, ds_config = db.select_one("select name, config from dataset where id = %s", (ds_id,))
@@ -71,6 +71,8 @@ if __name__ == '__main__':
                         help='SQL WHERE clause for picking rows from the dataset table, e.g. "status = \'FINISHED\'"')
     parser.add_argument('--fix-missing', action='store_true',
                         help='Run classification on all datasets that are missing off-sample data')
+    parser.add_argument('--overwrite-existing', action='store_true',
+                        help='Run classification for annotations even if they have already been classified')
     args = parser.parse_args()
 
     SMConfig.set_path(args.config)
@@ -79,4 +81,5 @@ if __name__ == '__main__':
 
     run_off_sample(ds_id=args.ds_id,
                    sql_where=args.sql_where,
-                   fix_missing=args.fix_missing)
+                   fix_missing=args.fix_missing,
+                   overwrite_existing=args.overwrite_existing)

--- a/metaspace/engine/sm/engine/daemon_action.py
+++ b/metaspace/engine/sm/engine/daemon_action.py
@@ -3,7 +3,7 @@ class DaemonAction(object):
     UPDATE = 'update'
     INDEX = 'index'
     DELETE = 'delete'
-    ANALYZE_OFF_SAMPLE = 'analyze_off_sample'
+    CLASSIFY_OFF_SAMPLE = 'classify_off_sample'
 
 
 class DaemonActionStage(object):

--- a/metaspace/engine/sm/engine/daemon_action.py
+++ b/metaspace/engine/sm/engine/daemon_action.py
@@ -3,6 +3,7 @@ class DaemonAction(object):
     UPDATE = 'update'
     INDEX = 'index'
     DELETE = 'delete'
+    ANALYZE_OFF_SAMPLE = 'analyze_off_sample'
 
 
 class DaemonActionStage(object):

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -32,7 +32,9 @@ ANNOTATIONS_SEL = '''SELECT
     j.id AS job_id,
     m.fdr AS fdr,
     m.iso_image_ids AS iso_image_ids,
-    ds.config->'isotope_generation'->'charge'->'polarity' AS polarity
+    ds.config->'isotope_generation'->'charge'->'polarity' AS polarity,
+    m.off_sample->'prob' as off_sample_prob,
+    m.off_sample->'label' as off_sample_label
 FROM iso_image_metrics m
 JOIN job j ON j.id = m.job_id
 JOIN dataset ds ON ds.id = j.ds_id
@@ -157,7 +159,9 @@ class ESIndexManager(object):
                         "min_iso_ints": {"type": "float"},
                         "max_iso_ints": {"type": "float"},
                         "msm": {"type": "float"},
-                        "fdr": {"type": "float"}
+                        "fdr": {"type": "float"},
+                        "off_sample_prob": {"type": "float"},
+                        "off_sample_label": {"type": "keyword"},
                     }
                 }
             }

--- a/metaspace/engine/sm/engine/off_sample_wrapper.py
+++ b/metaspace/engine/sm/engine/off_sample_wrapper.py
@@ -75,7 +75,7 @@ SEL_ION_IMAGES = (
     'from dataset d '
     'join job j on j.ds_id = d.id '
     'join iso_image_metrics m on m.job_id = j.id '
-    'where d.id = %s'
+    'where d.id = %s and (%s or m.off_sample is null)'
     'order by m.id '
 )
 UPD_OFF_SAMPLE = (
@@ -104,12 +104,12 @@ def classify_images(it, get_image):
     return image_predictions
 
 
-def classify_dataset_ion_images(db, ds):
+def classify_dataset_ion_images(db, ds, overwrite_existing=False):
     image_store_service = ImageStoreServiceWrapper(sm_config['services']['img_service_url'])
     storage_type = ds.get_ion_img_storage_type(db)
     get_image_by_id = partial(image_store_service.get_image_by_id, storage_type, 'iso_image')
 
-    annotations = db.select_with_fields(SEL_ION_IMAGES, (ds.id,))
+    annotations = db.select_with_fields(SEL_ION_IMAGES, (ds.id, overwrite_existing))
     image_ids = [a['img_id'] for a in annotations]
     image_predictions = classify_images(image_ids, get_image_by_id)
 

--- a/metaspace/engine/sm/engine/sm_daemons.py
+++ b/metaspace/engine/sm/engine/sm_daemons.py
@@ -273,9 +273,6 @@ class SMIndexUpdateDaemon(object):
                                                 on_failure=self._on_failure,
                                                 logger=self.logger,
                                                 poll_interval=poll_interval)
-        self._update_queue_pub = QueuePublisher(config=self._sm_config['rabbitmq'],
-                                                qdesc=update_qdesc,
-                                                logger=self.logger)
         self._status_queue_pub = QueuePublisher(config=self._sm_config['rabbitmq'],
                                                 qdesc=SM_DS_STATUS,
                                                 logger=self.logger)

--- a/metaspace/engine/sm/engine/sm_daemons.py
+++ b/metaspace/engine/sm/engine/sm_daemons.py
@@ -238,7 +238,7 @@ class SMAnnotateDaemon(object):
         analyze_msg = {
             'ds_id': msg['ds_id'],
             'ds_name': msg['ds_name'],
-            'action': DaemonAction.ANALYZE_OFF_SAMPLE,
+            'action': DaemonAction.CLASSIFY_OFF_SAMPLE,
         }
         self._upd_queue_pub.publish(msg=analyze_msg, priority=DatasetActionPriority.LOW)
 
@@ -328,7 +328,7 @@ class SMIndexUpdateDaemon(object):
         if msg['action'] == DaemonAction.INDEX:
             self._manager.index(ds=ds)
 
-        elif msg['action'] == DaemonAction.ANALYZE_OFF_SAMPLE:
+        elif msg['action'] == DaemonAction.CLASSIFY_OFF_SAMPLE:
             # depending on number of annotations may take up to several minutes
             classify_dataset_ion_images(self._db, ds)
             self._manager.index(ds=ds)

--- a/metaspace/engine/tests/test_sm_daemons.py
+++ b/metaspace/engine/tests/test_sm_daemons.py
@@ -49,6 +49,17 @@ def clean_isotope_storage():
         local('rm -rf {}'.format(sm_config['isotope_storage']['path']))
 
 
+@pytest.fixture()
+def reset_queues():
+    from sm.engine.queue import QueuePublisher, SM_ANNOTATE, SM_UPDATE
+    # Delete queues to clean up remaining messages so that they don't interfere with other tests
+    for qdesc in [SM_ANNOTATE, SM_UPDATE]:
+        queue_pub = QueuePublisher(config=sm_config['rabbitmq'],
+                                   qdesc=qdesc,
+                                   logger=logger)
+        queue_pub.delete_queue()
+
+
 def init_mol_db_service_wrapper_mock(MolDBServiceWrapperMock):
     mol_db_wrapper_mock = MolDBServiceWrapperMock()
     mol_db_wrapper_mock.find_db_by_name_version.return_value = [{'id': 0, 'name': 'HMDB-v4', 'version': '2018'}]
@@ -122,6 +133,7 @@ def test_sm_daemons(calc_metrics_mock,
                     MolDBServiceWrapperMock,
                     # fixtures
                     test_db, es_dsl_search, clean_isotope_storage,
+                    reset_queues,
                     metadata, ds_config):
     init_mol_db_service_wrapper_mock(MolDBServiceWrapperMock)
 
@@ -245,6 +257,7 @@ def test_sm_daemons_annot_fails(calc_metrics_mock,
                                 MolDBServiceWrapperMock,
                                 test_db, es_dsl_search,
                                 clean_isotope_storage,
+                                reset_queues,
                                 metadata, ds_config):
     init_mol_db_service_wrapper_mock(MolDBServiceWrapperMock)
 
@@ -307,6 +320,7 @@ def test_sm_daemon_es_export_fails(calc_metrics_mock,
                                    MolDBServiceWrapperMock,
                                    test_db, es_dsl_search,
                                    clean_isotope_storage,
+                                   reset_queues,
                                    metadata, ds_config):
     init_mol_db_service_wrapper_mock(MolDBServiceWrapperMock)
 

--- a/metaspace/graphql/schema.graphql
+++ b/metaspace/graphql/schema.graphql
@@ -30,6 +30,7 @@ enum AnnotationOrderBy {
   ORDER_BY_DATASET
   ORDER_BY_FORMULA
   ORDER_BY_COLOCALIZATION
+  ORDER_BY_OFF_SAMPLE
 }
 
 enum DatasetOrderBy {
@@ -125,6 +126,9 @@ type Annotation {
   # If `colocalizationCoeffFilter` is null, this will return null, allowing queries to include this field even if it's not
   # applicable with the current set of filters. Otherwise the values must match the parent `allAnnotations`' filter.
   colocalizationCoeff(colocalizationCoeffFilter: ColocalizationCoeffFilter): Float
+
+  offSample: Boolean    # false = only on-sample, true = only off-sample
+  offSampleProb: Float  # 0.0 = probably on-sample, 1.0 = probably off-sample
 }
 
 # [min, max) interval
@@ -145,6 +149,7 @@ input AnnotationFilter {
   colocalizedWith: String         # Should be an ion string (sf+adduct+polarity). Requires DatasetFilter.datasetIds to be set to a specific dataset
   colocalizationSamples: Boolean  # Requires DatasetFilter.datasetIds to be set to a specific dataset
   colocalizationAlgo: String
+  offSample: Boolean
 }
 
 input ColocalizationCoeffFilter {

--- a/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
+++ b/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
@@ -80,6 +80,10 @@ const Annotation: FieldResolversFor<Annotation, ESAnnotation | ESAnnotationWithC
 
   rhoChaos: (hit) => hit._source.chaos,
 
+  offSample: (hit) => hit._source.off_sample_label == null ? null : hit._source.off_sample_label === 'off',
+
+  offSampleProb: (hit) => hit._source.off_sample_prob == null ? null : hit._source.off_sample_prob,
+
   dataset(hit) {
 
     return {

--- a/metaspace/graphql/src/modules/dataset/controller/Subscription.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Subscription.ts
@@ -34,9 +34,13 @@ async function waitForChangeAndPublish(payload: DatasetStatusPayload) {
   // wait until updates are reflected in ES so that clients can refresh their data
   const maxAttempts = 8;
 
+  if (!KNOWN_ACTIONS.includes(action)) {
+    return;
+  }
+
   try {
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      logger.debug(JSON.stringify({attempt, status}));
+      logger.debug(JSON.stringify({attempt, action, status}));
       const ds = await esDatasetByID(ds_id, null, true);
 
       if (action === 'DELETE' && stage === 'FINISHED') {
@@ -45,7 +49,7 @@ async function waitForChangeAndPublish(payload: DatasetStatusPayload) {
           publishDatasetDeleted({ id: ds_id });
           return;
         }
-      } else if (ds != null && KNOWN_ACTIONS.includes(action)) {
+      } else if (ds != null) {
         publishDatasetStatusUpdated({
           dataset: {
             ...ds,

--- a/metaspace/graphql/src/modules/dataset/controller/Subscription.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Subscription.ts
@@ -15,6 +15,7 @@ import {
 
 /** From `DaemonAction` in sm-engine, but capitalized */
 type EngineDatasetAction = 'ANNOTATE' | 'UPDATE' | 'INDEX' | 'DELETE';
+const KNOWN_ACTIONS = ['ANNOTATE','UPDATE','INDEX','DELETE'];
 /** From `DaemonActionStage` in sm-engine */
 type EngineDatasetActionStage = 'QUEUED' | 'STARTED' | 'FINISHED' | 'FAILED';
 
@@ -44,7 +45,7 @@ async function waitForChangeAndPublish(payload: DatasetStatusPayload) {
           publishDatasetDeleted({ id: ds_id });
           return;
         }
-      } else if (ds != null) {
+      } else if (ds != null && KNOWN_ACTIONS.includes(action)) {
         publishDatasetStatusUpdated({
           dataset: {
             ...ds,

--- a/metaspace/webapp/docs/csv_export.md
+++ b/metaspace/webapp/docs/csv_export.md
@@ -1,4 +1,6 @@
-## CSV Export
+# CSV Export
+
+## Loading the .csv file
 
 ### Comment lines
 
@@ -20,6 +22,15 @@ annotations_lines = open('metaspace_annotations.csv').readlines()[2:]
 annotations = list(DictReader(annotations_lines))
 ```
 
+### Character Encoding 
+
+Some spreadsheet programs will occasionally incorrectly detect the character encoding of the CSV files,
+causing names such as [8-hydroxy-2-phenyl-1λ⁴-chromen-1-ylium](http://www.hmdb.ca/metabolites/HMDB0133413) to appear
+mangled, e.g. as "8-hydroxy-2-phenyl-1Î»â´-chromen-1-ylium". The solution to this is to close the file, reopen it 
+and select **Unicode (UTF-8)** or **UTF-8** as the character encoding when prompted. 
+
+## Information about specific columns
+
 ### Molecule IDs
 
 In the Annotations CSV file, each row may specify multiple values in the moleculeNames and moleculeIds columns. 
@@ -28,11 +39,12 @@ followed by one or more spaces, such as [HMDB0032389](http://www.hmdb.ca/metabol
 removed to ensure they're unambiguously parseable, e.g. 
 "Methyl acrylate-divinylbenzene, completely hydrolyzed, copolymer" would become
 "Methyl acrylate-divinylbenzene,completely hydrolyzed,copolymer".
-
-### Character Encoding 
-
-Some spreadsheet programs will occasionally incorrectly detect the character encoding of the CSV files,
-causing names such as [8-hydroxy-2-phenyl-1λ⁴-chromen-1-ylium](http://www.hmdb.ca/metabolites/HMDB0133413) to appear
-mangled, e.g. as "8-hydroxy-2-phenyl-1Î»â´-chromen-1-ylium". The solution to this is to close the file, reopen it 
-and select **Unicode (UTF-8)** or **UTF-8** as the character encoding when prompted. 
  
+### Off-sample
+
+The `rawOffSampleProb` column contains the unmodified raw output of the off-sample prediction model as a number from 
+`0.0` to `1.0`. For most datasets this number is close to the probability that the ion image is off-sample, 
+however it is not guaranteed to be accurate. Datasets that are too dissimilar to the datasets that the model 
+was trained on will have less accuracy. Furthermore, toward the extremes of the scale, the model tends to be 
+overconfident. e.g. a prediction with a `rawOffSampleProb` value of `0.0000001` may still have a 1-10% chance of 
+being off-sample. 

--- a/metaspace/webapp/package.json
+++ b/metaspace/webapp/package.json
@@ -55,7 +55,7 @@
     "node-sass": "4.5.3",
     "numeric": "^1.2.6",
     "plotly.js": "^1.34.0",
-    "popper.js": "1.0.8",
+    "popper.js": "^1.14.7",
     "raven": "^2.6.2",
     "raven-js": "^3.25.2",
     "sanitize-html": "^1.20.0",

--- a/metaspace/webapp/src/api/annotation.ts
+++ b/metaspace/webapp/src/api/annotation.ts
@@ -20,6 +20,8 @@ gql`query GetAnnotations($orderBy: AnnotationOrderBy, $sortingOrder: SortingOrde
         fdrLevel
         mz
         colocalizationCoeff(colocalizationCoeffFilter: $colocalizationCoeffFilter)
+        offSample
+        offSampleProb
         dataset {
           id
           submitter { id name email }
@@ -65,12 +67,14 @@ gql`query Export($orderBy: AnnotationOrderBy, $sortingOrder: SortingOrder,
       sumFormula
       adduct
       ion
+      mz
       msmScore
+      fdrLevel
       rhoSpatial
       rhoSpectral
       rhoChaos
-      fdrLevel
-      mz
+      offSample
+      offSampleProb
       dataset {
         id
         name

--- a/metaspace/webapp/src/config.ts
+++ b/metaspace/webapp/src/config.ts
@@ -24,6 +24,10 @@ type FineUploaderConfig = FineUploaderConfigS3 | FineUploaderConfigLocal;
 
 interface Features {
   coloc: boolean;
+  ion_thumbs: boolean;
+  off_sample: boolean;
+  off_sample_col: boolean;
+  new_feature_popups: boolean;
 }
 
 interface ClientConfig {
@@ -49,6 +53,10 @@ const defaultConfig: ClientConfig = {
   metadataTypes: ["ims"],
   features: {
     coloc: false,
+    ion_thumbs: false,
+    off_sample: true,
+    off_sample_col: false,
+    new_feature_popups: true,
   }
 };
 
@@ -75,7 +83,7 @@ export const updateConfigFromQueryString = () => {
 };
 
 export const replaceConfigWithDefaultForTests = () => {
-  config = defaultsDeep({}, defaultConfig);
+  Object.assign(config, defaultConfig);
 };
 
 export default config;

--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.spec.ts
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.spec.ts
@@ -49,8 +49,10 @@ describe('AnnotationTable', () => {
       { "name": "C.I. Food Red 6", "information": [{ "databaseId": "HMDB0032738" }] },
     ],
     colocalizationCoeff: 0.840809,
+    offSample: 'on',
+    offSampleProb: 0.03,
   };
-  const propsData = {hideColumns: []};
+  const propsData = {hideColumns: ["OffSampleProb"]};
 
   it('should match snapshot', async () => {
     initMockGraphqlClient({

--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
@@ -128,6 +128,17 @@
         </template>
       </el-table-column>
 
+      <el-table-column key="offSampleProb"
+                       v-if="!hidden('OffSampleProb')"
+                       property="offSampleProb"
+                       label="Off-sample %"
+                       sortable="custom"
+                       min-width="60">
+        <template slot-scope="props">
+          <span> {{(props.row.offSampleProb * 100).toFixed(0)}}% </span>
+        </template>
+      </el-table-column>
+
       <el-table-column key="msmScore"
                        property="msmScore"
                        label="MSM"
@@ -216,7 +227,8 @@
  import Vue from 'vue';
  import FileSaver from 'file-saver';
   import formatCsvRow, {csvExportHeader, formatCsvTextArray} from '../../lib/formatCsvRow';
- import {get, invert} from 'lodash-es';
+ import {invert} from 'lodash-es';
+ import config from '../../config';
 
  // 38 = up, 40 = down, 74 = j, 75 = k
  const KEY_TO_ACTION = {38: 'up', 75: 'up', 40: 'down', 74: 'down'};
@@ -226,6 +238,7 @@
    ORDER_BY_MSM: 'msmScore',
    ORDER_BY_FDR_MSM: 'fdrLevel',
    ORDER_BY_FORMULA: 'sumFormula',
+   ORDER_BY_OFF_SAMPLE: 'offSampleProb',
    ORDER_BY_COLOCALIZATION: 'colocalizationCoeff'
  };
  const COLUMN_TO_SORT_ORDER = invert(SORT_ORDER_TO_COLUMN);
@@ -515,6 +528,7 @@
      async startExport () {
        const chunkSize = this.csvChunkSize;
        const includeColoc = !this.hidden('ColocalizationCoeff');
+       const includeOffSample = config.features.off_sample;
        const colocalizedWith = this.filter.colocalizedWith;
        let csv = csvExportHeader();
        const columns = ['group', 'datasetName', 'datasetId', 'formula', 'adduct', 'mz',
@@ -523,6 +537,9 @@
        if (includeColoc) {
          columns.push('colocalizationCoeff');
        }
+       if (includeOffSample) {
+         columns.push('offSample', 'offSampleProb');
+       }
        csv += formatCsvRow(columns);
 
        function databaseId(compound) {
@@ -530,19 +547,25 @@
        }
 
        function formatRow(row) {
-         const {sumFormula, adduct, ion, msmScore, mz,
-                rhoSpatial, rhoSpectral, rhoChaos, fdrLevel, colocalizationCoeff} = row;
+         const {
+           dataset, sumFormula, adduct, ion, mz,
+           msmScore, fdrLevel, rhoSpatial, rhoSpectral, rhoChaos, possibleCompounds,
+           offSample, offSampleProb, colocalizationCoeff
+         } = row;
          const cells = [
-           row.dataset.groupApproved && row.dataset.group ? row.dataset.group.name : '',
-           row.dataset.name,
-           row.dataset.id,
+           dataset.groupApproved && dataset.group ? dataset.group.name : '',
+           dataset.name,
+           dataset.id,
            sumFormula, "M" + adduct, mz,
            msmScore, fdrLevel, rhoSpatial, rhoSpectral, rhoChaos,
-           formatCsvTextArray(row.possibleCompounds.map(m => m.name)),
-           formatCsvTextArray(row.possibleCompounds.map(databaseId))
+           formatCsvTextArray(possibleCompounds.map(m => m.name)),
+           formatCsvTextArray(possibleCompounds.map(databaseId))
          ];
          if (includeColoc) {
            cells.push(colocalizedWith === ion ? 'Reference annotation' : colocalizationCoeff);
+         }
+         if (includeOffSample) {
+           cells.push(offSample, offSampleProb);
          }
 
          return formatCsvRow(cells);

--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
@@ -538,7 +538,7 @@
          columns.push('colocalizationCoeff');
        }
        if (includeOffSample) {
-         columns.push('offSample', 'offSampleProb');
+         columns.push('offSample', 'rawOffSampleProb');
        }
        csv += formatCsvRow(columns);
 

--- a/metaspace/webapp/src/modules/Annotations/AnnotationsPage.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationsPage.vue
@@ -27,6 +27,7 @@
  import AnnotationTable from './AnnotationTable.vue';
  import AnnotationView from './AnnotationView.vue';
  import {FilterPanel} from '../Filters/index';
+ import config from '../../config';
 
  export default {
    name: 'annotations-page',
@@ -43,6 +44,8 @@
          hiddenColumns.push('Database');
        if (!singleDatasetSelected || colocalizedWith == null || fdrLevel == null)
          hiddenColumns.push('ColocalizationCoeff');
+       if (!config.features.off_sample_col)
+         hiddenColumns.push('OffSampleProb');
        return hiddenColumns;
      },
 

--- a/metaspace/webapp/src/modules/Annotations/AnnotationsPage.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationsPage.vue
@@ -50,7 +50,9 @@
      },
 
      tableWidth() {
-       return 14 - 2 * this.hiddenColumns.length;
+       return (14
+         - (this.hiddenColumns.filter(c => ['Dataset', 'Group'].includes(c)).length * 2)
+         - (this.hiddenColumns.filter(c => ['ColocalizationCoeff', 'OffSampleProb'].includes(c)).length * 1));
      },
 
      selectedAnnotation() {

--- a/metaspace/webapp/src/modules/Annotations/__snapshots__/AnnotationTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/__snapshots__/AnnotationTable.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`AnnotationTable should be able to export a CSV 1`] = `
 "# URL: http://localhost/
-\\"group\\",\\"datasetName\\",\\"datasetId\\",\\"formula\\",\\"adduct\\",\\"mz\\",\\"msm\\",\\"fdr\\",\\"rhoSpatial\\",\\"rhoSpectral\\",\\"rhoChaos\\",\\"moleculeNames\\",\\"moleculeIds\\",\\"colocalizationCoeff\\",\\"offSample\\",\\"offSampleProb\\"
+\\"group\\",\\"datasetName\\",\\"datasetId\\",\\"formula\\",\\"adduct\\",\\"mz\\",\\"msm\\",\\"fdr\\",\\"rhoSpatial\\",\\"rhoSpectral\\",\\"rhoChaos\\",\\"moleculeNames\\",\\"moleculeIds\\",\\"colocalizationCoeff\\",\\"offSample\\",\\"rawOffSampleProb\\"
 \\"Laboratory of European Molecular Biology\\",\\"Untreated_3_434\\",\\"2019-02-12_15h55m06s\\",\\"C19H18N2O7S2\\",\\"M-H\\",\\"1\\",\\"0.657486\\",\\"0.1\\",\\"0.686362\\",\\"0.959122\\",\\"0.998756\\",\\"C.I. Food Red 6\\",\\"HMDB0032738\\",\\"0.840809\\",\\"true\\",\\"0.03\\"
 \\"Laboratory of European Molecular Biology\\",\\"Untreated_3_434\\",\\"2019-02-12_15h55m06s\\",\\"C19H18N2O7S2\\",\\"M-H\\",\\"2\\",\\"0.657486\\",\\"0.1\\",\\"0.686362\\",\\"0.959122\\",\\"0.998756\\",\\"C.I. Food Red 6\\",\\"HMDB0032738\\",\\"0.840809\\",\\"true\\",\\"0.03\\"
 \\"Laboratory of European Molecular Biology\\",\\"Untreated_3_434\\",\\"2019-02-12_15h55m06s\\",\\"C19H18N2O7S2\\",\\"M-H\\",\\"3\\",\\"0.657486\\",\\"0.1\\",\\"0.686362\\",\\"0.959122\\",\\"0.998756\\",\\"C.I. Food Red 6\\",\\"HMDB0032738\\",\\"0.840809\\",\\"true\\",\\"0.03\\"

--- a/metaspace/webapp/src/modules/Annotations/__snapshots__/AnnotationTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/__snapshots__/AnnotationTable.spec.ts.snap
@@ -2,11 +2,11 @@
 
 exports[`AnnotationTable should be able to export a CSV 1`] = `
 "# URL: http://localhost/
-\\"group\\",\\"datasetName\\",\\"datasetId\\",\\"formula\\",\\"adduct\\",\\"mz\\",\\"msm\\",\\"fdr\\",\\"rhoSpatial\\",\\"rhoSpectral\\",\\"rhoChaos\\",\\"moleculeNames\\",\\"moleculeIds\\",\\"colocalizationCoeff\\"
-\\"Laboratory of European Molecular Biology\\",\\"Untreated_3_434\\",\\"2019-02-12_15h55m06s\\",\\"C19H18N2O7S2\\",\\"M-H\\",\\"1\\",\\"0.657486\\",\\"0.1\\",\\"0.686362\\",\\"0.959122\\",\\"0.998756\\",\\"C.I. Food Red 6\\",\\"HMDB0032738\\",\\"0.840809\\"
-\\"Laboratory of European Molecular Biology\\",\\"Untreated_3_434\\",\\"2019-02-12_15h55m06s\\",\\"C19H18N2O7S2\\",\\"M-H\\",\\"2\\",\\"0.657486\\",\\"0.1\\",\\"0.686362\\",\\"0.959122\\",\\"0.998756\\",\\"C.I. Food Red 6\\",\\"HMDB0032738\\",\\"0.840809\\"
-\\"Laboratory of European Molecular Biology\\",\\"Untreated_3_434\\",\\"2019-02-12_15h55m06s\\",\\"C19H18N2O7S2\\",\\"M-H\\",\\"3\\",\\"0.657486\\",\\"0.1\\",\\"0.686362\\",\\"0.959122\\",\\"0.998756\\",\\"C.I. Food Red 6\\",\\"HMDB0032738\\",\\"0.840809\\"
-\\"Laboratory of European Molecular Biology\\",\\"Untreated_3_434\\",\\"2019-02-12_15h55m06s\\",\\"C19H18N2O7S2\\",\\"M-H\\",\\"4\\",\\"0.657486\\",\\"0.1\\",\\"0.686362\\",\\"0.959122\\",\\"0.998756\\",\\"C.I. Food Red 6\\",\\"HMDB0032738\\",\\"0.840809\\"
+\\"group\\",\\"datasetName\\",\\"datasetId\\",\\"formula\\",\\"adduct\\",\\"mz\\",\\"msm\\",\\"fdr\\",\\"rhoSpatial\\",\\"rhoSpectral\\",\\"rhoChaos\\",\\"moleculeNames\\",\\"moleculeIds\\",\\"colocalizationCoeff\\",\\"offSample\\",\\"offSampleProb\\"
+\\"Laboratory of European Molecular Biology\\",\\"Untreated_3_434\\",\\"2019-02-12_15h55m06s\\",\\"C19H18N2O7S2\\",\\"M-H\\",\\"1\\",\\"0.657486\\",\\"0.1\\",\\"0.686362\\",\\"0.959122\\",\\"0.998756\\",\\"C.I. Food Red 6\\",\\"HMDB0032738\\",\\"0.840809\\",\\"true\\",\\"0.03\\"
+\\"Laboratory of European Molecular Biology\\",\\"Untreated_3_434\\",\\"2019-02-12_15h55m06s\\",\\"C19H18N2O7S2\\",\\"M-H\\",\\"2\\",\\"0.657486\\",\\"0.1\\",\\"0.686362\\",\\"0.959122\\",\\"0.998756\\",\\"C.I. Food Red 6\\",\\"HMDB0032738\\",\\"0.840809\\",\\"true\\",\\"0.03\\"
+\\"Laboratory of European Molecular Biology\\",\\"Untreated_3_434\\",\\"2019-02-12_15h55m06s\\",\\"C19H18N2O7S2\\",\\"M-H\\",\\"3\\",\\"0.657486\\",\\"0.1\\",\\"0.686362\\",\\"0.959122\\",\\"0.998756\\",\\"C.I. Food Red 6\\",\\"HMDB0032738\\",\\"0.840809\\",\\"true\\",\\"0.03\\"
+\\"Laboratory of European Molecular Biology\\",\\"Untreated_3_434\\",\\"2019-02-12_15h55m06s\\",\\"C19H18N2O7S2\\",\\"M-H\\",\\"4\\",\\"0.657486\\",\\"0.1\\",\\"0.686362\\",\\"0.959122\\",\\"0.998756\\",\\"C.I. Food Red 6\\",\\"HMDB0032738\\",\\"0.840809\\",\\"true\\",\\"0.03\\"
 "
 `;
 
@@ -19,6 +19,7 @@ exports[`AnnotationTable should match snapshot 1`] = `
       <div></div>
       <div></div>
       <div></div>
+      <!---->
       <div></div>
       <div></div>
       <div></div>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
@@ -1,14 +1,24 @@
 <template>
 <div>
     <el-row id="scores-table">
-        MSM score =
-        <span>{{ annotation.msmScore.toFixed(3) }}</span> =
-        <span>{{ annotation.rhoSpatial.toFixed(3) }}</span>
-        (&rho;<sub>spatial</sub>) &times;
-        <span>{{ annotation.rhoSpectral.toFixed(3) }}</span>
-        (&rho;<sub>spectral</sub>) &times;
-        <span>{{ annotation.rhoChaos.toFixed(3) }}</span>
-        (&rho;<sub>chaos</sub>)
+        <div class="msm-score-calc">
+            MSM score =
+            <span>{{ annotation.msmScore.toFixed(3) }}</span> =
+            <span>{{ annotation.rhoSpatial.toFixed(3) }}</span>
+            (&rho;<sub>spatial</sub>) &times;
+            <span>{{ annotation.rhoSpectral.toFixed(3) }}</span>
+            (&rho;<sub>spectral</sub>) &times;
+            <span>{{ annotation.rhoChaos.toFixed(3) }}</span>
+            (&rho;<sub>chaos</sub>)
+        </div>
+        <div v-if="showOffSample">
+            <el-popover trigger="hover" :open-delay="100">
+                Image analysis gave an off-sample probability of {{formattedOffSampleProb}}.
+                <span slot="reference" :class="annotation.offSample ? 'off-sample-tag' : 'on-sample-tag'">
+                    {{annotation.offSample ? 'Off-sample' : 'On-sample'}}
+                </span>
+            </el-popover>
+        </div>
     </el-row>
     <el-row id="isotope-images-container">
         <el-col :xs="24" :sm="12" :md="12" :lg="6"
@@ -47,6 +57,7 @@ import ImageLoader from '../../../../components/ImageLoader.vue';
 import PlotLegend from '../PlotLegend.vue';
 import IsotopePatternPlot from '../IsotopePatternPlot.vue';
 import {sortBy} from 'lodash-es';
+import config from '../../../../config'
 
 @Component({
     name: 'diagnostics',
@@ -79,19 +90,42 @@ export default class Diagnostics extends Vue {
         // Usually isotope images are pre-sorted by the server, but it's not an explicit guarantee of the API
         return sortBy(this.annotation.isotopeImages, img => img.mz);
     }
+
+    get showOffSample(): boolean {
+        return config.features.off_sample && this.annotation.offSample != null;
+    }
+
+    get formattedOffSampleProb(): string {
+        if (this.annotation.offSampleProb < 0.1) {
+            return 'less than 10%';
+        } else if (this.annotation.offSampleProb > 0.9) {
+            return 'greater than 90%';
+        } else {
+            return (+this.annotation.offSampleProb * 100).toFixed(0) + '%'
+        }
+    }
 }
 </script>
 
 <style lang="scss" scoped>
+@import "~element-ui/packages/theme-chalk/src/common/var";
+
 #scores-table {
+    display: flex;
     border-collapse: collapse;
     border: 1px solid lightblue;
     font-size: 16px;
-    text-align: center;
-    padding: 3px;
+    padding: 3px 10px;
+    align-items: center;
 }
 
-#scores-table > span {
+.msm-score-calc {
+    text-align: center;
+    flex-grow: 1;
+    justify-content: center;
+}
+
+.msm-score-calc > span {
     color: blue;
 }
 
@@ -117,4 +151,18 @@ export default class Diagnostics extends Vue {
 #isotope-plot-container text {
     font-family: "Roboto" !important;
 }
+    .off-sample-tag {
+        margin-left: 10px;
+        color: white;
+        padding: 0 3px;
+        background: $--color-warning;
+        border-radius: 3px;
+    }
+    .on-sample-tag {
+        margin-left: 10px;
+        color: white;
+        padding: 0 3px;
+        background: $--color-success;
+        border-radius: 3px;
+    }
 </style>

--- a/metaspace/webapp/src/modules/App/App.vue
+++ b/metaspace/webapp/src/modules/App/App.vue
@@ -16,8 +16,8 @@
     <dialog-controller />
     <!--<release-notes-dialog />-->
 
-    <tour-step ref="tour" :tour="this.$store.state.currentTour"></tour-step>
-    <new-feature-popup v-if="features.new_feature_popups"/>
+    <tour-step ref="tour" :tour="$store.state.currentTour"></tour-step>
+    <new-feature-popup v-if="features.new_feature_popups && $store.state.currentTour == null"/>
   </div>
 </template>
 

--- a/metaspace/webapp/src/modules/App/App.vue
+++ b/metaspace/webapp/src/modules/App/App.vue
@@ -17,6 +17,7 @@
     <!--<release-notes-dialog />-->
 
     <tour-step ref="tour" :tour="this.$store.state.currentTour"></tour-step>
+    <new-feature-popup v-if="features.new_feature_popups"/>
   </div>
 </template>
 
@@ -25,6 +26,7 @@
  import MetaspaceHeader from './MetaspaceHeader.vue';
  import MetaspaceFooter from './MetaspaceFooter.vue';
  // import ReleaseNotesDialog from './ReleaseNotesDialog.vue';
+ import NewFeaturePopup from './NewFeaturePopup.vue';
  import TourStep from './TourStep.vue';
  import {DialogController} from '../Account';
  import config from '../../config';
@@ -35,6 +37,7 @@
      MetaspaceHeader,
      MetaspaceFooter,
      // ReleaseNotesDialog,
+     NewFeaturePopup,
      TourStep,
      DialogController,
    },

--- a/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
+++ b/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
@@ -92,6 +92,7 @@ We recommend including off-sample area around your sample during data acquisitio
     }
     beforeDestroy() {
       this.mutationObserver.disconnect();
+      this.close();
     }
 
     getStorageDismissedFeatures() {

--- a/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
+++ b/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
@@ -1,0 +1,254 @@
+<template>
+  <div>
+    <div ref="container" class="nf-container" v-show="activeFeature != null">
+      <div v-if="activeFeature != null">
+        <div class="nf-container-corner-tag">NEW FEATURE!</div>
+        <div class="bubble-container">
+          <div class="bubble-content">
+            <h3 v-if="activeFeature.title !== ''">
+              {{ activeFeature.title }}
+            </h3>
+            <div v-html="activeFeature.contentHtml">
+            </div>
+          </div>
+
+          <div class="nf-actions">
+            <el-button size="small" @click="remindMeLater">
+              Remind me later
+            </el-button>
+
+            <el-button size="small" type="primary" @click.native="dismissCurrentFeature">
+              Got it!
+            </el-button>
+          </div>
+
+        </div>
+
+        <div class="popper__arrow" x-arrow=''> </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+  import Vue from 'vue';
+  import Popper, {Placement} from 'popper.js';
+
+  import config from '../../config';
+  import Component from 'vue-class-component';
+  import {debounce, isArray} from 'lodash-es';
+  import {safeJsonParse} from '../../util';
+
+  interface FeatureSpec {
+    name: string;
+    title: string;
+    contentHtml: string;
+    placement: Placement;
+    getAnchorIfActive: (vue: Vue) => HTMLElement | null;
+  }
+
+  const STORAGE_KEY = 'dismissedFeaturePopups';
+
+  const NEW_FEATURES: FeatureSpec[] = [
+    {
+      name: 'offSample',
+      title: 'Off-Sample Prediction',
+      contentHtml: `
+<p>We've trained a deep learning model to filter out annotations which represent molecules localized in the off-sample area,
+such as those corresponding to the MALDI matrix. You can now hide these annotations from the results,
+allowing you to find important molecules faster.</p>
+<p>Add the <u style="white-space: nowrap;">Show/hide off-sample annotations</u> filter to try it out.</p>
+<p>Please keep in mind that the accuracy of this model is greatly improved in datasets that include some off-sample area.
+We recommend including off-sample area around your sample during data acquisition.</p>
+      `,
+      placement: 'bottom',
+      getAnchorIfActive(vue: Vue) {
+        if (config.features.off_sample && vue.$route.path === '/annotations') {
+          return document.querySelector('.tf-outer[data-test-key=offSample]')
+            || document.querySelector('.filter-select');
+        }
+        return null;
+      },
+    },
+  ];
+
+
+  @Component({})
+  export default class NewFeaturePopup extends Vue {
+    activeFeature: FeatureSpec | null = null;
+    lastPopperAnchor: HTMLElement | null = null;
+    popper: Popper | null = null;
+    mutationObserver!: MutationObserver;
+    sessionDismissedFeatures: string[] = [];
+
+    mounted() {
+      this.checkForPopups = debounce(this.checkForPopups, 100);
+      this.mutationObserver = new MutationObserver(() => { this.checkForPopups() });
+      // Ignore DOM elements outside of #app - it's unlikely that features will care about e.g. elements inside dialogs or tooltips
+      this.mutationObserver.observe(document.querySelector('#app')!, {
+        childList: true,
+        subtree: true,
+      });
+    }
+    beforeDestroy() {
+      this.mutationObserver.disconnect();
+    }
+
+    getStorageDismissedFeatures() {
+      try {
+        const json = localStorage.getItem(STORAGE_KEY);
+        const list = json && safeJsonParse(json);
+        if (isArray(list)) {
+          // Filter out invalid/old entries
+          return list.filter(item => NEW_FEATURES.some(f => f.name === item));
+        } else {
+          return []
+        }
+      } catch (ex) {
+        return [];
+      }
+
+    }
+
+    getDismissedFeatures() {
+      return [...this.getStorageDismissedFeatures(), ...this.sessionDismissedFeatures];
+    }
+
+    close() {
+      this.activeFeature = null;
+
+      if (this.popper != null) {
+        this.popper.destroy();
+        this.popper = null;
+      }
+    }
+
+    remindMeLater() {
+      if (this.activeFeature != null) {
+        this.sessionDismissedFeatures.push(this.activeFeature.name);
+        this.close();
+      }
+    }
+
+    dismissCurrentFeature() {
+      const activeFeatureName = this.activeFeature && this.activeFeature.name;
+      // Close before updating localStorage, in case of error updating localStorage.
+      this.close();
+
+      if (activeFeatureName != null) {
+        const currentFeatureStatus = this.getStorageDismissedFeatures();
+        localStorage.setItem(STORAGE_KEY, JSON.stringify([...currentFeatureStatus, activeFeatureName]));
+      }
+    }
+
+    checkForPopups() {
+      if (this.$refs.container != null) {
+        const dismissedFeatures = this.getDismissedFeatures();
+        const activatableFeatures = NEW_FEATURES
+          .filter(feature => !dismissedFeatures.includes(feature.name))
+          .map(feature => [feature, feature.getAnchorIfActive(this)] as [FeatureSpec, HTMLElement | null])
+          .filter(([feature, anchor]) => anchor != null);
+
+        if (activatableFeatures.length > 0) {
+          const [feature, anchor] = activatableFeatures[0];
+          this.activeFeature = feature;
+          if (anchor != this.lastPopperAnchor && this.popper != null) {
+            this.popper.destroy();
+          }
+
+          this.popper = new Popper(anchor!, this.$refs.container as Element, { placement: feature.placement });
+          this.lastPopperAnchor = anchor;
+        } else if (this.activeFeature != null) {
+          this.close();
+        }
+      }
+    }
+  }
+</script>
+
+<style lang="scss">
+
+  .nf-actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  $popper-background-color: rgba(250, 250, 250, 0.98);
+  $popper-border-color: #ddddce;
+  $popper-arrow-color: black;
+
+  .nf-container {
+    background: $popper-background-color;
+    color: black;
+    width: 400px;
+    padding: 10px;
+    border-radius: 3px;
+    margin: 5px;
+    z-index: 10100;
+    box-shadow: 1px 1px 0px rgba(0, 0, 0, 0.1);
+    border: 2px solid $popper-border-color;
+    font-size: 14px;
+
+    .popper__arrow {
+      width: 0;
+      height: 0;
+      border-style: solid;
+      position: absolute;
+      margin: 5px;
+    }
+
+    &[x-placement^="top"] {
+      .popper__arrow {
+        border-width: 5px 5px 0 5px;
+        border-color: $popper-arrow-color transparent transparent transparent;
+        bottom: -5px;
+        left: calc(50% - 5px);
+        margin-top: 0;
+        margin-bottom: 0;
+      }
+    }
+
+    &[x-placement^="bottom"] {
+      .popper__arrow {
+        border-width: 0 5px 5px 5px;
+        border-color: transparent transparent $popper-arrow-color transparent;
+        top: -5px;
+        left: calc(50% - 5px);
+        margin-top: 0;
+        margin-bottom: 0;
+      }
+    }
+
+    &[x-placement^="right"] {
+      .popper__arrow {
+        border-width: 5px 5px 5px 0;
+        border-color: transparent $popper-arrow-color transparent transparent;
+        left: -5px;
+        top: calc(50% - 5px);
+        margin-left: 0;
+        margin-right: 0;
+      }
+    }
+
+    &[x-placement^="left"] {
+      .popper__arrow {
+        border-width: 5px 0 5px 5px;
+        border-color: transparent transparent transparent $popper-arrow-color;
+        right: -5px;
+        top: calc(50% - 5px);
+        margin-left: 0;
+        margin-right: 0;
+      }
+    }
+  }
+
+  .nf-container-corner-tag {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 5px;
+    font-weight: bold;
+    background-color: orangered;
+    color: white;
+  }
+</style>

--- a/metaspace/webapp/src/modules/Filters/FilterPanel.vue
+++ b/metaspace/webapp/src/modules/Filters/FilterPanel.vue
@@ -15,7 +15,7 @@
                :is="f.type"
                :filterKey="f.filterKey"
                :name="f.name"
-               :helpHtml="f.helpHtml"
+               :helpComponent="f.helpComponent"
                :options="f.options"
                :labels="f.labels"
                :clearable="f.clearable"

--- a/metaspace/webapp/src/modules/Filters/FilterPanel.vue
+++ b/metaspace/webapp/src/modules/Filters/FilterPanel.vue
@@ -15,6 +15,7 @@
                :is="f.type"
                :filterKey="f.filterKey"
                :name="f.name"
+               :helpHtml="f.helpHtml"
                :options="f.options"
                :labels="f.labels"
                :clearable="f.clearable"
@@ -34,6 +35,7 @@
 
 <script>
  import {FILTER_SPECIFICATIONS} from './filterSpecs';
+ import {isFunction} from 'lodash-es';
 
  const orderedFilterKeys = [
    'database',
@@ -44,6 +46,7 @@
    'datasetIds',
    'compoundName',
    'mz',
+   'offSample',
    'polarity',
    'adduct',
    'organism',
@@ -98,11 +101,13 @@
      availableFilters() {
        let available = [];
        for (let key of orderedFilterKeys) {
-         if (FILTER_SPECIFICATIONS[key].levels.indexOf(this.level) == -1)
-           continue;
-         if (this.activeKeys.indexOf(key) == -1)
-           available.push({key,
-                           description: FILTER_SPECIFICATIONS[key].description})
+         const filterSpec = FILTER_SPECIFICATIONS[key];
+         if (filterSpec.levels.includes(this.level)
+           && !this.activeKeys.includes(key)
+           && (filterSpec.hidden == null || filterSpec.hidden === false
+             || (isFunction(filterSpec.hidden) && !filterSpec.hidden()))) {
+           available.push({key, description: filterSpec.description});
+         }
        }
        return available;
      },

--- a/metaspace/webapp/src/modules/Filters/__snapshots__/FilterPanel.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Filters/__snapshots__/FilterPanel.spec.ts.snap
@@ -2,7 +2,9 @@
 
 exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
 <div class="filter-panel">
-  <!---->
+  <mock-el-select placeholder="Add filter" class="filter-select">
+    <mock-el-option value="offSample" label="Show/hide off-sample annotations"></mock-el-option>
+  </mock-el-select>
   <div class="tf-outer" data-test-key="simpleQuery" filterkey="simpleQuery" name="Simple query" options="">
     <div class="tf-name">
       <i class="el-icon-search" style="color: white;"></i>
@@ -13,6 +15,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="polarity" filterkey="polarity">
     <div class="tf-name">
       Polarity:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container">
       <div slot-key="default">
@@ -23,6 +26,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
       </div>
       <div slot-key="reference">
         <div class="tf-value"><span class="tf-value-span"><span>Positive</span></span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -31,6 +35,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="project" options="">
     <div class="tf-name">
       Project:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container">
       <div slot-key="default">
@@ -45,6 +50,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
           <!---->
           <!---->
           </span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -53,6 +59,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="submitter" options="">
     <div class="tf-name">
       Submitter:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container">
       <div slot-key="default">
@@ -67,6 +74,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
           <!---->
           <!---->
           </span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -75,6 +83,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="datasetIds" options="">
     <div class="tf-name">
       Dataset:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="900" class="tf-value-container">
       <div slot-key="default">
@@ -90,6 +99,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
     </span>
           <!---->
           </span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -118,6 +128,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="adduct" filterkey="adduct">
     <div class="tf-name">
       Adduct:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container">
       <div slot-key="default">
@@ -128,6 +139,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
       </div>
       <div slot-key="reference">
         <div class="tf-value"><span class="tf-value-span"><span>[M + K]undefined</span></span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -146,6 +158,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="fdrLevel" filterkey="fdrLevel">
     <div class="tf-name">
       FDR:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container">
       <div slot-key="default">
@@ -158,6 +171,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
       </div>
       <div slot-key="reference">
         <div class="tf-value"><span class="tf-value-span"><span>10%</span></span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -166,6 +180,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="group" options="">
     <div class="tf-name">
       Group:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container">
       <div slot-key="default">
@@ -180,6 +195,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
           <!---->
           <!---->
           </span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -188,6 +204,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="organism" filterkey="organism">
     <div class="tf-name">
       Organism:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container">
       <div slot-key="default">
@@ -198,6 +215,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
       </div>
       <div slot-key="reference">
         <div class="tf-value"><span class="tf-value-span"><span>cow</span></span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -206,6 +224,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="organismPart" filterkey="organismPart">
     <div class="tf-name">
       Organism part:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container">
       <div slot-key="default">
@@ -216,6 +235,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
       </div>
       <div slot-key="reference">
         <div class="tf-value"><span class="tf-value-span"><span>stomach</span></span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -224,6 +244,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="condition" filterkey="condition">
     <div class="tf-name">
       Organism condition:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container">
       <div slot-key="default">
@@ -234,6 +255,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
       </div>
       <div slot-key="reference">
         <div class="tf-value"><span class="tf-value-span"><span>hungry</span></span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -242,6 +264,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="growthConditions" filterkey="growthConditions">
     <div class="tf-name">
       Sample growth conditions:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container">
       <div slot-key="default">
@@ -252,6 +275,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
       </div>
       <div slot-key="reference">
         <div class="tf-value"><span class="tf-value-span"><span>paddock</span></span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -260,6 +284,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="ionisationSource" filterkey="ionisationSource">
     <div class="tf-name">
       Source:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container">
       <div slot-key="default">
@@ -270,6 +295,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
       </div>
       <div slot-key="reference">
         <div class="tf-value"><span class="tf-value-span"><span>MALDI</span></span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -278,6 +304,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="maldiMatrix" filterkey="maldiMatrix">
     <div class="tf-name">
       Matrix:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container">
       <div slot-key="default">
@@ -288,6 +315,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
       </div>
       <div slot-key="reference">
         <div class="tf-value"><span class="tf-value-span"><span>DHB</span></span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -296,6 +324,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="analyzerType" filterkey="analyzerType">
     <div class="tf-name">
       Analyzer type:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container">
       <div slot-key="default">
@@ -306,6 +335,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
       </div>
       <div slot-key="reference">
         <div class="tf-value"><span class="tf-value-span"><span>FTICR</span></span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -314,6 +344,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="database" filterkey="database">
     <div class="tf-name">
       Database:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container">
       <div slot-key="default">
@@ -324,6 +355,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
       </div>
       <div slot-key="reference">
         <div class="tf-value"><span class="tf-value-span"><span>HMDBv4</span></span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -332,6 +364,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
   <div class="tf-outer" data-test-key="metadataType" filterkey="metadataType">
     <div class="tf-name">
       Data type:
+      <!---->
     </div>
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container">
       <div slot-key="default">
@@ -342,6 +375,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
       </div>
       <div slot-key="reference">
         <div class="tf-value"><span class="tf-value-span"><span>ims</span></span>
+          <!---->
         </div>
       </div>
     </mock-el-popover>
@@ -361,6 +395,7 @@ exports[`FilterPanel should match snapshot (no filters) 1`] = `
     <mock-el-option value="datasetIds" label="Select dataset"></mock-el-option>
     <mock-el-option value="compoundName" label="Search molecule"></mock-el-option>
     <mock-el-option value="mz" label="Search by m/z"></mock-el-option>
+    <mock-el-option value="offSample" label="Show/hide off-sample annotations"></mock-el-option>
     <mock-el-option value="polarity" label="Select polarity"></mock-el-option>
     <mock-el-option value="adduct" label="Select adduct"></mock-el-option>
     <mock-el-option value="organism" label="Select organism"></mock-el-option>

--- a/metaspace/webapp/src/modules/Filters/filter-components/OffSampleHelp.vue
+++ b/metaspace/webapp/src/modules/Filters/filter-components/OffSampleHelp.vue
@@ -1,0 +1,26 @@
+<template>
+  <el-popover trigger="hover">
+    <div class="off-sample-help-content">
+      <p>
+        This filter uses a machine learning model to classify annotations as either on- or off-sample.
+        The classifications are based on image analysis, and may be less accurate in datasets that don't include an
+        off-sample area, or where the off-sample area isn't visually distinct such as with dense cells.
+      </p>
+      <p>
+        If you find this feature helpful, we would appreciate citations to the following paper:
+      </p>
+      <p>
+        <a href="https://doi.org/10.1101/518977">Recognizing off-sample mass spectrometry images with machine and deep learning</a>, Ovchinnikova <i>et al.</i>
+      </p>
+    </div>
+    <i slot="reference" class="el-icon-question help-icon"></i>
+  </el-popover>
+</template>
+<style lang="scss" scoped>
+  .off-sample-help-content {
+    max-width: 450px;
+  }
+  .help-icon {
+    margin-left: 2px;
+  }
+</style>

--- a/metaspace/webapp/src/modules/Filters/filter-components/SingleSelectFilter.vue
+++ b/metaspace/webapp/src/modules/Filters/filter-components/SingleSelectFilter.vue
@@ -1,5 +1,5 @@
 <template>
-  <tag-filter :name="name" :removable="removable"
+  <tag-filter :name="name" :removable="removable" :helpHtml="helpHtml"
               @destroy="destroy">
     <el-select slot="edit"
                :filterable="filterable" :clearable="clearable" :value="value" @change="onChange">
@@ -9,7 +9,7 @@
     </el-select>
 
     <span slot="show" class="tf-value-span">
-      <span v-if="value" v-html="formatValue(value)"></span>
+      <span v-if="value != null && value !== ''" v-html="formatValue(value)"></span>
       <span v-else>
         (any)
       </span>
@@ -35,6 +35,8 @@
 
    @Prop({required: true})
    name!: string;
+   @Prop()
+   helpHtml!: string | null;
    @Prop({required: true})
    options!: any[];
    @Prop()

--- a/metaspace/webapp/src/modules/Filters/filter-components/SingleSelectFilter.vue
+++ b/metaspace/webapp/src/modules/Filters/filter-components/SingleSelectFilter.vue
@@ -1,5 +1,5 @@
 <template>
-  <tag-filter :name="name" :removable="removable" :helpHtml="helpHtml"
+  <tag-filter :name="name" :removable="removable" :helpComponent="helpComponent"
               @destroy="destroy">
     <el-select slot="edit"
                :filterable="filterable" :clearable="clearable" :value="value" @change="onChange">
@@ -36,7 +36,7 @@
    @Prop({required: true})
    name!: string;
    @Prop()
-   helpHtml!: string | null;
+   helpComponent!: string | null;
    @Prop({required: true})
    options!: any[];
    @Prop()

--- a/metaspace/webapp/src/modules/Filters/filter-components/TagFilter.vue
+++ b/metaspace/webapp/src/modules/Filters/filter-components/TagFilter.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="tf-outer" :style="helpHtml ? 'max-width: none;' : ''">
+  <div class="tf-outer">
     <div class="tf-name" v-if="name || 'name' in $slots">
       <slot name="name">
         {{ name }}:
       </slot>
-      <component v-if="helpHtml" :is="helpHtml" />
+      <component v-if="helpComponent" :is="helpComponent" />
     </div>
 
     <el-popover v-if="'edit' in $slots"
@@ -15,7 +15,7 @@
       <slot name="edit"></slot>
       <div class="tf-value" slot="reference">
         <slot name="show"></slot>
-        <component v-if="helpHtml && !(name || 'name' in $slots)" :is="helpHtml" style="align-self: center" />
+        <component v-if="helpComponent && !(name || 'name' in $slots)" :is="helpComponent" style="align-self: center" />
       </div>
     </el-popover>
     <div v-else-if="'show' in $slots || 'reference' in $slots"
@@ -45,7 +45,7 @@
    name: 'tag-filter',
    props: {
      name: String,
-     helpHtml: Object,
+     helpComponent: Object,
      removable: {type: Boolean, default: true},
      width: {type: Number, default: 300}
    },

--- a/metaspace/webapp/src/modules/Filters/filter-components/TagFilter.vue
+++ b/metaspace/webapp/src/modules/Filters/filter-components/TagFilter.vue
@@ -1,9 +1,10 @@
 <template>
-  <div class="tf-outer">
-    <div class="tf-name">
+  <div class="tf-outer" :style="helpHtml ? 'max-width: none;' : ''">
+    <div class="tf-name" v-if="name || 'name' in $slots">
       <slot name="name">
         {{ name }}:
       </slot>
+      <component v-if="helpHtml" :is="helpHtml" />
     </div>
 
     <el-popover v-if="'edit' in $slots"
@@ -14,6 +15,7 @@
       <slot name="edit"></slot>
       <div class="tf-value" slot="reference">
         <slot name="show"></slot>
+        <component v-if="helpHtml && !(name || 'name' in $slots)" :is="helpHtml" style="align-self: center" />
       </div>
     </el-popover>
     <div v-else-if="'show' in $slots || 'reference' in $slots"
@@ -43,6 +45,7 @@
    name: 'tag-filter',
    props: {
      name: String,
+     helpHtml: Object,
      removable: {type: Boolean, default: true},
      width: {type: Number, default: 300}
    },

--- a/metaspace/webapp/src/modules/Filters/filterSpecs.ts
+++ b/metaspace/webapp/src/modules/Filters/filterSpecs.ts
@@ -75,7 +75,7 @@ export interface FilterSpecification {
   type: Component;
   name: string;
   description?: string;
-  helpHtml?: any;
+  helpComponent?: Component;
   levels: Level[];
   defaultInLevels?: Level[];
   initialValue: undefined | null | number | string | boolean | ((lists: MetadataLists) => any);
@@ -336,7 +336,7 @@ export const FILTER_SPECIFICATIONS: Record<FilterKey, FilterSpecification> = {
     type: SingleSelectFilter,
     name: '',
     description: 'Show/hide off-sample annotations',
-    helpHtml: OffSampleHelp,
+    helpComponent: OffSampleHelp,
     levels: ['annotation'],
     defaultInLevels: [],
     initialValue: false,

--- a/metaspace/webapp/src/modules/Filters/filterSpecs.ts
+++ b/metaspace/webapp/src/modules/Filters/filterSpecs.ts
@@ -2,12 +2,14 @@ import { renderMolFormula } from '../../util';
 import InputFilter from './filter-components/InputFilter.vue';
 import SingleSelectFilter from './filter-components/SingleSelectFilter.vue';
 import SearchableFilter from './filter-components/SearchableFilter.vue';
+import OffSampleHelp from './filter-components/OffSampleHelp.vue';
 import MzFilter from './filter-components/MzFilter.vue';
 import SearchBox from './filter-components/SearchBox.vue';
 import {metadataTypes, defaultMetadataType} from '../../assets/metadataRegistry';
 import { Component } from 'vue';
 import SimpleFilterBox from './filter-components/SimpleFilterBox.vue';
 import BooleanFilter from './filter-components/BooleanFilter.vue';
+import config from '../../config';
 
 // Filled during the initialization of adduct filter below
 const ADDUCT_POLARITY: Record<string, string> = {};
@@ -65,7 +67,7 @@ export type Level = 'annotation' | 'dataset' | 'upload' | 'projects';
 export type FilterKey = 'database' | 'datasetIds' | 'minMSM' | 'compoundName' | 'adduct' | 'mz' | 'fdrLevel'
   | 'group' | 'project' | 'submitter' | 'polarity' | 'organism' | 'organismPart' | 'condition' | 'growthConditions'
   | 'ionisationSource' | 'maldiMatrix' | 'analyzerType' | 'simpleFilter' | 'simpleQuery' | 'metadataType'
-  | 'colocalizedWith' | 'colocalizationSamples';
+  | 'colocalizedWith' | 'colocalizationSamples' | 'offSample';
 
 export type MetadataLists = Record<string, any[]>;
 
@@ -73,10 +75,11 @@ export interface FilterSpecification {
   type: Component;
   name: string;
   description?: string;
+  helpHtml?: any;
   levels: Level[];
   defaultInLevels?: Level[];
   initialValue: undefined | null | number | string | boolean | ((lists: MetadataLists) => any);
-  options?: string | number[] | string[] | ((lists: MetadataLists) => any[]);
+  options?: string | number[] | boolean[] | string[] | ((lists: MetadataLists) => any[]);
   removable?: boolean;
   filterable?: boolean;
   multiple?: boolean;
@@ -327,13 +330,28 @@ export const FILTER_SPECIFICATIONS: Record<FilterKey, FilterSpecification> = {
     encoding: 'bool',
     dependsOnFilters: ['fdrLevel', 'database', 'datasetIds'],
     conflictsWithFilters: ['colocalizedWith'],
+  },
+
+  offSample: {
+    type: SingleSelectFilter,
+    name: '',
+    description: 'Show/hide off-sample annotations',
+    helpHtml: OffSampleHelp,
+    levels: ['annotation'],
+    defaultInLevels: [],
+    initialValue: false,
+    options: [true, false],
+    encoding: 'bool',
+    optionFormatter: option => `${option ? 'Off' : 'On'}-sample only`,
+    valueFormatter: option => `${option ? 'Off' : 'On'}-sample only`,
+    hidden: () => !config.features.off_sample,
   }
 };
 
 
 export const DATASET_FILTERS: FilterKey[] = ['datasetIds', 'group', 'project', 'submitter', 'polarity', 'organism', 'organismPart', 'condition', 'growthConditions', 'ionisationSource', 'maldiMatrix', 'analyzerType', 'metadataType'];
 /** = all annotation-affecting filters - dataset-affecting filters*/
-export const ANNOTATION_FILTERS: FilterKey[] = ['database', 'minMSM', 'compoundName', 'adduct', 'mz', 'fdrLevel', 'colocalizedWith'];
+export const ANNOTATION_FILTERS: FilterKey[] = ['database', 'minMSM', 'compoundName', 'adduct', 'mz', 'fdrLevel', 'colocalizedWith', 'offSample'];
 /** Filters that are very specific to particular annotations and should be cleared when navigating to other annotations */
 export const ANNOTATION_SPECIFIC_FILTERS: FilterKey[] = ['compoundName', 'adduct', 'mz', 'colocalizedWith', 'colocalizationSamples'];
 

--- a/metaspace/webapp/src/modules/Filters/url.ts
+++ b/metaspace/webapp/src/modules/Filters/url.ts
@@ -31,6 +31,7 @@ const FILTER_TO_URL: Record<FilterKey, string> = {
   metadataType: 'mdtype',
   colocalizedWith: 'colo',
   colocalizationSamples: 'locs',
+  offSample: 'offs',
 };
 
 const URL_TO_FILTER = invert(FILTER_TO_URL) as Record<string, FilterKey>;

--- a/metaspace/webapp/src/store/getters.js
+++ b/metaspace/webapp/src/store/getters.js
@@ -17,6 +17,7 @@ export default {
   gqlAnnotationFilter(state, getters) {
     const filter = getters.filter;
     const colocalizationAlgo = getters.settings.annotationView.colocalizationAlgo;
+
     const f = {
       database: filter.database,
       compoundQuery: filter.compoundName,
@@ -25,6 +26,7 @@ export default {
       colocalizedWith: filter.colocalizedWith,
       colocalizationAlgo,
       colocalizationSamples: filter.colocalizationSamples,
+      offSample: filter.offSample == null ? undefined : !!filter.offSample,
     };
 
     if (filter.minMSM)

--- a/metaspace/webapp/yarn.lock
+++ b/metaspace/webapp/yarn.lock
@@ -11106,10 +11106,10 @@ polytope-closest-point@^1.0.0:
   dependencies:
     numeric "^1.2.6"
 
-popper.js@1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.0.8.tgz#05c2cb34fdf78af99eb33337605a1384fbaffa32"
-  integrity sha1-BcLLNP33ivmeszM3YFoThPuv+jI=
+popper.js@^1.14.7:
+  version "1.14.7"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.7.tgz#e31ec06cfac6a97a53280c3e55e4e0c860e7738e"
+  integrity sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ==
 
 portfinder@^1.0.9:
   version "1.0.13"


### PR DESCRIPTION
@intsco Please review engine & graphql changes

@Ren22 If you have time, please review the webapp changes. If not, don't worry about it.


In `engine`:

* Adds off-sample fields to ElasticSearch
* Changes update-daemon to do off-sample analysis in two daemon actions: one high-priority `INDEX`, and one low-priority `CLASSIFY_OFF_SAMPLE` (which also indexes afterwards)
* Updates `scripts.run_off_sample` to also reindex the dataset
* Added a test fixture to `test_sm_daemons` that resets the test queues before the tests. This was needed because `run_daemons` would only cause 1 message from each queue to be processed, and annotation jobs now produce 2 messages - `INDEX` and `CLASSIFY_OFF_SAMPLE`. This seemed to cause the second test to not process its intended annotation message.

In `graphql`:

* Adds API for viewing, filtering & sorting annotations by off-sample label/prob
* Ignores unrecognized status queue messages so that `CLASSIFY_OFF_SAMPLE` doesn't log errors

In `webapp`:

* Adds UI for viewing, filtering & sorting by the off-sample label
* Adds 3 feature flags:
    * `off_sample` for hiding/showing the off-sample filter & diagnostics indicator
    * `off_sample_col` that shows the off-sample `prob` in the annotations table so that we can easily it. We don't have much space in that table, so I don't want it permanently visible. It can be temporarily activated by adding `?feat=off_sample_col` to the URL
    * `new_feature_popup` that enables the "New Feature" popups. If this and `off_sample` are activated, the popup should appear when you first visit the Annotations page. If you dismiss it and want to see it again, run this in the browser console: `localStorage.removeItem('dismissedFeaturePopups')`
