### PR TITLE
Show ion intensity under cursor

### DIFF
--- a/metaspace/webapp/src/components/IonImageViewer.vue
+++ b/metaspace/webapp/src/components/IonImageViewer.vue
@@ -306,13 +306,13 @@
          const sY = scrollDistance(event);
 
          const newZoom = Math.max(this.minZoom, Math.min(this.maxZoom, this.zoom - this.zoom * sY / 10.0));
-         const rect = event.currentTarget.getBoundingClientRect();
+         const rect = this.$refs.imageLoader.getBoundingClientRect();
 
          // Adjust the offsets so that the pixel under the mouse stays still while the image expands around it
          const mouseXOffset = (event.clientX - (rect.left + rect.right) / 2) / this.zoom;
          const mouseYOffset = (event.clientY - (rect.top + rect.bottom) / 2) / this.zoom;
-         const xOffset = this.xOffset * (this.zoom / newZoom) + mouseXOffset * (this.zoom / newZoom - 1);
-         const yOffset = this.yOffset * (this.zoom / newZoom) + mouseYOffset * (this.zoom / newZoom - 1);
+         const xOffset = this.xOffset + mouseXOffset * (this.zoom / newZoom - 1);
+         const yOffset = this.yOffset + mouseYOffset * (this.zoom / newZoom - 1);
 
          this.$emit('move', {zoom: newZoom, xOffset, yOffset});
 
@@ -384,8 +384,9 @@
        const rect = this.$refs.imageLoader.getBoundingClientRect();
        if (this.ionImage != null) {
          const { width = 0, height = 0 } = this.ionImage;
-         const x = Math.floor((event.clientX - 2 - (rect.left + rect.right) / 2) / this.zoom - this.xOffset + width / 2);
-         const y = Math.floor((event.clientY - 2 - (rect.top + rect.bottom) / 2) / this.zoom - this.yOffset + height / 2);
+         // Includes a 2px offset up and left so that the selected pixel is less obscured by the mouse cursor
+         const x = Math.floor((event.clientX - (rect.left + rect.right) / 2 - 2) / this.zoom - this.xOffset + width / 2);
+         const y = Math.floor((event.clientY - (rect.top + rect.bottom) / 2 - 2) / this.zoom - this.yOffset + height / 2);
 
          this.cursorPixelPos = [x, y];
        } else {

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImageHeader.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImageHeader.vue
@@ -39,7 +39,7 @@ interface colorObjType {
 }
 
 @Component({
-    name: 'main-image',
+    name: 'main-image-header',
     components: { IonImageSettings }
 })
 export default class MainImageHeader extends Vue {

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -444,9 +444,9 @@
 
  .dataset-item {
    position: relative;
-   box-sizing: border-box;
    border-radius: 5px;
-   flex: 1 1 100%;
+   // Can't use box-sizing:border-box due to IE11 flexbox limitations, so instead using `calc(100% - 2px)`
+   flex: 1 1 calc(100% - 2px);
    min-height: 120px;
    min-width: 600px;
    max-width: 950px;

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetList.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetList.vue
@@ -70,10 +70,9 @@
   .allow-double-column {
     >.dataset-item {
       width: calc(50% - 8px);
+      flex-basis: calc(50% - 8px);
       // NOTE: In IE11, box-sizing:border-box is ignored in flex-basis calculations, so it's reverted to the
-      // default value here. Single-column
-      //
-      /*box-sizing: content-box;*/
+      // default value here.
     }
   }
 


### PR DESCRIPTION
Resolves #281 

![image](https://user-images.githubusercontent.com/26366936/57611840-00b48f00-7574-11e9-966c-b1ac49574e9c.png)

Includes three unrelated minor fixes:
* Correctly calculate the change of offset when zooming in/out of ion images
* Fix an issue in the width of DatasetList which made Firefox always show it as only one column
* Fix the component name of `MainImageHeader`. This only showed up in the dev tools, but it was confusing.