### PR TITLE
Persistent feature flags & hidden mol DBs

### DIFF
--- a/ansible/aws/templates/all.yml.template
+++ b/ansible/aws/templates/all.yml.template
@@ -197,6 +197,7 @@ sm_webapp_features:
   off_sample_col: false
   new_feature_popups: true
   optical_transform: true
+  all_dbs: false
 
 sm_activate_venv: source {{ miniconda_prefix }}/bin/activate {{ miniconda_env.name }}
 

--- a/metaspace/graphql/schema.graphql
+++ b/metaspace/graphql/schema.graphql
@@ -92,6 +92,7 @@ type MolecularDatabase {
   name: String!
   version: String!
   default: Boolean!
+  hidden: Boolean!  # True if database is deprecated/superseded and would not be useful for most users
 }
 
 type ColocalizationAlgo {

--- a/metaspace/graphql/utils.js
+++ b/metaspace/graphql/utils.js
@@ -51,8 +51,9 @@ const logger = new (winston.Logger)({
 });
 
 const deprecatedMolDBs = new Set([
-  'HMDB', 'ChEBI', 'LIPID_MAPS', 'SwissLipids', 'COTTON_HMDB',
-  'HMDB-v2.5', 'HMDB-v2.5-cotton', 'EMBL-dev1', 'EMBL-dev2',
+  'HMDB', 'ChEBI', 'LIPID_MAPS', 'SwissLipids', 'COTTON_HMDB', 'HMDB-v2.5', 'HMDB-v2.5-cotton',
+  // EMBL-dev1/2 aren't actually deprecated. Their inclusion in this list is just for hiding them from normal users in the UI
+  'EMBL-dev1', 'EMBL-dev2',
 ]);
 
 async function fetchMolecularDatabases() {

--- a/metaspace/graphql/utils.js
+++ b/metaspace/graphql/utils.js
@@ -50,7 +50,10 @@ const logger = new (winston.Logger)({
   ]
 });
 
-const deprecatedMolDBs = new Set(['HMDB', 'ChEBI', 'LIPID_MAPS', 'SwissLipids', 'COTTON_HMDB']);
+const deprecatedMolDBs = new Set([
+  'HMDB', 'ChEBI', 'LIPID_MAPS', 'SwissLipids', 'COTTON_HMDB',
+  'HMDB-v2.5', 'HMDB-v2.5-cotton', 'EMBL-dev1', 'EMBL-dev2',
+]);
 
 async function fetchMolecularDatabases() {
   const host = config.services.moldb_service_host,

--- a/metaspace/webapp/src/api/metadata.ts
+++ b/metaspace/webapp/src/api/metadata.ts
@@ -96,12 +96,12 @@ export const fetchOptionListsQuery = gql`query fetchOptionListsQuery {
   maldiMatrices: metadataSuggestions(field: "Sample_Preparation.MALDI_Matrix", query: "", limit: 1000)
   analyzerTypes: metadataSuggestions(field: "MS_Analysis.Analyzer", query: "", limit: 1000)
   colocalizationAlgos {id, name}
-  molecularDatabases: molecularDatabases(hideDeprecated: false){name, default}
+  molecularDatabases: molecularDatabases(hideDeprecated: false, onlyLastVersion: false){name, default, hidden}
   adducts: adductSuggestions{adduct, charge}
 }`;
 
 export const metadataOptionsQuery = gql`query metadataOptionsQuery {
-  molecularDatabases: molecularDatabases{name, default}
+  molecularDatabases: molecularDatabases(hideDeprecated: false, onlyLastVersion: false){name, default, hidden}
   adducts: adductSuggestions{adduct, charge}
 }`;
 

--- a/metaspace/webapp/src/components/DatasetInfo.vue
+++ b/metaspace/webapp/src/components/DatasetInfo.vue
@@ -13,7 +13,7 @@
 <script>
   import {defaultMetadataType, metadataSchemas} from '../assets/metadataRegistry';
   import {get, flatMap} from 'lodash-es';
-  import { safeJsonParse } from '../util'
+  import safeJsonParse from '../lib/safeJsonParse';
   import {optionalSuffixInParens} from '../lib/vueFilters';
 
   export default {

--- a/metaspace/webapp/src/config.ts
+++ b/metaspace/webapp/src/config.ts
@@ -30,6 +30,7 @@ interface Features {
   off_sample_col: boolean;
   new_feature_popups: boolean;
   optical_transform: boolean;
+  all_dbs: boolean;
 }
 
 interface ClientConfig {
@@ -61,6 +62,7 @@ const defaultConfig: ClientConfig = {
     off_sample_col: false,
     new_feature_popups: true,
     optical_transform: true,
+    all_dbs: false,
   }
 };
 

--- a/metaspace/webapp/src/config.ts
+++ b/metaspace/webapp/src/config.ts
@@ -1,5 +1,6 @@
 const fileConfig = require('./clientConfig.json');
 import {defaultsDeep} from 'lodash-es';
+import safeJsonParse from './lib/safeJsonParse';
 
 
 interface AWSConfig {
@@ -63,25 +64,41 @@ const defaultConfig: ClientConfig = {
   }
 };
 
+const FEATURE_STORAGE_KEY = 'featureFlags';
+
 let config = defaultsDeep({}, fileConfig, defaultConfig) as ClientConfig;
 
 export const updateConfigFromQueryString = () => {
   if (typeof window !== 'undefined' && window.location && window.location.search) {
     // hackily parse the querystring because vue-router hasn't initialized yet and IE doesn't support the
     // URLSearchParams class that can do this properly
-    window.location.search
+    const queryStringFeatures = window.location.search
       .substring(1)
       .split('&')
       .filter(part => part.startsWith('feat='))
-      .forEach(features => {
-        features.substring('feat='.length)
-          .split(',')
-          .forEach(feat => {
-            const val = !feat.startsWith('-');
-            const key = val ? feat : feat.substring(1);
-            (config.features as any)[key] = val;
-          });
-      });
+      .map(features => features.substring('feat='.length).split(','))
+      .reduce((a, b) => a.concat(b), []);
+
+    const overrides: Partial<Features> = {};
+    if (queryStringFeatures.includes('reset')) {
+      localStorage.removeItem(FEATURE_STORAGE_KEY);
+    } else {
+      Object.assign(overrides, safeJsonParse(localStorage.getItem(FEATURE_STORAGE_KEY)));
+    }
+
+    queryStringFeatures.forEach(feat => {
+      const val = !feat.startsWith('-');
+      const key = (val ? feat : feat.substring(1));
+      if (key !== 'reset' && key !== 'save') {
+        overrides[key as keyof Features] = val;
+      }
+    });
+
+    Object.assign(config.features, overrides);
+
+    if (queryStringFeatures.includes('save')) {
+      localStorage.setItem(FEATURE_STORAGE_KEY, JSON.stringify(overrides));
+    }
   }
 };
 

--- a/metaspace/webapp/src/lib/safeJsonParse.ts
+++ b/metaspace/webapp/src/lib/safeJsonParse.ts
@@ -1,0 +1,12 @@
+import * as Raven from 'raven-js';
+
+export default function safeJsonParse(json: string | null | undefined) {
+  if (json) {
+    try {
+      return JSON.parse(json);
+    } catch (err) {
+      Raven.captureException(err);
+    }
+  }
+  return undefined;
+}

--- a/metaspace/webapp/src/modules/Account/signInReturnUrl.ts
+++ b/metaspace/webapp/src/modules/Account/signInReturnUrl.ts
@@ -1,7 +1,7 @@
 import {Route} from 'vue-router';
 import * as cookie from 'js-cookie';
 import {pick} from 'lodash-es';
-import {safeJsonParse} from '../../util';
+import safeJsonParse from '../../lib/safeJsonParse';
 
 const STORAGE_KEY = 'signInRedirect';
 const DEFAULT_ROUTE = {path:'/datasets'};

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
@@ -16,7 +16,7 @@
  import { Component, Prop } from 'vue-property-decorator';
  import { Location } from 'vue-router';
  import { currentUserRoleQuery, CurrentUserRoleResult} from '../../api/user';
- import { safeJsonParse } from '../../util';
+ import safeJsonParse from '../../lib/safeJsonParse';
  import {omit, pick, sortBy, throttle} from 'lodash-es';
  import {ANNOTATION_SPECIFIC_FILTERS} from '../Filters/filterSpecs';
  import config from '../../config';

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/RelatedAnnotations.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/RelatedAnnotations.vue
@@ -58,7 +58,7 @@
 
 <script>
   import {get, omit} from 'lodash-es';
-  import {renderMolFormula, safeJsonParse} from '../../../../util';
+  import {renderMolFormula} from '../../../../util';
   import ImageLoader from '../../../../components/ImageLoader.vue';
   import { relatedAnnotationsQuery } from '../../../../api/annotation';
   import {encodeParams, stripFilteringParams} from '../../../Filters';

--- a/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
+++ b/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
@@ -37,7 +37,7 @@
   import config from '../../config';
   import Component from 'vue-class-component';
   import {debounce, isArray} from 'lodash-es';
-  import {safeJsonParse} from '../../util';
+  import safeJsonParse from '../../lib/safeJsonParse';
 
   interface FeatureSpec {
     name: string;

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -145,7 +145,7 @@
  import {mdTypeSupportsOpticalImages} from '../../../util';
  import {encodeParams} from '../../Filters/index';
  import reportError from '../../../lib/reportError';
- import {safeJsonParse} from "../../../util";
+ import safeJsonParse from '../../../lib/safeJsonParse';
  import {plural} from '../../../lib/vueFilters';
 
  function removeUnderscores(str) {

--- a/metaspace/webapp/src/modules/Filters/__snapshots__/FilterPanel.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Filters/__snapshots__/FilterPanel.spec.ts.snap
@@ -350,7 +350,6 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
       <div slot-key="default">
         <mock-el-select filterable="true" value="HMDBv4">
           <mock-el-option label="molecularDatabases.0.name" value="molecularDatabases.0.name"></mock-el-option>
-          <mock-el-option label="molecularDatabases.1.name" value="molecularDatabases.1.name"></mock-el-option>
         </mock-el-select>
       </div>
       <div slot-key="reference">

--- a/metaspace/webapp/src/modules/Filters/filterSpecs.ts
+++ b/metaspace/webapp/src/modules/Filters/filterSpecs.ts
@@ -103,7 +103,9 @@ export const FILTER_SPECIFICATIONS: Record<FilterKey, FilterSpecification> = {
     initialValue: lists => lists.molecularDatabases
                                 .filter(d => d.default)
                                 .map(d => d.name)[0],
-    options: lists => lists.molecularDatabases.map(d => d.name),
+    options: lists => lists.molecularDatabases
+      .filter(d => config.features.all_dbs || !d.hidden)
+      .map(d => d.name),
     removable: false
   },
 

--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -69,7 +69,7 @@
  import FormSection from './sections/FormSection.vue';
  import DataManagementSection from './sections/DataManagementSection.vue'
  import emailRegex from '../../lib/emailRegex';
- import { safeJsonParse } from '../../util'
+ import safeJsonParse from '../../lib/safeJsonParse';
 
  const factories = {
    'string': schema => schema.default || '',

--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -70,6 +70,7 @@
  import DataManagementSection from './sections/DataManagementSection.vue'
  import emailRegex from '../../lib/emailRegex';
  import safeJsonParse from '../../lib/safeJsonParse';
+ import config from '../../config';
 
  const factories = {
    'string': schema => schema.default || '',
@@ -226,7 +227,14 @@
          query: metadataOptionsQuery,
          fetchPolicy: 'cache-first',
        });
-       return data;
+       if (!config.features.all_dbs) {
+         return {
+           ...data,
+           molecularDatabases: data.molecularDatabases.filter(db => !db.hidden),
+         }
+       } else {
+         return data;
+       }
      },
 
      async initializeForm() {

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -653,28 +653,6 @@ exports[`MetadataEditor should match snapshot 1`] = `
                                 <div slot-key="reference"><span class="desc-cite">Citation</span></div>
                               </mock-el-popover>
                             </div>
-                            <div>
-                              <b>EMBL-dev1:</b>
-                              A molecular database used for developmental and testing purposes by the Alexandrov team at EMBL.
-                              <mock-el-popover trigger="hover" placement="top">
-                                <div slot-key="default">
-                                  <div class="desc-cite-popover">
-                                    <i>EMBL</i>, developers database 1</div>
-                                </div>
-                                <div slot-key="reference"><span class="desc-cite">Citation</span></div>
-                              </mock-el-popover>
-                            </div>
-                            <div>
-                              <b>EMBL-dev2:</b>
-                              A molecular database used for developmental and testing purposes by the Alexandrov team at EMBL.
-                              <mock-el-popover trigger="hover" placement="top">
-                                <div slot-key="default">
-                                  <div class="desc-cite-popover">
-                                    <i>EMBL</i>, developers database 2</div>
-                                </div>
-                                <div slot-key="reference"><span class="desc-cite">Citation</span></div>
-                              </mock-el-popover>
-                            </div>
                           </div>
                         </div>
                         <div slot-key="reference">
@@ -686,7 +664,6 @@ exports[`MetadataEditor should match snapshot 1`] = `
                     <div class="el-form-item__content">
                       <mock-el-select value="molecularDatabases.0.name" required="true" multiple="" multiple-limit="3">
                         <mock-el-option value="molecularDatabases.0.name" label="molecularDatabases.0.name"></mock-el-option>
-                        <mock-el-option value="molecularDatabases.1.name" label="molecularDatabases.1.name"></mock-el-option>
                       </mock-el-select>
                       <!---->
                     </div>

--- a/metaspace/webapp/src/modules/MetadataEditor/inputs/DatabaseDescriptions.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/inputs/DatabaseDescriptions.vue
@@ -97,22 +97,6 @@
         <span slot="reference" class="desc-cite">Citation</span>
       </el-popover>
     </div>
-    <div>
-      <b>EMBL-dev1:</b>
-      A molecular database used for developmental and testing purposes by the Alexandrov team at EMBL.
-      <el-popover trigger="hover" placement="top">
-        <div class="desc-cite-popover"><i>EMBL</i>, developers database 1</div>
-        <span slot="reference" class="desc-cite">Citation</span>
-      </el-popover>
-    </div>
-    <div>
-      <b>EMBL-dev2:</b>
-      A molecular database used for developmental and testing purposes by the Alexandrov team at EMBL.
-      <el-popover trigger="hover" placement="top">
-        <div class="desc-cite-popover"><i>EMBL</i>, developers database 2</div>
-        <span slot="reference" class="desc-cite">Citation</span>
-      </el-popover>
-    </div>
   </div>
 </template>
 <script>

--- a/metaspace/webapp/src/util.ts
+++ b/metaspace/webapp/src/util.ts
@@ -1,6 +1,5 @@
 import config from './config';
-import * as Raven from 'raven-js';
-import sanitizeHtml from 'sanitize-html'
+import sanitizeHtml from 'sanitize-html';
 
 const fuConfig = config.fineUploader;
 
@@ -95,17 +94,6 @@ function getOS() {
   return os;
 }
 
-function safeJsonParse(json: string | null | undefined) {
-  if (json) {
-    try {
-      return JSON.parse(json);
-    } catch (err) {
-      Raven.captureException(err);
-    }
-  }
-  return undefined;
-}
-
 function sanitizeIt(descriptionText: string) {
   return sanitizeHtml(
     descriptionText,
@@ -132,6 +120,5 @@ export {
   scrollDistance,
   mdTypeSupportsOpticalImages,
   getOS,
-  safeJsonParse,
   sanitizeIt
 };


### PR DESCRIPTION
URL-triggered feature flags can now be persisted by specifying the "save" feature, e.g. `https://metaspace2020.eu/?feat=all_dbs,save` or `https://metaspace2020.eu/?feat=-all_dbs,save` (the `-` before `all_dbs` turns the feature off even if it's globally enabled). The saved overrides can be cleared by using the "reset" feature i.e. `https://metaspace2020.eu/?feat=reset`

I've added a feature flag for showing hidden DBs and added HMDB-v2.5 and the EMBL-dev DBs to the "deprecated" list to hide them. They're now only accessible after someone goes to https://metaspace2020.eu/?feat=all_dbs,save