### PR TITLE
Pixel intensity display fixes

### DIFF
--- a/metaspace/webapp/src/api/annotation.ts
+++ b/metaspace/webapp/src/api/annotation.ts
@@ -122,6 +122,7 @@ gql`query GetRelatedAnnotations($datasetId: String!, $filter: AnnotationFilter!,
       fdrLevel
       isotopeImages {
         url
+        minIntensity
         maxIntensity
       }
       possibleCompounds {

--- a/metaspace/webapp/src/components/ImageLoader.vue
+++ b/metaspace/webapp/src/components/ImageLoader.vue
@@ -46,6 +46,10 @@
     imageFitParams!: any;
     @Prop()
     imageStyle!: any;
+    @Prop()
+    minIntensity?: number;
+    @Prop()
+    maxIntensity?: number;
 
     containerWidth = 500;
     containerHeight = 500;
@@ -76,7 +80,7 @@
           const png = await loadPngFromUrl((config.imageStorage || '') + newUrl);
 
           if (newUrl === this.src) {
-            this.ionImage = processIonImage(png);
+            this.ionImage = processIonImage(png, this.minIntensity, this.maxIntensity);
             this.ionImageIsLoading = false;
           }
         } catch (err) {

--- a/metaspace/webapp/src/components/IonImageViewer.vue
+++ b/metaspace/webapp/src/components/IonImageViewer.vue
@@ -152,6 +152,10 @@
      scaleBarColor: {
        type: String,
        default: '#000000'
+     },
+     showPixelIntensity: {
+       type: Boolean,
+       default: false
      }
    },
    data () {
@@ -277,7 +281,11 @@
      },
 
      pixelIntensityStyle() {
-       if (this.ionImage != null && this.cursorPixelPos != null && this.cursorOverPixelIntensity != null) {
+       if (this.showPixelIntensity
+         && this.ionImage != null
+         && this.cursorPixelPos != null
+         && this.cursorOverPixelIntensity != null) {
+
          const baseX = this.width / 2 + (this.xOffset - this.ionImage.width / 2) * this.zoom;
          const baseY = this.height / 2 + (this.yOffset - this.ionImage.height / 2) * this.zoom;
          const [cursorX, cursorY] = this.cursorPixelPos;

--- a/metaspace/webapp/src/components/IonImageViewer.vue
+++ b/metaspace/webapp/src/components/IonImageViewer.vue
@@ -47,7 +47,7 @@
         popper-class="pointer-events-none"
         placement="top"
       >
-        <div :style="pixelIntensityStyle" />
+        <div :style="pixelIntensityStyle" class="pixel-intensity" />
       </el-tooltip>
     </div>
 
@@ -294,10 +294,6 @@
            top: (baseY + cursorY * this.zoom - 0.5) + 'px',
            width: `${this.zoom - 0.5}px`,
            height: `${this.zoom - 0.5}px`,
-           position: 'absolute',
-           border: '1px solid red',
-           display: 'block',
-           zIndex: 3,
          }
        } else {
          return null;
@@ -466,7 +462,13 @@
    transition: 0.7s;
  }
 
-
+  .pixel-intensity {
+    position: absolute;
+    border: 1px solid red;
+    display: block;
+    z-index: 3;
+    pointer-events: none;
+  }
 </style>
 <style>
   /* Unscoped, because the tooltip is appended to document.body */

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
@@ -32,6 +32,9 @@
                               v-bind="imageLoaderSettings"
                               v-if="img.url !== null"
                               style="overflow: hidden"
+                              :minIntensity="img.minIntensity"
+                              :maxIntensity="img.maxIntensity"
+                              showPixelIntensity
                 />
             </div>
         </el-col>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
@@ -19,6 +19,7 @@
               :yOffset="imageLoaderSettings.imagePosition.yOffset"
               ref="imageLoader"
               scrollBlock
+              showPixelIntensity
               class="image-loader"
               v-bind="imageLoaderSettings"
               @move="handleImageMove"

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/RelatedAnnotations.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/RelatedAnnotations.vue
@@ -22,6 +22,9 @@
           :imageFitParams="{areaWidth: 260, areaHeight: 250, areaMinHeight: 50}"
           v-bind="imageLoaderSettings"
           :colormap="colormap"
+          :minIntensity="other.isotopeImages[0].minIntensity"
+          :maxIntensity="other.isotopeImages[0].maxIntensity"
+          showPixelIntensity
         />
         <el-popover
           trigger="hover"


### PR DESCRIPTION
* Disable pixel intensity popup on optical image alignment page
* Fix pixel intensity display in related annotations & diagnostics (without `minIntensity`/`maxIntensity` it was defaulting to a range of 0 to 1