### PR TITLE
Filter out null values from isotopeImages

### DIFF
--- a/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
+++ b/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
@@ -111,15 +111,17 @@ const Annotation: FieldResolversFor<Annotation, ESAnnotation | ESAnnotationWithC
 
   isotopeImages(hit) {
     const {iso_image_ids, centroid_mzs, total_iso_ints, min_iso_ints, max_iso_ints} = hit._source;
-    return centroid_mzs.map(function(mz, i) {
-      return {
-        url: iso_image_ids[i] !== null ? `/${hit._source.ds_ion_img_storage}${config.img_upload.categories.iso_image.path}${iso_image_ids[i]}` : null,
-        mz: parseFloat(mz as any),
-        totalIntensity: total_iso_ints[i],
-        minIntensity: min_iso_ints[i],
-        maxIntensity: max_iso_ints[i],
-      };
-    });
+    return centroid_mzs
+      .map(function(mz, i) {
+        return {
+          mz: parseFloat(mz as any),
+          url: iso_image_ids[i] !== null ? `/${hit._source.ds_ion_img_storage}${config.img_upload.categories.iso_image.path}${iso_image_ids[i]}` : null,
+          totalIntensity: total_iso_ints[i],
+          minIntensity: min_iso_ints[i],
+          maxIntensity: max_iso_ints[i],
+        };
+      })
+      .filter(mzImage => mzImage.mz != null && mzImage.totalIntensity != null && mzImage.minIntensity != null && mzImage.maxIntensity != null);
   },
 
   async colocalizationCoeff(hit, args: {colocalizationCoeffFilter: ColocalizationCoeffFilter | null}, context) {


### PR DESCRIPTION
I'm merging & deploying this immediately as this issue is quite obvious on prod, e.g. https://metaspace2020.eu/annotations?fdr=0.5&sort=mz

The issue is that for some annotations, e.g. "2018-04-17_02h07m06s_HMDB-v4_2018-04-09_CH2O3_plus_H", `centroid_mzs` has 4 values but `min_iso_ints` only has 3. e.g.: 
```json
> curl http://localhost:9200/sm/annotation/2018-04-17_02h07m06s_HMDB-v4_2018-04-09_CH2O3_plus_H
{
  "_index": "sm-yang",
  "_type": "annotation",
  "_id": "2018-04-17_02h07m06s_HMDB-v4_2018-04-09_CH2O3_plus_H",
  "_version": 3,
  "found": true,
  "_source": {
    "total_iso_ints": [
      62900864.66796875,
      64990553.53515625,
      64048036.80859375
    ],
    "min_iso_ints": [
      0,
      0,
      0
    ],
    "max_iso_ints": [
      240057.6015625,
      281769.234375,
      291419.671875
    ],
    "iso_image_ids": [
      "cabb5579eeb395273a78b6cb4385e955",
      "bc02fcc3cce704bb6e442e5c427f8ece",
      "6b0597ae582a09923b5c53af36f24336",
      null
    ],
    "centroid_mzs": [
      63.00764840920746,
      64.01106217023735,
      65.01192747564579,
      0.0
    ],
    "mz": 63.00764840920746
  }
}
```

When a null/undefined `minIntensity` is returned via graphql, apollo detects that it violates the schema and returns an error to the client, preventing anything from being rendered in the browser.

If the `graphql_mocks` feature flag was previously on, but is now off, that would explain why this hasn't happened before.