### PR TITLE
Improve ds segmentation speed and fix OOM error in process segment

### DIFF
--- a/metaspace/engine/sm/engine/annotation_job.py
+++ b/metaspace/engine/sm/engine/annotation_job.py
@@ -15,7 +15,7 @@ from sm.engine.msm_basic.formula_validator import METRICS
 from sm.engine.msm_basic.msm_basic_search import MSMSearch
 from sm.engine.db import DB
 from sm.engine.search_results import SearchResults
-from sm.engine.util import SMConfig, split_s3_path
+from sm.engine.util import SMConfig, split_s3_path, find_file_by_ext
 from sm.engine.es_export import ESExporter
 from sm.engine.mol_db import MolecularDB
 from sm.engine.queue import QueuePublisher, SM_DS_STATUS
@@ -85,9 +85,8 @@ class AnnotationJob(object):
 
     def create_imzml_parser(self):
         logger.info('Parsing imzml')
-        imzml_path = next(str(p) for p in Path(self._ds_data_path).iterdir()
-                          if str(p).lower().endswith('.imzml'))
-        return ImzMLParser(imzml_path)
+        imzml_path = find_file_by_ext(self._ds_data_path, 'imzml')
+        return ImzMLParser(imzml_path, parse_lib='ElementTree')
 
     def _run_annotation_jobs(self, imzml_parser, moldb_ids):
         if moldb_ids:

--- a/metaspace/engine/sm/engine/msm_basic/msm_basic_search.py
+++ b/metaspace/engine/sm/engine/msm_basic/msm_basic_search.py
@@ -11,7 +11,7 @@ from sm.engine.formula_parser import generate_ion_formula
 from sm.engine.formula_centroids import CentroidsGenerator
 from sm.engine.isocalc_wrapper import IsocalcWrapper, ISOTOPIC_PEAK_N
 from sm.engine.util import SMConfig
-from sm.engine.msm_basic.formula_imager import create_process_segment
+from sm.engine.msm_basic.formula_imager import create_process_segment, ds_dims
 from sm.engine.msm_basic.segmenter import define_ds_segments, segment_spectra, segment_centroids, clip_centroids_df, \
     calculate_centroids_segments_n, spectra_sample_gen, check_spectra_quality, calculate_chunk_sp_n
 
@@ -94,7 +94,9 @@ class MSMSearch(object):
         return formula_centroids
 
     def process_segments(self, centr_segm_n, func):
-        results_rdd = (self._sc.parallelize(range(centr_segm_n), numSlices=centr_segm_n)
+        centr_segm_inds = np.arange(centr_segm_n)
+        np.random.shuffle(centr_segm_inds)
+        results_rdd = (self._sc.parallelize(centr_segm_inds, numSlices=centr_segm_n)
                        .map(func)
                        .persist(storageLevel=StorageLevel.MEMORY_AND_DISK))
         return results_rdd
@@ -111,7 +113,7 @@ class MSMSearch(object):
         for file_path in path.iterdir():
             self._sc.addFile(str(file_path))
 
-    def remove_temp_files(self):
+    def remove_spark_temp_files(self):
         logger.debug(f'Cleaning spark master temp dir {SparkFiles.getRootDirectory()}')
         rmtree(SparkFiles.getRootDirectory(), ignore_errors=True)
 
@@ -154,7 +156,7 @@ class MSMSearch(object):
                                          self._imzml_parser.mzPrecision, ds_segm_size_mb)
 
         sample_sp_n = int(len(self._imzml_parser.coordinates) * sample_ratio)
-        chunk_sp_n = calculate_chunk_sp_n(sample_mzs.nbytes, sample_sp_n)
+        chunk_sp_n = calculate_chunk_sp_n(sample_mzs.nbytes, sample_sp_n, max_chunk_size_mb=1000)
 
         ds_segments_path = self._ds_data_path / 'ds_segments'
         coordinates = [coo[:2] for coo in self._imzml_parser.coordinates]
@@ -166,7 +168,7 @@ class MSMSearch(object):
         centr_df = clip_centroids_df(centroids_df, mz_min=ds_segments[0, 0], mz_max=ds_segments[-1, 1])
 
         centr_segments_path = self._ds_data_path / 'centr_segments'
-        centr_segm_n = calculate_centroids_segments_n(centr_df, ds_segments, ds_segm_size_mb)
+        centr_segm_n = calculate_centroids_segments_n(centr_df, ds_dims(coordinates))
         segment_centroids(centr_df, centr_segm_n, centr_segments_path)
 
         logger.info('Putting centroids segments to workers')
@@ -178,7 +180,7 @@ class MSMSearch(object):
         results_rdd = self.process_segments(centr_segm_n, process_centr_segment)
         formula_metrics_df, formula_images_rdd = merge_results(results_rdd, formula_centroids.formulas_df)
 
-        self.remove_temp_files()
+        self.remove_spark_temp_files()
 
         # Compute fdr for each moldb search results
         for moldb, fdr in moldb_fdr_list:

--- a/metaspace/engine/sm/engine/msm_basic/segmenter.py
+++ b/metaspace/engine/sm/engine/msm_basic/segmenter.py
@@ -46,7 +46,7 @@ def define_ds_segments(sample_mzs, total_mz_n, mz_precision, ds_segm_size_mb=5):
     float_prec = 4 if mz_precision == 'f' else 8
     segm_arr_column_n = 3  # sp_idx, mzs, ints
     segm_n = segm_arr_column_n * (total_mz_n * float_prec) // (ds_segm_size_mb * 2**20)
-    segm_n = max(16, int(segm_n))
+    segm_n = max(1, int(segm_n))
 
     segm_bounds_q = [i * 1 / segm_n for i in range(0, segm_n + 1)]
     segm_lower_bounds = np.quantile(sample_mzs, segm_bounds_q)

--- a/metaspace/engine/sm/engine/msm_basic/segmenter.py
+++ b/metaspace/engine/sm/engine/msm_basic/segmenter.py
@@ -1,5 +1,5 @@
 import logging
-from collections import defaultdict
+from math import ceil
 from shutil import rmtree
 import pandas as pd
 import numpy as np
@@ -46,7 +46,7 @@ def define_ds_segments(sample_mzs, total_mz_n, mz_precision, ds_segm_size_mb=5):
     float_prec = 4 if mz_precision == 'f' else 8
     segm_arr_column_n = 3  # sp_idx, mzs, ints
     segm_n = segm_arr_column_n * (total_mz_n * float_prec) // (ds_segm_size_mb * 2**20)
-    segm_n = max(1, int(segm_n))
+    segm_n = max(16, int(segm_n))
 
     segm_bounds_q = [i * 1 / segm_n for i in range(0, segm_n + 1)]
     segm_lower_bounds = np.quantile(sample_mzs, segm_bounds_q)
@@ -57,10 +57,14 @@ def define_ds_segments(sample_mzs, total_mz_n, mz_precision, ds_segm_size_mb=5):
 
 
 def segment_spectra_chunk(sp_mz_int_buf, mz_segments, ds_segments_path):
-    for segm_i, (l, r) in mz_segments:
-        segm_start, segm_end = np.searchsorted(sp_mz_int_buf[:, 1], (l, r))  # mz expected to be in column 1
+    segm_left_bounds, segm_right_bounds = zip(*mz_segments)
+
+    segm_starts = np.searchsorted(sp_mz_int_buf[:, 1], segm_left_bounds)  # mz expected to be in column 1
+    segm_ends = np.searchsorted(sp_mz_int_buf[:, 1], segm_right_bounds)
+
+    for segm_i, (start, end) in enumerate(zip(segm_starts, segm_ends)):
         pd.to_msgpack(ds_segments_path / f'ds_segm_{segm_i:04}.msgpack',
-                      sp_mz_int_buf[segm_start:segm_end],
+                      sp_mz_int_buf[start:end],
                       append=True)
 
 
@@ -89,18 +93,18 @@ def segment_spectra(imzml_parser, coordinates, chunk_sp_n, ds_segments, ds_segme
     mz_segments = ds_segments.copy()
     mz_segments[0, 0] = 0
     mz_segments[-1, 1] = MAX_MZ_VALUE
-    mz_segments = list(enumerate(mz_segments))
 
     sp_id_to_idx = get_pixel_indices(coordinates)
 
-    coord_chunk_it = chunk_list(coordinates, chunk_sp_n)
+    coord_chunks = list(chunk_list(coordinates, chunk_sp_n))
+    chunk_n = len(coord_chunks)
 
     sp_i = 0
     sp_inds_list, mzs_list, ints_list = [], [], []
-    for ch_i, coord_chunk in enumerate(coord_chunk_it):
-        logger.debug(f'Segmenting spectra chunk {ch_i}')
+    for ch_i, coord_chunk in enumerate(coord_chunks):
+        logger.debug(f'Segmenting spectra chunk {ch_i+1}/{chunk_n}')
 
-        for x, y in coord_chunk:
+        for _ in coord_chunk:
             mzs_, ints_ = imzml_parser.getspectrum(sp_i)
             mzs_, ints_ = map(np.array, [mzs_, ints_])
             sp_idx = sp_id_to_idx[sp_i]
@@ -127,24 +131,22 @@ def clip_centroids_df(centroids_df, mz_min, mz_max):
     return centr_df
 
 
-def calculate_centroids_segments_n(centr_df, ds_segments, ds_segm_size_mb):
-    ds_size_mb = len(ds_segments) * ds_segm_size_mb
-    data_per_centr_segm_mb = 50
-    peaks_per_centr_segm = 1e4
-    centr_segm_n = int(max(ds_size_mb // data_per_centr_segm_mb,
-                           centr_df.shape[0] // peaks_per_centr_segm,
-                           32))
+def calculate_centroids_segments_n(centr_df, image_dims):
+    rows, cols = image_dims
+    max_total_dense_images_size = 10 * 2 ** 30
+    peaks_per_centr_segm = int(max_total_dense_images_size / (rows * cols * 8))
+    centr_segm_n = max(16, ceil(centr_df.shape[0] / peaks_per_centr_segm))
     return centr_segm_n
 
 
-def segment_centroids(centr_df, segm_n, centr_segm_path):
-    logger.info(f'Segmenting centroids into {segm_n} segments')
+def segment_centroids(centr_df, centr_segm_n, centr_segm_path):
+    logger.info(f'Segmenting centroids into {centr_segm_n} segments')
 
     rmtree(centr_segm_path, ignore_errors=True)
     centr_segm_path.mkdir(parents=True)
 
     first_peak_df = centr_df[centr_df.peak_i == 0].copy()
-    segm_bounds_q = [i * 1 / segm_n for i in range(0, segm_n)]
+    segm_bounds_q = [i * 1 / centr_segm_n for i in range(0, centr_segm_n)]
     segm_lower_bounds = list(np.quantile(first_peak_df.mz, q) for q in segm_bounds_q)
 
     segment_mapping = np.searchsorted(segm_lower_bounds, first_peak_df.mz.values, side='right') - 1

--- a/metaspace/engine/sm/engine/util.py
+++ b/metaspace/engine/sm/engine/util.py
@@ -151,3 +151,8 @@ def split_s3_path(path):
     Returns a pair of (bucket, key)
     """
     return path.split('s3a://')[-1].split('/', 1)
+
+
+def find_file_by_ext(path, ext):
+    return next(str(p) for p in Path(path).iterdir()
+                if str(p).lower().endswith(ext))


### PR DESCRIPTION
When processing large datasets (>8GB), dataset segmentation slows down significantly and out of memory exceptions are thrown in Spark. This PR fixes that.

* Calculate centroids segment size based on ion image dimensions
* Segment spectra chunk: move np.searchsorted out of loop
* Use ElementTree XML-parsing library in ImzMlParser