### PR TITLE
Changes to support Ansible configs transfer to a separate repository

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,8 +1,7 @@
 .*
 *.retry
-vbox/group_vars/*.yml
-aws/*/group_vars/*.yml
-aws/*/hosts*
+aws/env
 aws/provision/elk-vars.yml
 *.ipynb
 *.pyc
+aws/vault_pass.txt

--- a/ansible/aws/ansible.cfg
+++ b/ansible/aws/ansible.cfg
@@ -3,6 +3,7 @@ roles_path = ../roles
 callback_plugins = /usr/share/ansible/plugins/callback
 allow_world_readable_tmpfiles = True
 host_key_checking = False
+vault_password_file = ./vault_pass.txt
 
 [ssh_connection]
 ssh_args = -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/ansible/roles/sm_cluster_autostart_app/tasks/main.yml
+++ b/ansible/roles/sm_cluster_autostart_app/tasks/main.yml
@@ -1,11 +1,15 @@
 ---
 
 - name: Make sure a folder for the config file exists
-  file: path={{ sm_ansible_home }}/aws/{{ stage }}/group_vars/ state=directory mode=0755
+  file: path={{ sm_ansible_home }}/aws/{{ stage }}/group_vars/all state=directory mode=0755
 
-- name: Upload {{ stage }}/group_vars/all.yml with variables resolved
-  template: src=../{{ stage }}/group_vars/all.yml dest={{ sm_ansible_home }}/aws/{{ stage }}/group_vars/all.yml
-            owner=ubuntu group=ubuntu mode=0600
+- name: Upload {{ stage }}/group_vars/all/vars.yml with variables resolved
+  template:
+    src: "../{{ stage }}/group_vars/all/vars.yml"
+    dest: "{{ sm_ansible_home }}/aws/{{ stage }}/group_vars/all/vars.yml"
+    owner: ubuntu
+    group: ubuntu
+    mode: "0600"
 
 - name: Update the inventory file
   command: "{{ sm_cluster_autostart_python }} update_inventory.py --stage={{ stage }}"


### PR DESCRIPTION
I added `ansible/aws/env` directory to `ansible/.gitignore` so having another repository in it shouldn't be a problem.