### PR TITLE
Production hotfixes

### DIFF
--- a/ansible/aws/templates/all.yml.template
+++ b/ansible/aws/templates/all.yml.template
@@ -182,7 +182,6 @@ sm_webapp_aws_access_key_id: WEBAPP_AWS_ACCESS_KEY_ID
 sm_webapp_aws_secret_access_key: WEBAPP_AWS_SECRET_ACCESS_KEY
 sm_webapp_s3_bucket: BUCKET-NAME-UPLOAD  # just plain bucket name
 sm_webapp_google_client_id: ""
-sm_webapp_sentry_dsn: ""
 sm_webapp_upload_destination: s3
 sm_webapp_jwt_secret: "{{ sm_graphql_jwt_secret }}"
 sm_webapp_redis_host: "{{ web_redis.host }}"
@@ -222,6 +221,8 @@ spark_env_extras_master:
 
 slack_channel:
 slack_webhook_url:
+
+sentry_dsn: ""
 
 ssl:
   path: ../files

--- a/metaspace/graphql/config/config.js.template
+++ b/metaspace/graphql/config/config.js.template
@@ -52,6 +52,10 @@ config.jwt = {};
 config.jwt.secret = "{{ sm_graphql_jwt_secret }}";
 config.jwt.algorithm = "HS256";
 
+config.sentry = {
+  dsn: "{{ sm_webapp_sentry_dsn }}",
+};
+
 config.aws = {
   aws_access_key_id: "{{ sm_graphql_aws_access_key_id }}",
   aws_secret_access_key: "{{ sm_graphql_aws_secret_access_key }}",

--- a/metaspace/graphql/config/config.js.template
+++ b/metaspace/graphql/config/config.js.template
@@ -50,6 +50,7 @@ config.slack.channel = "{{ sm_graphql_slack_channel }}";
 
 config.jwt = {};
 config.jwt.secret = "{{ sm_graphql_jwt_secret }}";
+config.jwt.algorithm = "HS256";
 
 config.aws = {
   aws_access_key_id: "{{ sm_graphql_aws_access_key_id }}",

--- a/metaspace/graphql/config/config.js.template
+++ b/metaspace/graphql/config/config.js.template
@@ -53,7 +53,7 @@ config.jwt.secret = "{{ sm_graphql_jwt_secret }}";
 config.jwt.algorithm = "HS256";
 
 config.sentry = {
-  dsn: "{{ sm_webapp_sentry_dsn }}",
+  dsn: "{{ sentry_dsn }}",
 };
 
 config.aws = {

--- a/metaspace/graphql/config/default.js
+++ b/metaspace/graphql/config/default.js
@@ -82,6 +82,10 @@ module.exports = {
     algorithm: 'HS256',
   },
 
+  sentry: {
+    dsn: null,
+  },
+
   google: {
     client_id: '',
     client_secret: '',

--- a/metaspace/graphql/config/default.js
+++ b/metaspace/graphql/config/default.js
@@ -79,6 +79,7 @@ module.exports = {
 
   jwt: {
     secret: 'secret',
+    algorithm: 'HS256',
   },
 
   google: {

--- a/metaspace/graphql/config/test.js
+++ b/metaspace/graphql/config/test.js
@@ -63,6 +63,7 @@ config.slack.channel = "";
 
 config.jwt = {};
 config.jwt.secret = "";
+config.jwt.algorithm = "HS256";
 
 config.aws = {
   aws_access_key_id: "",

--- a/metaspace/graphql/package.json
+++ b/metaspace/graphql/package.json
@@ -16,6 +16,7 @@
   },
   "license": "ISC",
   "dependencies": {
+    "@sentry/node": "5.4.0",
     "@types/amqplib": "^0.5.9",
     "@types/aws-sdk": "^2.7.0",
     "@types/bcrypt": "^2.0.0",

--- a/metaspace/graphql/package.json
+++ b/metaspace/graphql/package.json
@@ -56,7 +56,7 @@
     "html-entities": "^1.2.1",
     "json-schema-deref-sync": "^0.9.0",
     "jsondiffpatch": "^0.3.9",
-    "jwt-simple": "^0.5.1",
+    "jwt-simple": "^0.5.6",
     "knex": "^0.15.2",
     "lodash": "^4.17.4",
     "merge-graphql-schemas": "^1.5.3",

--- a/metaspace/graphql/server.js
+++ b/metaspace/graphql/server.js
@@ -110,7 +110,7 @@ async function createHttpServerAsync(config) {
       schema: executableSchema,
       onOperation(message, params) {
         const jwt = message.payload.jwt;
-        const user = jwt != null ? jwtSimple.decode(jwt, config.jwt.secret) : null;
+        const user = jwt != null ? jwtSimple.decode(jwt, config.jwt.secret, false, config.jwt.algorithm) : null;
         params.context = getContext(user && user.user, connection.manager, null, null);
         return params;
       }

--- a/metaspace/graphql/server.js
+++ b/metaspace/graphql/server.js
@@ -1,17 +1,20 @@
 // Before loading anything graphql-related, polyfill Symbol.asyncIterator because it's needed by TypeScript to support
 // async iterators, and the 'iterall' package imported by graphql-js will make its own symbol and reject others
 // if this isn't defined when 'iterall' is loaded
+
 Symbol.asyncIterator = Symbol.asyncIterator || Symbol.for("Symbol.asyncIterator");
 if (require('iterall').$$asyncIterator !== Symbol.asyncIterator) {
   throw new Error('iterall is using the wrong symbol for asyncIterator')
 }
 
+
 const bodyParser = require('body-parser'),
   compression = require('compression'),
-  config = require('config'),
+  config = require('./src/utils/config').default,
   express = require('express'),
   session = require('express-session'),
   connectRedis = require('connect-redis'),
+  Sentry = require('@sentry/node'),
   {ApolloServer} = require('apollo-server-express'),
   jwt = require('express-jwt'),
   jwtSimple = require('jwt-simple'),
@@ -28,8 +31,10 @@ const {createImgServerAsync} = require('./imageUpload.js'),
 
 // subscriptions setup
 const http = require('http'),
-      { execute, subscribe } = require('graphql'),
+      { execute, subscribe, GraphQLError } = require('graphql'),
       { SubscriptionServer } = require('subscriptions-transport-ws');
+
+const env = process.env.NODE_ENV || 'development';
 
 let wsServer = http.createServer((req, res) => {
   res.writeHead(404);
@@ -54,9 +59,55 @@ const configureSession = (app) => {
   }));
 };
 
+const configureSentryRequestHandler = (app) => {
+  // if (env !== 'development' && config.sentry.dsn) {
+  if (config.sentry.dsn) {
+    Sentry.init({ dsn: config.sentry.dsn });
+    // Sentry.Handlers.requestHandler should be the first middleware
+    app.use(Sentry.Handlers.requestHandler());
+  }
+};
+
+const configureSentryErrorHandler = (app) => {
+  // if (env !== 'development' && config.sentry.dsn) {
+  if (config.sentry.dsn) {
+    // Raven.errorHandler should go after all normal handlers/middleware, but before any other error handlers
+    app.use(Sentry.Handlers.errorHandler());
+  }
+};
+
+const formatGraphQLError = (error) => {
+  const {message, extensions, source, path, name, positions} = error;
+  if (error instanceof GraphQLError) {
+    logger.error(extensions.exception || message, source);
+  } else {
+    logger.error(error);
+
+  }
+
+  Sentry.withScope(scope => {
+    scope.setExtras({
+      source: source && source.body,
+      positions,
+      path,
+    });
+    if (path || name !== 'GraphQLError') {
+      scope.setTag('graphql', 'exec_error');
+      Sentry.captureException(error);
+    } else {
+      scope.setTag('graphql', 'bad_query');
+      Sentry.captureMessage(`GraphQLBadQuery: ${error.message}`)
+    }
+  });
+
+  return error;
+};
+
 async function createHttpServerAsync(config) {
   let app = express();
   let httpServer = http.createServer(app);
+
+  configureSentryRequestHandler(app);
 
   app.use(cors());
   app.use(compression());
@@ -82,14 +133,12 @@ async function createHttpServerAsync(config) {
         'editor.cursorShape': 'line',
       }
     },
-    formatError: error => {
-      const {message, extensions, source} = error;
-      logger.error(extensions.exception || message, source);
-      return error;
-    },
+    formatError: formatGraphQLError,
     introspection: true,
   });
   apollo.applyMiddleware({ app });
+
+  configureSentryErrorHandler(app);
 
   app.use(function (err, req, res, next) {
     res.status(err.status || 500);
@@ -112,6 +161,7 @@ async function createHttpServerAsync(config) {
         const jwt = message.payload.jwt;
         const user = jwt != null ? jwtSimple.decode(jwt, config.jwt.secret, false, config.jwt.algorithm) : null;
         params.context = getContext(user && user.user, connection.manager, null, null);
+        params.formatError = formatGraphQLError;
         return params;
       }
     }, {

--- a/metaspace/graphql/src/modules/auth/controller.ts
+++ b/metaspace/graphql/src/modules/auth/controller.ts
@@ -86,7 +86,7 @@ const configureJwt = (router: IRouter<any>) => {
         }
       };
     }
-    return JwtSimple.encode(payload as JwtPayload, config.jwt.secret);
+    return JwtSimple.encode(payload as JwtPayload, config.jwt.secret, config.jwt.algorithm);
   }
 
   // Gives a one-time token, which expires in 60 seconds.

--- a/metaspace/graphql/src/modules/dataset/controller/Subscription.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Subscription.ts
@@ -1,4 +1,5 @@
 import * as Amqplib from 'amqplib';
+import * as Sentry from '@sentry/node';
 import {esDatasetByID} from '../../../../esConnector';
 import {logger, wait} from '../../../../utils';
 import config from '../../../utils/config';
@@ -68,6 +69,7 @@ async function waitForChangeAndPublish(payload: DatasetStatusPayload) {
     }
   } catch (err) {
     logger.error(err);
+    Sentry.captureException(err);
   }
 
   logger.warn(`Failed to propagate dataset update for ${ds_id}`);

--- a/metaspace/graphql/src/utils/config.ts
+++ b/metaspace/graphql/src/utils/config.ts
@@ -1,5 +1,6 @@
 import * as config from 'config';
 import { IConfig } from 'config';
+import {TAlgorithm} from 'jwt-simple';
 
 export interface ImageCategoryConfig {
   type: string,
@@ -63,6 +64,7 @@ export interface Config {
   };
   jwt: {
     secret: string;
+    algorithm: TAlgorithm;
   };
   features: {
     graphqlMocks: boolean;

--- a/metaspace/graphql/src/utils/config.ts
+++ b/metaspace/graphql/src/utils/config.ts
@@ -66,6 +66,9 @@ export interface Config {
     secret: string;
     algorithm: TAlgorithm;
   };
+  sentry: {
+    dsn: string | null;
+  };
   features: {
     graphqlMocks: boolean;
     impersonation: boolean;

--- a/metaspace/graphql/yarn.lock
+++ b/metaspace/graphql/yarn.lock
@@ -3764,10 +3764,10 @@ jws@^3.1.5:
     jwa "^1.1.5"
     safe-buffer "^5.0.1"
 
-jwt-simple@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/jwt-simple/-/jwt-simple-0.5.1.tgz#79ea01891b61de6b68e13e67c0b4b5bda937b294"
-  integrity sha1-eeoBiRth3mto4T5nwLS1vak3spQ=
+jwt-simple@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/jwt-simple/-/jwt-simple-0.5.6.tgz#3357adec55b26547114157be66748995b75b333a"
+  integrity sha512-40aUybvhH9t2h71ncA1/1SbtTNCVZHgsTsTgqPUxGWDmUDrXyDf2wMNQKEbdBjbf4AI+fQhbECNTV6lWxQKUzg==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"

--- a/metaspace/graphql/yarn.lock
+++ b/metaspace/graphql/yarn.lock
@@ -206,6 +206,62 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@sentry/core@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.4.0.tgz#c40969ace80d637195bcc0ae6e5819f0c5e8ae46"
+  integrity sha512-luIJPftVnrW0ZKqs9W6YCpzKZVbOgQv8Ae7KB0Acsvqeoqjtx4zHHfVfu5VPkfhrOYN3NsM1IpApXtSdMiJCfg==
+  dependencies:
+    "@sentry/hub" "5.4.0"
+    "@sentry/minimal" "5.4.0"
+    "@sentry/types" "5.4.0"
+    "@sentry/utils" "5.4.0"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.4.0.tgz#03ab154bf2e2c33cb80d951b464de84ad2a6fbf9"
+  integrity sha512-X0iLNcouXcLWzuOJz2YjTn1E11b7pzcG98/iFTHW3AKPjnJNt92XRpjsDI2iT8+ODUDiFqaFmACSn2oZK80WGQ==
+  dependencies:
+    "@sentry/types" "5.4.0"
+    "@sentry/utils" "5.4.0"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.4.0.tgz#e3c569c68d6c09aad533832b2c713ad94bb2a511"
+  integrity sha512-MuOLavHHTXXWKyfTcwqpjhkdYlJDyOfjfcf+b/d38+8cs064rpNScxTZyYj2KKxNGcCqDgUsY175fNp/D1fyMw==
+  dependencies:
+    "@sentry/hub" "5.4.0"
+    "@sentry/types" "5.4.0"
+    tslib "^1.9.3"
+
+"@sentry/node@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-5.4.0.tgz#ceb99318296d3543acefa34a51389e2e0dafb832"
+  integrity sha512-+OWgt/bLYZd+aJzepTycEK442SUaERBrEVsU7Q30XHznxWEKfpcWRflnmhFClA1DnnLYW40J7qUbajjHAhsN4g==
+  dependencies:
+    "@sentry/core" "5.4.0"
+    "@sentry/hub" "5.4.0"
+    "@sentry/types" "5.4.0"
+    "@sentry/utils" "5.4.0"
+    cookie "0.3.1"
+    https-proxy-agent "2.2.1"
+    lru_map "0.3.3"
+    tslib "^1.9.3"
+
+"@sentry/types@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.4.0.tgz#340854be18618e4435f9c168adfa2c9e407fbcb3"
+  integrity sha512-R8IFM77rzp0ngR/XQFLsXUK2uE7jLf21MsU9mpUwLtxcJp8rs7I77HgzA5MEerdG9Sbxw5RaLq9wO7noHGfUmQ==
+
+"@sentry/utils@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.4.0.tgz#32882f16cd516f341ba1dafeb020614aaf6d4b5c"
+  integrity sha512-NlYMAyiI9iIItLDxJ17tLMtuu7261t93tcOGSMdDQZlmryR6ZAMenbCKTf5MrpA2iHfX84gyfmr67lh8uSHkPg==
+  dependencies:
+    "@sentry/types" "5.4.0"
+    tslib "^1.9.3"
+
 "@types/accepts@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
@@ -463,6 +519,13 @@ acorn@^5.0.0, acorn@^5.3.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
   integrity sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==
+
+agent-base@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
+  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
+  dependencies:
+    es6-promisify "^5.0.0"
 
 ajv@4.10.0:
   version "4.10.0"
@@ -1904,10 +1967,22 @@ es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
+es6-promise@^4.0.3:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
+
 es6-promise@^4.0.5:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
   integrity sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
+  dependencies:
+    es6-promise "^4.0.3"
 
 es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
@@ -2770,6 +2845,14 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
+
+https-proxy-agent@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
+  integrity sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
 
 iconv-lite@0.4.19:
   version "0.4.19"
@@ -3993,6 +4076,11 @@ lru-cache@^4.0.1, lru-cache@^4.1.3:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+lru_map@0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
 
 make-dir@^1.0.0, make-dir@^1.3.0:
   version "1.3.0"
@@ -6129,6 +6217,11 @@ ts-node@^6.0.2, ts-node@^6.2.0:
     mkdirp "^0.5.1"
     source-map-support "^0.5.6"
     yn "^2.0.0"
+
+tslib@^1.9.3:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"

--- a/metaspace/webapp/ci/clientConfig.json
+++ b/metaspace/webapp/ci/clientConfig.json
@@ -16,7 +16,7 @@
     "storage": "s3"
   },
 
-  "ravenDsn": "{{ sm_webapp_sentry_dsn }}",
+  "ravenDsn": "",
 
   "metadataTypes": ["ims", "lcms"],
 

--- a/metaspace/webapp/conf.js.template
+++ b/metaspace/webapp/conf.js.template
@@ -10,4 +10,4 @@ exports.UPLOAD_DESTINATION = "{{ sm_webapp_upload_destination }}";
 // must match 's3_bucket' in src/clientConfig.js
 exports.S3_UPLOAD_BUCKET = "{{ sm_webapp_s3_bucket }}";
 
-exports.RAVEN_DSN = "{{ sm_webapp_sentry_dsn }}";
+exports.RAVEN_DSN = "{{ sentry_dsn }}";

--- a/metaspace/webapp/src/clientConfig.json.template
+++ b/metaspace/webapp/src/clientConfig.json.template
@@ -16,7 +16,7 @@
     "storage": "{{ sm_webapp_upload_destination }}"
   },
 
-  "ravenDsn": "{{ sm_webapp_sentry_dsn }}",
+  "ravenDsn": "{{ sentry_dsn }}",
 
   "metadataTypes": {{ sm_webapp_metadata_types | to_json }},
 

--- a/metaspace/webapp/src/components/DatasetInfo.vue
+++ b/metaspace/webapp/src/components/DatasetInfo.vue
@@ -13,15 +13,15 @@
 <script>
   import {defaultMetadataType, metadataSchemas} from '../assets/metadataRegistry';
   import {get, flatMap} from 'lodash-es';
-  import safeJsonParse from '../lib/safeJsonParse';
   import {optionalSuffixInParens} from '../lib/vueFilters';
+  import {getLocalStorage, setLocalStorage} from '../lib/localStorage';
 
   export default {
     name: 'dataset-info',
     props: ['metadata', 'expandedKeys', 'currentUser'],
     data() {
       return {
-        expandedTreeNodes: safeJsonParse(localStorage.getItem('expandedTreeNodes')) || [],
+        expandedTreeNodes: getLocalStorage('expandedTreeNodes') || [],
       };
     },
     created() {
@@ -90,12 +90,12 @@
             this.expandedTreeNodes.splice(nodeId, 1);
           }
         }
-        localStorage.setItem('expandedTreeNodes', JSON.stringify(this.expandedTreeNodes));
+        setLocalStorage('expandedTreeNodes', this.expandedTreeNodes);
       },
 
       handleNodeExpand(node) {
         this.expandedTreeNodes.push(node.id);
-        localStorage.setItem('expandedTreeNodes', JSON.stringify(this.expandedTreeNodes));
+        setLocalStorage('expandedTreeNodes', this.expandedTreeNodes);
       },
 
       prettify(str) {

--- a/metaspace/webapp/src/config.ts
+++ b/metaspace/webapp/src/config.ts
@@ -1,6 +1,6 @@
 const fileConfig = require('./clientConfig.json');
 import {defaultsDeep} from 'lodash-es';
-import safeJsonParse from './lib/safeJsonParse';
+import {getLocalStorage, removeLocalStorage, setLocalStorage} from './lib/localStorage';
 
 
 interface AWSConfig {
@@ -83,9 +83,9 @@ export const updateConfigFromQueryString = () => {
 
     const overrides: Partial<Features> = {};
     if (queryStringFeatures.includes('reset')) {
-      localStorage.removeItem(FEATURE_STORAGE_KEY);
+      removeLocalStorage(FEATURE_STORAGE_KEY);
     } else {
-      Object.assign(overrides, safeJsonParse(localStorage.getItem(FEATURE_STORAGE_KEY)));
+      Object.assign(overrides, getLocalStorage(FEATURE_STORAGE_KEY));
     }
 
     queryStringFeatures.forEach(feat => {
@@ -99,7 +99,7 @@ export const updateConfigFromQueryString = () => {
     Object.assign(config.features, overrides);
 
     if (queryStringFeatures.includes('save')) {
-      localStorage.setItem(FEATURE_STORAGE_KEY, JSON.stringify(overrides));
+      setLocalStorage(FEATURE_STORAGE_KEY, overrides);
     }
   }
 };

--- a/metaspace/webapp/src/lib/localStorage.ts
+++ b/metaspace/webapp/src/lib/localStorage.ts
@@ -1,0 +1,64 @@
+import safeJsonParse from './safeJsonParse';
+import * as cookie from 'js-cookie';
+
+const memoryStorage: Record<string, string> = {};
+
+export const setLocalStorage = (key: string, value: any, cookieFallback = false) => {
+  const json = JSON.stringify(value);
+  memoryStorage[key] = json;
+  try {
+    localStorage.setItem(key, json);
+  } catch (err) {
+    console.error(err);
+    if (cookieFallback) {
+      try {
+        cookie.set('storage_' + key, json, { expires: 90 });
+      } catch (err2) { console.error(err2); }
+    }
+  }
+};
+
+export const getLocalStorage = <T>(key: string): (T | undefined) => {
+  try {
+    const json = localStorage.getItem(key) || memoryStorage[key] || cookie.get('storage_' + key);
+    return json && safeJsonParse(json);
+  } catch (err) {
+    console.error(err);
+    return undefined;
+  }
+};
+
+export const removeLocalStorage = (key: string) => {
+  delete memoryStorage[key];
+  try {
+    localStorage.removeItem(key);
+  } catch (err) { console.error(err); }
+  try {
+    cookie.remove('storage_' + key);
+  } catch (err) { console.error(err); }
+};
+
+export const migrateLocalStorage = () => {
+  try {
+    // Clean up old data stored by Upload page
+    removeLocalStorage('latestMetadataSubmission');
+    removeLocalStorage('latestMetadataOptions');
+    removeLocalStorage('latestMetadataSubmissionVersion');
+
+    // Convert storage cookies to localStorage
+    try {
+      const hideReleaseNotes = cookie.getJSON('hideReleaseNotes');
+      if (hideReleaseNotes != null) {
+        setLocalStorage('hideReleaseNotes', hideReleaseNotes, true);
+        cookie.remove('hideReleaseNotes');
+      }
+    } catch (err) { console.error(err); }
+    try {
+      const show_descr_hint = cookie.getJSON('show_descr_hint') as any;
+      if (show_descr_hint != null) {
+        setLocalStorage('hideMarkdownHint', show_descr_hint === 0, true);
+        cookie.remove('show_descr_hint');
+      }
+    } catch (err) { console.error(err); }
+  } catch (err) { console.error(err); }
+};

--- a/metaspace/webapp/src/main.ts
+++ b/metaspace/webapp/src/main.ts
@@ -42,6 +42,9 @@ const isProd = process.env.NODE_ENV === 'production';
 import VueAnalytics from 'vue-analytics';
 import { setErrorNotifier } from './lib/reportError'
 import {updateConfigFromQueryString} from './config';
+import {migrateLocalStorage} from './lib/localStorage';
+
+migrateLocalStorage();
 
 Vue.use(VueAnalytics, {
   id: 'UA-73509518-1',

--- a/metaspace/webapp/src/modules/Account/signInReturnUrl.ts
+++ b/metaspace/webapp/src/modules/Account/signInReturnUrl.ts
@@ -7,7 +7,7 @@ const DEFAULT_ROUTE = {path:'/datasets'};
 
 
 export const setSignInReturnUrl = (route: Route) => {
-  const val = JSON.stringify(pick(route, ['name','path','hash','query','params']));
+  const val = pick(route, ['name','path','hash','query','params']);
   setLocalStorage(STORAGE_KEY, val, true);
 };
 

--- a/metaspace/webapp/src/modules/Account/signInReturnUrl.ts
+++ b/metaspace/webapp/src/modules/Account/signInReturnUrl.ts
@@ -1,7 +1,6 @@
 import {Route} from 'vue-router';
-import * as cookie from 'js-cookie';
 import {pick} from 'lodash-es';
-import safeJsonParse from '../../lib/safeJsonParse';
+import {getLocalStorage, removeLocalStorage, setLocalStorage} from '../../lib/localStorage';
 
 const STORAGE_KEY = 'signInRedirect';
 const DEFAULT_ROUTE = {path:'/datasets'};
@@ -9,22 +8,11 @@ const DEFAULT_ROUTE = {path:'/datasets'};
 
 export const setSignInReturnUrl = (route: Route) => {
   const val = JSON.stringify(pick(route, ['name','path','hash','query','params']));
-  if (typeof window.localStorage != 'undefined') {
-    window.localStorage.setItem(STORAGE_KEY, val);
-  } else {
-    cookie.set(STORAGE_KEY, val);
-  }
+  setLocalStorage(STORAGE_KEY, val, true);
 };
 
 export const redirectAfterSignIn = () => {
-  let redirect;
-  if ('localStorage' in window) {
-    redirect = safeJsonParse(window.localStorage.getItem(STORAGE_KEY));
-    window.localStorage.removeItem(STORAGE_KEY);
-  }
-  if (redirect == null) {
-    redirect = safeJsonParse(cookie.get(STORAGE_KEY));
-  }
-  cookie.remove(STORAGE_KEY);
+  let redirect = getLocalStorage(STORAGE_KEY);
+  removeLocalStorage(STORAGE_KEY);
   return redirect || DEFAULT_ROUTE;
 };

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
@@ -175,7 +175,6 @@ export default class MainImage extends Vue {
     }
 
     get ionImage(): IonImage | null {
-        console.log('rerender')
         if (this.ionImagePng != null) {
             const isotopeImage = get(this.annotation, 'isotopeImages[0]');
             const { minIntensity, maxIntensity } = isotopeImage;

--- a/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
+++ b/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
@@ -37,7 +37,7 @@
   import config from '../../config';
   import Component from 'vue-class-component';
   import {debounce, isArray} from 'lodash-es';
-  import safeJsonParse from '../../lib/safeJsonParse';
+  import {getLocalStorage, setLocalStorage} from '../../lib/localStorage';
 
   interface FeatureSpec {
     name: string;
@@ -97,8 +97,7 @@ We recommend including off-sample area around your sample during data acquisitio
 
     getStorageDismissedFeatures() {
       try {
-        const json = localStorage.getItem(STORAGE_KEY);
-        const list = json && safeJsonParse(json);
+        const list = getLocalStorage(STORAGE_KEY);
         if (isArray(list)) {
           // Filter out invalid/old entries
           return list.filter(item => NEW_FEATURES.some(f => f.name === item));
@@ -138,7 +137,7 @@ We recommend including off-sample area around your sample during data acquisitio
 
       if (activeFeatureName != null) {
         const currentFeatureStatus = this.getStorageDismissedFeatures();
-        localStorage.setItem(STORAGE_KEY, JSON.stringify([...currentFeatureStatus, activeFeatureName]));
+        setLocalStorage(STORAGE_KEY, [...currentFeatureStatus, activeFeatureName]);
       }
     }
 

--- a/metaspace/webapp/src/modules/App/ReleaseNotesDialog.vue
+++ b/metaspace/webapp/src/modules/App/ReleaseNotesDialog.vue
@@ -45,19 +45,19 @@
 <script lang="ts">
   import Vue from 'vue';
   import Component from 'vue-class-component';
-  import * as cookie from 'js-cookie';
+  import {getLocalStorage, setLocalStorage} from '../../lib/localStorage';
 
   const CURRENT_VERSION = 1;
 
   @Component
   export default class ReleaseNotesDialog extends Vue {
-    visible = (cookie.getJSON('hideReleaseNotes') as any as number || 0) < CURRENT_VERSION;
+    visible = (getLocalStorage<number>('hideReleaseNotes') || 0) < CURRENT_VERSION;
     dontShowAgain = false;
 
     handleClose() {
       this.visible = false;
       if (this.dontShowAgain) {
-        cookie.set('hideReleaseNotes', CURRENT_VERSION as any, {expires: 365});
+        setLocalStorage('hideReleaseNotes', CURRENT_VERSION, true);
       }
     }
   }

--- a/metaspace/webapp/src/modules/GroupProfile/GroupDescription.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/GroupDescription.vue
@@ -61,11 +61,11 @@
   import Vue from 'vue';
   import {Component, Prop} from 'vue-property-decorator';
   import marked from 'marked';
-  import * as cookie from 'js-cookie';
   import {
     ViewGroupResult,
   } from '../../api/group';
   import {sanitizeIt} from '../../util'
+  import {getLocalStorage, setLocalStorage} from '../../lib/localStorage';
 
   interface Modes {
     preview: boolean
@@ -98,7 +98,7 @@
         edit: true
       };
       this.$nextTick(()=> {
-        this.showHint = ((cookie.getJSON('show_descr_hint') as any as number) !== 0);
+        this.showHint = !getLocalStorage<boolean>('hideMarkdownHint');
       })
     }
 
@@ -129,7 +129,7 @@
 
     disableHint() {
       this.showHint = false;
-      cookie.set('show_descr_hint', 0 as any)
+      setLocalStorage('hideMarkdownHint', true);
     }
 
     embedMarkdownAsHtml() {

--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -54,7 +54,7 @@
  import {
    get, set, cloneDeep, defaults,
    isEmpty, isEqual, isPlainObject,
-   mapValues, forEach, without, pick, omit,
+   mapValues, forEach, without, omit,
  } from 'lodash-es';
  import {
    newDatasetQuery,
@@ -106,11 +106,6 @@
 
    created() {
      this.loadingPromise = this.initializeForm();
-
-     // Clean up local storage from previous versions
-     localStorage.removeItem('latestMetadataSubmission');
-     localStorage.removeItem('latestMetadataOptions');
-     localStorage.removeItem('latestMetadataSubmissionVersion');
    },
 
    data() {

--- a/metaspace/webapp/src/modules/Project/ProjectDescription.vue
+++ b/metaspace/webapp/src/modules/Project/ProjectDescription.vue
@@ -61,8 +61,8 @@
   import Vue from 'vue';
   import {Component, Prop} from 'vue-property-decorator';
   import marked from 'marked';
-  import * as cookie from 'js-cookie';
   import {sanitizeIt} from '../../util'
+  import {getLocalStorage, setLocalStorage} from '../../lib/localStorage';
 
   interface Modes {
     preview: boolean
@@ -94,7 +94,7 @@
         edit: true
       };
       this.$nextTick(()=> {
-        this.showHint = ((cookie.getJSON('show_descr_hint') as any as number) !== 0);
+        this.showHint = !getLocalStorage<boolean>('hideMarkdownHint');
       })
     }
 
@@ -125,7 +125,7 @@
 
     disableHint() {
       this.showHint = false;
-      cookie.set('show_descr_hint', 0 as any)
+      setLocalStorage('hideMarkdownHint', true);
     }
 
     embedMarkdownAsHtml() {


### PR DESCRIPTION
Several small fixes - see individual commits

The `jwt-simple` vulnerability *probably* doesn't affect us. Looking at the code it appears as though the issue in `jwt-simple` was [this issue](https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/): when an application uses the RSA public/private key algorithm for generating JWTs, a user can use the RSA public key to generate a valid signature for an HMAC/SHA-based JWT. I.e. if a developer publishes a public key used for JWTs, `jwt-simple` could be tricked into treating that public key as a `secret`. We don't use RSA JWTs and we've never published our `secret`, so we shouldn't be affected.

Since it's a security-critical dependency, I updated it as a precaution and also followed Auth0's advice on explicitly specifying the `algorithm` so that it couldn't be changed to a weaker algorithm in the JWT.

I also added Sentry error reporting to GraphQL. There will be a matching PR in the ansible repo to update some of the settings.

I will probably merge & deploy this hotfix on Tuesday once I'm happy it's stable, but a code review would still be appreciated when you get back.