### PR TITLE
Ion image options improvements

### DIFF
--- a/metaspace/webapp/src/components/ImageLoader.vue
+++ b/metaspace/webapp/src/components/ImageLoader.vue
@@ -23,7 +23,7 @@
   import config from '../config';
   import {Component, Prop, Watch} from 'vue-property-decorator';
   import IonImageViewer from './IonImageViewer.vue';
-  import {IonImage, loadPngFromUrl, processIonImage} from '../lib/ionImageRendering';
+  import {IonImage, loadPngFromUrl, processIonImage, ScaleType} from '../lib/ionImageRendering';
   import fitImageToArea, {FitImageToAreaResult} from '../lib/fitImageToArea';
   import reportError from '../lib/reportError';
 
@@ -55,6 +55,8 @@
     hotspotQuantile?: number;
     @Prop()
     pixelAspectRatio!: number;
+    @Prop({type: String})
+    scaleType?: ScaleType;
 
     containerWidth = 500;
     containerHeight = 500;
@@ -85,7 +87,8 @@
           const png = await loadPngFromUrl((config.imageStorage || '') + newUrl);
 
           if (newUrl === this.src) {
-            this.ionImage = processIonImage(png, this.minIntensity, this.maxIntensity, this.hotspotQuantile);
+            this.ionImage = processIonImage(png, this.minIntensity, this.maxIntensity,
+              this.hotspotQuantile, this.scaleType);
             this.ionImageIsLoading = false;
           }
         } catch (err) {

--- a/metaspace/webapp/src/components/ImageLoader.vue
+++ b/metaspace/webapp/src/components/ImageLoader.vue
@@ -52,8 +52,6 @@
     @Prop()
     maxIntensity?: number;
     @Prop()
-    hotspotQuantile?: number;
-    @Prop()
     pixelAspectRatio!: number;
     @Prop({type: String})
     scaleType?: ScaleType;
@@ -87,8 +85,7 @@
           const png = await loadPngFromUrl((config.imageStorage || '') + newUrl);
 
           if (newUrl === this.src) {
-            this.ionImage = processIonImage(png, this.minIntensity, this.maxIntensity,
-              this.hotspotQuantile, this.scaleType);
+            this.ionImage = processIonImage(png, this.minIntensity, this.maxIntensity, this.scaleType);
             this.ionImageIsLoading = false;
           }
         } catch (err) {

--- a/metaspace/webapp/src/components/IonImageViewer.vue
+++ b/metaspace/webapp/src/components/IonImageViewer.vue
@@ -151,7 +151,7 @@
      },
      scaleBarColor: {
        type: String,
-       default: '#000000'
+       default: null
      },
      showPixelIntensity: {
        type: Boolean,

--- a/metaspace/webapp/src/components/IonImageViewer.vue
+++ b/metaspace/webapp/src/components/IonImageViewer.vue
@@ -51,7 +51,7 @@
       </el-tooltip>
     </div>
 
-    <scale-bar v-if="!showScaleBar"
+    <scale-bar v-if="scaleBarColor"
                :xScale="xScale"
                :yScale="yScale"
                :scaleBarColor="scaleBarColor" />
@@ -148,10 +148,6 @@
      pixelAspectRatio: {
        type: Number,
        default: 1
-     },
-     showScaleBar: {
-       type: Boolean,
-       default: false
      },
      scaleBarColor: {
        type: String,

--- a/metaspace/webapp/src/lib/constants.ts
+++ b/metaspace/webapp/src/lib/constants.ts
@@ -1,2 +1,2 @@
 export const MAX_MOL_DBS = 3;
-export const DEFAULT_SCALE_TYPE = 'log';
+export const DEFAULT_SCALE_TYPE = 'linear';

--- a/metaspace/webapp/src/lib/constants.ts
+++ b/metaspace/webapp/src/lib/constants.ts
@@ -1,1 +1,2 @@
 export const MAX_MOL_DBS = 3;
+export const DEFAULT_SCALE_TYPE = 'log';

--- a/metaspace/webapp/src/lib/createColormap.ts
+++ b/metaspace/webapp/src/lib/createColormap.ts
@@ -1,5 +1,6 @@
 import * as d3 from 'd3';
 import getColorScale from './getColorScale';
+import {ScaleType} from './ionImageRendering';
 
 export type OpacityMode = 'constant' | 'linear' | 'quadratic';
 
@@ -22,4 +23,9 @@ export default function createColormap(name: string, opacityMode: OpacityMode = 
     colors.push([color.r, color.g, color.b, alpha].map(Math.round));
   }
   return colors;
+}
+
+export function renderColorbar(cmap: number[][], scaleType: ScaleType, height: number) {
+
+
 }

--- a/metaspace/webapp/src/lib/createColormap.ts
+++ b/metaspace/webapp/src/lib/createColormap.ts
@@ -24,8 +24,3 @@ export default function createColormap(name: string, opacityMode: OpacityMode = 
   }
   return colors;
 }
-
-export function renderColorbar(cmap: number[][], scaleType: ScaleType, height: number) {
-
-
-}

--- a/metaspace/webapp/src/lib/createColormap.ts
+++ b/metaspace/webapp/src/lib/createColormap.ts
@@ -1,6 +1,5 @@
 import * as d3 from 'd3';
 import getColorScale from './getColorScale';
-import {ScaleType} from './ionImageRendering';
 
 export type OpacityMode = 'constant' | 'linear' | 'quadratic';
 

--- a/metaspace/webapp/src/lib/getColorScale.ts
+++ b/metaspace/webapp/src/lib/getColorScale.ts
@@ -1,4 +1,5 @@
 import * as d3 from 'd3';
+import {reverse} from 'lodash-es';
 // WORKAROUND: Jest had an issue with these CommonJS exports. `import * as extractScale` sets extractScale
 // to a regular function in the browser, but to {default: [Function]} when run in Jest. There doesn't appear to be
 // a good framework-level solution, so this horror is needed:
@@ -17,7 +18,10 @@ export default function getColorScale(name: string): ColorScale {
   {
     return extractScale(scales[name], 0, 1); // normal
   }
-  else
-    return extractScale(scales[name.slice(1)], 1, 0); // inverted
+  else {
+    // inverted
+    const {domain, range} = extractScale(scales[name.slice(1)], 1, 0);
+    return {domain: reverse(domain), range: reverse(range)};
+  }
 }
 

--- a/metaspace/webapp/src/lib/getColorScale.ts
+++ b/metaspace/webapp/src/lib/getColorScale.ts
@@ -19,7 +19,7 @@ export default function getColorScale(name: string): ColorScale {
     return extractScale(scales[name], 0, 1); // normal
   }
   else {
-    // inverted
+    // inverted - reverse both arrays so that the domain is always in ascending order
     const {domain, range} = extractScale(scales[name.slice(1)], 1, 0);
     return {domain: reverse(domain), range: reverse(range)};
   }

--- a/metaspace/webapp/src/lib/ionImageRendering.spec.ts
+++ b/metaspace/webapp/src/lib/ionImageRendering.spec.ts
@@ -38,7 +38,7 @@ describe('ionImageRendering.ts', () => {
       test(`processIonImage correctly decodes a ${bits}-bit ${colorType} image`, () => {
         const png = getGradientPng(is16Bit, isRGBA);
 
-        const image = processIonImage(png, 0, 1, 0.5);
+        const image = processIonImage(png, 0, 1, 'test');
 
         expect(image.width).toBe(256);
         expect(image.height).toBe(1);
@@ -55,7 +55,7 @@ describe('ionImageRendering.ts', () => {
         });
         // First half of non-masked pixels should be a linear gradient to 255
         range(128, 192).forEach(i => {
-          expect(image.clippedValues[i]).toBeCloseTo(i/0.75, -1);
+          expect(image.clippedValues[i]).toBeCloseTo(i / 0.75, -1);
         });
         // Second half of non-masked pixels should be clipped to 255
         range(193, 256).forEach(i => {
@@ -66,7 +66,7 @@ describe('ionImageRendering.ts', () => {
       test(`processIonImage correctly decodes a ${bits}-bit ${colorType} image without alpha`, () => {
         const png = getGradientPng(is16Bit, isRGBA, false);
 
-        const image = processIonImage(png, 0, 1, 0.5);
+        const image = processIonImage(png, 0, 1, 'test');
 
         expect(image.width).toBe(256);
         expect(image.height).toBe(1);

--- a/metaspace/webapp/src/lib/ionImageRendering.spec.ts
+++ b/metaspace/webapp/src/lib/ionImageRendering.spec.ts
@@ -1,4 +1,4 @@
-import {getHotspotThreshold, processIonImage, renderIonImage, renderIonImageToBuffer} from './ionImageRendering';
+import {processIonImage, renderIonImageToBuffer} from './ionImageRendering';
 import {range, times} from 'lodash-es';
 import {decode, encodeLL, Image} from 'upng-js';
 import {readFile} from 'fs';

--- a/metaspace/webapp/src/lib/ionImageRendering.ts
+++ b/metaspace/webapp/src/lib/ionImageRendering.ts
@@ -1,6 +1,7 @@
 import {decode, Image} from 'upng-js';
 import {quantile} from 'simple-statistics';
 import {range} from 'lodash-es';
+import {DEFAULT_SCALE_TYPE} from './constants';
 
 export interface IonImage {
   intensityValues: Float32Array;
@@ -209,8 +210,8 @@ export const loadPngFromUrl = async (url: string) => {
 };
 
 export const processIonImage = (png: Image, minIntensity: number = 0, maxIntensity: number = 1,
-                                scaleType: ScaleType = 'linear'): IonImage => {
-  const [scaleMode, minQuantile, maxQuantile] = scaleType in SCALES ? SCALES[scaleType] : SCALES['linear'];
+                                scaleType: ScaleType = DEFAULT_SCALE_TYPE): IonImage => {
+  const [scaleMode, minQuantile, maxQuantile] = SCALES[scaleType];
 
   const {width, height} = png;
   const {intensityValues, mask} = extractIntensityAndMask(png, minIntensity, maxIntensity);

--- a/metaspace/webapp/src/lib/ionImageRendering.ts
+++ b/metaspace/webapp/src/lib/ionImageRendering.ts
@@ -20,15 +20,15 @@ export interface IonImage {
   maxQuantile: number | null;
 }
 
-export type ScaleType = 'linear' | 'linear-full' | 'log' | 'log-full' | 'rank' | 'test';
-export type ScaleMode = 'linear' | 'log' | 'rank';
+export type ScaleType = 'linear' | 'linear-full' | 'log' | 'log-full' | 'hist' | 'test';
+export type ScaleMode = 'linear' | 'log' | 'hist';
 
 const SCALES: Record<ScaleType, [ScaleMode, number | null, number | null]> = {
   linear: ['linear', null, 0.99],
   'linear-full': ['linear', null, null],
   log: ['log', 0.01, 0.99],
   'log-full': ['log', 0, 1],
-  rank: ['rank', null, null],
+  hist: ['hist', null, null],
   test: ['linear', null, 0.5], // For unit tests, because it's easier to make test data for 50% threshold than 99%
 };
 
@@ -122,7 +122,7 @@ const getScaleParams = (intensityValues: Float32Array, mask: Uint8ClampedArray,
   const clippedMaxIntensity = highQuantile == null ? maxIntensity : quantile(values, highQuantile);
 
   let rankValues: Float32Array | null = null;
-  if (scaleMode === 'rank') {
+  if (scaleMode === 'hist') {
     const lo = lowQuantile || 0, hi = highQuantile || 1;
     const quantiles = range(256).map(i => lo + (hi - lo) * i / 255);
     rankValues = new Float32Array(quantile(values, quantiles));
@@ -185,7 +185,7 @@ const quantizeIonImageRank = (intensityValues: Float32Array, rankValues: Float32
 
 const quantizeIonImage = (intensityValues: Float32Array, minIntensity: number, maxIntensity: number,
                           rankValues: Float32Array | null, scaleMode: ScaleMode): Uint8ClampedArray => {
-  if (scaleMode === 'rank') {
+  if (scaleMode === 'hist') {
     return quantizeIonImageRank(intensityValues, rankValues!);
   } else if (scaleMode === 'log') {
     return quantizeIonImageLog(intensityValues, minIntensity, maxIntensity);

--- a/metaspace/webapp/src/lib/ionImageRendering.ts
+++ b/metaspace/webapp/src/lib/ionImageRendering.ts
@@ -210,7 +210,7 @@ export const loadPngFromUrl = async (url: string) => {
 
 export const processIonImage = (png: Image, minIntensity: number = 0, maxIntensity: number = 1,
                                 scaleType: ScaleType = 'linear'): IonImage => {
-  const [scaleMode, minQuantile, maxQuantile] = SCALES[scaleType] || SCALES['linear'];
+  const [scaleMode, minQuantile, maxQuantile] = scaleType in SCALES ? SCALES[scaleType] : SCALES['linear'];
 
   const {width, height} = png;
   const {intensityValues, mask} = extractIntensityAndMask(png, minIntensity, maxIntensity);

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
@@ -157,6 +157,10 @@
      return this.$store.getters.settings.annotationView.colormap;
    }
 
+   get scaleType(): string {
+     return this.$store.getters.settings.annotationView.scaleType;
+   }
+
    get hotspotQuantile(): number | undefined {
      const threshold = this.$store.getters.settings.annotationView.hotspotThreshold;
      return threshold ? threshold / 100 : undefined;
@@ -195,7 +199,7 @@
        path,
        query: {
          ...encodeParams(filter, path, this.$store.state.filterLists),
-         ...pick(this.$route.query, 'sections', 'sort', 'hideopt', 'cmap', 'hotspotthreshold'),
+         ...pick(this.$route.query, 'sections', 'sort', 'hideopt', 'cmap', 'hotspotthreshold', 'scale'),
        },
      };
    }

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
@@ -160,10 +160,6 @@
      return this.$store.getters.settings.annotationView.scaleType;
    }
 
-   get colormapName(): string {
-     return this.colormap.replace('-', '');
-   }
-
    get formattedMolFormula(): string {
      if (!this.annotation) return '';
      const { sumFormula, adduct, dataset } = this.annotation;
@@ -193,7 +189,7 @@
        path,
        query: {
          ...encodeParams(filter, path, this.$store.state.filterLists),
-         ...pick(this.$route.query, 'sections', 'sort', 'hideopt', 'cmap', 'hotspotthreshold', 'scale'),
+         ...pick(this.$route.query, 'sections', 'sort', 'hideopt', 'cmap', 'scale'),
        },
      };
    }

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
@@ -41,10 +41,10 @@
    opticalSrc: string | null
    opticalTransform: number[][] | null
    pixelAspectRatio: number
-   // hotspotQuantile is deliberately not included here, because every time it changes some slow computation occurs,
+   // scaleType is deliberately not included here, because every time it changes some slow computation occurs,
    // and the computed getters were being triggered by any part of the ImageSettings object changing, such as opacity,
    // causing a lot of jank.
-   //hotspotQuantile?: number
+   //scaleType?: ScaleType
  }
 
  const metadataDependentComponents: any = {};
@@ -128,10 +128,9 @@
    msAcqGeometry: any
    peakChartData: any
    opticalImages!: OpticalImage[] | null
-   showScaleBar: boolean = false
    datasetVisibility: DatasetVisibilityResult | null = null
    currentUser: CurrentUserRoleResult | null = null
-   scaleBarColor: string = '#000000'
+   scaleBarColor: string | null = '#000000'
    failedImages: string[] = []
    noImageURL = noImageURL
 
@@ -159,11 +158,6 @@
 
    get scaleType(): string {
      return this.$store.getters.settings.annotationView.scaleType;
-   }
-
-   get hotspotQuantile(): number | undefined {
-     const threshold = this.$store.getters.settings.annotationView.hotspotThreshold;
-     return threshold ? threshold / 100 : undefined;
    }
 
    get colormapName(): string {
@@ -327,16 +321,12 @@
      }
    }
 
-   toggleScaleBar(): void {
-     this.showScaleBar = !this.showScaleBar
-   }
-
    loadVisibility() {
      this.$apollo.queries.datasetVisibility.start();
    }
 
-   setScaleBarColor(colorObj: colorObjType) {
-     this.scaleBarColor = colorObj.code;
+   setScaleBarColor(color: string | null) {
+     this.scaleBarColor = color;
    }
 
    filterColocSamples() {

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.vue
@@ -51,8 +51,7 @@
                      :showOpticalImage="showOpticalImage"
                      :resetViewport="resetViewport"
                      :toggleOpticalImage="toggleOpticalImage"
-                     :toggleScaleBar="toggleScaleBar"
-                     @colorInput="colorObj=>setScaleBarColor(colorObj)"
+                     @scaleBarColorChange="setScaleBarColor"
                      slot="title">
           </component>
           <component :is="metadataDependentComponent('main-image')"
@@ -66,9 +65,7 @@
                      :acquisitionGeometry="msAcqGeometry"
                      :pixelSizeX="pixelSizeX"
                      :pixelSizeY="pixelSizeY"
-                     :showScaleBar="showScaleBar"
                      :scaleBarColor="scaleBarColor"
-                     :hotspotQuantile="hotspotQuantile"
                      :scaleType="scaleType"
                      @opacityInput="newVal => opacity = newVal">
           </component>
@@ -140,7 +137,6 @@
                      :database="this.$store.getters.filter.database"
                      :acquisitionGeometry="msAcqGeometry"
                      :image-loader-settings="imageLoaderSettings"
-                     :hotspotQuantile="hotspotQuantile"
                      :scaleType="scaleType">
           </component>
         </el-collapse-item>
@@ -153,7 +149,6 @@
                      :database="this.$store.getters.filter.database"
                      :acquisitionGeometry="msAcqGeometry"
                      :image-loader-settings="imageLoaderSettings"
-                     :hotspotQuantile="hotspotQuantile"
                      :scaleType="scaleType">
           </component>
         </el-collapse-item>
@@ -164,7 +159,6 @@
                      :annotation="annotation"
                      :colormap="colormap"
                      :imageLoaderSettings="imageLoaderSettings"
-                     :hotspotQuantile="hotspotQuantile"
                      :scaleType="scaleType"
                      :peakChartData="peakChartData"
                      :acquisitionGeometry="msAcqGeometry">

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.vue
@@ -57,7 +57,6 @@
           <component :is="metadataDependentComponent('main-image')"
                      :annotation="annotation"
                      :colormap="colormap"
-                     :colormapName="colormapName"
                      :opacity="opacity"
                      :imagePosition="imagePosition"
                      :imageLoaderSettings="imageLoaderSettings"

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.vue
@@ -69,6 +69,7 @@
                      :showScaleBar="showScaleBar"
                      :scaleBarColor="scaleBarColor"
                      :hotspotQuantile="hotspotQuantile"
+                     :scaleType="scaleType"
                      @opacityInput="newVal => opacity = newVal">
           </component>
         </el-collapse-item>
@@ -139,7 +140,8 @@
                      :database="this.$store.getters.filter.database"
                      :acquisitionGeometry="msAcqGeometry"
                      :image-loader-settings="imageLoaderSettings"
-                     :hotspotQuantile="hotspotQuantile">
+                     :hotspotQuantile="hotspotQuantile"
+                     :scaleType="scaleType">
           </component>
         </el-collapse-item>
 
@@ -151,7 +153,8 @@
                      :database="this.$store.getters.filter.database"
                      :acquisitionGeometry="msAcqGeometry"
                      :image-loader-settings="imageLoaderSettings"
-                     :hotspotQuantile="hotspotQuantile">
+                     :hotspotQuantile="hotspotQuantile"
+                     :scaleType="scaleType">
           </component>
         </el-collapse-item>
 
@@ -162,6 +165,7 @@
                      :colormap="colormap"
                      :imageLoaderSettings="imageLoaderSettings"
                      :hotspotQuantile="hotspotQuantile"
+                     :scaleType="scaleType"
                      :peakChartData="peakChartData"
                      :acquisitionGeometry="msAcqGeometry">
           </component>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Colorbar.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Colorbar.vue
@@ -7,24 +7,38 @@
  import getColorScale from '../../../../lib/getColorScale';
  import Vue, { ComponentOptions } from 'vue';
  import { Prop, Component  } from 'vue-property-decorator';
+ import {IonImage, renderScaleBar} from '../../../../lib/ionImageRendering';
+ import createColormap from '../../../../lib/createColormap';
 
  @Component({})
- export default class Colorbar extends Vue{
+ export default class Colorbar extends Vue {
    @Prop({type: String, default: 'Viridis'})
-   map!: string
-   @Prop({type: String, default: 'right'})
-   direction!: string
+   map!: string;
+   @Prop({type: Boolean, default: false})
+   horizontal!: boolean;
+   @Prop({type: Object})
+   ionImage!: IonImage;
 
    get style(): object {
-     const {domain, range} = getColorScale(this.map);
-     let colors = [];
-     for (let i = 0; i < domain.length; i++)
-       colors.push(range[i] + ' ' + (domain[i] * 100 + '%'));
-     const background = "linear-gradient(to " + this.direction + ", " +
-                        colors.join(", ") + ")";
-     return {
-       background
-     };
+     if (this.ionImage != null) {
+       const cmap = createColormap(this.map);
+       return {
+         backgroundImage: `url(${renderScaleBar(this.ionImage, cmap, this.horizontal)}`,
+         backgroundSize: 'contain',
+         backgroundRepeat: 'repeat-x'
+       };
+     } else {
+       const { domain, range } = getColorScale(this.map);
+       const direction = this.map[0] == '-' ? 'bottom' : 'top';
+
+       const colors = [];
+       for (let i = 0; i < domain.length; i++)
+         colors.push(range[i] + ' ' + (domain[i] * 100 + '%'));
+
+       return {
+         background: `linear-gradient(to ${this.horizontal ? 'right' : 'top'}, ${colors.join(", ")}`,
+       };
+     }
    }
  }
 </script>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
@@ -34,7 +34,6 @@
                               style="overflow: hidden"
                               :minIntensity="img.minIntensity"
                               :maxIntensity="img.maxIntensity"
-                              :hotspotQuantile="hotspotQuantile"
                               showPixelIntensity
                 />
             </div>
@@ -80,8 +79,6 @@ export default class Diagnostics extends Vue {
     colormap: any
     @Prop()
     imageLoaderSettings: any
-    @Prop()
-    hotspotQuantile?: number
 
     sampleIsotopeColor: string = 'red'
     theorIsotopeColor: string = 'blue'

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/IonImageSettings.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/IonImageSettings.vue
@@ -9,7 +9,7 @@
           <el-option value="linear-full" label="Linear (without hotspot clipping)" />
           <el-option value="log" label="Logarithmic" />
           <el-option value="log-full" label="Logarithmic (without outlier clipping)" />
-          <el-option value="rank" label="Rank" />
+          <el-option value="hist" label="Equalized Histogram" />
         </el-select>
       </el-form-item>
       <el-form-item label="Colormap">

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/IonImageSettings.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/IonImageSettings.vue
@@ -13,6 +13,15 @@
                       :map="scale"></color-bar>
           </el-option>
         </el-select>
+        <el-form-item label="Color scale" data-feature-anchor="ion-image-color-scale">
+          <el-select :value="scaleType"
+                     style="width: 120px;"
+                     title="Color scale"
+                     @input="onScaleTypeChange">
+            <el-option value="linear" label="Linear" />
+            <el-option value="log" label="Logarithmic" />
+          </el-select>
+        </el-form-item>
         <el-form-item>
           <el-checkbox :checked="inverted" @input="onInvertChange">Invert</el-checkbox>
         </el-form-item>
@@ -42,6 +51,7 @@
  import Vue from 'vue';
  import ColorBar from './Colorbar.vue';
  import { Component } from 'vue-property-decorator'
+ import {ScaleType} from '../../../../lib/ionImageRendering';
 
  interface colorObjType {
    code: string,
@@ -79,6 +89,10 @@
      return this.colormap[0] == '-';
    }
 
+   get scaleType() {
+     return this.$store.getters.settings.annotationView.scaleType;
+   }
+
    get hotspotThreshold() {
      return this.$store.getters.settings.annotationView.hotspotThreshold;
    }
@@ -97,6 +111,10 @@
 
    onInvertChange(invert: any) {
      this.$store.commit('setColormap', (invert ? '-' : '') + this.colormapName);
+   }
+
+   onScaleTypeChange(scaleType: ScaleType) {
+     this.$store.commit('setScaleType', scaleType);
    }
 
    onHotspotThresholdChange(enableHotspotClipping: boolean) {

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/IonImageSettings.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/IonImageSettings.vue
@@ -2,46 +2,48 @@
   <span id="ion-image-settings">
     <el-form>
       <el-form-item label="Colormap">
-        <el-select :value="colormapName"
-                   style="width: 120px;"
-                   title="Colormap"
+        <el-select :value="colormap"
+                   style="width: 150px;"
                    @input="onColormapChange">
           <el-option v-for="scale in availableScales"
                      :value="scale" :label="scale" :key="scale">
-            <color-bar direction="right"
-                      style="width: 100px; height: 20px;"
-                      :map="scale"></color-bar>
+            <color-bar style="width: 100px; height: 20px;"
+                       :map="scale"
+                       horizontal />
           </el-option>
+          <el-option-group label="Inverted">
+            <el-option v-for="scale in availableScales"
+                       :value="'-' + scale" :label="scale" :key="'-' + scale">
+              <color-bar style="width: 100px; height: 20px;"
+                         :map="'-' + scale"
+                         horizontal />
+            </el-option>
+          </el-option-group>
         </el-select>
-        <el-form-item label="Color scale" data-feature-anchor="ion-image-color-scale">
-          <el-select :value="scaleType"
-                     style="width: 120px;"
-                     title="Color scale"
-                     @input="onScaleTypeChange">
-            <el-option value="linear" label="Linear" />
-            <el-option value="log" label="Logarithmic" />
-          </el-select>
-        </el-form-item>
-        <el-form-item>
-          <el-checkbox :checked="inverted" @input="onInvertChange">Invert</el-checkbox>
-        </el-form-item>
-        <el-form-item>
-          <el-checkbox :checked="hotspotThreshold !== 'none'" @change="onHotspotThresholdChange">Hotspot clipping</el-checkbox>
-        </el-form-item>
+      </el-form-item>
+      <el-form-item label="Intensity scaling" data-feature-anchor="ion-image-color-scale">
+        <el-select :value="scaleType"
+                   style="width: 150px;"
+                   @input="onScaleTypeChange">
+          <el-option value="linear" label="Linear" />
+          <el-option value="linear-full" label="Linear (without hotspot clipping)" />
+          <el-option value="log" label="Logarithmic" />
+          <el-option value="log-full" label="Logarithmic (without outlier clipping)" />
+          <el-option value="rank" label="Percentile Rank" />
+        </el-select>
       </el-form-item>
       <el-form-item label="Scale bar color">
         <el-select :value="pickedColor"
-                   style="width: 120px;"
-                   title="Scale_bar_color"
-                   @input="handlerClick">
+                   style="width: 150px;"
+                   @input="onScaleBarColorChange">
           <el-option v-for="color in paletteColors"
                      :value="color.code" :label="color.colorName" :key="color.code">
-              <div :style="scaleBarColors(color.code)"></div>
+            <div :style="{position: 'relative', background: color.bgColor, height: '50px', width: '150px'}">
+              <scale-bar :xScale="50" :yScale="50" :scaleBarColor="color.code" />
+            </div>
           </el-option>
+          <el-option value="hidden" label="Hidden" />
         </el-select>
-        <el-form-item>
-          <el-checkbox @click="$event.stopPropagation()" @input="setBarVisibility">Disable</el-checkbox>
-        </el-form-item>
       </el-form-item>
     </el-form>
   </span>
@@ -52,41 +54,37 @@
  import ColorBar from './Colorbar.vue';
  import { Component } from 'vue-property-decorator'
  import {ScaleType} from '../../../../lib/ionImageRendering';
+ import ScaleBar from '../../../../components/ScaleBar.vue';
 
  interface colorObjType {
    code: string,
+   bgColor: string,
    colorName: string
  }
 
  @Component({
    name: 'ion-image-setting',
-   components: { ColorBar }
+   components: { ColorBar, ScaleBar }
  })
  export default class IonImageSettings extends Vue {
    availableScales: string[] = ["Viridis", "Cividis", "Hot", "YlGnBu", "Portland", "Greys"];
    paletteColors: colorObjType[] = [{
      code: '#000000',
+     bgColor: 'transparent',
      colorName: "Black"
    }, {
-     code: '#FFFFFF',
-     colorName: 'White'
-   }, {
      code: '#999999',
+     bgColor: 'transparent',
      colorName: "Gray"
+   }, {
+     code: '#FFFFFF',
+     bgColor: '#CCCCCC',
+     colorName: 'White'
    }];
-   disableBar = false;
    pickedColor: string = this.paletteColors[0].code;
 
    get colormap() {
      return this.$store.getters.settings.annotationView.colormap;
-   }
-
-   get colormapName() {
-     return this.colormap.replace('-', '');
-   }
-
-   get inverted() {
-     return this.colormap[0] == '-';
    }
 
    get scaleType() {
@@ -106,34 +104,16 @@
    }
 
    onColormapChange(selection: string) {
-     this.$store.commit('setColormap', (this.inverted ? '-' : '') + selection);
-   }
-
-   onInvertChange(invert: any) {
-     this.$store.commit('setColormap', (invert ? '-' : '') + this.colormapName);
+     this.$store.commit('setColormap', selection);
    }
 
    onScaleTypeChange(scaleType: ScaleType) {
      this.$store.commit('setScaleType', scaleType);
    }
 
-   onHotspotThresholdChange(enableHotspotClipping: boolean) {
-     this.$store.commit('setHotspotThreshold', enableHotspotClipping ? null : 'none');
-   }
-
-   setBarVisibility() {
-     this.disableBar = !this.disableBar;
-     this.$emit('toggleScaleBar')
-   }
-
-   handlerClick(c: string) {
+   onScaleBarColorChange(c: string) {
      this.pickedColor = c;
-     let colorObj = this.paletteColors.find(el => {
-       return el.code === c;
-     });
-     if (colorObj !== undefined) {
-       this.$emit('colorInput', colorObj)
-     }
+     this.$emit('scaleBarColorChange', c === 'hidden' ? null : c)
    }
  }
 </script>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/IonImageSettings.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/IonImageSettings.vue
@@ -1,16 +1,29 @@
 <template>
   <span id="ion-image-settings">
-    <el-form>
+    <el-form label-position="top">
+      <el-form-item label="Intensity scaling" data-feature-anchor="ion-image-color-scale">
+        <el-select :value="scaleType"
+                   style="width: 300px;"
+                   @input="onScaleTypeChange">
+          <el-option value="linear" label="Linear" />
+          <el-option value="linear-full" label="Linear (without hotspot clipping)" />
+          <el-option value="log" label="Logarithmic" />
+          <el-option value="log-full" label="Logarithmic (without outlier clipping)" />
+          <el-option value="rank" label="Rank" />
+        </el-select>
+      </el-form-item>
       <el-form-item label="Colormap">
         <el-select :value="colormap"
                    style="width: 150px;"
                    @input="onColormapChange">
-          <el-option v-for="scale in availableScales"
-                     :value="scale" :label="scale" :key="scale">
-            <color-bar style="width: 100px; height: 20px;"
-                       :map="scale"
-                       horizontal />
-          </el-option>
+          <el-option-group>
+            <el-option v-for="scale in availableScales"
+                       :value="scale" :label="scale" :key="scale">
+              <color-bar style="width: 100px; height: 20px;"
+                         :map="scale"
+                         horizontal />
+            </el-option>
+          </el-option-group>
           <el-option-group label="Inverted">
             <el-option v-for="scale in availableScales"
                        :value="'-' + scale" :label="scale" :key="'-' + scale">
@@ -21,25 +34,14 @@
           </el-option-group>
         </el-select>
       </el-form-item>
-      <el-form-item label="Intensity scaling" data-feature-anchor="ion-image-color-scale">
-        <el-select :value="scaleType"
-                   style="width: 150px;"
-                   @input="onScaleTypeChange">
-          <el-option value="linear" label="Linear" />
-          <el-option value="linear-full" label="Linear (without hotspot clipping)" />
-          <el-option value="log" label="Logarithmic" />
-          <el-option value="log-full" label="Logarithmic (without outlier clipping)" />
-          <el-option value="rank" label="Percentile Rank" />
-        </el-select>
-      </el-form-item>
       <el-form-item label="Scale bar color">
         <el-select :value="pickedColor"
                    style="width: 150px;"
                    @input="onScaleBarColorChange">
           <el-option v-for="color in paletteColors"
                      :value="color.code" :label="color.colorName" :key="color.code">
-            <div :style="{position: 'relative', background: color.bgColor, height: '50px', width: '150px'}">
-              <scale-bar :xScale="50" :yScale="50" :scaleBarColor="color.code" />
+            <div :style="{position: 'relative', background: color.bgColor, height: '50px'}">
+              <scale-bar :xScale="8" :yScale="8" :scaleBarColor="color.code" />
             </div>
           </el-option>
           <el-option value="hidden" label="Hidden" />
@@ -91,10 +93,6 @@
      return this.$store.getters.settings.annotationView.scaleType;
    }
 
-   get hotspotThreshold() {
-     return this.$store.getters.settings.annotationView.hotspotThreshold;
-   }
-
    scaleBarColors(color: string): string {
      let cssBaseRule = `width: 100px; height: 20px; margin: 2px auto; background-color:${color};`;
      if (color === '#FFFFFF') {
@@ -128,4 +126,8 @@
  #ion-image-settings > .el-select {
    display: inline-flex;
  }
+
+  #ion-image-settings > .el-form--label-top .el-form-item__label {
+    padding: 0;
+  }
 </style>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
@@ -48,7 +48,7 @@
                 </div>
                 <div slot="content">
                     Hot-spot removal has been applied to this image. <br/>
-                    Pixel intensities above the 99th percentile, {{ ionImage.clippedMaxIntensity.toExponential(2) }},
+                    Pixel intensities above the {{ionImage.maxQuantile*100}}th percentile, {{ ionImage.clippedMaxIntensity.toExponential(2) }},
                     have been reduced to {{ ionImage.clippedMaxIntensity.toExponential(2) }}. <br/>
                     The highest intensity before hot-spot removal was {{ ionImage.maxIntensity.toExponential(2) }}.
                 </div>
@@ -60,7 +60,7 @@
                       :direction="colorbarDirection" :map="colormapName"
                       slot="reference">
             </colorbar>
-            {{ ionImage && ionImage.minIntensity.toExponential(2) }}
+            {{ ionImage && ionImage.clippedMinIntensity.toExponential(2) }}
 
             <div class="annot-view__image-download">
                 <!-- see https://github.com/tsayen/dom-to-image/issues/155 -->
@@ -89,7 +89,7 @@ import { saveAs } from 'file-saver';
 import Colorbar from './Colorbar.vue';
 import IonImageViewer from '../../../../components/IonImageViewer.vue';
 import domtoimage from 'dom-to-image-google-font-issue';
-import {IonImage, loadPngFromUrl, processIonImage} from '../../../../lib/ionImageRendering';
+import {IonImage, loadPngFromUrl, processIonImage, ScaleType} from '../../../../lib/ionImageRendering';
 import {get} from 'lodash-es';
 import fitImageToArea, {FitImageToAreaResult} from '../../../../lib/fitImageToArea';
 import reportError from '../../../../lib/reportError';
@@ -131,6 +131,8 @@ export default class MainImage extends Vue {
     scaleBarColor!: string
     @Prop({type: Number})
     hotspotQuantile?: number
+    @Prop({type: String})
+    scaleType?: ScaleType
 
     ionImageUrl: string | null = null;
     ionImagePng: Image | null = null;
@@ -152,7 +154,6 @@ export default class MainImage extends Vue {
     }
 
     @Watch('annotation')
-    @Watch('imageLoaderSettings.hotspotQuantile')
     async updateIonImage() {
         const isotopeImage = get(this.annotation, 'isotopeImages[0]');
         const newUrl = isotopeImage != null ? isotopeImage.url : null;
@@ -179,7 +180,7 @@ export default class MainImage extends Vue {
         if (this.ionImagePng != null) {
             const isotopeImage = get(this.annotation, 'isotopeImages[0]');
             const { minIntensity, maxIntensity } = isotopeImage;
-            return processIonImage(this.ionImagePng, minIntensity, maxIntensity, this.hotspotQuantile);
+            return processIonImage(this.ionImagePng, minIntensity, maxIntensity, this.hotspotQuantile, this.scaleType);
         } else {
             return null;
         }

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
@@ -9,7 +9,6 @@
               :pixelSizeX="pixelSizeX"
               :pixelSizeY="pixelSizeY"
               :pixelAspectRatio="imageLoaderSettings.pixelAspectRatio"
-              :showScaleBar="showScaleBar"
               :scaleBarColor="scaleBarColor"
               :width="imageViewerWidth"
               :height="imageViewerHeight"
@@ -57,7 +56,8 @@
                 {{ ionImage && ionImage.maxIntensity.toExponential(2) }}
             </div>
             <colorbar style="width: 20px; height: 160px; align-self: center;"
-                      :direction="colorbarDirection" :map="colormapName"
+                      :map="colormap"
+                      :ionImage="ionImage"
                       slot="reference">
             </colorbar>
             {{ ionImage && ionImage.clippedMinIntensity.toExponential(2) }}
@@ -113,8 +113,6 @@ export default class MainImage extends Vue {
     annotation!: any
     @Prop({required: true, type: String})
     colormap!: string
-    @Prop({required: true, type: String})
-    colormapName!: string
     @Prop({required: true, type: Number})
     opacity!: number
     @Prop({required: true})
@@ -125,12 +123,8 @@ export default class MainImage extends Vue {
     pixelSizeX!: number
     @Prop({type: Number})
     pixelSizeY!: number
-    @Prop({type: Boolean})
-    showScaleBar!: boolean
     @Prop({type: String})
-    scaleBarColor!: string
-    @Prop({type: Number})
-    hotspotQuantile?: number
+    scaleBarColor!: string | null
     @Prop({type: String})
     scaleType?: ScaleType
 
@@ -180,15 +174,12 @@ export default class MainImage extends Vue {
         if (this.ionImagePng != null) {
             const isotopeImage = get(this.annotation, 'isotopeImages[0]');
             const { minIntensity, maxIntensity } = isotopeImage;
-            return processIonImage(this.ionImagePng, minIntensity, maxIntensity, this.hotspotQuantile, this.scaleType);
+            return processIonImage(this.ionImagePng, minIntensity, maxIntensity, this.scaleType);
         } else {
             return null;
         }
     }
 
-    get colorbarDirection(): string {
-      return this.colormap[0] == '-' ? 'bottom' : 'top';
-    }
     get imageFit(): FitImageToAreaResult {
         const {width=500, height=500} = this.ionImage || {};
         return fitImageToArea({

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImageHeader.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImageHeader.vue
@@ -7,7 +7,10 @@
     <el-popover placement="bottom" trigger="click">
         <ion-image-settings @colorInput="updateColor" @toggleScaleBar="toggleScaleBar"></ion-image-settings>
         <div slot="reference" @click="$event.stopPropagation()">
-        <i class="el-icon-setting" style="font-size: 20px; vertical-align: middle;"></i>
+        <i class="el-icon-setting"
+           style="font-size: 20px; vertical-align: middle;"
+           data-feature-anchor="ion-image-settings"
+        />
         </div>
     </el-popover>
 

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImageHeader.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImageHeader.vue
@@ -5,7 +5,7 @@
     </span>
 
     <el-popover placement="bottom" trigger="click">
-        <ion-image-settings @colorInput="updateColor" @toggleScaleBar="toggleScaleBar"></ion-image-settings>
+        <ion-image-settings @scaleBarColorChange="onScaleBarColorChange"></ion-image-settings>
         <div slot="reference" @click="$event.stopPropagation()">
         <i class="el-icon-setting"
            style="font-size: 20px; vertical-align: middle;"
@@ -54,11 +54,9 @@ export default class MainImageHeader extends Vue {
     resetViewport!: Function;
     @Prop({required: true, type: Function})
     toggleOpticalImage!: Function;
-    @Prop({required: true, type: Function})
-    toggleScaleBar!: Function;
 
-    updateColor(colorObj: colorObjType) {
-      this.$emit('colorInput', colorObj)
+    onScaleBarColorChange(color: string | null) {
+      this.$emit('scaleBarColorChange', color)
     }
 }
 </script>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/RelatedAnnotations.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/RelatedAnnotations.vue
@@ -24,7 +24,6 @@
           :colormap="colormap"
           :minIntensity="other.isotopeImages[0].minIntensity"
           :maxIntensity="other.isotopeImages[0].maxIntensity"
-          :hotspotQuantile="hotspotQuantile"
           showPixelIntensity
         />
         <el-popover
@@ -69,7 +68,7 @@
   import {ANNOTATION_SPECIFIC_FILTERS} from '../../../Filters/filterSpecs';
 
 export default {
-  props: ['query', 'annotation', 'database', 'imageLoaderSettings', 'hotspotQuantile'],
+  props: ['query', 'annotation', 'database', 'imageLoaderSettings'],
   components: { ImageLoader },
   data() {
     return {

--- a/metaspace/webapp/src/modules/App/MetaspaceHeader.vue
+++ b/metaspace/webapp/src/modules/App/MetaspaceHeader.vue
@@ -314,7 +314,9 @@
  .b-header {
    background-color: rgba(0, 105, 224, 0.85);
    position: fixed;
-   z-index: 1000;
+   // z-index should be higher than v-loading's .el-loading-mask (z-index: 2000) so that loading spinners
+   // don't overlap the header, but can't be higher than v-tooltip's initial z-index (2001)
+   z-index: 2001;
    top: 0;
    left: 0;
    right: 0;

--- a/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
+++ b/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
@@ -76,7 +76,7 @@ We recommend including off-sample area around your sample during data acquisitio
       name: 'logScale',
       title: 'Log-scale colormaps',
       contentHtml: `
-<p>Ion images are now displayed with a log-scale by default. The colormap can be configured in this menu.</p>
+<p>Ion images are now displayed with a log-scale colormap by default. The colormap can be configured in this menu.</p>
       `,
       dontShowAfter: new Date('2019-07-22'),
       placement: 'bottom',

--- a/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
+++ b/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
@@ -76,9 +76,9 @@ We recommend including off-sample area around your sample during data acquisitio
       name: 'logScale',
       title: 'Log-scale colormaps',
       contentHtml: `
-<p>Ion images are now displayed with a log-scale colormap by default. The colormap can be configured in this menu.</p>
+<p>Ion images can now be viewed with a logarithmic-scale colormap. The colormap can be configured in this menu.</p>
       `,
-      dontShowAfter: new Date('2019-07-22'),
+      dontShowAfter: new Date('2019-08-22'),
       placement: 'bottom',
       getAnchorIfActive(vue: Vue) {
         if (config.features.off_sample && vue.$route.path === '/annotations') {

--- a/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
+++ b/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
@@ -43,6 +43,7 @@
     name: string;
     title: string;
     contentHtml: string;
+    dontShowAfter: Date;
     placement: Placement;
     getAnchorIfActive: (vue: Vue) => HTMLElement | null;
   }
@@ -61,11 +62,27 @@ allowing you to find important molecules faster.</p>
 <p>Please keep in mind that the accuracy of this model is greatly improved in datasets that include some off-sample area.
 We recommend including off-sample area around your sample during data acquisition.</p>
       `,
+      dontShowAfter: new Date('2019-07-22'),
       placement: 'bottom',
       getAnchorIfActive(vue: Vue) {
         if (config.features.off_sample && vue.$route.path === '/annotations') {
           return document.querySelector('.tf-outer[data-test-key=offSample]')
             || document.querySelector('.filter-select');
+        }
+        return null;
+      },
+    },
+    {
+      name: 'logScale',
+      title: 'Log-scale colormaps',
+      contentHtml: `
+<p>Ion images are now displayed with a log-scale by default. The colormap can be configured in this menu.</p>
+      `,
+      dontShowAfter: new Date('2019-07-22'),
+      placement: 'bottom',
+      getAnchorIfActive(vue: Vue) {
+        if (config.features.off_sample && vue.$route.path === '/annotations') {
+          return document.querySelector('[data-feature-anchor="ion-image-settings"]');
         }
         return null;
       },

--- a/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
+++ b/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
@@ -76,12 +76,12 @@ We recommend including off-sample area around your sample during data acquisitio
       name: 'logScale',
       title: 'Log-scale colormaps',
       contentHtml: `
-<p>Ion images can now be viewed with a logarithmic-scale colormap. The colormap can be configured in this menu.</p>
+<p>Ion images can now be viewed with a logarithmic-scale colormap. The ion image display options can be configured in this menu.</p>
       `,
-      dontShowAfter: new Date('2019-08-22'),
+      dontShowAfter: new Date('2019-08-30'),
       placement: 'bottom',
       getAnchorIfActive(vue: Vue) {
-        if (config.features.off_sample && vue.$route.path === '/annotations') {
+        if (vue.$route.path === '/annotations') {
           return document.querySelector('[data-feature-anchor="ion-image-settings"]');
         }
         return null;
@@ -163,6 +163,7 @@ We recommend including off-sample area around your sample during data acquisitio
         const dismissedFeatures = this.getDismissedFeatures();
         const activatableFeatures = NEW_FEATURES
           .filter(feature => !dismissedFeatures.includes(feature.name))
+          .filter(feature => feature.dontShowAfter > new Date())
           .map(feature => [feature, feature.getAnchorIfActive(this)] as [FeatureSpec, HTMLElement | null])
           .filter(([feature, anchor]) => anchor != null);
 

--- a/metaspace/webapp/src/modules/Filters/url.ts
+++ b/metaspace/webapp/src/modules/Filters/url.ts
@@ -214,7 +214,7 @@ export function decodeSettings(location: Location): UrlSettings | undefined {
       activeSections: DEFAULT_ANNOTATION_VIEW_SECTIONS,
       colormap: DEFAULT_COLORMAP,
       colocalizationAlgo: null,
-      scaleType: 'linear',
+      scaleType: 'log',
       hotspotThreshold: null,
     },
 
@@ -234,7 +234,7 @@ export function decodeSettings(location: Location): UrlSettings | undefined {
     settings.annotationView.hotspotThreshold = parseFloat(query.hotspotthreshold) || 100;
   }
   if (query.scale) {
-    settings.annotationView.scaleType = (query.scale || 'linear') as ScaleType;
+    settings.annotationView.scaleType = (query.scale || 'log') as ScaleType;
   }
   if (query.sections !== undefined)
     settings.annotationView.activeSections = decodeSections(query.sections);

--- a/metaspace/webapp/src/modules/Filters/url.ts
+++ b/metaspace/webapp/src/modules/Filters/url.ts
@@ -3,6 +3,7 @@ import { FILTER_SPECIFICATIONS, FilterKey, getDefaultFilter, Level, MetadataList
 import {invert} from 'lodash-es';
 import { Location } from 'vue-router';
 import {ScaleType} from '../../lib/ionImageRendering';
+import {DEFAULT_SCALE_TYPE} from '../../lib/constants';
 
 interface Dictionary<T> {
   [key: string]: T;
@@ -214,7 +215,7 @@ export function decodeSettings(location: Location): UrlSettings | undefined {
       activeSections: DEFAULT_ANNOTATION_VIEW_SECTIONS,
       colormap: DEFAULT_COLORMAP,
       colocalizationAlgo: null,
-      scaleType: 'log',
+      scaleType: DEFAULT_SCALE_TYPE,
       hotspotThreshold: null,
     },
 
@@ -234,7 +235,7 @@ export function decodeSettings(location: Location): UrlSettings | undefined {
     settings.annotationView.hotspotThreshold = parseFloat(query.hotspotthreshold) || 100;
   }
   if (query.scale) {
-    settings.annotationView.scaleType = (query.scale || 'log') as ScaleType;
+    settings.annotationView.scaleType = (query.scale || DEFAULT_SCALE_TYPE) as ScaleType;
   }
   if (query.sections !== undefined)
     settings.annotationView.activeSections = decodeSections(query.sections);

--- a/metaspace/webapp/src/modules/Filters/url.ts
+++ b/metaspace/webapp/src/modules/Filters/url.ts
@@ -187,7 +187,6 @@ export interface UrlAnnotationViewSettings {
   colormap: string;
   colocalizationAlgo: string | null;
   scaleType: ScaleType;
-  hotspotThreshold: number | null;
 }
 
 export interface UrlDatasetsSettings {
@@ -216,7 +215,6 @@ export function decodeSettings(location: Location): UrlSettings | undefined {
       colormap: DEFAULT_COLORMAP,
       colocalizationAlgo: null,
       scaleType: DEFAULT_SCALE_TYPE,
-      hotspotThreshold: null,
     },
 
     datasets: {
@@ -230,10 +228,6 @@ export function decodeSettings(location: Location): UrlSettings | undefined {
     settings.table.order = decodeSortOrder(query.sort);
   if (query.cmap)
     settings.annotationView.colormap = query.cmap;
-  if (query.hotspotthreshold) {
-    // Note: this also accepts the string 'none' to mean no hotspot removal (100%) for the sake of readable URLs
-    settings.annotationView.hotspotThreshold = parseFloat(query.hotspotthreshold) || 100;
-  }
   if (query.scale) {
     settings.annotationView.scaleType = (query.scale || DEFAULT_SCALE_TYPE) as ScaleType;
   }

--- a/metaspace/webapp/src/modules/Filters/url.ts
+++ b/metaspace/webapp/src/modules/Filters/url.ts
@@ -2,6 +2,7 @@ import { FILTER_SPECIFICATIONS, FilterKey, getDefaultFilter, Level, MetadataList
 
 import {invert} from 'lodash-es';
 import { Location } from 'vue-router';
+import {ScaleType} from '../../lib/ionImageRendering';
 
 interface Dictionary<T> {
   [key: string]: T;
@@ -184,6 +185,7 @@ export interface UrlAnnotationViewSettings {
   activeSections: string[];
   colormap: string;
   colocalizationAlgo: string | null;
+  scaleType: ScaleType;
   hotspotThreshold: number | null;
 }
 
@@ -212,7 +214,8 @@ export function decodeSettings(location: Location): UrlSettings | undefined {
       activeSections: DEFAULT_ANNOTATION_VIEW_SECTIONS,
       colormap: DEFAULT_COLORMAP,
       colocalizationAlgo: null,
-      hotspotThreshold: null
+      scaleType: 'linear',
+      hotspotThreshold: null,
     },
 
     datasets: {
@@ -229,6 +232,9 @@ export function decodeSettings(location: Location): UrlSettings | undefined {
   if (query.hotspotthreshold) {
     // Note: this also accepts the string 'none' to mean no hotspot removal (100%) for the sake of readable URLs
     settings.annotationView.hotspotThreshold = parseFloat(query.hotspotthreshold) || 100;
+  }
+  if (query.scale) {
+    settings.annotationView.scaleType = (query.scale || 'linear') as ScaleType;
   }
   if (query.sections !== undefined)
     settings.annotationView.activeSections = decodeSections(query.sections);

--- a/metaspace/webapp/src/store/mutations.js
+++ b/metaspace/webapp/src/store/mutations.js
@@ -12,6 +12,7 @@ import {
   stripFilteringParams,
 } from '../modules/Filters';
 import {DEFAULT_ANNOTATION_VIEW_SECTIONS, DEFAULT_COLORMAP, DEFAULT_TABLE_ORDER} from '../modules/Filters/url';
+import {DEFAULT_SCALE_TYPE} from '../lib/constants';
 
 
 function updatedLocation(state, filter) {
@@ -183,7 +184,7 @@ export default {
 
   setScaleType(state, scaleType) {
     router.replace({
-      query: scaleType !== 'linear'
+      query: scaleType !== DEFAULT_SCALE_TYPE
         ? { ...state.route.query, scale: scaleType }
         : omit(state.route.query, 'scale'),
     });

--- a/metaspace/webapp/src/store/mutations.js
+++ b/metaspace/webapp/src/store/mutations.js
@@ -181,6 +181,14 @@ export default {
     });
   },
 
+  setScaleType(state, scaleType) {
+    router.replace({
+      query: scaleType !== 'linear'
+        ? { ...state.route.query, scale: scaleType }
+        : omit(state.route.query, 'scale'),
+    });
+  },
+
   setHotspotThreshold(state, hotspotThreshold) {
     // hotspotThreshold should be a number or 'none'
     router.replace({

--- a/metaspace/webapp/src/store/mutations.js
+++ b/metaspace/webapp/src/store/mutations.js
@@ -190,15 +190,6 @@ export default {
     });
   },
 
-  setHotspotThreshold(state, hotspotThreshold) {
-    // hotspotThreshold should be a number or 'none'
-    router.replace({
-      query: hotspotThreshold != null
-        ? { ...state.route.query, hotspotthreshold: hotspotThreshold }
-        : omit(state.route.query, 'hotspotthreshold'),
-    });
-  },
-
   setCurrentPage(state, page) {
     router.replace({
       query: page !== 1


### PR DESCRIPTION
Resolves #340 

This PR cleans up the ion image options panel and adds options for log-scale and rank-scale colormapping. 

![Peek 2019-06-14 15-37](https://user-images.githubusercontent.com/26366936/59513091-68833000-8eba-11e9-95be-efb433e285cc.gif)

Full changes:
* Added `log` and `rank` ion image quantization modes
* Replaced `hotspotThreshold` querystring parameter with `scaleType`, which can be one of several presets that is used to determine the scale mode (linear/log/rank) and upper/lower percentiles for clipping (outlier clipping / full range)
* Simplified `IonImageSettings` component by moving `Inverted` into the colormap options dropdown and moving "hidden" into the scale bar color options. Also remove some redundant parameters (`colormapName` and `showScaleBar`) as they can be nicely encoded in their related parameters (`colormap` and `scaleBarColor`)
* Added `dontShowAfter` parameter to `NewFeaturePopup` configs so that we don't need to worry about manually turning the notices off. I've set the off-sample popup to stop appearing 2 months after we turned the feature on in production.
* Changed `ColorBar` to show an accurate scale in log/rank modes. Also support displaying inverted colormaps in the `IonImageSettings` dropdown (required a change to reverse array order in `getColorScale`, because CSS gradients must be in ascending order)
* Unrelated: fixed the z-order of `MetaspaceHeader` so that loading overlays don't appear over the top of the header bar. 