### PR TITLE
Further fixes to prevent OOM errors in Spark

### DIFF
--- a/ansible/aws/aws_start.yml
+++ b/ansible/aws/aws_start.yml
@@ -13,9 +13,9 @@
     - debug: var=aws_key_name
 
     - name: Spin up SM instances
-      shell: python3 aws_instance_manager.py create --key-name {{ aws_key_name }}
+      shell: "{{ sm_cluster_autostart_python }} aws_instance_manager.py create --key-name {{ aws_key_name }}
              --components {{ components }} --stage {{ stage }}
-             {{ ' --credentials-file' if cred_file is defined else '' }}
+             {{ ' --credentials-file' if cred_file is defined else '' }}"
 
   tags: ["web", "spark", "elk"]
 

--- a/ansible/aws/aws_stop.yml
+++ b/ansible/aws/aws_stop.yml
@@ -22,5 +22,6 @@
 
   tasks:
     - name: Stopping SM cluster instances
-      shell: python3 aws_instance_manager.py stop --key-name {{ aws_key_name }}
+      shell: "{{ sm_cluster_autostart_python }} aws_instance_manager.py stop --key-name {{ aws_key_name }}
              --components {{ components }} --stage {{ stage }}
+             {{ ' --credentials-file' if cred_file is defined else '' }}"

--- a/ansible/roles/metaspace_repo/tasks/main.yml
+++ b/ansible/roles/metaspace_repo/tasks/main.yml
@@ -92,8 +92,8 @@
       dest: "{{ sm_home }}/"
       rsync_opts:
         - --exclude=.*
-        - --exclude=conf/*
-        - --exclude=logs/*.json
+        - --exclude=conf/*.json
+        - --exclude=logs/*
         - --exclude=docker/*
         - --exclude=docs/*
   tags: [master, slave, web]

--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -42,11 +42,11 @@
   },
   "spark": {
     "master": "{{ spark_master_host | default('local[*]') }}",
-    "spark.executor.memory": "2g",
+    "spark.executor.memory": "10g",
     "spark.driver.memory": "4g",
     "spark.driver.maxResultSize": "3g",
     "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
-    "spark.kryoserializer.buffer.max": "128m",
+    "spark.kryoserializer.buffer.max": "512m",
     "spark.python.worker.memory": "1g",
     "spark.rdd.compress": true,
     "spark.ui.showConsoleProgress": false,

--- a/metaspace/engine/sm/engine/formula_centroids.py
+++ b/metaspace/engine/sm/engine/formula_centroids.py
@@ -152,7 +152,7 @@ class FormulaCentroids(object):
     def __init__(self, formulas_df, centroids_df):
         u_index_formulas = set(formulas_df.index.unique())
         u_index_centroids = set(centroids_df.index.unique())
-        assert u_index_formulas == u_index_centroids, (u_index_formulas, u_index_centroids)
+        assert u_index_formulas == u_index_centroids
 
         self.formulas_df = formulas_df.sort_values(by='formula')
         self._centroids_df = centroids_df.sort_values(by='mz')

--- a/metaspace/engine/sm/engine/msm_basic/segmenter.py
+++ b/metaspace/engine/sm/engine/msm_basic/segmenter.py
@@ -133,7 +133,7 @@ def clip_centroids_df(centroids_df, mz_min, mz_max):
 
 def calculate_centroids_segments_n(centr_df, image_dims):
     rows, cols = image_dims
-    max_total_dense_images_size = 10 * 2 ** 30
+    max_total_dense_images_size = 5 * 2 ** 30
     peaks_per_centr_segm = int(max_total_dense_images_size / (rows * cols * 8))
     centr_segm_n = max(16, ceil(centr_df.shape[0] / peaks_per_centr_segm))
     return centr_segm_n


### PR DESCRIPTION
The key changes in this PR are increased Spark worker memory and decreased `max_total_dense_images_size` in `calculate_centroids_segments_n`