### PR TITLE
Increase Spark network timeouts

### DIFF
--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -50,7 +50,9 @@
     "spark.python.worker.memory": "1g",
     "spark.rdd.compress": true,
     "spark.ui.showConsoleProgress": false,
-    "spark.sql.execution.arrow.enabled": true
+    "spark.sql.execution.arrow.enabled": true,
+    "spark.network.timeout": "360s",
+    "spark.executor.heartbeatInterval": "60s"
   },
   "aws": {
     "aws_access_key_id": "{{ aws_access_key_id }}",


### PR DESCRIPTION
For some reason on really large datasets Spark executors timeout (loose connection to the driver) on the image search step