### PR TITLE
Include intensity scale when saving ion images

### DIFF
--- a/metaspace/webapp/src/lib/ionImageRendering.ts
+++ b/metaspace/webapp/src/lib/ionImageRendering.ts
@@ -280,11 +280,12 @@ export const renderIonImage = (ionImage: IonImage, cmap?: number[][]) => {
 
 export const renderScaleBar = (ionImage: IonImage, cmap: number[][], horizontal: boolean) => {
   const outputBytes = new Uint8ClampedArray(256 * 4);
-  ionImage.scaleBarValues.forEach((val, i) => {
+  for (let i = 0; i < ionImage.scaleBarValues.length; i++) {
+    const val = ionImage.scaleBarValues[i];
     for (let j = 0; j < 4; j++) {
       outputBytes[(255 - i) * 4 + j] = cmap[val][j];
     }
-  });
+  }
 
   if (horizontal) {
     return createDataUrl(outputBytes, 256, 1);

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Colorbar.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Colorbar.vue
@@ -23,7 +23,7 @@
      if (this.ionImage != null) {
        const cmap = createColormap(this.map);
        return {
-         backgroundImage: `url(${renderScaleBar(this.ionImage, cmap, this.horizontal)}`,
+         backgroundImage: `url(${renderScaleBar(this.ionImage, cmap, this.horizontal)})`,
          backgroundSize: 'contain',
          backgroundRepeat: 'repeat-x'
        };

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
@@ -1,81 +1,79 @@
 <template>
-<div class="main-ion-image-container">
-    <div class="main-ion-image-container-row1">
-        <div class="image-viewer-container" ref="imageViewerContainer" v-resize="onResize">
-            <ion-image-viewer
-              :ionImage="ionImage"
-              :isLoading="ionImageIsLoading"
-              :colormap="colormap"
-              :pixelSizeX="pixelSizeX"
-              :pixelSizeY="pixelSizeY"
-              :pixelAspectRatio="imageLoaderSettings.pixelAspectRatio"
-              :scaleBarColor="scaleBarColor"
-              :width="imageViewerWidth"
-              :height="imageViewerHeight"
-              :zoom="imageLoaderSettings.imagePosition.zoom * imageFit.imageZoom"
-              :minZoom="imageFit.imageZoom / 4"
-              :maxZoom="imageFit.imageZoom * 20"
-              :xOffset="imageLoaderSettings.imagePosition.xOffset"
-              :yOffset="imageLoaderSettings.imagePosition.yOffset"
-              ref="imageLoader"
-              scrollBlock
-              showPixelIntensity
-              class="image-loader"
-              v-bind="imageLoaderSettings"
-              @move="handleImageMove"
-            />
+<div class="main-ion-image-container" ref="container">
+    <div class="image-viewer-container" ref="imageViewerContainer" v-resize="onResize">
+        <ion-image-viewer
+          :ionImage="ionImage"
+          :isLoading="ionImageIsLoading"
+          :colormap="colormap"
+          :pixelSizeX="pixelSizeX"
+          :pixelSizeY="pixelSizeY"
+          :pixelAspectRatio="imageLoaderSettings.pixelAspectRatio"
+          :scaleBarColor="scaleBarColor"
+          :width="imageViewerWidth"
+          :height="imageViewerHeight"
+          :zoom="imageLoaderSettings.imagePosition.zoom * imageFit.imageZoom"
+          :minZoom="imageFit.imageZoom / 4"
+          :maxZoom="imageFit.imageZoom * 20"
+          :xOffset="imageLoaderSettings.imagePosition.xOffset"
+          :yOffset="imageLoaderSettings.imagePosition.yOffset"
+          ref="imageLoader"
+          scrollBlock
+          showPixelIntensity
+          class="image-loader"
+          v-bind="imageLoaderSettings"
+          @move="handleImageMove"
+        />
+    </div>
+
+    <div class="colorbar-container">
+        <div v-if="imageLoaderSettings.opticalSrc" class="opacity-slider dom-to-image-hidden">
+            Opacity:
+            <el-slider
+                    vertical
+                    height="150px"
+                    :value="opacity"
+                    @input="onOpacityInput"
+                    :min=0
+                    :max=1
+                    :step=0.01
+                    style="margin: 10px 0px 30px 0px;">
+            </el-slider>
         </div>
 
-        <div class="colorbar-container">
-            <div v-if="imageLoaderSettings.opticalSrc">
-                Opacity:
-                <el-slider
-                        vertical
-                        height="150px"
-                        :value="opacity"
-                        @input="onOpacityInput"
-                        :min=0
-                        :max=1
-                        :step=0.01
-                        style="margin: 10px 0px 30px 0px;">
-                </el-slider>
+        <el-tooltip v-if="ionImage && ionImage.maxIntensity !== ionImage.clippedMaxIntensity" placement="left">
+            <div>
+                <div style="color: red">{{ ionImage.clippedMaxIntensity.toExponential(2) }}</div>
             </div>
+            <div slot="content">
+                Hot-spot removal has been applied to this image. <br/>
+                Pixel intensities above the {{ionImage.maxQuantile*100}}th percentile, {{ ionImage.clippedMaxIntensity.toExponential(2) }},
+                have been reduced to {{ ionImage.clippedMaxIntensity.toExponential(2) }}. <br/>
+                The highest intensity before hot-spot removal was {{ ionImage.maxIntensity.toExponential(2) }}.
+            </div>
+        </el-tooltip>
+        <div v-else>
+            {{ ionImage && ionImage.maxIntensity.toExponential(2) }}
+        </div>
+        <colorbar style="width: 20px; height: 160px; align-self: center;"
+                  :map="colormap"
+                  :ionImage="ionImage"
+                  slot="reference">
+        </colorbar>
+        {{ ionImage && ionImage.clippedMinIntensity.toExponential(2) }}
 
-            <el-tooltip v-if="ionImage && ionImage.maxIntensity !== ionImage.clippedMaxIntensity" placement="left">
-                <div>
-                    <div style="color: red">{{ ionImage.clippedMaxIntensity.toExponential(2) }}</div>
-                </div>
-                <div slot="content">
-                    Hot-spot removal has been applied to this image. <br/>
-                    Pixel intensities above the {{ionImage.maxQuantile*100}}th percentile, {{ ionImage.clippedMaxIntensity.toExponential(2) }},
-                    have been reduced to {{ ionImage.clippedMaxIntensity.toExponential(2) }}. <br/>
-                    The highest intensity before hot-spot removal was {{ ionImage.maxIntensity.toExponential(2) }}.
-                </div>
-            </el-tooltip>
-            <div v-else>
-                {{ ionImage && ionImage.maxIntensity.toExponential(2) }}
-            </div>
-            <colorbar style="width: 20px; height: 160px; align-self: center;"
-                      :map="colormap"
-                      :ionImage="ionImage"
-                      slot="reference">
-            </colorbar>
-            {{ ionImage && ionImage.clippedMinIntensity.toExponential(2) }}
-
-            <div class="annot-view__image-download">
-                <!-- see https://github.com/tsayen/dom-to-image/issues/155 -->
-                <img src="../../../../assets/download-icon.png"
-                     width="32px"
-                     title="Save visible region in PNG format"
-                     @click="saveImage"
-                     v-if="browserSupportsDomToImage"/>
-                <img src="../../../../assets/download-icon.png"
-                     width="32px"
-                     style="opacity: 0.3"
-                     title="Your browser is not supported"
-                     @click="showBrowserWarning"
-                     v-else/>
-            </div>
+        <div class="annot-view__image-download dom-to-image-hidden">
+            <!-- see https://github.com/tsayen/dom-to-image/issues/155 -->
+            <img src="../../../../assets/download-icon.png"
+                 width="32px"
+                 title="Save visible region in PNG format"
+                 @click="saveImage"
+                 v-if="browserSupportsDomToImage"/>
+            <img src="../../../../assets/download-icon.png"
+                 width="32px"
+                 style="opacity: 0.3"
+                 title="Your browser is not supported"
+                 @click="showBrowserWarning"
+                 v-else/>
         </div>
     </div>
 </div>
@@ -191,10 +189,11 @@ export default class MainImage extends Vue {
     }
 
     async saveImage() {
-        const node = this.$refs.imageViewerContainer;
+        const node = this.$refs.container;
         const blob = await domtoimage.toBlob(node, {
             width: node.clientWidth,
             height: node.clientHeight,
+            filter: el => !el.classList || !el.classList.contains('dom-to-image-hidden'),
         });
         saveAs(blob, `${this.annotation.id}.png`);
     }
@@ -228,11 +227,6 @@ export default class MainImage extends Vue {
 <style>
 .main-ion-image-container {
     display: flex;
-    flex-direction: column;
-}
-
-.main-ion-image-container-row1 {
-    display: flex;
     flex-direction: row;
     justify-content: center;
 }
@@ -247,9 +241,14 @@ export default class MainImage extends Vue {
     display: flex;
     flex:none;
     flex-direction: column;
+    align-items: center;
     justify-content: flex-end;
-    padding-left: 10px;
-    padding-bottom: 6px;
+    padding: 6px 5px 0 5px;
+}
+.opacity-slider {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .annot-view__image-download {

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
@@ -56,8 +56,7 @@
         </div>
         <colorbar style="width: 20px; height: 160px; align-self: center;"
                   :map="colormap"
-                  :ionImage="ionImage"
-                  slot="reference">
+                  :ionImage="ionImage">
         </colorbar>
         {{ ionImage && ionImage.clippedMinIntensity.toExponential(2) }}
 


### PR DESCRIPTION
* Includes the intensity scale bar when saving ion images. 
* Properly centers the controls on the right side of the ion image (previously their alignment was slightly off
* Fixes a bug with IE11 not displaying the intensity scale due to `.forEach` not being supported on typed arrays, and a missing `)` after `background-image: url(...`
* Remove a redundant `slot="reference"` attribute that did nothing but shouldn't be there

## Saved images from before this PR (with/without optical images):

![Chrome,Opt,Before](https://user-images.githubusercontent.com/26366936/60966491-a1c38a00-a318-11e9-8365-7cd45048bd02.png)
![Chrome,NoOpt,Before](https://user-images.githubusercontent.com/26366936/60966492-a25c2080-a318-11e9-8b74-aa0e15704e2a.png)

## Saved images from after this PR:

#### Chrome

![Chrome,Opt,After](https://user-images.githubusercontent.com/26366936/60966553-c881c080-a318-11e9-888b-cb0f83a2a6ab.png)
![Chrome,NoOpt,After](https://user-images.githubusercontent.com/26366936/60966552-c881c080-a318-11e9-90fe-eea0d28eea81.png)

#### Firefox

![Firefox,Opt,After](https://user-images.githubusercontent.com/26366936/60966567-d20b2880-a318-11e9-814b-4c5883ab9101.png)
![Firefox,NoOpt,After](https://user-images.githubusercontent.com/26366936/60966568-d2a3bf00-a318-11e9-8faf-4109b83db783.png)


## Web interface alignment change

Before:
![image](https://user-images.githubusercontent.com/26366936/60967393-d9cbcc80-a31a-11e9-8b65-0017fda431b5.png)

After:
![image](https://user-images.githubusercontent.com/26366936/60967376-c9b3ed00-a31a-11e9-9c1a-66a6fe52f312.png)
