### PR TITLE
Bug fixes & tweaks

### DIFF
--- a/ansible/aws/templates/all/vars.yml.template
+++ b/ansible/aws/templates/all/vars.yml.template
@@ -199,6 +199,7 @@ sm_webapp_features:
   all_dbs: false
   all_adducts: false
   neutral_losses: false
+  neutral_losses_new_ds: true
   chem_mods: false
   advanced_ds_config: false
 

--- a/metaspace/engine/requirements.txt
+++ b/metaspace/engine/requirements.txt
@@ -8,7 +8,7 @@ pytest
 recommonmark
 boto3
 fabric3
-pypng
+pypng==0.0.19    # 0.0.20 introduced incompatible API changes
 pyyaml
 elasticsearch-dsl>=5.0.0,<6.0.0
 pika==0.11.0b1

--- a/metaspace/webapp/package.json
+++ b/metaspace/webapp/package.json
@@ -71,7 +71,7 @@
     "vue-apollo": "3.0.0-beta.13",
     "vue-clickaway": "^2.1.0",
     "vue-lazyload": "^1.0.0-rc5",
-    "vue-resize-directive": "^1.0.0",
+    "vue-resize-directive": "^1.2.0",
     "vue-router": "^3.0.1",
     "vue-slide-up-down": "^1.3.3",
     "vuex": "~3.0.1",

--- a/metaspace/webapp/src/components/DatasetInfo.vue
+++ b/metaspace/webapp/src/components/DatasetInfo.vue
@@ -144,8 +144,23 @@
   }
 </script>
 
-<style>
+<style lang="scss" scoped>
  #metadata-tree {
    text-align: left;
+
+   // Allow line breaks & word wrap on very long lines
+   /deep/ .el-tree-node {
+     white-space: normal;
+   }
+   /deep/ .el-tree-node__content {
+     height: auto;
+     padding: 1px 0;
+   }
+   /deep/ .el-tree-node__label {
+     width: calc(100% - 30px); // Flex-shrink doesn't seem to work with overflow-wrap, so subtract 30px as an approximation of the space consumed the parent's padding
+     overflow-wrap: break-word;
+   }
  }
+
+
 </style>

--- a/metaspace/webapp/src/config.ts
+++ b/metaspace/webapp/src/config.ts
@@ -34,6 +34,7 @@ interface Features {
   all_dbs: boolean;
   all_adducts: boolean;
   neutral_losses: boolean;
+  neutral_losses_new_ds: boolean; // False prevents neutral losses being set on the first upload
   chem_mods: boolean;
   advanced_ds_config: boolean;
 }
@@ -71,6 +72,7 @@ const defaultConfig: ClientConfig = {
     all_dbs: false,
     all_adducts: false,
     neutral_losses: false,
+    neutral_losses_new_ds: true,
     chem_mods: false,
     advanced_ds_config: false,
   }

--- a/metaspace/webapp/src/graphqlClient.ts
+++ b/metaspace/webapp/src/graphqlClient.ts
@@ -14,9 +14,9 @@ import {get} from 'lodash-es';
 const graphqlUrl = config.graphqlUrl || `${window.location.origin}/graphql`;
 const wsGraphqlUrl = config.wsGraphqlUrl || `${window.location.origin.replace(/^http/, 'ws')}/ws`;
 
-let $alert: ((message: string, title: string, options?: any) => void) | null = null;
+let $alert: ((message: string, title: string, options?: any) => Promise<any>) | null = null;
 
-export function setMaintenanceMessageHandler(_$alert: (message: string, title: string, options?: any) => void) {
+export function setMaintenanceMessageHandler(_$alert: (message: string, title: string, options?: any) => Promise<any>) {
   $alert = _$alert;
 }
 
@@ -50,7 +50,8 @@ const errorLink = onError(({ graphQLErrors, networkError, forward, operation }) 
         readOnlyErrors.forEach(err => { (err as any).isHandled = true; });
         $alert('This operation could not be completed. METASPACE is currently in read-only mode for scheduled maintenance. Please try again later.',
           'Scheduled Maintenance',
-          {type: 'error'});
+          {type: 'error'})
+          .catch(() => {/*Ignore exception raised when alert is closed*/});
       }
     }
   } else if (networkError) {

--- a/metaspace/webapp/src/modules/Account/components/ForgotPasswordDialog.vue
+++ b/metaspace/webapp/src/modules/Account/components/ForgotPasswordDialog.vue
@@ -60,7 +60,10 @@
         await sendPasswordResetToken(this.model.email);
         this.hasSucceeded = true;
       } catch (err) {
-        reportError(err);
+        // form.validate() throws false if something is invalid. Detect it so that we don't log "false" as an error
+        if (err !== false) {
+          reportError(err);
+        }
       } finally {
         this.isSubmitting = false;
       }

--- a/metaspace/webapp/src/modules/Account/components/ResetPasswordPage.vue
+++ b/metaspace/webapp/src/modules/Account/components/ResetPasswordPage.vue
@@ -103,7 +103,8 @@
         await resetPassword(this.token, this.email, this.model.password);
         await refreshLoginStatus();
         this.$router.push('/');
-        this.$alert('Your password has been successfully reset.', 'Password reset', {type: 'success'});
+        this.$alert('Your password has been successfully reset.', 'Password reset', {type: 'success'})
+          .catch(() => {/*Ignore exception raised when alert is closed*/});
       } catch (err) {
         reportError(err);
       } finally {

--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
@@ -90,24 +90,16 @@
                        sortable="custom"
                        min-width="120">
         <template slot-scope="props">
-        <el-popover trigger="hover" placement="right">
-            <div>Candidate molecules ({{ props.row.possibleCompounds.length }}):
-                <ul>
-                    <li v-for="comp in props.row.possibleCompounds">
-                        {{ comp.name }}
-                    </li>
-                </ul>
-            </div>
-
-            <div slot="reference" class="cell-wrapper">
+          <candidate-molecules-popover placement="right" :possibleCompounds="props.row.possibleCompounds">
+            <div class="cell-wrapper">
                 <span class="sf cell-span"
                       v-html="renderMolFormulaHtml(props.row.ion)"></span>
-                <img src="../../assets/filter-icon.png"
-                     v-if="!filter.compoundName"
-                     @click="filterMolFormula(props.row)"
-                     title="Limit results to this molecular formula"/>
+              <img src="../../assets/filter-icon.png"
+                   v-if="!filter.compoundName"
+                   @click="filterMolFormula(props.row)"
+                   title="Limit results to this molecular formula"/>
             </div>
-        </el-popover>
+          </candidate-molecules-popover>
         </template>
       </el-table-column>
 
@@ -219,6 +211,7 @@
 <script>
   import {renderMolFormulaHtml} from '../../util';
  import ProgressButton from './ProgressButton.vue';
+  import CandidateMoleculesPopover from './annotation-widgets/CandidateMoleculesPopover.vue';
  import {
    annotationListQuery,
    tableExportQuery
@@ -246,7 +239,10 @@
  export default {
    name: 'annotation-table',
    props: ["hideColumns"],
-   components: {ProgressButton},
+   components: {
+     ProgressButton,
+     CandidateMoleculesPopover,
+   },
    data () {
      return {
        annotations: [],

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
@@ -22,6 +22,7 @@
  import config from '../../config';
  import noImageURL from '../../assets/no-image.svg';
  import {OpacityMode} from '../../lib/createColormap';
+ import CandidateMoleculesPopover from './annotation-widgets/CandidateMoleculesPopover.vue';
 
  type colorObjType = {
    code: string,
@@ -48,7 +49,11 @@
  }
 
  const metadataDependentComponents: any = {};
- const componentsToRegister: any = { DatasetInfo, ColocalizationSettings };
+ const componentsToRegister: any = {
+   DatasetInfo,
+   ColocalizationSettings,
+   CandidateMoleculesPopover,
+ };
  for (let category of Object.keys(annotationWidgets)) {
    metadataDependentComponents[category] = {};
    for (let mdType of Object.keys(annotationWidgets[category])) {

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
@@ -67,12 +67,15 @@
        update: (data: any) => {
          const {annotation} = data;
          if (annotation != null) {
-           let chart = safeJsonParse(annotation.peakChartData);
-           chart.sampleData = {
-             mzs: annotation.isotopeImages.map((im: any) => im.mz),
-             ints: annotation.isotopeImages.map((im: any) => im.totalIntensity),
+           const chart = safeJsonParse(annotation.peakChartData);
+           const isotopes = annotation.isotopeImages.filter((im: any) => im.mz > 0);
+           return {
+             ...chart,
+             sampleData: {
+               mzs: isotopes.map((im: any) => im.mz),
+               ints: isotopes.map((im: any) => im.totalIntensity),
+             },
            };
-           return chart;
          } else {
            return null;
          }

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.vue
@@ -7,17 +7,9 @@
         <div class="el-collapse-item grey-bg">
           <div class="el-collapse-item__header av-header grey-bg">
 
-            <el-popover trigger="hover" placement="bottom">
-              <div>Candidate molecules ({{ annotation.possibleCompounds.length }}):
-                <ul>
-                  <li v-for="comp in annotation.possibleCompounds">
-                    {{ comp.name }}
-                  </li>
-                </ul>
-              </div>
-
-              <span slot="reference" class="sf-big" v-html="formattedMolFormula" />
-            </el-popover>
+            <candidate-molecules-popover placement="bottom" :possibleCompounds="annotation.possibleCompounds">
+              <span class="sf-big" v-html="formattedMolFormula" />
+            </candidate-molecules-popover>
 
             <span class="mz-big">{{ annotation.mz.toFixed(4) }}</span>
             <el-popover trigger="hover" placement="bottom">

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/CandidateMoleculesPopover.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/CandidateMoleculesPopover.vue
@@ -1,0 +1,48 @@
+<template>
+  <el-popover trigger="hover" ref="popover" v-bind="$attrs">
+    <div>Candidate molecules ({{ possibleCompounds.length }}):
+      <ul>
+        <li v-for="comp in possibleCompounds">
+          {{ comp.name }}
+        </li>
+      </ul>
+    </div>
+
+    <slot slot="reference" />
+  </el-popover>
+</template>
+
+<script>
+
+
+  export default {
+    inheritAttrs: false,
+    props: {
+      possibleCompounds: { type: Array, required: true }
+    },
+    mounted() {
+      const {popover} = this.$refs;
+      // WORKAROUND: popover doesn't have a "closeDelay" prop yet, so replace its event listeners with patched versions
+      // TODO: Replace this with `:close-delay="0"` once https://github.com/ElemeFE/element/pull/16671 is available
+      if (popover != null) {
+        const patchedHandleMouseLeave = (function() {
+          clearTimeout(this._timer);
+          this.showPopper = false;
+        }).bind(popover);
+
+        if (popover.referenceElm != null) {
+          popover.referenceElm.removeEventListener('mouseleave', popover.handleMouseLeave);
+          popover.referenceElm.addEventListener('mouseleave', patchedHandleMouseLeave);
+        }
+        if (popover.popper != null) {
+          popover.popper.removeEventListener('mouseleave', popover.handleMouseLeave);
+          popover.popper.addEventListener('mouseleave', patchedHandleMouseLeave);
+        }
+      }
+    }
+  };
+</script>
+
+<style scoped>
+
+</style>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
@@ -30,7 +30,6 @@
                               :colormap="colormap"
                               :imageFitParams="{areaMinHeight: 50, areaHeight: 250}"
                               v-bind="imageLoaderSettings"
-                              v-if="img.url !== null"
                               style="overflow: hidden"
                               :minIntensity="img.minIntensity"
                               :maxIntensity="img.maxIntensity"
@@ -91,7 +90,8 @@ export default class Diagnostics extends Vue {
 
     get sortedIsotopeImages(): any[] {
         // Usually isotope images are pre-sorted by the server, but it's not an explicit guarantee of the API
-        return sortBy(this.annotation.isotopeImages, img => img.mz);
+        return sortBy(this.annotation.isotopeImages, img => img.mz)
+          .filter(img => img.mz > 0);
     }
 
     get showOffSample(): boolean {

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
@@ -201,7 +201,8 @@ export default class MainImage extends Vue {
       this.$alert('Due to technical limitations we are only able to support downloading layered and/or zoomed images' +
       ' on Chrome and Firefox. As a workaround, it is possible to get a copy of the raw ion image by right-clicking ' +
       'it and clicking "Save picture as", however this will not take into account your current zoom ' +
-      'settings or show the optical image.');
+      'settings or show the optical image.')
+        .catch(() => {/*Ignore exception raised when alert is closed*/});
     }
 
     get browserSupportsDomToImage(): boolean {

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/RelatedAnnotations.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/RelatedAnnotations.vue
@@ -3,18 +3,15 @@
     <div class="small-peak-image" v-for="(other, idx) in annotations" :key="other.ion">
       <component :is="other.ion !== colocReferenceIon ? 'router-link' : 'span'" :to="linkToAnnotation(other)" class="ion-link">
 
-        <el-popover trigger="hover" placement="top" :openDelay="100" class="mol-formula-line">
-          <div>Candidate molecules ({{ other.possibleCompounds.length }}):
-            <ul>
-              <li v-for="comp in other.possibleCompounds">
-                {{ comp.name }}
-              </li>
-            </ul>
-          </div>
+        <candidate-molecules-popover
+          class="mol-formula-line"
+          placement="top"
+          :possibleCompounds="other.possibleCompounds"
+          :openDelay="100">
+          <span v-if="other.ion !== colocReferenceIon" class="sf cell-span" v-html="renderFormula(other)" />
+          <span v-else>Reference annotation<sub><!-- Subscript to make height consistent with formulas --></sub></span>
+        </candidate-molecules-popover>
 
-          <span v-if="other.ion !== colocReferenceIon" slot="reference" class="sf cell-span" v-html="renderFormula(other)" />
-          <span v-else slot="reference">Reference annotation<sub><!-- Subscript to make height consistent with formulas --></sub></span>
-        </el-popover>
         <br/>
         {{  other.mz.toFixed(4) }} <br/>
         <image-loader
@@ -66,10 +63,11 @@
   import { relatedAnnotationsQuery } from '../../../../api/annotation';
   import {encodeParams, stripFilteringParams} from '../../../Filters';
   import {ANNOTATION_SPECIFIC_FILTERS} from '../../../Filters/filterSpecs';
+  import CandidateMoleculesPopover from '../CandidateMoleculesPopover';
 
 export default {
   props: ['query', 'annotation', 'database', 'imageLoaderSettings'],
-  components: { ImageLoader },
+  components: { ImageLoader, CandidateMoleculesPopover },
   data() {
     return {
       loading: 0,

--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditPage.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditPage.vue
@@ -127,7 +127,8 @@
              dataset processing has been temporarily suspended so that we can safely update the website.\n\n
              Please wait a few hours and try again.`,
                'Dataset processing suspended',
-               { type: 'warning' });
+               { type: 'warning' })
+                 .catch(() => {/*Ignore exception raised when alert is closed*/});
              return false;
            } else if (await this.confirmReprocess()) {
              return await this.saveDataset(datasetId, payload, {...options, reprocess: true});

--- a/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
@@ -65,7 +65,7 @@
                 </span>
                 <el-select
                   class="md-ac"
-                  :disabled="!features.advanced_ds_config && isNewDataset"
+                  :disabled="!features.advanced_ds_config && !features.neutral_losses_new_ds && isNewDataset"
                   :value="value.neutralLosses"
                   @input="val => onInput('neutralLosses', val)"
                   multiple filterable default-first-option remote

--- a/metaspace/webapp/yarn.lock
+++ b/metaspace/webapp/yarn.lock
@@ -3568,9 +3568,10 @@ css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
 
-css-element-queries@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/css-element-queries/-/css-element-queries-0.4.0.tgz#cb5bcde9d980ac3699e7471f798e70600088d3de"
+css-element-queries@^1.0.2:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/css-element-queries/-/css-element-queries-1.2.1.tgz#70d1a0f676fc0bd0a3306522a5b2d3bcc55c9fe6"
+  integrity sha512-hiI1tSzf+U/gE13qhfwnCvN90Ay0THnE+mT3pjN/c/mvFmEUHZVNrvMJrrkw2ppOzkl69FdgH2ZGZENYQUaN2A==
 
 css-loader@^0.28.11:
   version "0.28.11"
@@ -6690,6 +6691,11 @@ internal-ip@1.2.0:
 interpret@^1.0.0, interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
+
+intersection-observer@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.5.1.tgz#e340fc56ce74290fe2b2394d1ce88c4353ac6dfa"
+  integrity sha512-Zd7Plneq82kiXFixs7bX62YnuZ0BMRci9br7io88LwDyF3V43cQMI+G5IiTlTNTt+LsDUppl19J/M2Fp9UkH6g==
 
 interval-tree-1d@^1.0.1:
   version "1.0.3"
@@ -12976,11 +12982,13 @@ vue-property-decorator@6.1.0:
     reflect-metadata "^0.1.10"
     vue-class-component "^6.1.0"
 
-vue-resize-directive@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/vue-resize-directive/-/vue-resize-directive-1.0.0.tgz#e1197131390ac8d5e20116198679b06eb6cec985"
+vue-resize-directive@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/vue-resize-directive/-/vue-resize-directive-1.2.0.tgz#4214ca8a80a425529b036ea868cad54a38f613e4"
+  integrity sha512-LmpFexQcl1XYyz3DQrTrq3Efgj50MKEON60nR9MMAq1D2ZtXFg1WDcy1wy1T0SeduNtIu9hos2aLTsJUplvjlQ==
   dependencies:
-    css-element-queries "^0.4.0"
+    css-element-queries "^1.0.2"
+    intersection-observer "^0.5.0"
     lodash.debounce "^4.0.8"
 
 vue-router@^3.0.1:


### PR DESCRIPTION
Best reviewed commit-by-commit.

The first two commits are for handling changes in sm-engine behavior. I'm not sure what the cause for these changes is, and I couldn't actually reproduce the "completely black ion images" locally. Handling it on the client side seemed to be the easiest and most future-proof fix, though ideally we wouldn't generate empty PNG files.

Example DS with black images: https://metaspace2020.eu/annotations?db=ChEBI-2018-01&ds=2019-06-25_22h19m11s&cmap=Hot&scale=hist&sections=5 (Look in the Diagnostics tab)

"Prevent logging 'false' error" and "Ignore promise rejections when $alerts are closed" fix benign bugs.  ElementUI rejects promises with `false` when a form is invalid and `'cancel'` when a popup is closed by its "X" button. Since neither value inherits from `Error`, they don't get a stack trace which makes them a huge pain in Sentry to debug.

I'm really not proud of the "Make candidate molecule popups close faster" hack, but it makes the annotations page feel noticeably better. I submitted a PR to ElementUI to add an option that would allow the hack to be removed.