### PR TITLE
Fix issue in python-client downloading isotope images 

### DIFF
--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,2 +1,2 @@
 name = 'metaspace2020'
-__version__ = u'1.4.1'
+__version__ = u'1.4.3'

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -598,7 +598,7 @@ class SMDataset(object):
             if images[i] is None:
                 images[i] = np.zeros(shape, dtype=non_empty_images[0].dtype)
             else:
-                images[i] *= image_metadata[i]['maxIntensity']
+                images[i] *= float(image_metadata[i]['maxIntensity'])
 
         return IsotopeImages(images, sf, adduct, [r['mz'] for r in image_metadata], [r['url'] for r in image_metadata])
 


### PR DESCRIPTION
This issue happens when maxIntensity is too big for a regular integer. NumPy's type coercion in the `*=` operation doesn't automatically cast the bigint to a float, instead raising an error:

```python
from metaspace.sm_annotation_utils import SMInstance
sm = SMInstance()
ds = sm.dataset(id='2018-06-29_23h21m28s')
anns = ds.annotations()
ds.isotope_images('C42H78NO10P', '-H')
```

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-de884037fdd5> in <module>
      3 ds = sm.dataset(id='2018-06-29_23h21m28s')
      4 anns = ds.annotations()
----> 5 ds.isotope_images('C42H78NO10P', '-H')

~/dev/metaspace/metaspace/python-client/metaspace/sm_annotation_utils.py in isotope_images(self, sf, adduct)
    599                 images[i] = np.zeros(shape, dtype=non_empty_images[0].dtype)
    600             else:
--> 601                 images[i] *= image_metadata[i]['maxIntensity']
    602 
    603         return IsotopeImages(images, sf, adduct, [r['mz'] for r in image_metadata], [r['url'] for r in image_metadata])

TypeError: ufunc 'multiply' output (typecode 'O') could not be coerced to provided output parameter (typecode 'f') according to the casting rule ''same_kind''
```

The solution is to just explicitly cast the value to a float.

I've already released this to PyPI as ~1.4.2~ 1.4.3, as someone was waiting on the fix.