### PR TITLE
Optimize FDR computation for cases when neutral loss and chem modification are used

### DIFF
--- a/metaspace/engine/sm/engine/colocalization.py
+++ b/metaspace/engine/sm/engine/colocalization.py
@@ -202,13 +202,8 @@ def analyze_colocalization(ds_id, mol_db, images, ion_ids, fdrs):
         return
 
     logger.debug('Calculating colocalization metrics')
-    pca_images = PCA(min(20, *images.ref.shape)).fit_transform(images.ref)
     cos_scores = pairwise_kernels(images.ref, metric='cosine')
     images.free()
-
-    pca_cos_scores = pairwise_kernels(pca_images, metric='cosine')
-    pca_pear_scores = np.float32(np.corrcoef(pca_images))
-    pca_sper_scores = np.float32(spearmanr(pca_images, axis=1)[0])  # TODO: Discard low p-value entries?
 
     for fdr in [0.05, 0.1, 0.2, 0.5]:
         fdr_mask = fdrs <= fdr + 0.001
@@ -242,9 +237,6 @@ def analyze_colocalization(ds_id, mol_db, images, ion_ids, fdrs):
                                          coloc_annotations=coloc_annotations)
 
             yield run_alg('cosine', cos_scores, True)
-            yield run_alg('pca_cosine', pca_cos_scores, False)
-            yield run_alg('pca_pearson', pca_pear_scores, False)
-            yield run_alg('pca_spearman', pca_sper_scores, False)
         else:
             logger.debug(f'Skipping FDR {fdr} as there are only {len(masked_ion_ids)} annotation(s)')
 

--- a/metaspace/engine/sm/engine/fdr.py
+++ b/metaspace/engine/sm/engine/fdr.py
@@ -37,7 +37,7 @@ class FDR(object):
         self.random_seed = 42
         self.target_modifiers_df = _make_target_modifiers_df(chem_mods, neutral_losses, target_adducts)
 
-    def choose_decoys(self, decoys):
+    def _choose_decoys(self, decoys):
         copy = decoys.copy()
         np.random.shuffle(copy)
         return copy[:self.decoy_sample_size]
@@ -46,7 +46,7 @@ class FDR(object):
         np.random.seed(self.random_seed)
         target_modifiers = list(self.target_modifiers_df.decoy_modifier_prefix.items())
         for formula, (tm, dm_prefix) in product(target_formulas, target_modifiers):
-            for da in self.choose_decoys(decoy_adducts_cand):
+            for da in self._choose_decoys(decoy_adducts_cand):
                 yield (formula, tm, dm_prefix + da)
 
     def decoy_adducts_selection(self, target_formulas):

--- a/metaspace/engine/sm/engine/tests/msm_basic/test_msm_basic_search.py
+++ b/metaspace/engine/sm/engine/tests/msm_basic/test_msm_basic_search.py
@@ -1,8 +1,5 @@
-import pandas as pd
-
 from sm.engine.msm_basic.msm_basic_search import init_fdr, collect_ion_formulas, compute_fdr
-from sm.engine.tests.util import make_moldb_mock
-
+from sm.engine.tests.util import make_moldb_mock, spark_context
 
 BASIC_ISOTOPE_GENERATION_CONFIG = {
     "adducts": ["+H"],
@@ -21,6 +18,7 @@ FULL_ISOTOPE_GENERATION_CONFIG = {
     "chem_mods": ["-H+O"]
 }
 
+
 def test_init_fdr():
     moldb_fdr_list = init_fdr({'decoy_sample_size': 20}, BASIC_ISOTOPE_GENERATION_CONFIG, [make_moldb_mock()])
 
@@ -29,28 +27,28 @@ def test_init_fdr():
     assert not fdr.td_df.empty
 
 
-def test_collect_ion_formulas():
+def test_collect_ion_formulas(spark_context):
     moldb_fdr_list = init_fdr({'decoy_sample_size': 20}, BASIC_ISOTOPE_GENERATION_CONFIG, [make_moldb_mock()])
 
-    df = collect_ion_formulas(moldb_fdr_list)
+    df = collect_ion_formulas(spark_context, moldb_fdr_list)
 
     assert df.columns.tolist() == ['moldb_id', 'ion_formula', 'formula', 'modifier']
     assert df.shape == (42, 4)
 
 
-def test_decoy_sample_size_30():
+def test_decoy_sample_size_30(spark_context):
     moldb_fdr_list = init_fdr({'decoy_sample_size': 30}, BASIC_ISOTOPE_GENERATION_CONFIG, [make_moldb_mock()])
 
-    df = collect_ion_formulas(moldb_fdr_list)
+    df = collect_ion_formulas(spark_context, moldb_fdr_list)
 
     assert df.columns.tolist() == ['moldb_id', 'ion_formula', 'formula', 'modifier']
     assert df.shape == (62, 4)
 
 
-def test_neutral_losses_and_chem_mods():
+def test_neutral_losses_and_chem_mods(spark_context):
     moldb_fdr_list = init_fdr({'decoy_sample_size': 1}, FULL_ISOTOPE_GENERATION_CONFIG, [make_moldb_mock()])
 
-    df = collect_ion_formulas(moldb_fdr_list)
+    df = collect_ion_formulas(spark_context, moldb_fdr_list)
 
     assert df.columns.tolist() == ['moldb_id', 'ion_formula', 'formula', 'modifier']
     # 2 formulas * (4 target adducts + (4 target adducts * 1 decoy adducts per target adduct)

--- a/metaspace/engine/sm/engine/tests/test_fdr.py
+++ b/metaspace/engine/sm/engine/tests/test_fdr.py
@@ -9,6 +9,7 @@ from sm.engine.formula_parser import format_modifiers
 
 FDR_CONFIG = {'decoy_sample_size': 2}
 
+
 @patch('sm.engine.fdr.DECOY_ADDUCTS', ['+He', '+Li'])
 def test_fdr_decoy_adduct_selection_saves_corr():
     fdr = FDR(fdr_config=FDR_CONFIG, chem_mods=[], neutral_losses=[], target_adducts=['+H', '+K', '[M]+'])
@@ -42,9 +43,9 @@ def test_estimate_fdr_returns_correct_df():
                           ['H2O', '+Co', 0.5],
                           ['C2H2', '+Ag', 0.75],
                           ['C2H2', '+Ar', 0.0]],
-                          columns=['formula', 'modifier', 'msm']).set_index(['formula', 'modifier']).sort_index()
+                          columns=['formula', 'modifier', 'msm'])
     exp_sf_df = pd.DataFrame([['H2O', '+H', 0.2], ['C2H2', '+H', 0.8]],
-                             columns=['formula', 'modifier', 'fdr']).set_index(['formula', 'modifier'])
+                             columns=['formula', 'modifier', 'fdr'])
 
     assert_frame_equal(fdr.estimate_fdr(msm_df), exp_sf_df)
 
@@ -67,12 +68,12 @@ def test_estimate_fdr_digitize_works():
                           ['C2', '+Ag', 0.3],
                           ['C3', '+Cl', 0.25],
                           ['C4', '+Co', 0.1]],
-                          columns=['formula', 'modifier', 'msm']).set_index(['formula', 'modifier']).sort_index()
+                          columns=['formula', 'modifier', 'msm'])
     exp_sf_df = pd.DataFrame([['C1', '+H', 0.4],
                               ['C2', '+H', 0.4],
                               ['C3', '+H', 0.4],
                               ['C4', '+H', 0.8]],
-                             columns=['formula', 'modifier', 'fdr']).set_index(['formula', 'modifier'])
+                             columns=['formula', 'modifier', 'fdr'])
 
     assert_frame_equal(fdr.estimate_fdr(msm_df), exp_sf_df)
 

--- a/metaspace/engine/tests/test_msm_basic_search_integr.py
+++ b/metaspace/engine/tests/test_msm_basic_search_integr.py
@@ -2,6 +2,7 @@ from itertools import product
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch, Mock
+
 import numpy as np
 import pandas as pd
 
@@ -43,20 +44,20 @@ def make_formula_image_metrics_mock_side_effect():
     return formula_image_metrics_mock
 
 
-def test_compute_fdr(ds_config):
+def test_compute_fdr(spark_context, ds_config):
     moldb_fdr_list = init_fdr(ds_config['fdr'], ds_config['isotope_generation'], [make_moldb_mock()])
     _, fdr = moldb_fdr_list[0]
-    formula_map_df = collect_ion_formulas(moldb_fdr_list).drop('moldb_id', axis=1)
+    formula_map_df = collect_ion_formulas(spark_context, moldb_fdr_list).drop('moldb_id', axis=1)
 
     formula_metrics_df = (pd.DataFrame([(10, 'H3O', 0.99),
                                         (11, 'C5H4O', 0.5),
-                                        (12, 'H2ONa', 0.0)],
+                                        (12, 'H2ONa', 0.1)],
                                        columns=['formula_i', 'ion_formula', 'msm'])
                           .set_index('formula_i'))
 
     metrics_df = compute_fdr(fdr, formula_metrics_df, formula_map_df)
 
-    assert len(metrics_df) == 2
+    assert len(metrics_df) == 3
     assert sorted(metrics_df.columns.tolist()) == sorted(['ion_formula', 'msm', 'formula', 'modifier', 'fdr'])
 
 


### PR DESCRIPTION
After the neutral loss changes were merged, performance tests showed new bottlenecks in the engine, specifically FDR related computations. This PR reduces the time spend in those bottlenecks.

* Optimized pandas operations when selecting decoy adducts and joining formula msm dataframe with target-decoy mapping dataframe
* Parallelized ion formulas generation with Spark
* Removed all colocalization algorithms except for 'cosine' as it's the only one used
* Limited number of images used for clustering to 5000 to prevent out of memory exceptions