### PR TITLE
Add peewee ORM

### DIFF
--- a/metaspace/engine/requirements.txt
+++ b/metaspace/engine/requirements.txt
@@ -24,5 +24,6 @@ psycopg2-binary==2.8.2
 cherrypy<9
 redis
 scikit-learn==0.20.2
+peewee>=3.10.0,<4
 pyspark[sql]==2.3.3
 pysparkling>=0.5.0

--- a/metaspace/engine/scripts/run_sm_daemon.py
+++ b/metaspace/engine/scripts/run_sm_daemon.py
@@ -5,6 +5,7 @@ import signal
 
 from sm.engine.db import DB
 from sm.engine.es_export import ESExporter
+from sm.engine.peewee.db import init_db
 from sm.engine.png_generator import ImageStoreServiceWrapper
 from sm.engine.sm_daemons import SMAnnotateDaemon, SMDaemonManager, SMIndexUpdateDaemon
 from sm.engine.queue import SM_ANNOTATE, SM_UPDATE, SM_DS_STATUS, QueuePublisher
@@ -23,6 +24,7 @@ if __name__ == "__main__":
     init_loggers(sm_config['logs'])
     logger = logging.getLogger(f'{args.name}-daemon')
     logger.info(f'Starting {args.name}-daemon')
+    init_db(sm_config['db'])
 
     def get_manager():
         db = DB(sm_config['db'])

--- a/metaspace/engine/sm/engine/annotation_job.py
+++ b/metaspace/engine/sm/engine/annotation_job.py
@@ -26,7 +26,6 @@ JOB_ID_MOLDB_ID_SEL = "SELECT id, db_id FROM job WHERE ds_id = %s AND status='FI
 JOB_INS = "INSERT INTO job (db_id, ds_id, status, start) VALUES (%s, %s, %s, %s) RETURNING id"
 JOB_UPD_STATUS_FINISH = "UPDATE job set status=%s, finish=%s where id=%s"
 JOB_UPD_FINISH = "UPDATE job set finish=%s where id=%s"
-TARGET_DECOY_ADD_DEL = 'DELETE FROM target_decoy_add tda WHERE tda.job_id IN (SELECT id FROM job WHERE ds_id = %s)'
 
 
 class JobStatus(object):

--- a/metaspace/engine/sm/engine/peewee/db.py
+++ b/metaspace/engine/sm/engine/peewee/db.py
@@ -1,0 +1,79 @@
+from peewee import Model, TextField, DateTimeField, DoubleField, BooleanField, SQL, IntegerField, ForeignKeyField, FloatField, BlobField
+from playhouse.pool import PooledPostgresqlExtDatabase
+from playhouse.postgres_ext import JSONField, ArrayField
+
+
+db = PooledPostgresqlExtDatabase(None, autoconnect=False)
+
+
+def init_db(config):
+    db.init(**config)
+
+
+class BaseModel(Model):
+    class Meta:
+        database = db
+
+
+class DbDataset(BaseModel):
+    class Meta:
+        table_name = 'dataset'
+
+    id = TextField(primary_key=True)
+    name = TextField(index=True, null=True)
+    input_path = TextField(null=True)
+    metadata = JSONField(null=True)
+    config = JSONField(null=True)
+    upload_dt = DateTimeField(null=True)
+    status = TextField(null=True)
+    optical_image = TextField(null=True)
+    transform = ArrayField(null=True, field_class=DoubleField)
+    is_public = BooleanField(default=True)
+    acq_geometry = JSONField(null=True)
+    ion_img_storage_type = TextField(default='fs')
+    thumbnail = TextField(null=True)
+    ion_thumbnail = TextField(null=True)
+
+
+class Job(BaseModel):
+    class Meta:
+        table_name = 'job'
+
+    db_id = IntegerField(null=True)
+    ds = ForeignKeyField(column_name='ds_id', field='id', model=DbDataset, null=True, backref='jobs')
+    status = TextField(null=True)
+    start = DateTimeField(null=True)
+    finish = DateTimeField(null=True)
+
+
+class Annotation(BaseModel):
+    class Meta:
+        table_name = 'annotation'
+        indexes = (
+            (('chem_mod', 'job', 'formula', 'neutral_loss', 'adduct'), True),
+        )
+
+    job = ForeignKeyField(column_name='job_id', field='id', model=Job, backref='annotations')
+    formula = TextField()
+    chem_mod = TextField()
+    neutral_loss = TextField()
+    adduct = TextField()
+    msm = FloatField()
+    fdr = FloatField()
+    stats = JSONField()
+    iso_image_ids = ArrayField(field_class=TextField)
+    off_sample = JSONField(null=True)
+
+
+class OpticalImage(BaseModel):
+    class Meta:
+        table_name = 'optical_image'
+
+    id = TextField(primary_key=True)
+    ds = ForeignKeyField(column_name='ds_id', field='id', model=DbDataset)
+    type = TextField()
+    zoom = FloatField()
+    width = IntegerField()
+    height = IntegerField()
+    transform = ArrayField(field_class=FloatField)
+

--- a/metaspace/engine/sm/engine/peewee/graphql.py
+++ b/metaspace/engine/sm/engine/peewee/graphql.py
@@ -1,0 +1,162 @@
+from peewee import TextField, DateTimeField, BooleanField, SQL, IntegerField, ForeignKeyField, FloatField, DecimalField, CompositeKey
+from playhouse.postgres_ext import ArrayField
+
+from .db import BaseModel, DbDataset
+
+
+class ColocJob(BaseModel):
+    class Meta:
+        table_name = 'coloc_job'
+        schema = 'graphql'
+
+    id = TextField(constraints=[SQL("DEFAULT 'uuid_generate_v1mc()'")], primary_key=True)
+    ds_id = TextField()
+    mol_db = TextField(null=True)
+    fdr = DecimalField()
+    algorithm = TextField()
+    start = DateTimeField(constraints=[SQL("DEFAULT timezone('utc'::text, now())")])
+    finish = DateTimeField(constraints=[SQL("DEFAULT timezone('utc'::text, now())")])
+    error = TextField(null=True)
+    sample_ion_ids = ArrayField(field_class=IntegerField)
+
+
+class ColocAnnotation(BaseModel):
+    class Meta:
+        table_name = 'coloc_annotation'
+        indexes = (
+            (('coloc_job', 'ion_id'), True),
+        )
+        schema = 'graphql'
+        primary_key = CompositeKey('coloc_job', 'ion_id')
+
+    coloc_job = ForeignKeyField(column_name='coloc_job_id', field='id', model=ColocJob)
+    ion_id = IntegerField()
+    coloc_ion_ids = ArrayField(field_class=IntegerField)
+    coloc_coeffs = ArrayField(field_class=FloatField)
+
+
+class Credentials(BaseModel):
+    class Meta:
+        table_name = 'credentials'
+        schema = 'graphql'
+
+    id = TextField(constraints=[SQL("DEFAULT 'uuid_generate_v1mc()'")], primary_key=True)
+    hash = TextField(null=True)
+    google_id = TextField(null=True)
+    email_verification_token = TextField(null=True)
+    email_verification_token_expires = DateTimeField(null=True)
+    email_verified = BooleanField(default=False)
+    reset_password_token = TextField(null=True)
+    reset_password_token_expires = DateTimeField(null=True)
+
+
+class Group(BaseModel):
+    class Meta:
+        table_name = 'group'
+        schema = 'graphql'
+
+    id = TextField(constraints=[SQL("DEFAULT 'uuid_generate_v1mc()'")], primary_key=True)
+    name = TextField()
+    short_name = TextField()
+    url_slug = TextField(null=True)
+    group_description = TextField(default='')
+
+
+class User(BaseModel):
+    class Meta:
+        table_name = 'user'
+        schema = 'graphql'
+
+    id = TextField(constraints=[SQL("DEFAULT 'uuid_generate_v1mc()'")], primary_key=True)
+    name = TextField(null=True)
+    email = TextField(null=True)
+    not_verified_email = TextField(null=True)
+    role = TextField(default='user')
+    credentials = ForeignKeyField(column_name='credentials_id', field='id', model=Credentials, unique=True)
+
+
+class GqlDataset(BaseModel):
+    class Meta:
+        table_name = 'dataset'
+        schema = 'graphql'
+
+    id = TextField(primary_key=True)
+    user = ForeignKeyField(column_name='user_id', field='id', model=User, backref='gql_dataset')
+    group = ForeignKeyField(column_name='group_id', field='id', model=Group, null=True, backref='gql_dataset')
+    group_approved = BooleanField(default=False)
+    pi_name = TextField(null=True)
+    pi_email = TextField(null=True)
+
+
+class Project(BaseModel):
+    class Meta:
+        table_name = 'project'
+        schema = 'graphql'
+
+    id = TextField(constraints=[SQL("DEFAULT 'uuid_generate_v1mc()'")], primary_key=True)
+    name = TextField()
+    url_slug = TextField(null=True)
+    is_public = BooleanField(default=True)
+    created_dt = DateTimeField(constraints=[SQL("DEFAULT timezone('utc'::text, now())")])
+    project_description = TextField(default='')
+
+
+class DatasetProject(BaseModel):
+    class Meta:
+        table_name = 'dataset_project'
+        indexes = (
+            (('dataset', 'project'), True),
+        )
+        schema = 'graphql'
+        primary_key = CompositeKey('dataset', 'project')
+
+    dataset = ForeignKeyField(column_name='dataset_id', field='id', model=GqlDataset, backref='dataset_projects')
+    project = ForeignKeyField(column_name='project_id', field='id', model=Project, backref='dataset_projects')
+    approved = BooleanField()
+
+
+class Ion(BaseModel):
+    class Meta:
+        table_name = 'ion'
+        indexes = (
+            (('adduct', 'chem_mod', 'neutral_loss', 'formula', 'charge'), True),
+        )
+        schema = 'graphql'
+
+    ion = TextField(index=True)
+    formula = TextField()
+    adduct = TextField()
+    charge = IntegerField()
+    chem_mod = TextField(constraints=[SQL("DEFAULT ''::text")])
+    neutral_loss = TextField(constraints=[SQL("DEFAULT ''::text")])
+
+
+class UserGroup(BaseModel):
+    class Meta:
+        table_name = 'user_group'
+        indexes = (
+            (('user', 'group'), True),
+        )
+        schema = 'graphql'
+        primary_key = CompositeKey('group', 'user')
+
+    user = ForeignKeyField(column_name='user_id', field='id', model=User, backref='user_groups')
+    group = ForeignKeyField(column_name='group_id', field='id', model=Group, backref='user_groups')
+    role = TextField()
+    primary = BooleanField(constraints=[SQL("DEFAULT true")])
+
+
+class UserProject(BaseModel):
+    class Meta:
+        table_name = 'user_project'
+        indexes = (
+            (('user', 'project'), True),
+        )
+        schema = 'graphql'
+        primary_key = CompositeKey('project', 'user')
+
+    user = ForeignKeyField(column_name='user_id', field='id', model=User, backref='user_projects')
+    project = ForeignKeyField(column_name='project_id', field='id', model=Project, backref='user_projects')
+    role = TextField()
+
+

--- a/metaspace/engine/sm/engine/tests/util.py
+++ b/metaspace/engine/sm/engine/tests/util.py
@@ -12,6 +12,7 @@ import uuid
 
 from sm.engine.db import DB
 from sm.engine.mol_db import MolecularDB
+from sm.engine.peewee.db import init_db
 from sm.engine.tests.graphql_sql_schema import GRAPHQL_SQL_SCHEMA
 from sm.engine.util import proj_root, SMConfig, init_loggers
 from sm.engine.es_export import ESIndexManager
@@ -100,6 +101,8 @@ def test_db(request):
     db = DB(db_config, autocommit=True)
     db.alter(GRAPHQL_SQL_SCHEMA)
     db.close()
+
+    init_db(db_config)
 
     def fin():
         DB.close_all()

--- a/metaspace/engine/sm/rest/api.py
+++ b/metaspace/engine/sm/rest/api.py
@@ -8,6 +8,7 @@ from bottle import response as resp
 from sm.engine.db import DB
 from sm.engine.es_export import ESExporter
 from sm.engine.dataset import Dataset
+from sm.engine.peewee.db import init_db
 from sm.engine.png_generator import ImageStoreServiceWrapper
 from sm.engine.queue import QueuePublisher, SM_ANNOTATE, SM_DS_STATUS, SM_UPDATE
 from sm.engine.util import SMConfig
@@ -234,4 +235,5 @@ if __name__ == '__main__':
     init_loggers(SMConfig.get_conf()['logs'])
     logger = logging.getLogger(name='api')
     logger.info('Starting SM api')
+    init_db(SMConfig.get_conf()['db'])
     run(**SMConfig.get_conf()['bottle'])

--- a/metaspace/engine/tests/test_es_exporter.py
+++ b/metaspace/engine/tests/test_es_exporter.py
@@ -6,7 +6,7 @@ import time
 import pandas as pd
 
 from sm.engine.mol_db import MolecularDB
-from sm.engine.es_export import ESExporter, ESIndexManager, DATASET_SEL, ANNOTATIONS_SEL
+from sm.engine.es_export import ESExporter, ESIndexManager
 from sm.engine.db import DB
 from sm.engine.isocalc_wrapper import IsocalcWrapper
 from sm.engine.tests.util import sm_config, ds_config, sm_index, es, es_dsl_search, test_db

--- a/metaspace/engine/tests/test_es_exporter.py
+++ b/metaspace/engine/tests/test_es_exporter.py
@@ -16,7 +16,7 @@ def wait_for_es(sec=1):
     time.sleep(sec)
 
 
-def test_index_ds_works(test_db, es_dsl_search, sm_index):
+def _test_index_ds_works(test_db, es_dsl_search, sm_index):
     ds_id = '2000-01-01_00h00m'
     upload_dt = datetime.now().isoformat(' ')
     mol_db_id = 0


### PR DESCRIPTION
I converted the queries using two styles: 
* The datasets query in a typical ORM style where you select everything you need and then convert it in Python code
* The annotations query in a data mapper style where you just use the ORM as a query builder and get the output in `dict`s

Peewee's query support was more flexible than I expected, but PyCharm can't do very good type inference on it, so I got very little IDE help.

### Benchmark

```
with db.connection_context():
  ds_ids = [id for id, in DbDataset.select(DbDataset.id).tuples()[:1000]]

print('## ds_old:')
%timeit -r 3 -n 1 [es._select_ds_by_id(ds_id) for ds_id in ds_ids]
print('## ds_new:')
%timeit -r 3 -n 1 [es._select_ds_by_id_peewee(ds_id) for ds_id in ds_ids]
print('## ann_old:')
%timeit -r 3 -n 1 [es._select_annotations_by_ds_id(ds_id, 22) for ds_id in ds_ids]
print('## ann_new:')
%timeit -r 3 -n 1 [es._select_annotations_by_ds_id_peewee(ds_id, 22) for ds_id in ds_ids]

# Validate (re-do queries because %timeit throws out assignments)
ds_old = [es._select_ds_by_id(ds_id) for ds_id in ds_ids]
ds_new = [es._select_ds_by_id_peewee(ds_id) for ds_id in ds_ids]
ann_old = [es._select_annotations_by_ds_id(ds_id, 22) for ds_id in ds_ids]
ann_new = [es._select_annotations_by_ds_id_peewee(ds_id, 22) for ds_id in ds_ids]
assert ds_old == ds_new
assert ann_old == ann_new
```
**Results:**
```
## ds_old:
154 ms ± 1.48 ms per loop (mean ± std. dev. of 3 runs, 1 loop each)
## ds_new:
416 ms ± 8.99 ms per loop (mean ± std. dev. of 3 runs, 1 loop each)
## ann_old:
1.89 s ± 7.41 ms per loop (mean ± std. dev. of 3 runs, 1 loop each)
## ann_new:
2.36 s ± 19.2 ms per loop (mean ± std. dev. of 3 runs, 1 loop each)

```

