### PR TITLE
Use database connection pool in sm.engine.db

### DIFF
--- a/metaspace/engine/scripts/run_colocalization.py
+++ b/metaspace/engine/scripts/run_colocalization.py
@@ -74,7 +74,7 @@ def run_coloc_jobs(ds_id, sql_where, fix_missing, fix_corrupt, skip_existing):
 
     conf = SMConfig.get_conf()
 
-    db = DB(conf['db'])
+    db = DB()
 
     if ds_id:
         ds_ids = ds_id.split(',')

--- a/metaspace/engine/scripts/run_colocalization.py
+++ b/metaspace/engine/scripts/run_colocalization.py
@@ -1,9 +1,8 @@
 import argparse
-import logging
-from itertools import groupby
+from functools import partial
 
 from sm.engine.mol_db import MolDBServiceWrapper
-from sm.engine.util import init_loggers, SMConfig
+from sm.engine.util import bootstrap_and_run
 from sm.engine.db import DB
 from sm.engine.colocalization import Colocalization
 
@@ -67,12 +66,10 @@ ORDER BY j.ds_id DESC;
 """
 
 
-def run_coloc_jobs(ds_id, sql_where, fix_missing, fix_corrupt, skip_existing):
+def run_coloc_jobs(sm_config, logger, ds_id, sql_where, fix_missing, fix_corrupt, skip_existing):
     assert len([data_source for data_source in [ds_id, sql_where, fix_missing, fix_corrupt] if data_source]) == 1, \
            "Exactly one data source (ds_id, sql_where, fix_missing, fix_corrupt) must be specified"
     assert not (ds_id and sql_where)
-
-    conf = SMConfig.get_conf()
 
     db = DB()
 
@@ -81,7 +78,7 @@ def run_coloc_jobs(ds_id, sql_where, fix_missing, fix_corrupt, skip_existing):
     elif sql_where:
         ds_ids = [id for (id, ) in db.select(f'SELECT DISTINCT dataset.id FROM dataset WHERE {sql_where}')]
     else:
-        mol_db_service = MolDBServiceWrapper(conf['services']['mol_db'])
+        mol_db_service = MolDBServiceWrapper(sm_config['services']['mol_db'])
         mol_dbs = [(db['id'], db['name']) for db in mol_db_service.fetch_all_dbs()]
         mol_db_ids, mol_db_names = map(list, zip(*mol_dbs))
         fdrs = [0.05, 0.1, 0.2, 0.5]
@@ -126,12 +123,10 @@ if __name__ == '__main__':
                         help='Re-run colocalization jobs even if they have already successfully run')
     args = parser.parse_args()
 
-    SMConfig.set_path(args.config)
-    init_loggers(SMConfig.get_conf()['logs'])
-    logger = logging.getLogger('engine')
-
-    run_coloc_jobs(ds_id=args.ds_id,
-                   sql_where=args.sql_where,
-                   fix_missing=args.fix_missing,
-                   fix_corrupt=args.fix_corrupt,
-                   skip_existing=args.skip_existing)
+    bootstrap_and_run(args.config,
+                      partial(run_coloc_jobs,
+                              ds_id=args.ds_id,
+                              sql_where=args.sql_where,
+                              fix_missing=args.fix_missing,
+                              fix_corrupt=args.fix_corrupt,
+                              skip_existing=args.skip_existing))

--- a/metaspace/engine/scripts/run_off_sample.py
+++ b/metaspace/engine/scripts/run_off_sample.py
@@ -26,7 +26,7 @@ def run_off_sample(ds_id, sql_where, fix_missing, overwrite_existing):
     assert not (ds_id and sql_where)
 
     conf = SMConfig.get_conf()
-    db = DB(conf['db'])
+    db = DB()
     es_exp = ESExporter(db)
 
     if ds_id:

--- a/metaspace/engine/scripts/set_md_type.py
+++ b/metaspace/engine/scripts/set_md_type.py
@@ -34,9 +34,7 @@ if __name__ == "__main__":
     init_logger()
     logger = logging.getLogger('engine')
 
-    db = DB(sm_config['db'])
-
     if args.ds_name and args.md_type:
-        set_metadata_type(db, args.md_type, args.ds_name)
+        set_metadata_type(DB(), args.md_type, args.ds_name)
     else:
         parser.print_help()

--- a/metaspace/engine/scripts/update_es_index.py
+++ b/metaspace/engine/scripts/update_es_index.py
@@ -29,7 +29,7 @@ def _reindex_all(conf):
     es_man.create_index(new_index)
 
     try:
-        db = DB(conf['db'])
+        db = DB()
         es_exp = ESExporter(db, inactive_es_config)
         ds_ids = [r[0] for r in db.select('select id from dataset')]
         _reindex_datasets(ds_ids, db, es_exp)
@@ -80,7 +80,7 @@ def reindex_results(ds_id, ds_mask, use_inactive_index):
         if use_inactive_index:
             es_config = get_inactive_index_es_config(es_config)
 
-        db = DB(conf['db'])
+        db = DB()
         es_exp = ESExporter(db, es_config=es_config)
 
         if ds_id:

--- a/metaspace/engine/scripts/update_es_index.py
+++ b/metaspace/engine/scripts/update_es_index.py
@@ -1,10 +1,10 @@
 import argparse
-import logging
 from copy import deepcopy
+from functools import partial
 
 from sm.engine.mol_db import MolecularDB
 from sm.engine.isocalc_wrapper import IsocalcWrapper, set_centroids_cache_enabled
-from sm.engine.util import init_loggers, SMConfig
+from sm.engine.util import bootstrap_and_run
 from sm.engine.db import DB
 from sm.engine.es_export import ESExporter, ESIndexManager
 
@@ -42,7 +42,7 @@ def _reindex_all(conf):
         es_man.delete_index(old_index)
 
 
-def _reindex_datasets(ds_ids, db, es_exp):
+def _reindex_datasets(logger, ds_ids, db, es_exp):
     logger.info('Reindexing %s dataset(s)', len(ds_ids))
     for idx, ds_id in enumerate(ds_ids):
         logger.info(f'Reindexing {idx+1} out of {len(ds_ids)}')
@@ -67,16 +67,15 @@ def _reindex_datasets(ds_ids, db, es_exp):
             logger.error(new_msg, exc_info=True)
 
 
-def reindex_results(ds_id, ds_mask, use_inactive_index):
+def reindex_results(sm_config, logger, ds_id, ds_mask, use_inactive_index):
     assert ds_id or ds_mask
 
-    conf = SMConfig.get_conf()
     set_centroids_cache_enabled(True)
 
     if ds_mask == '_all_':
-        _reindex_all(conf)
+        _reindex_all(sm_config)
     else:
-        es_config = conf['elasticsearch']
+        es_config = sm_config['elasticsearch']
         if use_inactive_index:
             es_config = get_inactive_index_es_config(es_config)
 
@@ -90,7 +89,7 @@ def reindex_results(ds_id, ds_mask, use_inactive_index):
         else:
             ds_ids = []
 
-        _reindex_datasets(ds_ids, db, es_exp)
+        _reindex_datasets(logger, ds_ids, db, es_exp)
 
 
 if __name__ == '__main__':
@@ -101,8 +100,8 @@ if __name__ == '__main__':
     parser.add_argument('--ds-name', dest='ds_name', default='', help='DS name prefix mask (_all_ for all datasets)')
     args = parser.parse_args()
 
-    SMConfig.set_path(args.config)
-    init_loggers(SMConfig.get_conf()['logs'])
-    logger = logging.getLogger('engine')
-
-    reindex_results(args.ds_id, args.ds_name, args.inactive)
+    bootstrap_and_run(args.config,
+                      partial(reindex_results,
+                              ds_id=args.ds_id,
+                              ds_mask=args.ds_name,
+                              use_inactive_index=args.inactive))

--- a/metaspace/engine/scripts/update_ion_thumbnails.py
+++ b/metaspace/engine/scripts/update_ion_thumbnails.py
@@ -1,17 +1,15 @@
 import argparse
-import logging
+from functools import partial
 
 from sm.engine.ion_thumbnail import DEFAULT_ALGORITHM, ALGORITHMS, generate_ion_thumbnail
 from sm.engine.png_generator import ImageStoreServiceWrapper
-from sm.engine.util import init_loggers, SMConfig
+from sm.engine.util import bootstrap_and_run
 from sm.engine.db import DB
 
 
-def run(ds_id, sql_where, algorithm):
-    conf = SMConfig.get_conf()
-
+def run(sm_config, logger, ds_id, sql_where, algorithm):
     db = DB()
-    img_store = ImageStoreServiceWrapper(conf['services']['img_service_url'])
+    img_store = ImageStoreServiceWrapper(sm_config['services']['img_service_url'])
 
     if sql_where:
         ds_ids = [id for (id, ) in db.select(f'SELECT DISTINCT dataset.id FROM dataset WHERE {sql_where}')]
@@ -46,8 +44,8 @@ if __name__ == '__main__':
         print('error: must specify either --ds-id or --sql-where')
         exit(1)
 
-    SMConfig.set_path(args.config)
-    init_loggers(SMConfig.get_conf()['logs'])
-    logger = logging.getLogger('engine')
-
-    run(args.ds_id, args.sql_where, args.algorithm)
+    bootstrap_and_run(args.config,
+                      partial(run,
+                              ds_id=args.ds_id,
+                              sql_where=args.sql_where,
+                              algorithm=args.algorithm))

--- a/metaspace/engine/scripts/update_ion_thumbnails.py
+++ b/metaspace/engine/scripts/update_ion_thumbnails.py
@@ -8,10 +8,9 @@ from sm.engine.db import DB
 
 
 def run(ds_id, sql_where, algorithm):
-
     conf = SMConfig.get_conf()
 
-    db = DB(conf['db'])
+    db = DB()
     img_store = ImageStoreServiceWrapper(conf['services']['img_service_url'])
 
     if sql_where:

--- a/metaspace/engine/scripts/update_optical_images.py
+++ b/metaspace/engine/scripts/update_optical_images.py
@@ -10,7 +10,7 @@ from sm.engine.png_generator import ImageStoreServiceWrapper
 def update_optical_images(ds_id, sql_where):
     config = SMConfig.get_conf()
     img_store = ImageStoreServiceWrapper(config['services']['img_service_url'])
-    db = DB(config['db'])
+    db = DB()
 
     if ds_id:
         ds_ids = ds_id.split(',')

--- a/metaspace/engine/sm/engine/annotation_job.py
+++ b/metaspace/engine/sm/engine/annotation_job.py
@@ -168,8 +168,6 @@ class AnnotationJob(object):
     def cleanup(self):
         if self._sc:
             self._sc.stop()
-        if self._db:
-            self._db.close()
         logger.debug(f'Cleaning dataset temp dir {self._ds_data_path}')
         rmtree(self._ds_data_path, ignore_errors=True)
 

--- a/metaspace/engine/sm/engine/annotation_job.py
+++ b/metaspace/engine/sm/engine/annotation_job.py
@@ -42,7 +42,7 @@ class AnnotationJob(object):
         self._img_store = img_store
 
         self._sc = None
-        self._db = None
+        self._db = DB()
         self._ds = None
         self._status_queue = None
         self._es = None
@@ -66,10 +66,6 @@ class AnnotationJob(object):
             sconf.set("spark.hadoop.fs.s3a.endpoint", "s3.{}.amazonaws.com".format(self._sm_config['aws']['aws_region']))
 
         self._sc = SparkContext(master=self._sm_config['spark']['master'], conf=sconf, appName='SM engine')
-
-    def _init_db(self):
-        logger.info('Connecting to the DB')
-        self._db = DB(self._sm_config['db'])
 
     def _store_job_meta(self, mol_db_id):
         """ Store search job metadata in the database """
@@ -187,7 +183,6 @@ class AnnotationJob(object):
             logger.info('*' * 150)
             start = time.time()
 
-            self._init_db()
             self._es = ESExporter(self._db)
             self._ds = ds
 

--- a/metaspace/engine/sm/engine/db.py
+++ b/metaspace/engine/sm/engine/db.py
@@ -16,12 +16,14 @@ _conn_pool = None
 def init_conn_pool(config):
     global _conn_pool
     if not _conn_pool:
+        logger.info('Initialising database connection pool')
         _conn_pool = ThreadedConnectionPool(4, 12, **config)
 
 
 def close_conn_pool():
     global _conn_pool
     if _conn_pool:
+        logger.info('Closing database connection pool')
         _conn_pool.closeall()
         _conn_pool = None
 
@@ -56,7 +58,7 @@ def db_decor(func):
 class DB(object):
     """Postgres database access provider."""
 
-    def __init__(self, *args):
+    def __init__(self):
         self._curs = None
 
     def _select(self, sql, params=None):

--- a/metaspace/engine/sm/engine/sm_daemons.py
+++ b/metaspace/engine/sm/engine/sm_daemons.py
@@ -198,7 +198,7 @@ class SMAnnotateDaemon(object):
         self._upd_queue_pub = QueuePublisher(config=self._sm_config['rabbitmq'],
                                              qdesc=upd_qdesc,
                                              logger=self.logger)
-        self._db = DB(self._sm_config['db'])
+        self._db = DB()
         self.redis_client = redis.Redis(**self._sm_config.get('redis', {}))
         Path(self._sm_config['fs']['spark_data_path']).mkdir(parents=True, exist_ok=True)
 
@@ -283,7 +283,7 @@ class SMIndexUpdateDaemon(object):
     def __init__(self, manager, update_qdesc, poll_interval=1):
         self._manager = manager
         self._sm_config = SMConfig.get_conf()
-        self._db = DB(self._sm_config['db'])
+        self._db = DB()
         self._update_queue_cons = QueueConsumer(config=self._sm_config['rabbitmq'],
                                                 qdesc=update_qdesc,
                                                 callback=self._callback,

--- a/metaspace/engine/sm/engine/sm_daemons.py
+++ b/metaspace/engine/sm/engine/sm_daemons.py
@@ -273,8 +273,6 @@ class SMAnnotateDaemon(object):
             self._annot_queue_consumer.stop()
             self._annot_queue_consumer.join()
             self._stopped = True
-        if self._db:
-            self._db.close()
 
 
 class SMIndexUpdateDaemon(object):
@@ -374,5 +372,3 @@ class SMIndexUpdateDaemon(object):
             self._update_queue_cons.stop()
             self._update_queue_cons.join()
             self._stopped = True
-        if self._db:
-            self._db.close()

--- a/metaspace/engine/sm/engine/tests/util.py
+++ b/metaspace/engine/sm/engine/tests/util.py
@@ -13,7 +13,7 @@ from pysparkling import Context
 import pandas as pd
 import uuid
 
-from sm.engine.db import DB, init_conn_pool, close_conn_pool
+from sm.engine.db import DB, ConnectionPool
 from sm.engine.mol_db import MolecularDB
 from sm.engine.tests.graphql_sql_schema import GRAPHQL_SQL_SCHEMA
 from sm.engine.util import proj_root, SMConfig, init_loggers
@@ -111,10 +111,10 @@ def test_db(request):
 
     autocommit_execute(sm_config['db'], GRAPHQL_SQL_SCHEMA)
 
-    init_conn_pool(sm_config['db'])
+    conn_pool = ConnectionPool(sm_config['db'])
 
     def fin():
-        close_conn_pool()
+        conn_pool.close()
         autocommit_execute(db_config_postgres,
                            'DROP DATABASE IF EXISTS sm_test')
     request.addfinalizer(fin)

--- a/metaspace/engine/sm/engine/util.py
+++ b/metaspace/engine/sm/engine/util.py
@@ -9,6 +9,8 @@ import re
 from fnmatch import translate
 from copy import deepcopy
 
+from sm.engine.db import ConnectionPool
+
 
 def proj_root():
     return os.getcwd()
@@ -155,3 +157,13 @@ def split_s3_path(path):
 def find_file_by_ext(path, ext):
     return next(str(p) for p in Path(path).iterdir()
                 if str(p).lower().endswith(ext))
+
+
+def bootstrap_and_run(config_path, func):
+    SMConfig.set_path(config_path)
+    sm_config = SMConfig.get_conf()
+    init_loggers(sm_config['logs'])
+    logger = logging.getLogger('engine')
+
+    with ConnectionPool(sm_config['db']):
+        func(sm_config, logger)

--- a/metaspace/engine/sm/rest/api.py
+++ b/metaspace/engine/sm/rest/api.py
@@ -77,7 +77,6 @@ def sm_modify_dataset(request_name):
                 ds_man = _create_dataset_manager(db)
                 res = handler(ds_man, ds_id, params)
 
-                db.close()
                 return {
                     'status': OK['status'],
                     'ds_id': ds_id or res.get('ds_id', None)

--- a/metaspace/engine/sm/rest/api.py
+++ b/metaspace/engine/sm/rest/api.py
@@ -41,11 +41,6 @@ ERROR = {
 }
 
 
-def _create_db_conn():
-    config = SMConfig.get_conf()
-    return DB(config['db'])
-
-
 def _json_params(req):
     b = req.body.getvalue()
     return json.loads(b.decode('utf-8'))
@@ -73,8 +68,7 @@ def sm_modify_dataset(request_name):
             try:
                 params = _json_params(req)
                 logger.info('Received %s request: %s', request_name, params)
-                db = _create_db_conn()
-                ds_man = _create_dataset_manager(db)
+                ds_man = _create_dataset_manager(DB())
                 res = handler(ds_man, ds_id, params)
 
                 return {

--- a/metaspace/engine/tests/test_colocalization.py
+++ b/metaspace/engine/tests/test_colocalization.py
@@ -38,7 +38,7 @@ def mock_get_ion_images_for_analysis(storage_type, img_ids, **kwargs):
 
 @patch('sm.engine.mol_db.MolDBServiceWrapper.find_db_by_name_version', return_value=[mol_db_mock])
 def test_new_ds_saves_to_db(find_db_by_name_version_mock, test_db, metadata, ds_config):
-    db = DB(sm_config['db'])
+    db = DB()
     ds = Dataset('ds_id', 'ds_name', 'input_path', datetime.now(), metadata, ds_config)
     ds.save(db)
 

--- a/metaspace/engine/tests/test_dataset.py
+++ b/metaspace/engine/tests/test_dataset.py
@@ -15,7 +15,7 @@ from sm.engine.tests.util import sm_config, test_db, metadata, ds_config
 def fill_db(test_db, metadata, ds_config):
     upload_dt = '2000-01-01 00:00:00'
     ds_id = '2000-01-01'
-    db = DB(sm_config['db'])
+    db = DB()
     db.insert(('INSERT INTO dataset (id, name, input_path, upload_dt, metadata, config, status, '
                'is_public) '
                'VALUES (%s, %s, %s, %s, %s, %s, %s, %s)'),
@@ -31,7 +31,7 @@ def test_generate_ds_config(metadata, ds_config):
 
 
 def test_dataset_load_existing_ds_works(fill_db, metadata, ds_config):
-    db = DB(sm_config['db'])
+    db = DB()
     upload_dt = datetime.strptime('2000-01-01 00:00:00', '%Y-%m-%d %H:%M:%S')
     ds_id = '2000-01-01'
 
@@ -47,7 +47,7 @@ def test_dataset_load_existing_ds_works(fill_db, metadata, ds_config):
 
 
 def test_dataset_save_overwrite_ds_works(fill_db, metadata, ds_config):
-    db = DB(sm_config['db'])
+    db = DB()
     es_mock = MagicMock(spec=ESExporter)
 
     upload_dt = datetime.now()
@@ -61,7 +61,7 @@ def test_dataset_save_overwrite_ds_works(fill_db, metadata, ds_config):
 
 
 def test_dataset_update_status_works(fill_db, metadata, ds_config):
-    db = DB(sm_config['db'])
+    db = DB()
     es_mock = MagicMock(spec=ESExporter)
 
     upload_dt = datetime.now()

--- a/metaspace/engine/tests/test_ion_thumbnails.py
+++ b/metaspace/engine/tests/test_ion_thumbnails.py
@@ -34,7 +34,7 @@ def _mock_get_ion_images_for_analysis(storage_type, img_ids, **kwargs):
 
 @pytest.mark.parametrize('algorithm', [alg for alg in ALGORITHMS.keys()])
 def test_creates_ion_thumbnail(test_db, algorithm, metadata, ds_config):
-    db = DB(sm_config['db'])
+    db = DB()
     img_store_mock = MagicMock(spec=ImageStoreServiceWrapper)
     img_store_mock.post_image.return_value = IMG_ID
     img_store_mock.get_ion_images_for_analysis.side_effect = _mock_get_ion_images_for_analysis

--- a/metaspace/engine/tests/test_off_sample_wrapper.py
+++ b/metaspace/engine/tests/test_off_sample_wrapper.py
@@ -21,7 +21,7 @@ def test_classify_ion_images_preds_saved(call_api_mock, ImageStoreServiceWrapper
     image_store_mock = ImageStoreServiceWrapperMock()
     image_store_mock.get_image_by_id.return_value = Image.new('RGBA', (10, 10))
 
-    db = DB(sm_config['db'])
+    db = DB()
     ds_id = '2000-01-01'
     ds = Dataset.load(db, ds_id)
 

--- a/metaspace/engine/tests/test_sm_daemon_manager.py
+++ b/metaspace/engine/tests/test_sm_daemon_manager.py
@@ -35,7 +35,7 @@ def create_ds(ds_id='2000-01-01', ds_name='ds_name', input_path='input_path', up
 
 
 def create_daemon_man(db=None, es=None, img_store=None, status_queue=None):
-    db = db or DB(sm_config['db'])
+    db = db or DB()
     es_mock = es or MagicMock(spec=ESExporter)
     status_queue_mock = status_queue or MagicMock(QueuePublisher)
     img_store_mock = img_store or MagicMock(spec=ImageStoreServiceWrapper)
@@ -57,7 +57,7 @@ class TestSMDaemonDatasetManager:
     @patch('sm.engine.mol_db.MolDBServiceWrapper.find_db_by_name_version', return_value=[mol_db_mock])
     def test_annotate_ds(self, find_db_by_name_version_mock, test_db, metadata, ds_config):
         es_mock = MagicMock(spec=ESExporter)
-        db = DB(sm_config['db'])
+        db = DB()
         manager = create_daemon_man(db=db, es=es_mock)
 
         ds_id = '2000-01-01'
@@ -93,7 +93,7 @@ class TestSMDaemonDatasetManager:
             assert ds_id in call_args and molecular_db_mock in call_args
 
     def test_delete_ds(self, fill_db):
-        db = DB(sm_config['db'])
+        db = DB()
         es_mock = MagicMock(spec=ESExporter)
         img_store_service_mock = MagicMock(spec=ImageStoreServiceWrapper)
         manager = create_daemon_man(db=db, es=es_mock, img_store=img_store_service_mock)

--- a/metaspace/engine/tests/test_sm_daemon_manager.py
+++ b/metaspace/engine/tests/test_sm_daemon_manager.py
@@ -58,25 +58,22 @@ class TestSMDaemonDatasetManager:
     def test_annotate_ds(self, find_db_by_name_version_mock, test_db, metadata, ds_config):
         es_mock = MagicMock(spec=ESExporter)
         db = DB(sm_config['db'])
-        try:
-            manager = create_daemon_man(db=db, es=es_mock)
+        manager = create_daemon_man(db=db, es=es_mock)
 
-            ds_id = '2000-01-01'
-            ds_name = 'ds_name'
-            input_path = 'input_path'
-            upload_dt = datetime.now()
-            ds = create_ds(ds_id=ds_id, ds_name=ds_name, input_path=input_path,
-                           upload_dt=upload_dt, metadata=metadata)
+        ds_id = '2000-01-01'
+        ds_name = 'ds_name'
+        input_path = 'input_path'
+        upload_dt = datetime.now()
+        ds = create_ds(ds_id=ds_id, ds_name=ds_name, input_path=input_path,
+                       upload_dt=upload_dt, metadata=metadata)
 
-            manager.annotate(ds, annotation_job_factory=self.SearchJob)
+        manager.annotate(ds, annotation_job_factory=self.SearchJob)
 
-            DS_SEL = 'select name, input_path, upload_dt, metadata, config from dataset where id=%s'
-            results = db.select_one(DS_SEL, params=(ds_id,))
-            assert results[3] == metadata
-            assert results[4] == ds_config
-            # assert db.select_one(DS_SEL, params=(ds_id,)) == (ds_name, input_path, upload_dt, metadata, ds_config)
-        finally:
-            db.close()
+        DS_SEL = 'select name, input_path, upload_dt, metadata, config from dataset where id=%s'
+        results = db.select_one(DS_SEL, params=(ds_id,))
+        assert results[3] == metadata
+        assert results[4] == ds_config
+        # assert db.select_one(DS_SEL, params=(ds_id,)) == (ds_name, input_path, upload_dt, metadata, ds_config)
 
     def test_index_ds(self, fill_db, metadata):
         es_mock = MagicMock(spec=ESExporter)

--- a/metaspace/engine/tests/test_sm_daemons.py
+++ b/metaspace/engine/tests/test_sm_daemons.py
@@ -169,7 +169,7 @@ def test_sm_daemons(MSMSearchMock,
         2: url_dict,
     }
 
-    db = DB(sm_config['db'])
+    db = DB()
     es = ESExporter(db)
 
     try:
@@ -268,7 +268,7 @@ def test_sm_daemons_annot_fails(MSMSearchMock,
         2: url_dict
     }
 
-    db = DB(sm_config['db'])
+    db = DB()
     es = ESExporter(db)
 
     try:
@@ -332,7 +332,7 @@ def test_sm_daemon_es_export_fails(MSMSearchMock,
         2: url_dict,
     }
 
-    db = DB(sm_config['db'])
+    db = DB()
     annotate_daemon = None
     update_daemon = None
 

--- a/metaspace/engine/tests/test_sm_daemons.py
+++ b/metaspace/engine/tests/test_sm_daemons.py
@@ -237,7 +237,6 @@ def test_sm_daemons(MSMSearchMock,
             assert doc['_id'].startswith(ds_id)
 
     finally:
-        db.close()
         with warn_only():
             local('rm -rf {}'.format(data_dir_path))
 
@@ -287,7 +286,6 @@ def test_sm_daemons_annot_fails(MSMSearchMock,
         assert len(row) == 1
         assert row[0] == 'FAILED'
     finally:
-        db.close()
         with warn_only():
             local('rm -rf {}'.format(data_dir_path))
 
@@ -360,7 +358,6 @@ def test_sm_daemon_es_export_fails(MSMSearchMock,
         row = db.select_one('SELECT status from dataset')
         assert row[0] == 'FAILED'
     finally:
-        db.close()
         if annotate_daemon:
             annotate_daemon.stop()
         if update_daemon:


### PR DESCRIPTION
The only real change in this PR is use of database connection pool in `sm.engine.db` module. This module opens and keeps a singleton object that holds a pool of connection to the database. The code of `db_decor` and `DB` was also refactored to better handle transactions and exceptions.

All the other code changes were caused by the updated DB interface.