### PR TITLE
Molecular databases names update

### DIFF
--- a/metaspace/engine/migrations/r1_5_20190829_update_moldb_names.py
+++ b/metaspace/engine/migrations/r1_5_20190829_update_moldb_names.py
@@ -7,7 +7,7 @@ from sm.engine.db import DB, ConnectionPool
 from sm.engine.util import init_loggers
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Update SwissLipids molecule names')
+    parser = argparse.ArgumentParser(description='Update molecular database molecule names')
     parser.add_argument('--config', default='conf/config.json', help='SM config path')
     parser.add_argument('file_path', help='Path to file with new names')
     args = parser.parse_args()

--- a/metaspace/engine/migrations/r1_5_20190829_update_swisslipids_names.py
+++ b/metaspace/engine/migrations/r1_5_20190829_update_swisslipids_names.py
@@ -1,0 +1,33 @@
+import argparse
+import logging
+
+import pandas as pd
+
+from sm.engine.db import DB, ConnectionPool
+from sm.engine.util import init_loggers
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Update SwissLipids molecule names')
+    parser.add_argument('--config', default='conf/config.json', help='SM config path')
+    parser.add_argument('file_path', help='Path to file with new names')
+    args = parser.parse_args()
+    init_loggers()
+    logger = logging.getLogger('engine')
+
+    logger.info(f'Importing new names from {args.file_path}')
+
+    db_config = {
+        "host": "localhost",
+        "database": "mol_db",
+        "user": "mol_db"
+    }
+    with ConnectionPool(db_config):
+        db = DB()
+        names_df = pd.read_csv(args.file_path, sep='\t')[['id', 'name']]
+
+        sql = (
+            'WITH molecule_name AS (SELECT UNNEST(%s::text[]) as id_, UNNEST(%s::text[]) as name_) '
+            'UPDATE molecule SET mol_name = molecule_name.name_ '
+            'FROM molecule_name WHERE molecule.mol_id = molecule_name.id_'
+        )
+        db.alter(sql, [names_df.id.values.tolist(), names_df.name.values.tolist()])

--- a/metaspace/engine/scripts/update_es_index.py
+++ b/metaspace/engine/scripts/update_es_index.py
@@ -19,7 +19,7 @@ def get_inactive_index_es_config(es_config):
     return tmp_es_config
 
 
-def _reindex_all(conf):
+def _reindex_all(logger, conf):
     es_config = conf['elasticsearch']
     inactive_es_config = get_inactive_index_es_config(es_config)
     alias = es_config['index']
@@ -32,7 +32,7 @@ def _reindex_all(conf):
         db = DB()
         es_exp = ESExporter(db, inactive_es_config)
         ds_ids = [r[0] for r in db.select('select id from dataset')]
-        _reindex_datasets(ds_ids, db, es_exp)
+        _reindex_datasets(logger, ds_ids, db, es_exp)
 
         es_man.remap_alias(inactive_es_config['index'], alias=alias)
     except Exception as e:
@@ -75,7 +75,7 @@ def reindex_results(sm_config, logger, ds_id, ds_mask, use_inactive_index):
     set_centroids_cache_enabled(True)
 
     if ds_mask == '_all_':
-        _reindex_all(sm_config)
+        _reindex_all(logger, sm_config)
     else:
         es_config = sm_config['elasticsearch']
         if use_inactive_index:


### PR DESCRIPTION
A migration script to fix wrong names of molecular databases in-place without re-importing them.

Resolves #403 