### PR TITLE
Ensure GraphQL server quits when any server fails

### DIFF
--- a/metaspace/graphql/src/modules/webServer/imageServer.ts
+++ b/metaspace/graphql/src/modules/webServer/imageServer.ts
@@ -201,19 +201,13 @@ export async function createImageServerApp(config: Config, knex: Knex) {
 }
 
 export async function createImgServerAsync(config: Config, knex: Knex) {
-  try {
-    let app = await createImageServerApp(config, knex);
+  const app = await createImageServerApp(config, knex);
 
-    let httpServer = http.createServer(app);
-    httpServer.listen(config.img_storage_port, (err?: Error) => {
-      if (err) {
-        logger.error('Could not start iso image server', err);
-      }
-      logger.info(`Image server is listening on ${config.img_storage_port} port...`);
-    });
-    return httpServer;
-  }
-  catch (e) {
-    logger.error(`${e.stack}`);
-  }
+  const httpServer = http.createServer(app);
+  await new Promise((resolve, reject) => {
+    httpServer.listen(config.img_storage_port).on('listening', resolve).on('error', reject);
+  });
+
+  logger.info(`Image server is listening on ${config.img_storage_port} port...`);
+  return httpServer;
 }


### PR DESCRIPTION
* Refactored to separate the WebSocket/Subscription server from the Http server
* Removed "log and continue" error handling
* Added an extra step so that the main code block will listen for any of the 3 servers to close, and then exit the process

This catches all realistic cases where either the initialization fails (port is already in use, etc.), or something causes the socket to close after the server has started. There is a tiny race condition where it wont listen for errors after a server has started but before all 3 servers have finished starting allowing the top-level `closeListeners` to be attached. It would be very strange to get an error during this time though...