### PR TITLE
Dataset molecule filter

### DIFF
--- a/metaspace/graphql/datasetFilters.js
+++ b/metaspace/graphql/datasetFilters.js
@@ -139,6 +139,7 @@ export const datasetFilters = {
   group: new GroupMatchFilter('', { esField: 'ds_group_id' }),
   project: new ExactMatchFilter('', { esField: 'ds_project_ids' }),
   metadataType: new ExactMatchFilter('Data_Type', {}),
+  hasAnnotationMatching: null,
 };
 
 export function dsField(hit, alias){

--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -117,49 +117,23 @@ type Analyzer {
 }
 
 input DatasetFilter {
-  # list of IDs separated by '|'
-  ids: String
-
-  # substring match
-  name: String
-
-  # exact match
+  ids: String # list of IDs separated by '|'
+  name: String # substring match
   submitter: ID
-
-  # exact match
   group: ID
   hasGroup: Boolean
-
-  # exact match
   project: ID
-
   polarity: Polarity
-
-  # exact match
   ionisationSource: String
-
-  # exact match
   analyzerType: String
-
-  # exact match
   maldiMatrix: String
-
-  # exact match
   organism: String
-
-  # exact match
   organismPart: String
-
-  # exact match
   condition: String
-
-  # exact match
   growthConditions: String
-
-  # exact match
   metadataType: String
-
   status: JobStatus
+  hasAnnotationMatching: AnnotationFilter # Does not support some advanced filters e.g. the colocalization filters
 }
 
 input DatasetCountPerGroupInput {

--- a/metaspace/graphql/src/modules/annotation/queryFilters.spec.ts
+++ b/metaspace/graphql/src/modules/annotation/queryFilters.spec.ts
@@ -13,6 +13,7 @@ import {Query} from '../../binding';
 import {applyQueryFilters} from './queryFilters';
 import {ESAnnotation} from '../../../esConnector';
 import {DeepPartial} from 'typeorm';
+import {ESAnnotationWithColoc} from './queryFilters';
 
 type Args = ArgsFromBinding<Query['allAnnotations']>
   | ArgsFromBinding<Query['countAnnotations']>;
@@ -76,7 +77,7 @@ describe('annotation/queryFilters applyQueryFilters', () => {
       limit: 1000,
       filter: {
         ion: ions.slice(1,4).map(ion => ion.ion),
-      }
+      } as any
     });
   });
 
@@ -97,7 +98,7 @@ describe('annotation/queryFilters applyQueryFilters', () => {
     expect(args).toMatchObject({
       filter: {
         ion: ions.slice(1,3).map(ion => ion.ion)
-      }
+      } as any
     });
   });
 
@@ -120,7 +121,7 @@ describe('annotation/queryFilters applyQueryFilters', () => {
       {_source: ionAnnotations[1]},
     ];
 
-    const result = postprocess!(annotations as ESAnnotation[]);
+    const result = postprocess!(annotations as ESAnnotation[]) as ESAnnotationWithColoc[];
 
     expect(result).toMatchObject([
       {_source: ionAnnotations[1], _isColocReference: true},

--- a/metaspace/graphql/src/modules/annotation/queryFilters/__snapshots__/queryFilters.spec.ts.snap
+++ b/metaspace/graphql/src/modules/annotation/queryFilters/__snapshots__/queryFilters.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`annotation/queryFilters applyQueryFilters should transform the args of a request with a colocalizationSamples filter 1`] = `
+exports[`annotation/queryFilters applyQueryFilters (colocalization) should transform the args of a request with a colocalizationSamples filter 1`] = `
 Object {
   "datasetFilter": Object {
     "ids": "datasetId",
@@ -18,7 +18,7 @@ Object {
 }
 `;
 
-exports[`annotation/queryFilters applyQueryFilters should transform the args of a request with a colocalizedWith filter 1`] = `
+exports[`annotation/queryFilters applyQueryFilters (colocalization) should transform the args of a request with a colocalizedWith filter 1`] = `
 Object {
   "datasetFilter": Object {
     "ids": "datasetId",

--- a/metaspace/graphql/src/modules/annotation/queryFilters/colocalizationSamples.ts
+++ b/metaspace/graphql/src/modules/annotation/queryFilters/colocalizationSamples.ts
@@ -1,6 +1,6 @@
 import {Context} from '../../../context';
 import {ColocJob, Ion} from '../model';
-import {Args, FilterResult} from './types';
+import {QueryFilterArgs, QueryFilterResult} from './types';
 import config from '../../../utils/config';
 import * as _ from 'lodash';
 import {setOrMerge} from '../../../utils/setOrMerge';
@@ -18,21 +18,22 @@ const getColocSampleIons = async (context: Context, datasetId: string, fdrLevel:
   }
 };
 
-export const applyColocalizationSamplesFilter = async function (context: Context, args: Args): Promise<FilterResult> {
-  const datasetId = args.datasetFilter && args.datasetFilter.ids;
-  const { fdrLevel = 0.1, database = null, colocalizationSamples = false } = args.filter || {};
-  const colocalizationAlgo =
-    args.filter && args.filter.colocalizationAlgo
-    || config.metadataLookups.defaultColocalizationAlgo;
+export const applyColocalizationSamplesFilter =
+  async (context: Context, args: QueryFilterArgs): Promise<QueryFilterResult> => {
+    const datasetId = args.datasetFilter && args.datasetFilter.ids;
+    const { fdrLevel = 0.1, database = null, colocalizationSamples = false } = args.filter || {};
+    const colocalizationAlgo =
+      args.filter && args.filter.colocalizationAlgo
+      || config.metadataLookups.defaultColocalizationAlgo;
 
-  if (datasetId != null && colocalizationAlgo != null && colocalizationSamples) {
-    const samples = await getColocSampleIons(context, datasetId, fdrLevel, database, colocalizationAlgo);
-    if (samples != null) {
-      return { args: setOrMerge(args, 'filter.ion', samples, _.intersection) };
+    if (datasetId != null && colocalizationAlgo != null && colocalizationSamples) {
+      const samples = await getColocSampleIons(context, datasetId, fdrLevel, database, colocalizationAlgo);
+      if (samples != null) {
+        return { args: setOrMerge(args, 'filter.ion', samples, _.intersection) };
+      } else {
+        return { args: setOrMerge(args, 'filter.ion', []) };
+      }
     } else {
-      return { args: setOrMerge(args, 'filter.ion', []) };
+      return { args };
     }
-  } else {
-    return { args };
-  }
-};
+  };

--- a/metaspace/graphql/src/modules/annotation/queryFilters/colocalizationSamples.ts
+++ b/metaspace/graphql/src/modules/annotation/queryFilters/colocalizationSamples.ts
@@ -1,0 +1,38 @@
+import {Context} from '../../../context';
+import {ColocJob, Ion} from '../model';
+import {Args, FilterResult} from './types';
+import config from '../../../utils/config';
+import * as _ from 'lodash';
+import {setOrMerge} from '../../../utils/setOrMerge';
+
+const getColocSampleIons = async (context: Context, datasetId: string, fdrLevel: number, database: string | null,
+                                  colocalizationAlgo: string) => {
+  const result = await context.entityManager.findOne(ColocJob,
+    { datasetId, fdr: fdrLevel, molDb: database, algorithm: colocalizationAlgo },
+    { select: ['sampleIonIds'] });
+  if (result == null) {
+    return null;
+  } else {
+    const ions = await context.entityManager.findByIds(Ion, result.sampleIonIds, { select: ['ion'] });
+    return ions.map(({ ion }) => ion);
+  }
+};
+
+export const applyColocalizationSamplesFilter = async function (context: Context, args: Args): Promise<FilterResult> {
+  const datasetId = args.datasetFilter && args.datasetFilter.ids;
+  const { fdrLevel = 0.1, database = null, colocalizationSamples = false } = args.filter || {};
+  const colocalizationAlgo =
+    args.filter && args.filter.colocalizationAlgo
+    || config.metadataLookups.defaultColocalizationAlgo;
+
+  if (datasetId != null && colocalizationAlgo != null && colocalizationSamples) {
+    const samples = await getColocSampleIons(context, datasetId, fdrLevel, database, colocalizationAlgo);
+    if (samples != null) {
+      return { args: setOrMerge(args, 'filter.ion', samples, _.intersection) };
+    } else {
+      return { args: setOrMerge(args, 'filter.ion', []) };
+    }
+  } else {
+    return { args };
+  }
+};

--- a/metaspace/graphql/src/modules/annotation/queryFilters/colocalizedWith.ts
+++ b/metaspace/graphql/src/modules/annotation/queryFilters/colocalizedWith.ts
@@ -1,11 +1,9 @@
 import {Context} from '../../../context';
 import config from '../../../utils/config';
-import {ArgsFromBinding} from '../../../bindingTypes';
-import {Query} from '../../../binding';
 import * as _ from 'lodash';
 import {ESAnnotation} from '../../../../esConnector';
 import {UserError} from 'graphql-errors';
-import {Args, ESAnnotationWithColoc, FilterResult} from './types';
+import {QueryFilterArgs, ESAnnotationWithColoc, QueryFilterResult} from './types';
 import {ColocAnnotation, Ion} from '../model';
 import {setOrMerge} from '../../../utils/setOrMerge';
 
@@ -59,80 +57,91 @@ const getColocCoeffInner = (baseAnnotation: ColocAnnotation, otherIonId: number)
   }
 };
 
-export const applyColocalizedWithFilter = async function (context: Context, args: Args): Promise<FilterResult> {
-  const datasetId = args.datasetFilter && args.datasetFilter.ids;
-  const {
-    fdrLevel = 0.1,
-    database = null,
-    colocalizedWith = null,
-  } = args.filter || {};
-  const colocalizationAlgo =
-    args.filter && args.filter.colocalizationAlgo
-    || config.metadataLookups.defaultColocalizationAlgo;
-  let newArgs = args;
-
-  if (datasetId != null && colocalizationAlgo != null && colocalizedWith != null) {
-    const annotationAndIons = await getColocAnnotation(context, datasetId, fdrLevel, database, colocalizedWith, colocalizationAlgo);
-    if (annotationAndIons != null) {
-      const { annotation, ionsById, lookupIon } = annotationAndIons;
-      const { offset, limit } = args as ArgsFromBinding<Query['allAnnotations']>;
-      const colocIons = _.uniq([annotation.ionId, ...annotation.colocIonIds])
-        .map(ionId => {
-          const ion = ionsById.get(ionId);
-          return ion != null ? ion.ion : null;
-        })
-        .filter(ion => ion != null);
-
-      newArgs = setOrMerge(newArgs, 'filter.ion', colocIons, _.intersection);
-      // Always select 1000 annotations so that sorting by colocalizationCoeff doesn't just sort per-page
-      newArgs = setOrMerge(newArgs, 'offset', 0);
-      newArgs = setOrMerge(newArgs, 'limit', 1000);
-
-      const postprocess = (annotations: ESAnnotation[]): ESAnnotationWithColoc[] => {
-        let newAnnotations: ESAnnotationWithColoc[] = annotations.map(ann => {
-          const ion = lookupIon(ann._source.formula, ann._source.chem_mod, ann._source.neutral_loss, ann._source.adduct);
-          return {
-            ...ann,
-            _cachedColocCoeff: ion != null ? getColocCoeffInner(annotation, ion.id) : null,
-            _isColocReference: ion != null && ion.id === annotation.ionId,
-            async getColocalizationCoeff(_colocalizedWith: string, _colocalizationAlgo: string, _database: string, _fdrLevel: number) {
-              if (_colocalizedWith === colocalizedWith && _colocalizationAlgo === colocalizationAlgo && _database === database && _fdrLevel === fdrLevel) {
-                return this._cachedColocCoeff;
-              } else {
-                throw new UserError('colocalizationCoeff arguments must match the parent allAnnotations filter values');
-                // return getColocCoeff(context, datasetId, _colocalizedWith, ann._source.sf_adduct, _colocalizationAlgo, _database, _fdrLevel)
-              }
-            },
-          };
-        });
-
-        if (!('orderBy' in args) || args.orderBy === 'ORDER_BY_COLOCALIZATION') {
-          const order = 'sortingOrder' in args && args.sortingOrder === 'ASCENDING' ? 1 : -1;
-
-          newAnnotations = _.sortBy(newAnnotations, ann => {
-            if (ann._isColocReference) {
-              // Always show reference annotations as the most colocalized,
-              // even if there are other annotations with a 1.0 colocalizationCoeff
-              return Infinity * order;
-            } else {
-              return (ann._cachedColocCoeff != null ? ann._cachedColocCoeff : -1) * order;
-            }
-          });
-        }
-        if (offset) {
-          newAnnotations = newAnnotations.slice(offset);
-        }
-        if (limit) {
-          newAnnotations = newAnnotations.slice(0, limit);
-        }
-
-        return newAnnotations;
+const createPostprocess = ({annotation, lookupIon}: AnnotationAndIons, args: QueryFilterArgs,
+                          colocalizedWith: string, colocalizationAlgo: string, database: string | null,
+                          fdrLevel: number) => {
+  return (annotations: ESAnnotation[]): ESAnnotationWithColoc[] => {
+    let newAnnotations: ESAnnotationWithColoc[] = annotations.map(ann => {
+      const ion = lookupIon(ann._source.formula, ann._source.chem_mod, ann._source.neutral_loss, ann._source.adduct);
+      return {
+        ...ann,
+        _cachedColocCoeff: ion != null ? getColocCoeffInner(annotation, ion.id) : null,
+        _isColocReference: ion != null && ion.id === annotation.ionId,
+        async getColocalizationCoeff(_colocalizedWith: string, _colocalizationAlgo: string, _database: string, _fdrLevel: number) {
+          if (_colocalizedWith === colocalizedWith
+            && _colocalizationAlgo === colocalizationAlgo
+            && _database === database
+            && _fdrLevel === fdrLevel) {
+            return this._cachedColocCoeff;
+          } else {
+            throw new UserError('colocalizationCoeff arguments must match the parent allAnnotations filter values');
+            // return getColocCoeff(context, datasetId, _colocalizedWith, ann._source.sf_adduct, _colocalizationAlgo, _database, _fdrLevel)
+          }
+        },
       };
-      return {args: newArgs, postprocess};
-    } else {
-      return {args: setOrMerge(newArgs, 'filter.ion', [])};
+    });
+
+    if (args.orderBy === undefined || args.orderBy === 'ORDER_BY_COLOCALIZATION') {
+      const order = 'sortingOrder' in args && args.sortingOrder === 'ASCENDING' ? 1 : -1;
+
+      newAnnotations = _.sortBy(newAnnotations, ann => {
+        if (ann._isColocReference) {
+          // Always show reference annotations as the most colocalized,
+          // even if there are other annotations with a 1.0 colocalizationCoeff
+          return Infinity * order;
+        } else {
+          return (ann._cachedColocCoeff != null ? ann._cachedColocCoeff : -1) * order;
+        }
+      });
     }
-  } else {
-    return { args }
-  }
+    if (args.offset) {
+      newAnnotations = newAnnotations.slice(args.offset);
+    }
+    if (args.limit) {
+      newAnnotations = newAnnotations.slice(0, args.limit);
+    }
+
+    return newAnnotations;
+  };
 };
+
+export const applyColocalizedWithFilter =
+  async (context: Context, args: QueryFilterArgs): Promise<QueryFilterResult> => {
+    const datasetId = args.datasetFilter && args.datasetFilter.ids;
+    const {
+      fdrLevel = 0.1,
+      database = null,
+      colocalizedWith = null,
+    } = args.filter || {};
+    const colocalizationAlgo =
+      args.filter && args.filter.colocalizationAlgo
+      || config.metadataLookups.defaultColocalizationAlgo;
+    let newArgs = args;
+
+    if (datasetId != null && colocalizationAlgo != null && colocalizedWith != null) {
+      const annotationAndIons = await getColocAnnotation(context, datasetId, fdrLevel, database, colocalizedWith, colocalizationAlgo);
+      if (annotationAndIons != null) {
+        const { annotation, ionsById, lookupIon } = annotationAndIons;
+        const colocIons = _.uniq([annotation.ionId, ...annotation.colocIonIds])
+          .map(ionId => {
+            const ion = ionsById.get(ionId);
+            return ion != null ? ion.ion : null;
+          })
+          .filter(ion => ion != null);
+
+        newArgs = setOrMerge(newArgs, 'filter.ion', colocIons, _.intersection);
+        // Always select 1000 annotations so that sorting by colocalizationCoeff doesn't just sort per-page
+        newArgs = setOrMerge(newArgs, 'offset', 0);
+        newArgs = setOrMerge(newArgs, 'limit', 1000);
+
+        return {
+          args: newArgs,
+          postprocess: createPostprocess(annotationAndIons, args, colocalizedWith, colocalizationAlgo, database, fdrLevel),
+        };
+      } else {
+        return {args: setOrMerge(newArgs, 'filter.ion', [])};
+      }
+    } else {
+      return { args }
+    }
+  };

--- a/metaspace/graphql/src/modules/annotation/queryFilters/colocalizedWith.ts
+++ b/metaspace/graphql/src/modules/annotation/queryFilters/colocalizedWith.ts
@@ -1,34 +1,13 @@
+import {Context} from '../../../context';
+import config from '../../../utils/config';
+import {ArgsFromBinding} from '../../../bindingTypes';
+import {Query} from '../../../binding';
 import * as _ from 'lodash';
-import {Context} from '../../context';
-import {ArgsFromBinding} from '../../bindingTypes';
-import {Query} from '../../binding';
-import {ColocAnnotation, ColocJob, Ion} from './model';
+import {ESAnnotation} from '../../../../esConnector';
 import {UserError} from 'graphql-errors';
-import config from '../../utils/config';
-import {ESAnnotation} from '../../../esConnector';
-
-type Args = ArgsFromBinding<Query['allAnnotations']>
-          | ArgsFromBinding<Query['countAnnotations']>;
-interface FilterResult {
-  args: Args;
-  postprocess?(annotations: ESAnnotation[]): ESAnnotationWithColoc[] ;
-}
-
-export interface ESAnnotationWithColoc extends ESAnnotation {
-  _cachedColocCoeff: number | null;
-  _isColocReference: boolean;
-  getColocalizationCoeff(_colocalizedWith: string, _colocalizationAlgo: string,
-                         _database: string, _fdrLevel: number): Promise<number | null>;
-}
-
-const setOrMerge = <T>(obj: any, path: string, value: T, onConflict = (val: T, oldVal: T) => val) => {
-  let newVal = value;
-  if (_.hasIn(obj, path)) {
-    const oldVal = _.get(obj, path);
-    newVal = onConflict(value, oldVal);
-  }
-  return _.merge({}, obj, _.set({}, path, newVal));
-};
+import {Args, ESAnnotationWithColoc, FilterResult} from './types';
+import {ColocAnnotation, Ion} from '../model';
+import {setOrMerge} from '../../../utils/setOrMerge';
 
 interface AnnotationAndIons {
   annotation: ColocAnnotation;
@@ -37,7 +16,7 @@ interface AnnotationAndIons {
 }
 
 const getColocAnnotation = async (context: Context, datasetId: string, fdrLevel: number, database: string | null,
-                           colocalizedWith: string, colocalizationAlgo: string): Promise<AnnotationAndIons | null> => {
+                                  colocalizedWith: string, colocalizationAlgo: string): Promise<AnnotationAndIons | null> => {
   const args = [datasetId, fdrLevel, database, colocalizedWith, colocalizationAlgo] as const;
   return await context.contextCacheGet('getColocAnnotation', args,
     async (datasetId, fdrLevel, database, colocalizedWith, colocalizationAlgo) => {
@@ -65,19 +44,6 @@ const getColocAnnotation = async (context: Context, datasetId: string, fdrLevel:
     });
 };
 
-const getColocSampleIons = async (context: Context, datasetId: string, fdrLevel: number, database: string | null,
-                           colocalizationAlgo: string) => {
-  const result = await context.entityManager.findOne(ColocJob,
-    {datasetId, fdr: fdrLevel, molDb: database, algorithm: colocalizationAlgo},
-    { select: ['sampleIonIds'] });
-  if (result == null) {
-    return null;
-  } else {
-    const ions = await context.entityManager.findByIds(Ion, result.sampleIonIds, {select: ['ion']});
-    return ions.map(({ion}) => ion);
-  }
-};
-
 const getColocCoeffInner = (baseAnnotation: ColocAnnotation, otherIonId: number) => {
   const { ionId, colocIonIds, colocCoeffs } = baseAnnotation;
 
@@ -93,51 +59,27 @@ const getColocCoeffInner = (baseAnnotation: ColocAnnotation, otherIonId: number)
   }
 };
 
-
-/**
- * Apply filters based on data that's not available in ElasticSearch by finding the matching data in postgres,
- * then using it to add additional filters to the ElasticSearch query. Some filters may also require that extra data
- * is added to the found annotations for other resolvers to use.
- *
- * When the datasetId is provided, ES can easily handle large numbers of arguments in "terms" queries.
- * Querying with 28000 valid values of sfAdduct ran in 55ms. It would cost a significant amount of disk space to
- * index colocalized molecules, so filtering only in postgres seems to be the better option.
- * */
-export const applyQueryFilters = async (context: Context, args: Args): Promise<FilterResult> => {
-
+export const applyColocalizedWithFilter = async function (context: Context, args: Args): Promise<FilterResult> {
   const datasetId = args.datasetFilter && args.datasetFilter.ids;
   const {
     fdrLevel = 0.1,
     database = null,
     colocalizedWith = null,
-    colocalizationSamples = false,
   } = args.filter || {};
   const colocalizationAlgo =
     args.filter && args.filter.colocalizationAlgo
     || config.metadataLookups.defaultColocalizationAlgo;
   let newArgs = args;
-  let postprocess: FilterResult['postprocess'];
-
-
-  if (datasetId != null && colocalizationAlgo != null && colocalizationSamples) {
-    const samples = await getColocSampleIons(context, datasetId, fdrLevel, database, colocalizationAlgo);
-    if (samples != null) {
-      newArgs = setOrMerge(newArgs, 'filter.ion', samples, _.intersection);
-    } else {
-      newArgs = setOrMerge(newArgs, 'filter.ion', []);
-    }
-  }
 
   if (datasetId != null && colocalizationAlgo != null && colocalizedWith != null) {
     const annotationAndIons = await getColocAnnotation(context, datasetId, fdrLevel, database, colocalizedWith, colocalizationAlgo);
-
     if (annotationAndIons != null) {
-      const {annotation, ionsById, lookupIon} = annotationAndIons;
-      const {offset, limit} = args as ArgsFromBinding<Query['allAnnotations']>;
+      const { annotation, ionsById, lookupIon } = annotationAndIons;
+      const { offset, limit } = args as ArgsFromBinding<Query['allAnnotations']>;
       const colocIons = _.uniq([annotation.ionId, ...annotation.colocIonIds])
         .map(ionId => {
           const ion = ionsById.get(ionId);
-          return ion != null ? ion.ion : null
+          return ion != null ? ion.ion : null;
         })
         .filter(ion => ion != null);
 
@@ -146,7 +88,7 @@ export const applyQueryFilters = async (context: Context, args: Args): Promise<F
       newArgs = setOrMerge(newArgs, 'offset', 0);
       newArgs = setOrMerge(newArgs, 'limit', 1000);
 
-      postprocess = (annotations: ESAnnotation[]): ESAnnotationWithColoc[] => {
+      const postprocess = (annotations: ESAnnotation[]): ESAnnotationWithColoc[] => {
         let newAnnotations: ESAnnotationWithColoc[] = annotations.map(ann => {
           const ion = lookupIon(ann._source.formula, ann._source.chem_mod, ann._source.neutral_loss, ann._source.adduct);
           return {
@@ -161,7 +103,7 @@ export const applyQueryFilters = async (context: Context, args: Args): Promise<F
                 // return getColocCoeff(context, datasetId, _colocalizedWith, ann._source.sf_adduct, _colocalizationAlgo, _database, _fdrLevel)
               }
             },
-          }
+          };
         });
 
         if (!('orderBy' in args) || args.orderBy === 'ORDER_BY_COLOCALIZATION') {
@@ -175,7 +117,7 @@ export const applyQueryFilters = async (context: Context, args: Args): Promise<F
             } else {
               return (ann._cachedColocCoeff != null ? ann._cachedColocCoeff : -1) * order;
             }
-          })
+          });
         }
         if (offset) {
           newAnnotations = newAnnotations.slice(offset);
@@ -185,11 +127,12 @@ export const applyQueryFilters = async (context: Context, args: Args): Promise<F
         }
 
         return newAnnotations;
-      }
+      };
+      return {args: newArgs, postprocess};
     } else {
-      newArgs = setOrMerge(newArgs, 'filter.ion', []);
+      return {args: setOrMerge(newArgs, 'filter.ion', [])};
     }
+  } else {
+    return { args }
   }
-
-  return {args: newArgs, postprocess};
 };

--- a/metaspace/graphql/src/modules/annotation/queryFilters/hasAnnotationMatching.spec.ts
+++ b/metaspace/graphql/src/modules/annotation/queryFilters/hasAnnotationMatching.spec.ts
@@ -1,0 +1,45 @@
+jest.mock('../../../../esConnector');
+import * as _mockEsConnector from '../../../../esConnector';
+import {
+  anonContext,
+  onAfterAll,
+  onAfterEach,
+  onBeforeAll,
+  onBeforeEach,
+} from '../../../tests/graphqlTestEnvironment';
+import {applyQueryFilters} from './index';
+import {QueryFilterArgs} from './types';
+
+const mockEsConnector = _mockEsConnector as jest.Mocked<typeof _mockEsConnector>;
+
+describe('annotation/queryFilters hasAnnotationMatching', () => {
+  beforeAll(onBeforeAll);
+  afterAll(onAfterAll);
+  beforeEach(onBeforeEach);
+  afterEach(onAfterEach);
+
+
+  it('should add dataset ID filters when "hasAnnotationMatching" filter is used', async () => {
+    const inputArgs: QueryFilterArgs = {
+      datasetFilter: {
+        hasAnnotationMatching: { compoundQuery: 'H2SO4' },
+        polarity: 'NEGATIVE',
+      },
+    };
+    mockEsConnector.esCountMatchingAnnotationsPerDataset.mockReturnValueOnce(Promise.resolve({
+      DS1: 123,
+      DS2: 123,
+    }));
+
+    const {args} = await applyQueryFilters(anonContext, inputArgs);
+
+    expect(args).toMatchObject({
+      datasetFilter: { ids: 'DS1|DS2', polarity: 'NEGATIVE' },
+    } as any);
+    expect(mockEsConnector.esCountMatchingAnnotationsPerDataset).toHaveBeenCalledWith({
+      datasetFilter: { polarity: 'NEGATIVE' },
+      filter: { compoundQuery: 'H2SO4' }
+    }, null);
+  });
+
+});

--- a/metaspace/graphql/src/modules/annotation/queryFilters/hasAnnotationMatching.ts
+++ b/metaspace/graphql/src/modules/annotation/queryFilters/hasAnnotationMatching.ts
@@ -1,0 +1,36 @@
+import {Context} from '../../../context';
+import {QueryFilterArgs, QueryFilterResult} from './types';
+import {esCountMatchingAnnotationsPerDataset} from '../../../../esConnector';
+import * as _ from 'lodash';
+
+
+export const applyHasAnnotationMatchingFilter =
+  async (context: Context, args: QueryFilterArgs): Promise<QueryFilterResult> => {
+    const {datasetFilter, ...otherArgs} = args;
+
+    if (datasetFilter != null && datasetFilter.hasAnnotationMatching != null) {
+      const {hasAnnotationMatching, ...otherDatasetFilters} = datasetFilter;
+      const result = await esCountMatchingAnnotationsPerDataset({
+        datasetFilter: otherDatasetFilters,
+        // simpleQuery: args.simpleQuery,
+        filter: hasAnnotationMatching,
+      }, context.user);
+
+      const datasetIds = Object.keys(result);
+      const ids = otherDatasetFilters.ids
+        ? _.intersection(datasetIds, otherDatasetFilters.ids.split('|')).join('|')
+        : datasetIds.join('|');
+
+      return {
+        args: {
+          ...otherArgs,
+          datasetFilter: {
+            ...otherDatasetFilters,
+            ids,
+          }
+        },
+      };
+    } else {
+      return { args };
+    }
+  };

--- a/metaspace/graphql/src/modules/annotation/queryFilters/index.ts
+++ b/metaspace/graphql/src/modules/annotation/queryFilters/index.ts
@@ -1,0 +1,37 @@
+import {Context} from '../../../context';
+import {Args, FilterResult, PostProcessFunc} from './types';
+import {applyColocalizationSamplesFilter} from './colocalizationSamples';
+import {applyColocalizedWithFilter} from './colocalizedWith';
+import * as _ from 'lodash';
+
+export {ESAnnotationWithColoc} from './types';
+
+const queryFilters = [
+  applyColocalizationSamplesFilter,
+  applyColocalizedWithFilter,
+];
+
+/**
+ * Apply filters based on data that's not available in ElasticSearch by finding the matching data in postgres,
+ * then using it to add additional filters to the ElasticSearch query. Some filters may also require that extra data
+ * is added to the found annotations for other resolvers to use.
+ *
+ * When the datasetId is provided, ES can easily handle large numbers of arguments in "terms" queries.
+ * Querying with 28000 valid values of sfAdduct ran in 55ms. It would cost a significant amount of disk space to
+ * index colocalized molecules, so filtering only in postgres seems to be the better option.
+ * */
+export const applyQueryFilters = async (context: Context, args: Args): Promise<FilterResult> => {
+  let newArgs = args;
+  let postprocessFuncs: PostProcessFunc[] = [];
+
+  for (const filter of queryFilters) {
+    const result = await filter(context, newArgs);
+    newArgs = result.args;
+    if (result.postprocess != null) {
+      postprocessFuncs.push(result.postprocess);
+    }
+  }
+
+  return { args: newArgs, postprocess: _.flow(postprocessFuncs) };
+};
+

--- a/metaspace/graphql/src/modules/annotation/queryFilters/index.ts
+++ b/metaspace/graphql/src/modules/annotation/queryFilters/index.ts
@@ -3,12 +3,14 @@ import {QueryFilterArgs, QueryFilterResult, PostProcessFunc} from './types';
 import {applyColocalizationSamplesFilter} from './colocalizationSamples';
 import {applyColocalizedWithFilter} from './colocalizedWith';
 import * as _ from 'lodash';
+import {applyHasAnnotationMatchingFilter} from './hasAnnotationMatching';
 
 export {ESAnnotationWithColoc} from './types';
 
 const queryFilters = [
   applyColocalizationSamplesFilter,
   applyColocalizedWithFilter,
+  applyHasAnnotationMatchingFilter,
 ];
 
 /**

--- a/metaspace/graphql/src/modules/annotation/queryFilters/queryFilters.spec.ts
+++ b/metaspace/graphql/src/modules/annotation/queryFilters/queryFilters.spec.ts
@@ -6,19 +6,15 @@ import {
   onBeforeAll,
   onBeforeEach,
   testEntityManager,
-} from '../../tests/graphqlTestEnvironment';
-import {ColocAnnotation, ColocJob, Ion} from './model';
-import {ArgsFromBinding} from '../../bindingTypes';
-import {Query} from '../../binding';
-import {applyQueryFilters} from './queryFilters';
-import {ESAnnotation} from '../../../esConnector';
+} from '../../../tests/graphqlTestEnvironment';
+import {ColocAnnotation, ColocJob, Ion} from '../model';
+import {applyQueryFilters} from './index';
+import {ESAnnotation} from '../../../../esConnector';
 import {DeepPartial} from 'typeorm';
-import {ESAnnotationWithColoc} from './queryFilters';
+import {ESAnnotationWithColoc} from './index';
+import {QueryFilterArgs} from './types';
 
-type Args = ArgsFromBinding<Query['allAnnotations']>
-  | ArgsFromBinding<Query['countAnnotations']>;
-
-describe('annotation/queryFilters applyQueryFilters', () => {
+describe('annotation/queryFilters applyQueryFilters (colocalization)', () => {
   beforeAll(onBeforeAll);
   afterAll(onAfterAll);
   // beforeEach(onBeforeEach);
@@ -59,7 +55,7 @@ describe('annotation/queryFilters applyQueryFilters', () => {
   });
 
   it('should transform the args of a request with a colocalizedWith filter', async () => {
-    const argsWithColocWith: Args = {
+    const argsWithColocWith: QueryFilterArgs = {
       datasetFilter: { ids: job.datasetId },
       filter: {
         database: job.molDb!,
@@ -82,7 +78,7 @@ describe('annotation/queryFilters applyQueryFilters', () => {
   });
 
   it('should transform the args of a request with a colocalizationSamples filter', async () => {
-    const argsWithColocWith: Args = {
+    const argsWithColocWith: QueryFilterArgs = {
       datasetFilter: { ids: job.datasetId },
       filter: {
         database: job.molDb!,
@@ -103,7 +99,7 @@ describe('annotation/queryFilters applyQueryFilters', () => {
   });
 
   it('should add colocalizationCoeffs to annotations', async () => {
-    const argsWithColocWith: Args = {
+    const argsWithColocWith: QueryFilterArgs = {
       datasetFilter: { ids: job.datasetId },
       filter: {
         database: job.molDb!,

--- a/metaspace/graphql/src/modules/annotation/queryFilters/types.ts
+++ b/metaspace/graphql/src/modules/annotation/queryFilters/types.ts
@@ -1,14 +1,27 @@
-import {ArgsFromBinding} from '../../../bindingTypes';
-import {Query} from '../../../binding';
+import {
+  AnnotationFilter,
+  AnnotationOrderBy,
+  DatasetFilter,
+  DatasetOrderBy, Query,
+  SortingOrder,
+} from '../../../binding';
 import {ESAnnotation} from '../../../../esConnector';
 
-export type Args = ArgsFromBinding<Query['allAnnotations']>
-  | ArgsFromBinding<Query['countAnnotations']>;
+// A superset of allAnnotations, countAnnotations, allDatasets and countDatasets
+export interface QueryFilterArgs {
+  orderBy?: AnnotationOrderBy | DatasetOrderBy;
+  sortingOrder?: SortingOrder;
+  offset?: number;
+  limit?: number;
+  filter?: AnnotationFilter;
+  datasetFilter?: DatasetFilter;
+  simpleQuery?: string;
+}
 
 export type PostProcessFunc = (annotations: ESAnnotation[]) => ESAnnotation[];
 
-export interface FilterResult {
-  args: Args;
+export interface QueryFilterResult {
+  args: QueryFilterArgs;
   postprocess?: PostProcessFunc;
 }
 

--- a/metaspace/graphql/src/modules/annotation/queryFilters/types.ts
+++ b/metaspace/graphql/src/modules/annotation/queryFilters/types.ts
@@ -1,0 +1,22 @@
+import {ArgsFromBinding} from '../../../bindingTypes';
+import {Query} from '../../../binding';
+import {ESAnnotation} from '../../../../esConnector';
+
+export type Args = ArgsFromBinding<Query['allAnnotations']>
+  | ArgsFromBinding<Query['countAnnotations']>;
+
+export type PostProcessFunc = (annotations: ESAnnotation[]) => ESAnnotation[];
+
+export interface FilterResult {
+  args: Args;
+  postprocess?: PostProcessFunc;
+}
+
+export interface ESAnnotationWithColoc extends ESAnnotation {
+  _cachedColocCoeff: number | null;
+  _isColocReference: boolean;
+
+  getColocalizationCoeff(_colocalizedWith: string, _colocalizationAlgo: string,
+                         _database: string, _fdrLevel: number): Promise<number | null>;
+}
+

--- a/metaspace/graphql/src/modules/dataset/controller/Query.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Query.ts
@@ -6,6 +6,7 @@ import {Dataset as DatasetModel} from '../model';
 import {UserGroup as UserGroupModel, UserGroupRoleOptions} from '../../group/model';
 import {Context} from '../../../context';
 import {thumbnailOpticalImageUrl} from './Dataset';
+import {applyQueryFilters} from '../../annotation/queryFilters';
 
 const resolveDatasetScopeRole = async (ctx: Context, dsId: string) => {
   let scopeRole = SRO.OTHER;
@@ -50,31 +51,34 @@ const QueryResolvers: FieldResolversFor<Query, void>  = {
   },
 
   async allDatasets(source, args, ctx): Promise<DatasetSource[]> {
-    const translatedArgs = {
+    const {args: filteredArgs} = await applyQueryFilters(ctx, {
       ...args,
       datasetFilter: args.filter,
       filter: {}
-    };
-    return await esSearchResults(translatedArgs, 'dataset', ctx.user);
+    });
+    return await esSearchResults(filteredArgs, 'dataset', ctx.user);
   },
 
   async countDatasets(source, args, ctx): Promise<number> {
-    const translatedArgs = {
+    const {args: filteredArgs} = await applyQueryFilters(ctx, {
       ...args,
       datasetFilter: args.filter,
       filter: {}
-    };
-    return await esCountResults(translatedArgs, 'dataset', ctx.user);
+    });
+    return await esCountResults(filteredArgs, 'dataset', ctx.user);
   },
 
   async countDatasetsPerGroup(source, {query}, ctx) {
-    const args = {
+    const {args} = await applyQueryFilters(ctx, {
       datasetFilter: query.filter,
       simpleQuery: query.simpleQuery,
       filter: {},
-      groupingFields: query.fields
+    });
+    const groupArgs = {
+      ...args,
+      groupingFields: query.fields,
     };
-    return await esCountGroupedResults(args, 'dataset', ctx.user);
+    return await esCountGroupedResults(groupArgs, 'dataset', ctx.user);
   },
 
   async opticalImageUrl(source, {datasetId: dsId, zoom = 1}, ctx) {

--- a/metaspace/graphql/src/utils/setOrMerge.ts
+++ b/metaspace/graphql/src/utils/setOrMerge.ts
@@ -1,0 +1,18 @@
+import * as _ from 'lodash';
+
+/**
+ * A specialized version of `_.set` that checks to see if a value already exists at `path`, and if so,
+ * calls `onConflict` to merge the old and new values.
+ * @param obj
+ * @param path
+ * @param value
+ * @param onConflict
+ */
+export const setOrMerge = <T>(obj: any, path: string, value: T, onConflict = (val: T, oldVal: T) => val) => {
+  let newVal = value;
+  if (_.hasIn(obj, path)) {
+    const oldVal = _.get(obj, path);
+    newVal = onConflict(value, oldVal);
+  }
+  return _.merge({}, obj, _.set({}, path, newVal));
+};

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -18,6 +18,7 @@ exports[`DatasetTable should match snapshot 1`] = `
       <mock-el-option value="project" label="Select project"></mock-el-option>
       <mock-el-option value="submitter" label="Select submitter"></mock-el-option>
       <mock-el-option value="datasetIds" label="Select dataset"></mock-el-option>
+      <mock-el-option value="compoundName" label="Search molecule"></mock-el-option>
       <mock-el-option value="polarity" label="Select polarity"></mock-el-option>
       <mock-el-option value="organism" label="Select organism"></mock-el-option>
       <mock-el-option value="organismPart" label="Select organism part"></mock-el-option>

--- a/metaspace/webapp/src/modules/Filters/filterSpecs.ts
+++ b/metaspace/webapp/src/modules/Filters/filterSpecs.ts
@@ -125,7 +125,7 @@ export const FILTER_SPECIFICATIONS: Record<FilterKey, FilterSpecification> = {
     type: InputFilter,
     name: 'Molecule',
     description: 'Search molecule',
-    levels: ['annotation'],
+    levels: ['dataset', 'annotation'],
     initialValue: undefined
   },
 

--- a/metaspace/webapp/src/modules/Filters/index.ts
+++ b/metaspace/webapp/src/modules/Filters/index.ts
@@ -9,6 +9,7 @@ export {
 } from './filterSpecs';
 
 export {
+  getLevel,
   encodeParams,
   decodeParams,
   stripFilteringParams,

--- a/metaspace/webapp/src/modules/Filters/url.ts
+++ b/metaspace/webapp/src/modules/Filters/url.ts
@@ -51,6 +51,10 @@ const PATH_TO_LEVEL: Record<string, Level> = {
   '/projects': 'projects',
 };
 
+export const getLevel = (path?: string): Level | null => {
+  return path != null && PATH_TO_LEVEL[path.toLowerCase()] || null;
+};
+
 export const DEFAULT_TABLE_ORDER: SortSettings = {
   by: 'ORDER_BY_MSM',
   dir: 'DESCENDING'
@@ -61,14 +65,14 @@ export const DEFAULT_ANNOTATION_VIEW_SECTIONS = ['images'];
 export const DEFAULT_COLORMAP = 'Viridis';
 
 export function encodeParams(filter: any, path?: string, filterLists?: MetadataLists): Dictionary<string> {
-  const level = path != null ? PATH_TO_LEVEL[path.toLowerCase()] : null;
+  const level = getLevel(path);
   const defaultFilter = level != null ? getDefaultFilter(level, filterLists) : null;
 
   let q: Dictionary<string> = {};
   let key: FilterKey;
   for (key in FILTER_TO_URL) {
     const {levels, encoding} = FILTER_SPECIFICATIONS[key];
-    if (path != null && level != null && levels.indexOf(level) == -1)
+    if (level != null && levels.indexOf(level) == -1)
       continue;
 
     if (key in filter && (defaultFilter == null || filter[key] != defaultFilter[key])) {
@@ -100,13 +104,12 @@ export function stripFilteringParams(query: Dictionary<string>): Dictionary<stri
 
 export function decodeParams(location: Location, filterLists: any): Object {
   const {query, path} = location;
+  const level = path ? getLevel(path) : null;
 
-  if (!path || !query)
+  if (!path || !query || !level)
     return {};
 
-  const level = PATH_TO_LEVEL[path];
-
-  const filter: any = getDefaultFilter(level, filterLists);
+  const filter = getDefaultFilter(level, filterLists);
 
   for (var key in query) {
     const fKey = URL_TO_FILTER[key];

--- a/metaspace/webapp/src/store/getters.js
+++ b/metaspace/webapp/src/store/getters.js
@@ -1,8 +1,12 @@
 import {mzFilterPrecision} from '../util';
-import {decodeParams, decodeSettings} from '../modules/Filters';
+import {decodeParams, decodeSettings, getLevel} from '../modules/Filters';
 import config from '../config';
 
 export default {
+  filterLevel(state) {
+    return getLevel(state.route.path);
+  },
+
   filter(state) {
     return decodeParams(state.route, state.filterLists);
   },
@@ -61,7 +65,10 @@ export default {
     const filter = getters.filter;
     const {group, project, submitter, datasetIds, polarity,
            organism, organismPart, condition, growthConditions,
-           ionisationSource, analyzerType, maldiMatrix, metadataType} = filter;
+           ionisationSource, analyzerType, maldiMatrix, metadataType,
+           compoundName} = filter;
+    const level = getters.filterLevel;
+    const hasAnnotationMatching = level === 'dataset' && compoundName ? { compoundQuery: compoundName } : undefined;
     return {
       group: group,
       project: project,
@@ -78,7 +85,8 @@ export default {
       maldiMatrix,
       analyzerType,
       polarity: polarity ? polarity.toUpperCase() : null,
-      metadataType
+      metadataType,
+      hasAnnotationMatching,
     }
   },
 


### PR DESCRIPTION
This contains substantial refactoring, so I suggest reviewing each commit individually:

* Commit 1 is mainly splitting up a big file into smaller files. Some annotation-specific data processing needed to be moved out of `applyQueryFilters` into `applyColocalizedWithFilter` and `applyColocalizationSamplesFilter`. 
* Commit 2 has refactoring to tidy up the existing filters and add a better `QueryFilterArgs` type that isn't derived from the graphql schema and can be more easily shared between annotations and datasets
* Commit 3 has the new functionality - graphql and webapp changes to add a `hasAnnotationsMatching` filter. This filter uses ElasticSearch to find all datasets that contain at least 1 annotation matching the supplied filter (which can be any annotation filter in the GraphQL API, but in the front-end it's limited to the `compoundQuery` filter)

![image](https://user-images.githubusercontent.com/26366936/64850528-d6eca100-d615-11e9-820e-e8895b833ef3.png)
