### PR TITLE
Changes required to support M4I databases

### DIFF
--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -231,7 +231,6 @@ class ESIndexManager(object):
         return ind_data['docs']['count'], ind_data['store']['size_in_bytes']
 
 
-
 def flatten_doc(doc, parent_key='', sep='.'):
     items = []
     for k, v in doc.items():
@@ -261,6 +260,7 @@ def retry_on_conflict(num_retries=3):
         return wrapper
 
     return decorator
+
 
 class ESExporter(object):
     def __init__(self, db, es_config=None):
@@ -416,7 +416,7 @@ class ESExporter(object):
                             'pipeline': pipeline_id,
                             'wait_for_completion': True,
                             'refresh': 'wait_for',
-                            'request_timeout': 60,
+                            'request_timeout': 5*60,
                         })
                 finally:
                     self._ingest.delete_pipeline(pipeline_id)

--- a/metaspace/engine/sm/engine/formula_centroids.py
+++ b/metaspace/engine/sm/engine/formula_centroids.py
@@ -124,9 +124,9 @@ class CentroidsGenerator(object):
     def _restore_df_chunks(self, spark_df, chunk_size=20 * 10 ** 6):
         total_n = spark_df.rdd.count()
         chunk_n = ceil(total_n / chunk_size)
-        spark_dfs = spark_df.randomSplit([1.0 for _ in range(chunk_n)])
-        dfs = [_.toPandas() for _ in spark_dfs]
-        return pd.concat(dfs).set_index('formula_i')
+        spark_dfs = spark_df.randomSplit(weights=np.ones(chunk_n))
+        pandas_dfs = [df.toPandas() for df in spark_dfs]
+        return pd.concat(pandas_dfs).set_index('formula_i')
 
     def _restore(self):
         logger.info('Restoring peaks')

--- a/metaspace/engine/sm/engine/formula_centroids.py
+++ b/metaspace/engine/sm/engine/formula_centroids.py
@@ -130,7 +130,7 @@ class CentroidsGenerator(object):
                 self._ion_centroids_path + '/centroids').toPandas().set_index('formula_i')
             return FormulaCentroids(formulas_df, centroids_df)
 
-    def _save_df_chunks(self, df, path, chunk_size=10 * 10 ** 6):
+    def _save_df_chunks(self, df, path, chunk_size=5 * 10 ** 6):
         chunks = int(ceil(df.shape[0] / chunk_size))
         for ch_i in range(chunks):
             sdf = self._spark_session.createDataFrame(df[ch_i * chunk_size:(ch_i + 1) * chunk_size])


### PR DESCRIPTION
* Read and write centroids parquet files in chunks to prevent OOM errors in Spark
* Set `request_timeout` to 300s in `update_by_query` to prevent timeout interruptions for long updates. For ~80k documents it takes 2-3 minutes
* Settings of nginx should also be updated to allow requests longer than 60s