### PR TITLE
Use pickle instead of msgpack for serialization of arrays and dataframes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,7 +334,7 @@ workflows:
           filters:
             branches:
               # Replace this with the branch to run sci-test against
-              only: feature/update-engine-docker-image
+              only: feature/replace-msgpack-with-arrow
 
 ## Disabled until we have time to redo these tests
 #  daily:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,7 +334,7 @@ workflows:
           filters:
             branches:
               # Replace this with the branch to run sci-test against
-              only: feature/replace-msgpack-with-arrow
+              only: master
 
 ## Disabled until we have time to redo these tests
 #  daily:
@@ -348,15 +348,15 @@ workflows:
 #              only:
 #                - master
 #                - feature/.*
-  weekly:
-    jobs:
-      - generate-graphql-schema
-      - test-engine-sci
-    triggers:
-      - schedule:
-          cron: "0 11 * * 1"
-          filters:
-            branches:
-              only:
-                - master
-
+#  weekly:
+#    jobs:
+#      - generate-graphql-schema
+#      - test-engine-sci
+#    triggers:
+#      - schedule:
+#          cron: "0 11 * * 1"
+#          filters:
+#            branches:
+#              only:
+#                - master
+#

--- a/metaspace/engine/.pylintrc
+++ b/metaspace/engine/.pylintrc
@@ -276,7 +276,7 @@ function-naming-style=snake_case
 #function-rgx=
 
 # Good variable names which should always be accepted, separated by a comma.
-good-names=_,i,j,k,n,a,e,m,v,h,w,x,db,df,ds,db,id,es,fn,fp,xs,Run,logger,parser,args,sm_config
+good-names=_,i,j,f,k,n,a,e,m,v,h,w,x,db,df,ds,db,id,es,fn,fp,xs,Run,logger,parser,args,sm_config
 
 # Include a hint for the correct naming format with invalid-name.
 include-naming-hint=no

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -386,8 +386,8 @@ class ESExporter:
             doc['ion'] = ion_without_pol + doc['polarity']
             doc['comp_ids'], doc['comp_names'] = mol_by_formula[formula]
             mzs, _ = isocalc.centroids(ion_without_pol)
-            doc['centroid_mzs'] = list(mzs)
-            doc['mz'] = mzs[0]
+            doc['centroid_mzs'] = list(mzs) if mzs is not None else []
+            doc['mz'] = mzs[0] if mzs is not None else 0
 
             fdr = round(doc['fdr'] * 100, 2)
             annotation_counts[fdr] += 1

--- a/metaspace/engine/sm/engine/formula_centroids.py
+++ b/metaspace/engine/sm/engine/formula_centroids.py
@@ -1,15 +1,14 @@
 import logging
 from copy import deepcopy
 from itertools import repeat
-from math import ceil
 from pathlib import Path
 
 import boto3
-import numpy as np
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 from botocore.exceptions import ClientError
 from pyspark import SparkContext  # pylint: disable=unused-import
-from pyspark.sql import SparkSession
 
 from sm.engine.isocalc_wrapper import IsocalcWrapper  # pylint: disable=unused-import
 from sm.engine.util import SMConfig, split_s3_path
@@ -32,13 +31,14 @@ class CentroidsGenerator:
         self._parquet_chunks_n = 64
         self._iso_gen_part_n = 512
 
-        self._spark_session = SparkSession(self._sc)
         self._ion_centroids_path = '{}/{}/{}/{}'.format(
             self._sm_config['isotope_storage']['path'],
             self._isocalc.n_peaks,
             self._isocalc.sigma,
             self._isocalc.charge,
         )
+        Path(self._ion_centroids_path).mkdir(parents=True, exist_ok=True)
+
         self._s3 = boto3.client(
             's3',
             self._sm_config['aws']['aws_region'],
@@ -116,61 +116,44 @@ class CentroidsGenerator:
         if self._ion_centroids_path.startswith('s3a://'):
             bucket, key = split_s3_path(self._ion_centroids_path)
             try:
-                self._s3.head_object(Bucket=bucket, Key=key + '/formulas/_SUCCESS')
+                self._s3.head_object(Bucket=bucket, Key=key + '/formulas.parquet')
+                self._s3.head_object(Bucket=bucket, Key=key + '/centroids.parquet')
             except ClientError:
                 return False
             else:
                 return True
         else:
-            return (
-                Path(self._ion_centroids_path + '/formulas/_SUCCESS').exists()
-                & Path(self._ion_centroids_path + '/centroids/_SUCCESS').exists()
-            )
-
-    @staticmethod
-    def _restore_df_chunks(spark_df, chunk_size=20 * 10 ** 6):
-        total_n = spark_df.rdd.count()
-        chunk_n = ceil(total_n / chunk_size)
-        logger.debug(f'Restoring peaks chunks, chunk_size={chunk_size / 1e6}M, chunk_n={chunk_n}')
-        spark_dfs = spark_df.randomSplit(weights=np.ones(chunk_n))
-        pandas_dfs = [df.toPandas() for df in spark_dfs]
-        return pd.concat(pandas_dfs).set_index('formula_i')
+            return (Path(self._ion_centroids_path) / 'formulas.parquet').exists() & (
+                Path(self._ion_centroids_path) / 'centroids.parquet'
+            ).exists()
 
     def _restore(self):
-        logger.info('Restoring peaks')
+        logger.info(f'Restoring peaks from {self._ion_centroids_path}')
         formula_centroids = None
         if self._saved():
-            formulas_df = self._restore_df_chunks(
-                self._spark_session.read.parquet(self._ion_centroids_path + '/formulas')
+            formulas_df = (
+                pq.read_table(f'{self._ion_centroids_path}/formulas.parquet')
+                .to_pandas()
+                .set_index('formula_i')
             )
-            centroids_df = self._restore_df_chunks(
-                self._spark_session.read.parquet(self._ion_centroids_path + '/centroids')
+            centroids_df = (
+                pq.read_table(f'{self._ion_centroids_path}/centroids.parquet')
+                .to_pandas()
+                .set_index('formula_i')
             )
             formula_centroids = FormulaCentroids(formulas_df, centroids_df)
         return formula_centroids
 
-    def _save_df_chunks(self, df, path, chunk_size=5 * 10 ** 6):
-        chunks = int(ceil(df.shape[0] / chunk_size))
-        for ch_i in range(chunks):
-            sdf = self._spark_session.createDataFrame(
-                df[ch_i * chunk_size : (ch_i + 1) * chunk_size]
-            )
-            mode = 'overwrite' if ch_i == 0 else 'append'
-            sdf.write.parquet(path, mode=mode)
-
     def _save(self, formula_centroids):
         """ Save isotopic peaks
         """
-        logger.info('Saving peaks')
+        logger.info(f'Saving peaks to {self._ion_centroids_path}')
         assert formula_centroids.formulas_df.index.name == 'formula_i'
 
-        self._save_df_chunks(
-            formula_centroids.centroids_df(fixed_size_centroids=True).reset_index(),
-            self._ion_centroids_path + '/centroids',
-        )
-        self._save_df_chunks(
-            formula_centroids.formulas_df.reset_index(), self._ion_centroids_path + '/formulas'
-        )
+        centroids_table = pa.Table.from_pandas(formula_centroids.centroids_df().reset_index())
+        pq.write_table(centroids_table, f'{self._ion_centroids_path}/centroids.parquet')
+        formulas_table = pa.Table.from_pandas(formula_centroids.formulas_df.reset_index())
+        pq.write_table(formulas_table, f'{self._ion_centroids_path}/formulas.parquet')
 
 
 class FormulaCentroids:

--- a/metaspace/engine/sm/engine/msm_basic/msm_basic_search.py
+++ b/metaspace/engine/sm/engine/msm_basic/msm_basic_search.py
@@ -162,7 +162,7 @@ class MSMSearch:
 
         sample_sp_n = int(len(self._coordinates) * sample_ratio)
         spectra_per_chunk_n = calculate_chunk_sp_n(
-            sample_mzs.nbytes, sample_sp_n, max_chunk_size_mb=1000
+            sample_mzs.nbytes, sample_sp_n, max_chunk_size_mb=5000
         )
 
         total_mz_n = sample_mzs.shape[0] / sample_ratio  # pylint: disable=unsubscriptable-object

--- a/metaspace/engine/sm/engine/msm_basic/msm_basic_search.py
+++ b/metaspace/engine/sm/engine/msm_basic/msm_basic_search.py
@@ -162,7 +162,7 @@ class MSMSearch:
 
         sample_sp_n = int(len(self._coordinates) * sample_ratio)
         spectra_per_chunk_n = calculate_chunk_sp_n(
-            sample_mzs.nbytes, sample_sp_n, max_chunk_size_mb=5000
+            sample_mzs.nbytes, sample_sp_n, max_chunk_size_mb=500
         )
 
         total_mz_n = sample_mzs.shape[0] / sample_ratio  # pylint: disable=unsubscriptable-object

--- a/metaspace/engine/sm/engine/msm_basic/segmenter.py
+++ b/metaspace/engine/sm/engine/msm_basic/segmenter.py
@@ -174,8 +174,6 @@ def segment_centroids(centr_df, centr_segm_n, centr_segm_path):
         centr_df, first_peak_df[['formula_i', 'segm_i']], on='formula_i'
     ).sort_values('mz')
     for segm_i, df in centr_segm_df.groupby('segm_i'):
-        table = pa.Table.from_pandas(df)
-        with pq.ParquetWriter(
-            f'{centr_segm_path}/centr_segm_{segm_i:04}.parquet', table.schema
-        ) as writer:
-            writer.write_table(table)
+        segment_path = centr_segm_path / f'centr_segm_{segm_i:04}.pickle'
+        with open(segment_path, 'wb') as f:
+            pickle.dump(df, f)

--- a/metaspace/engine/sm/engine/msm_basic/segmenter.py
+++ b/metaspace/engine/sm/engine/msm_basic/segmenter.py
@@ -5,8 +5,6 @@ from shutil import rmtree
 
 import numpy as np
 import pandas as pd
-import pyarrow as pa
-import pyarrow.parquet as pq
 
 from sm.engine.errors import SMError
 from sm.engine.msm_basic.formula_imager import get_pixel_indices

--- a/metaspace/engine/sm/engine/queue.py
+++ b/metaspace/engine/sm/engine/queue.py
@@ -441,8 +441,6 @@ class QueueConsumer(Thread):
                     self.logger.error(' [x] Failed in _on_success: {}'.format(body), exc_info=True)
             finally:
                 self._channel.basic_ack(method.delivery_tag)
-        else:
-            self.logger.debug('No messages in "{}" queue'.format(self._qname))
 
     def run(self):
         """ Use `start` method to kick off message polling """

--- a/metaspace/engine/sm/engine/tests/msm_basic/test_segmenter.py
+++ b/metaspace/engine/sm/engine/tests/msm_basic/test_segmenter.py
@@ -55,7 +55,7 @@ def test_define_ds_segments():
     assert np.allclose(ds_segments, exp_ds_segments)
 
 
-@patch('sm.engine.msm_basic.segmenter.pq.ParquetWriter.write_table')
+@patch('sm.engine.msm_basic.segmenter.pa.parquet.write_table')
 def test_segment_ds(write_table_mock):
     imzml_parser_mock = Mock()
     imzml_parser_mock.getspectrum.return_value = (np.linspace(0, 90, num=10), np.ones(10))
@@ -66,9 +66,10 @@ def test_segment_ds(write_table_mock):
     chunk_sp_n = 1000
     segment_ds(imzml_parser_mock, coordinates, chunk_sp_n, ds_segments, Path('/tmp/abc'))
 
-    for segm_i, (min_mz, max_mz) in enumerate(ds_segments):
-        args = write_table_mock.call_args_list[segm_i][0]
-        segm_arr = args[0].to_pandas().values
+    for (table, path), _ in write_table_mock.call_args_list:
+        segm_arr = table.to_pandas().values
+        segm_i = int(path.stem[-4:])
+        min_mz, max_mz = ds_segments[segm_i]
 
         assert segm_arr.shape == (50, 3)
         # mz stored in column 1

--- a/metaspace/engine/sm/engine/tests/msm_basic/test_segmenter.py
+++ b/metaspace/engine/sm/engine/tests/msm_basic/test_segmenter.py
@@ -55,8 +55,8 @@ def test_define_ds_segments():
     assert np.allclose(ds_segments, exp_ds_segments)
 
 
-@patch('sm.engine.msm_basic.segmenter.pd.to_msgpack')
-def test_segment_ds(to_msgpack_mock):
+@patch('sm.engine.msm_basic.segmenter.pq.ParquetWriter.write_table')
+def test_segment_ds(write_table_mock):
     imzml_parser_mock = Mock()
     imzml_parser_mock.getspectrum.return_value = (np.linspace(0, 90, num=10), np.ones(10))
     imzml_parser_mock.mzPrecision = 'f'
@@ -67,8 +67,8 @@ def test_segment_ds(to_msgpack_mock):
     segment_ds(imzml_parser_mock, coordinates, chunk_sp_n, ds_segments, Path('/tmp/abc'))
 
     for segm_i, (min_mz, max_mz) in enumerate(ds_segments):
-        args = to_msgpack_mock.call_args_list[segm_i][0]
-        segm_arr = args[1]
+        args = write_table_mock.call_args_list[segm_i][0]
+        segm_arr = args[0].to_pandas().values
 
         assert segm_arr.shape == (50, 3)
         # mz stored in column 1
@@ -76,8 +76,8 @@ def test_segment_ds(to_msgpack_mock):
         assert np.all(segm_arr[:, 1] <= max_mz)
 
 
-@patch('sm.engine.msm_basic.segmenter.pd.to_msgpack')
-def test_segment_centroids(to_msgpack_mock):
+@patch('sm.engine.msm_basic.segmenter.pq.ParquetWriter.write_table')
+def test_segment_centroids(write_table_mock):
     centr_df = pd.DataFrame(
         [
             (0, 0, 90),
@@ -96,8 +96,8 @@ def test_segment_centroids(to_msgpack_mock):
     segment_centroids(centr_df, segm_n, Path('/tmp/abc'))
 
     for segm_i in range(segm_n):
-        args = to_msgpack_mock.call_args_list[segm_i][0]
-        df = args[1]
+        args = write_table_mock.call_args_list[segm_i][0]
+        df = args[0].to_pandas()
 
         assert df.shape == (3, 4)
         assert set(df.formula_i) == {segm_i}

--- a/metaspace/engine/tests/sci_test/spheroid.py
+++ b/metaspace/engine/tests/sci_test/spheroid.py
@@ -3,11 +3,10 @@ from functools import partial
 from os.path import join
 import os
 import sys
+from pathlib import Path
 from pprint import pprint
 
 import numpy as np
-from fabric.api import local
-from fabric.context_managers import warn_only
 
 from sm.engine.annotation_job import AnnotationJob
 from sm.engine.db import DB
@@ -149,8 +148,9 @@ class SciTester:
         AnnotationJob(img_store).run(ds)
 
     def clear_data_dirs(self):
-        with warn_only():
-            local('rm -rf {}'.format(self.ds_data_path))
+        path = Path(self.ds_data_path)
+        if path.exists():
+            path.rmdir()
 
 
 def run(mock_img_store, sm_config, *args):

--- a/metaspace/mol-db/README.md
+++ b/metaspace/mol-db/README.md
@@ -16,31 +16,31 @@ CREATE DATABASE mol_db WITH OWNER sm;
 \q  # exit
 ```
 
-Python>=3.4 is required
+Python>=3.6 is required
 ```bash
 sudo pip install -U pip
 sudo pip install -r requirements.txt
 ```
 ## Usage
 
-To start the API in a development mode
+Start the API in development mode
 ```
 python app/main.py
 ```
 
-To start in a production mode
+Start in production mode
 ```
 gunicorn --log-level INFO --access-logfile - --workers 4 \
 --worker-class sync --timeout 90 --bind 0.0.0.0:5001 app.main:application
 ``` 
 
-To add a new database
+Add a new database
 ```
 curl -X POST "http://localhost:5001/v1/databases?name=mol-db-name&version=2019-12-12&drop=yes"
 curl -H "Content-Type: text/plain" --data-binary -d "@/path/to/import/file.csv" -X POST "http://localhost:5001/v1/databases/{moldb_id}/molecules"
 ```
 
-To delete a database
+Delete a database
 ```
 curl -X DELETE "http://localhost:5001/v1/databases/{moldb_id}"
 ```

--- a/metaspace/mol-db/app/api/molecular_dbs.py
+++ b/metaspace/mol-db/app/api/molecular_dbs.py
@@ -31,6 +31,7 @@ class MoleculeCollection(BaseResource):
             molecules = q.limit(limit).all()
 
         if fields:
+            fields = fields.split(',')
             selector = self.field_selector(fields)
             objs = [selector(mol.to_dict()) for mol in molecules]
         else:


### PR DESCRIPTION
Pandas recently deprecated msgpack use for data serialization so using pyarrow+parquet seemed to be the best alternative but didn't live up to the expectations, pickle turned out to be the fastest and easiest option.

* The code responsible for dataset and centroids segmentation switched to using pickle for serialization.
* The in-memory spectra chunk size was reduced to 500MB to speed things up.
* Centroids cache used parquet before. But I took the opportunity to switch it from Spark's implementation to pyarrow as it's Python only solution which should solve annoying Java OOM issues we've seen before.

Test dataset (CT26_xenograft) segmentation runtime.

msgpack:
1 GB chunk size, 33 sec
5 GB chunk size, 52 sec

pyarrow:
1 GB chunk size, 1 min 4 sec
5 GB chunk size, 1 min 9 sec

pickle:
0.5 GB chunk size, 28.9 s
1 GB chunk size, 32.1 s
5 GB chunk size, 52.2 s

Resolves #420 