### PR TITLE
Last minute fixes before deployment to production

### DIFF
--- a/ansible/aws/ansible.cfg
+++ b/ansible/aws/ansible.cfg
@@ -4,6 +4,7 @@ stdout_callback = yaml
 allow_world_readable_tmpfiles = True
 host_key_checking = False
 vault_password_file = ./vault_pass.txt
+interpreter_python = auto
 
 [ssh_connection]
 ssh_args = -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/ansible/aws/aws_instance_manager.py
+++ b/ansible/aws/aws_instance_manager.py
@@ -147,7 +147,7 @@ class AWSInstManager:
                 self.ec2.Instance(r['InstanceId']) for r in desc_resp['SpotInstanceRequests']
             ]
 
-        waiter = self.ec2_client.get_waiter('instance_running')
+        waiter = self.ec2_client.get_waiter('instance_status_ok')
         waiter.wait(InstanceIds=[inst.id for inst in instances])
 
         if el_ip_id:

--- a/ansible/aws/aws_instance_manager.py
+++ b/ansible/aws/aws_instance_manager.py
@@ -260,7 +260,7 @@ class AWSInstManager:
     def stop_all_instances(self, components):
         for component in components:
             i = self.conf['instances'][component]
-            method = 'stop' if i['price'] is None else 'terminate'
+            method = 'stop' if not i.get('price', None) else 'terminate'
             alarms = [self.conf['alarms'][id] for id in i.get('alarms', [])]
             self.stop_instances(i['hostgroup'], method=method, alarms=alarms)
 

--- a/metaspace/graphql/src/modules/dataset/controller/Mutation.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Mutation.ts
@@ -258,7 +258,10 @@ const MutationResolvers: FieldResolversFor<Mutation, void>  = {
 
     return await createDataset({
       datasetId: id,
-      input: engineDataset as any, // TODO: map this properly
+      input: {
+        ...engineDataset,
+        metadataJson: JSON.stringify(engineDataset.metadata)
+      } as any, // TODO: map this properly
       priority: priority,
       force: true,
       skipValidation: true,


### PR DESCRIPTION
* Fix GraphQL `reprocessDataset` mutation
* Fix Spark cluster instances start/stop behavior and Python path discovery on them