### PR TITLE
Fix "Cannot read property 'session' of null" subscription error

### DIFF
--- a/metaspace/graphql/server.js
+++ b/metaspace/graphql/server.js
@@ -114,7 +114,7 @@ async function createSubscriptionServerAsync(config, connection) {
     onOperation(message, params) {
       const jwt = message.payload.jwt;
       const user = jwt != null ? jwtSimple.decode(jwt, config.jwt.secret, false, config.jwt.algorithm) : null;
-      params.context = getContext(user && user.user, connection.manager, null, null);
+      params.context = getContext(user && user.user, connection.manager);
       params.formatError = formatGraphQLError;
       return params;
     }

--- a/metaspace/graphql/server.js
+++ b/metaspace/graphql/server.js
@@ -29,7 +29,7 @@ import config from './src/utils/config';
 import logger from './src/utils/logger';
 import {createConnection} from './src/utils';
 import {executableSchema} from './executableSchema';
-import getContext from './src/getContext';
+import getContext, {getContextForSubscription} from './src/getContext';
 
 const env = process.env.NODE_ENV || 'development';
 
@@ -114,7 +114,7 @@ async function createSubscriptionServerAsync(config, connection) {
     onOperation(message, params) {
       const jwt = message.payload.jwt;
       const user = jwt != null ? jwtSimple.decode(jwt, config.jwt.secret, false, config.jwt.algorithm) : null;
-      params.context = getContext(user && user.user, connection.manager);
+      params.context = getContextForSubscription(user && user.user, connection.manager);
       params.formatError = formatGraphQLError;
       return params;
     }

--- a/metaspace/graphql/src/context.ts
+++ b/metaspace/graphql/src/context.ts
@@ -15,9 +15,7 @@ export interface ContextUser {
   getMemberOfProjectIds: () => Promise<string[]>;  // only projects where user has UPRO.MEMBER, UPRO.MANAGER role
 }
 
-export interface Context {
-  req: Request;
-  res: Response;
+export interface SubscriptionContext {
   entityManager: EntityManager;
   user: ContextUser;
   isAdmin: boolean;
@@ -43,3 +41,7 @@ export interface Context {
   cachedGetEntityById: <T>(Model: ObjectType<T> & {}, id: string | number | Partial<T>) => Promise<T | null>
 }
 
+export interface Context extends SubscriptionContext {
+  req: Request;
+  res: Response;
+}

--- a/metaspace/graphql/src/context.ts
+++ b/metaspace/graphql/src/context.ts
@@ -15,7 +15,7 @@ export interface ContextUser {
   getMemberOfProjectIds: () => Promise<string[]>;  // only projects where user has UPRO.MEMBER, UPRO.MANAGER role
 }
 
-export interface SubscriptionContext {
+export interface BaseContext {
   entityManager: EntityManager;
   user: ContextUser;
   isAdmin: boolean;
@@ -41,7 +41,7 @@ export interface SubscriptionContext {
   cachedGetEntityById: <T>(Model: ObjectType<T> & {}, id: string | number | Partial<T>) => Promise<T | null>
 }
 
-export interface Context extends SubscriptionContext {
+export interface Context extends BaseContext {
   req: Request;
   res: Response;
 }

--- a/metaspace/graphql/src/getContext.ts
+++ b/metaspace/graphql/src/getContext.ts
@@ -1,5 +1,5 @@
 import {EntityManager, In, ObjectType} from 'typeorm';
-import {Context, ContextCacheKeyArg, ContextUser, SubscriptionContext} from './context';
+import {Context, ContextCacheKeyArg, ContextUser, BaseContext} from './context';
 import {Project as ProjectModel, UserProjectRoleOptions as UPRO} from './modules/project/model';
 import {UserError} from 'graphql-errors';
 import {JwtUser} from './modules/auth/controller';
@@ -8,7 +8,7 @@ import {Request, Response} from 'express';
 import * as _ from 'lodash';
 import * as DataLoader from 'dataloader';
 
-function getContext(jwtUser: JwtUser | null, entityManager: EntityManager): SubscriptionContext;
+function getContext(jwtUser: JwtUser | null, entityManager: EntityManager): BaseContext;
 function getContext(jwtUser: JwtUser | null, entityManager: EntityManager,
                     req: Request, res: Response): Context;
 function getContext(jwtUser: JwtUser | null, entityManager: EntityManager,

--- a/metaspace/graphql/src/getContext.ts
+++ b/metaspace/graphql/src/getContext.ts
@@ -1,5 +1,5 @@
 import {EntityManager, In, ObjectType} from 'typeorm';
-import {Context, ContextCacheKeyArg, ContextUser} from './context';
+import {Context, ContextCacheKeyArg, ContextUser, SubscriptionContext} from './context';
 import {Project as ProjectModel, UserProjectRoleOptions as UPRO} from './modules/project/model';
 import {UserError} from 'graphql-errors';
 import {JwtUser} from './modules/auth/controller';
@@ -8,9 +8,11 @@ import {Request, Response} from 'express';
 import * as _ from 'lodash';
 import * as DataLoader from 'dataloader';
 
-
-const getContext = (jwtUser: JwtUser | null, entityManager: EntityManager,
-                req: Request, res: Response): Context => {
+function getContext(jwtUser: JwtUser | null, entityManager: EntityManager): SubscriptionContext;
+function getContext(jwtUser: JwtUser | null, entityManager: EntityManager,
+                    req: Request, res: Response): Context;
+function getContext(jwtUser: JwtUser | null, entityManager: EntityManager,
+                req?: Request, res?: Response) {
   const user = jwtUser != null && jwtUser.id != null ? jwtUser : null;
   const contextCache: Record<string, any> = {};
 
@@ -28,7 +30,7 @@ const getContext = (jwtUser: JwtUser | null, entityManager: EntityManager,
     let projectRoles = user != null && user.id != null
       ? await getUserProjectRoles(entityManager, user.id)
       : {};
-    if (req.session && req.session.reviewTokens) {
+    if (req && req.session && req.session.reviewTokens) {
       const projectRepository = entityManager.getRepository(ProjectModel);
       const reviewProjects = await projectRepository.find({ where: { reviewToken: In(req.session.reviewTokens) }});
       if (reviewProjects.length > 0) {
@@ -106,7 +108,7 @@ const getContext = (jwtUser: JwtUser | null, entityManager: EntityManager,
     contextCacheGet,
     cachedGetEntityById,
   };
-};
+}
 export default getContext;
 
 export const getContextForTest = (jwtUser: JwtUser | null, entityManager: EntityManager): Context => {

--- a/metaspace/graphql/src/getContext.ts
+++ b/metaspace/graphql/src/getContext.ts
@@ -8,11 +8,8 @@ import {Request, Response} from 'express';
 import * as _ from 'lodash';
 import * as DataLoader from 'dataloader';
 
-function getContext(jwtUser: JwtUser | null, entityManager: EntityManager): BaseContext;
-function getContext(jwtUser: JwtUser | null, entityManager: EntityManager,
-                    req: Request, res: Response): Context;
-function getContext(jwtUser: JwtUser | null, entityManager: EntityManager,
-                req?: Request, res?: Response) {
+const getBaseContext = (jwtUser: JwtUser | null, entityManager: EntityManager,
+                req?: Request, res?: Response) => {
   const user = jwtUser != null && jwtUser.id != null ? jwtUser : null;
   const contextCache: Record<string, any> = {};
 
@@ -108,7 +105,17 @@ function getContext(jwtUser: JwtUser | null, entityManager: EntityManager,
     contextCacheGet,
     cachedGetEntityById,
   };
-}
+};
+
+const getContext = (jwtUser: JwtUser | null, entityManager: EntityManager,
+                        req: Request, res: Response): Context => {
+  return getBaseContext(jwtUser, entityManager, req, res) as Context;
+};
+
+export const getContextForSubscription = (jwtUser: JwtUser | null, entityManager: EntityManager): BaseContext => {
+  return getBaseContext(jwtUser, entityManager);
+};
+
 export default getContext;
 
 export const getContextForTest = (jwtUser: JwtUser | null, entityManager: EntityManager): Context => {

--- a/metaspace/graphql/src/modules/dataset/controller/Subscription.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Subscription.ts
@@ -4,7 +4,7 @@ import {esDatasetByID} from '../../../../esConnector';
 import logger from '../../../utils/logger';
 import wait from '../../../utils/wait';
 import config from '../../../utils/config';
-import {ContextUser, SubscriptionContext} from '../../../context';
+import {ContextUser, BaseContext} from '../../../context';
 import canViewEsDataset from '../operation/canViewEsDataset';
 import {relationshipToDataset} from '../operation/relationshipToDataset';
 import {
@@ -104,7 +104,7 @@ async function waitForChangeAndPublish(payload: DatasetStatusPayload) {
 
 const SubscriptionResolvers = {
   datasetStatusUpdated: {
-    subscribe: (source: any, args: any, context: SubscriptionContext) => {
+    subscribe: (source: any, args: any, context: BaseContext) => {
       const iterator = asyncIterateDatasetStatusUpdated();
       // This asyncIterator is manually implemented because there is a weird interaction between TypeScript and iterall.
       // Somehow `iterator.return()` doesn't get called. I suspect iterall doesn't recognize TypeScript's asyncIterators

--- a/metaspace/graphql/src/modules/dataset/controller/Subscription.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Subscription.ts
@@ -4,8 +4,7 @@ import {esDatasetByID} from '../../../../esConnector';
 import logger from '../../../utils/logger';
 import wait from '../../../utils/wait';
 import config from '../../../utils/config';
-import {DatasetStatus} from '../../engine/model';
-import {Context, ContextUser} from '../../../context';
+import {ContextUser, SubscriptionContext} from '../../../context';
 import canViewEsDataset from '../operation/canViewEsDataset';
 import {relationshipToDataset} from '../operation/relationshipToDataset';
 import {
@@ -105,7 +104,7 @@ async function waitForChangeAndPublish(payload: DatasetStatusPayload) {
 
 const SubscriptionResolvers = {
   datasetStatusUpdated: {
-    subscribe: (source: any, args: any, context: Context) => {
+    subscribe: (source: any, args: any, context: SubscriptionContext) => {
       const iterator = asyncIterateDatasetStatusUpdated();
       // This asyncIterator is manually implemented because there is a weird interaction between TypeScript and iterall.
       // Somehow `iterator.return()` doesn't get called. I suspect iterall doesn't recognize TypeScript's asyncIterators

--- a/metaspace/graphql/src/modules/dataset/operation/relationshipToDataset.ts
+++ b/metaspace/graphql/src/modules/dataset/operation/relationshipToDataset.ts
@@ -1,5 +1,5 @@
 import {DatasetSource} from '../../../bindingTypes';
-import {Context} from '../../../context';
+import {SubscriptionContext} from '../../../context';
 import {Project as ProjectModel, UserProjectRoleOptions as UPRO} from '../../project/model';
 
 interface DatasetRelationship {
@@ -13,7 +13,7 @@ interface DatasetRelationship {
  * @param dataset
  * @param ctx
  */
-export const relationshipToDataset = async (dataset: DatasetSource, ctx: Context): Promise<DatasetRelationship[]> => {
+export const relationshipToDataset = async (dataset: DatasetSource, ctx: SubscriptionContext): Promise<DatasetRelationship[]> => {
   const ds = dataset._source;
   const user = ctx.user;
   const relationships: DatasetRelationship[] = [];

--- a/metaspace/graphql/src/modules/dataset/operation/relationshipToDataset.ts
+++ b/metaspace/graphql/src/modules/dataset/operation/relationshipToDataset.ts
@@ -1,5 +1,5 @@
 import {DatasetSource} from '../../../bindingTypes';
-import {SubscriptionContext} from '../../../context';
+import {BaseContext} from '../../../context';
 import {Project as ProjectModel, UserProjectRoleOptions as UPRO} from '../../project/model';
 
 interface DatasetRelationship {
@@ -13,7 +13,7 @@ interface DatasetRelationship {
  * @param dataset
  * @param ctx
  */
-export const relationshipToDataset = async (dataset: DatasetSource, ctx: SubscriptionContext): Promise<DatasetRelationship[]> => {
+export const relationshipToDataset = async (dataset: DatasetSource, ctx: BaseContext): Promise<DatasetRelationship[]> => {
   const ds = dataset._source;
   const user = ctx.user;
   const relationships: DatasetRelationship[] = [];


### PR DESCRIPTION
2nd error with subscriptions, which only occurred during dataset updates.

The issue is that subscriptions don't have access to express's `req` and `res` variables, so `null`s were passed to `getContext`. As `getContext` was being called from a JS file, the types weren't checked. The code was later failing when it tried to access `req.session`.

This change splits the `Context` type definition into two types - one with, and one without `req`/`res`