### PR TITLE
More hotfixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
       - run:
           name: Upload coverage
           command: |
-            yarn run test-ci --coverage
+            yarn run test-ci --coverage --maxWorkers=1
             npx codecov -p ../.. -F webapp
 
   test-webapp-e2e:

--- a/metaspace/engine/sm/engine/ion_mapping.py
+++ b/metaspace/engine/sm/engine/ion_mapping.py
@@ -30,6 +30,8 @@ def get_ion_id_mapping(db, ion_tuples, charge):
     dict[tuple[str, str, str, str], int]
         (formula, chem_mod, neutral_loss, adduct) => ion_id
     """
+    if not ion_tuples:
+        return {}
 
     formulas, chem_mods, neutral_losses, adducts = map(list, zip(*ion_tuples))
     existing_ions = db.select(ION_SEL, [formulas, chem_mods, neutral_losses, adducts, charge])

--- a/metaspace/engine/tests/test_search_results.py
+++ b/metaspace/engine/tests/test_search_results.py
@@ -179,3 +179,13 @@ def test_non_native_python_number_types_handled(search_results):
             )
         ]
         db_mock.insert.assert_called_with(METRICS_INS, exp_rows)
+
+
+def test_save_ion_img_metrics_empty_call(search_results):
+    ion_img_ids = {}
+    ion_metrics_df = _mock_ion_metrics_df().iloc[0:0]
+    db_mock.select.side_effect = db_sel_side_effect
+
+    search_results.store_ion_metrics(ion_metrics_df, ion_img_ids, db_mock)
+
+    db_mock.insert.assert_called_with(METRICS_INS, [])

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -18,7 +18,6 @@ exports[`DatasetTable should match snapshot 1`] = `
       <mock-el-option value="project" label="Select project"></mock-el-option>
       <mock-el-option value="submitter" label="Select submitter"></mock-el-option>
       <mock-el-option value="datasetIds" label="Select dataset"></mock-el-option>
-      <mock-el-option value="compoundName" label="Search molecule"></mock-el-option>
       <mock-el-option value="polarity" label="Select polarity"></mock-el-option>
       <mock-el-option value="organism" label="Select organism"></mock-el-option>
       <mock-el-option value="organismPart" label="Select organism part"></mock-el-option>

--- a/metaspace/webapp/src/modules/Filters/filterSpecs.ts
+++ b/metaspace/webapp/src/modules/Filters/filterSpecs.ts
@@ -128,7 +128,7 @@ export const FILTER_SPECIFICATIONS: Record<FilterKey, FilterSpecification> = {
     type: InputFilter,
     name: 'Molecule',
     description: 'Search molecule',
-    levels: ['dataset', 'annotation'],
+    levels: ['annotation'], // ['dataset', 'annotation'],
     initialValue: undefined
   },
 


### PR DESCRIPTION
* Limit parallelism in CircleCI webapp tests to hopefully prevent OOMs
* Don't crash annotation if a dataset job doesn't produce any annotations
* Hide the "search Molecule" filter for datasets, because it's too slow (task to fix this: #432)