### PR TITLE
Use boto3 waiter to wait for earlier stopped instance to start

### DIFF
--- a/ansible/aws/aws_instance_manager.py
+++ b/ansible/aws/aws_instance_manager.py
@@ -147,9 +147,6 @@ class AWSInstManager:
                 self.ec2.Instance(r['InstanceId']) for r in desc_resp['SpotInstanceRequests']
             ]
 
-        waiter = self.ec2_client.get_waiter('instance_status_ok')
-        waiter.wait(InstanceIds=[inst.id for inst in instances])
-
         if el_ip_id:
             if inst_n == 1:
                 elastic_ip = self.ec2.VpcAddress(el_ip_id)
@@ -212,6 +209,9 @@ class AWSInstManager:
 
                 for inst in instances:
                     self.assign_tags(inst, inst_name, host_group, inst_tags)
+
+                waiter = self.ec2_client.get_waiter('instance_running')
+                waiter.wait(InstanceIds=[inst.id for inst in instances])
             else:
                 print('DRY RUN!')
 

--- a/ansible/aws/update_inventory.py
+++ b/ansible/aws/update_inventory.py
@@ -44,7 +44,7 @@ if __name__ == '__main__':
             ec2.instances.filter(
                 Filters=[
                     {'Name': 'tag:hostgroup', 'Values': [spec['hostgroup']]},
-                    {'Name': 'instance-state-name', 'Values': ['running', 'stopped', 'pending']},
+                    {'Name': 'instance-state-name', 'Values': ['running', 'pending']},
                 ]
             )
         )


### PR DESCRIPTION
Also, `update_inventory` - don't search for stopped instances as they don't have public IP assigned