### PR TITLE
MolDB import process update

### DIFF
--- a/ansible/aws/templates/all/vars.yml.template
+++ b/ansible/aws/templates/all/vars.yml.template
@@ -324,6 +324,8 @@ nginx_servers:
         params:
           - proxy_pass http://moldb_server/;
           - include proxy-params.conf;
+          - limit_except GET {allow 127.0.0.1/32; deny all;}
+          - client_max_body_size 200M;
 
   - desc: Elasticsearch redirect
     params:

--- a/ansible/roles/mol_db/tasks/main.yml
+++ b/ansible/roles/mol_db/tasks/main.yml
@@ -33,18 +33,6 @@
   shell: "conda env update -f environment.yml"
   when: env_status.stat.exists
 
-- name: Install OpenBabel
-  apt: name=openbabel state=latest
-  become: yes
-
-- name: Install openbabel into conda environment
-  args:
-    chdir: "{{ mol_db_home }}"
-    executable: /bin/bash
-  shell: >
-    source {{ mol_db_miniconda_prefix }}/bin/activate {{ mol_db_miniconda_env.name }}
-    && conda install -c openbabel openbabel
-
 - import_tasks: import_mol_databases.yml
   when: mol_db_import_databases | bool
 

--- a/ansible/roles/mol_db_app/tasks/main.yml
+++ b/ansible/roles/mol_db_app/tasks/main.yml
@@ -15,6 +15,12 @@
   template: src=mol-db.supervisor.j2 dest=/etc/supervisor/{{ mol_db_app_name }}.supervisor
             mode=0600 owner=ubuntu group=ubuntu
 
+- name: Install mol-db dependencies
+  args:
+    chdir: "{{ mol_db_home }}"
+  command: |
+    {{ mol_db_miniconda_prefix }}/envs/{{ mol_db_miniconda_env.name }}/bin/pip install -e .
+
 - name: Update and restart supervisor app
   supervisorctl:
     name: "{{ mol_db_app_name }}"

--- a/ansible/roles/sm_graphql/tasks/main.yml
+++ b/ansible/roles/sm_graphql/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: Re-compile and re-install nodejs binaries
   command: npm rebuild --update-binary bcrypt
-  when: sm_graphql_update_binary
+  when: sm_graphql_update_binary | bool
 
 - name: Dereference metadata schema
   shell: yarn run deref-schema

--- a/metaspace/graphql/src/modules/lookups/controller.ts
+++ b/metaspace/graphql/src/modules/lookups/controller.ts
@@ -2,7 +2,7 @@ import {FieldResolversFor} from '../../bindingTypes';
 import {Query} from '../../binding';
 import {esFilterValueCountResults} from '../../../esConnector';
 import config from '../../utils/config';
-import {deprecatedMolDBs, fetchMolecularDatabases} from '../../utils/molDb';
+import {publicMolDBs, deprecatedMolDBs, fetchMolecularDatabases} from '../../utils/molDb';
 import logger from '../../utils/logger';
 import {Context, ContextUser} from '../../context';
 import {IResolvers} from 'graphql-tools';
@@ -88,13 +88,15 @@ const QueryResolvers: FieldResolversFor<Query, void> = {
 
       const molDBs = await fetchMolecularDatabases();
       let dbs = molDBs.map(molDB => {
-        const deprecated = deprecatedMolDBs.has(molDB.name);
-        const superseded = molDBs.some(db => db.name === molDB.name && db.version > molDB.version);
+        const isDeprecated = deprecatedMolDBs.has(molDB.name);
+        const isPublic = publicMolDBs.has(molDB.name);
+        const isSuperseded = molDBs.some(db => db.name === molDB.name && db.version > molDB.version);
         return {
           ...molDB,
           default: config.defaults.moldb_names.includes(molDB.name),
-          hidden: deprecated || superseded,
-          deprecated, superseded,
+          hidden: !isPublic || isDeprecated || isSuperseded,
+          deprecated: isDeprecated,
+          superseded: isSuperseded,
         }
       });
       if (hideDeprecated) {

--- a/metaspace/graphql/src/utils/config.ts
+++ b/metaspace/graphql/src/utils/config.ts
@@ -31,8 +31,8 @@ export interface Config {
   };
   adducts: Adduct[];
   moldbs: {
+    public: string[];
     deprecated: string[];
-    custom: string[];
   },
   img_upload: {
     iso_img_fs_path: string;

--- a/metaspace/graphql/src/utils/molDb.ts
+++ b/metaspace/graphql/src/utils/molDb.ts
@@ -1,7 +1,8 @@
 import fetch from 'node-fetch';
 import config from './config';
 
-export const deprecatedMolDBs = new Set([...config.moldbs.deprecated, ...config.moldbs.custom]);
+export const publicMolDBs = new Set(config.moldbs.public);
+export const deprecatedMolDBs = new Set(config.moldbs.deprecated);
 
 export interface MolDb {
   id: number;

--- a/metaspace/mol-db/README.md
+++ b/metaspace/mol-db/README.md
@@ -2,7 +2,7 @@
 
 HMDB, ChEBI and other molecular databases.
 
-Molecular attributes: InChI, InChI key, sum formula, name, database id
+Molecule attributes: formula, name, database id
 
 ## Installation (Ubuntu)
 
@@ -15,18 +15,37 @@ CREATE ROLE mol_db LOGIN CREATEDB NOSUPERUSER PASSWORD 'simple_pass';
 CREATE DATABASE mol_db WITH OWNER sm;
 \q  # exit
 ```
-Install OpenBabel
 
-`sudo apt-get install openbabel`
-
-Python of at least 3.4 version is required
+Python>=3.4 is required
 ```bash
 sudo pip install -U pip
 sudo pip install -r requirements.txt
 ```
-## Running
+## Usage
 
-`python3 app/main.py`
+To start the API in a development mode
+```
+python app/main.py
+```
+
+To start in a production mode
+```
+gunicorn --log-level INFO --access-logfile - --workers 4 \
+--worker-class sync --timeout 90 --bind 0.0.0.0:5001 app.main:application
+``` 
+
+To add a new database
+```
+curl -X POST "http://localhost:5001/v1/databases?name=mol-db-name&version=2019-12-12&drop=yes"
+curl -H "Content-Type: text/plain" --data-binary -d "@/path/to/import/file.csv" -X POST "http://localhost:5001/v1/databases/{moldb_id}/molecules"
+```
+
+To delete a database
+```
+curl -X DELETE "http://localhost:5001/v1/databases/{moldb_id}"
+```
+
+Because the API doesn't have authentication, all non GET requests should be blocked for all IPs other than `127.0.0.1`
 
 ## Funding
 

--- a/metaspace/mol-db/app/api/base.py
+++ b/metaspace/mol-db/app/api/base.py
@@ -55,18 +55,15 @@ class BaseResource(object):
         obj['data'] = data
         res.body = self.to_json(obj)
 
-    def on_get(self, req, res):
+    def on_get(self, req, res, *args, **kwargs):
         if req.path == '/':
             res.status = falcon.HTTP_200
             res.body = self.to_json(self.HELLO_WORLD)
         else:
             raise NotSupportedError(method='GET', url=req.path)
 
-    def on_post(self, req, res):
+    def on_post(self, req, res, *args, **kwargs):
         raise NotSupportedError(method='POST', url=req.path)
 
-    def on_put(self, req, res):
-        raise NotSupportedError(method='PUT', url=req.path)
-
-    def on_delete(self, req, res):
+    def on_delete(self, req, res, *args, **kwargs):
         raise NotSupportedError(method='DELETE', url=req.path)

--- a/metaspace/mol-db/app/api/isotopic_pattern.py
+++ b/metaspace/mol-db/app/api/isotopic_pattern.py
@@ -3,7 +3,6 @@ from cpyMSpec import isotopePattern, InstrumentModel
 
 from app import log
 from app.api.base import BaseResource
-from app.errors import AppError, InvalidParameterError, ObjectNotExistError
 
 
 LOG = log.get_logger()

--- a/metaspace/mol-db/app/api/molecular_dbs.py
+++ b/metaspace/mol-db/app/api/molecular_dbs.py
@@ -1,60 +1,16 @@
-import re
-import falcon
+import logging
+from io import StringIO
 
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy import desc
+import pandas as pd
 
-# from cerberus import Validator, ValidationError
-
-from app import log
 from app.api.base import BaseResource
-from app.errors import AppError, InvalidParameterError, ObjectNotExistError, PasswordNotMatch
+from app.moldb_import import import_molecular_database
+from app.errors import ObjectNotExistError, BadRequestError
 from app.model import MolecularDB, Molecule
 
-LOG = log.get_logger()
-
-
-# FIELDS = {
-#     'username': {
-#         'type': 'string',
-#         'required': True,
-#         'minlength': 4,
-#         'maxlength': 20
-#     },
-#     'email': {
-#         'type': 'string',
-#         'regex': '[a-zA-Z0-9._-]+@(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,4}',
-#         'required': True,
-#         'maxlength': 320
-#     },
-#     'password': {
-#         'type': 'string',
-#         'regex': '[0-9a-zA-Z]\w{3,14}',
-#         'required': True,
-#         'minlength': 8,
-#         'maxlength': 64
-#     },
-#     'info': {
-#         'type': 'dict',
-#         'required': False
-#     }
-# }
-#
-#
-# def validate_user_create(req, res, resource, params):
-#     schema = {
-#         'username': FIELDS['username'],
-#         'email': FIELDS['email'],
-#         'password': FIELDS['password'],
-#         'info': FIELDS['info']
-#     }
-#
-#     v = Validator(schema)
-#     try:
-#         if not v.validate(req.context['data']):
-#             raise InvalidParameterError(v.errors)
-#     except ValidationError:
-#         raise InvalidParameterError('Invalid Request %s' % req.context)
+logger = logging.getLogger('API')
 
 
 class MoleculeCollection(BaseResource):
@@ -108,13 +64,12 @@ class MolDBCollection(BaseResource):
     Handle for endpoint: /v1/databases
     """
 
-    # @falcon.before(auth_required)
     def on_get(self, req, res):
-        db_session = req.context['session']
+        db = req.context['session']
         name = req.params.get('name', None)
         version = req.params.get('version', None)
 
-        q = db_session.query(MolecularDB)
+        q = db.query(MolecularDB)
         if name:
             q = q.filter(MolecularDB.name == name)
         if version:
@@ -127,17 +82,36 @@ class MolDBCollection(BaseResource):
         else:
             raise ObjectNotExistError('db_name: {}, db_version: {}'.format(name, version))
 
+    def on_post(self, req, res):
+        name = req.params.get('name', None)
+        version = req.params.get('version', None)
+        drop_moldb = req.params.get('drop', 'no').lower() in ['true', 'yes', '1']
+        if not (name and version):
+            BadRequestError(f'"Name" and "version" parameters required: {name}, {version}')
+
+        buffer = StringIO(req.stream.read(req.content_length).decode())
+        moldb_df = pd.read_csv(buffer, sep='\t')
+
+        moldb = import_molecular_database(name, version, moldb_df, drop_moldb=drop_moldb)
+        self.on_success(res, f'Created: {moldb}')
+
 
 class MolDBItem(BaseResource):
     """
     Handle for endpoint: /v1/databases/{db_id}
     """
 
-    # @falcon.before(auth_required)
     def on_get(self, req, res, db_id):
         session = req.context['session']
         try:
-            user_db = MolecularDB.find_one(session, db_id)
+            user_db = MolecularDB.find_by_id(session, db_id)
             self.on_success(res, user_db.to_dict())
         except NoResultFound:
             raise ObjectNotExistError('user id: %s' % db_id)
+
+    def on_delete(self, req, res, db_id):
+        db = req.context['session']
+        moldb = MolecularDB.find_by_id(db, db_id)
+        db.delete(moldb)
+        db.commit()
+        self.on_success(res)

--- a/metaspace/mol-db/app/api/molecular_dbs.py
+++ b/metaspace/mol-db/app/api/molecular_dbs.py
@@ -93,7 +93,7 @@ class MolDBCollection(BaseResource):
         moldb_df = pd.read_csv(buffer, sep='\t')
 
         moldb = import_molecular_database(name, version, moldb_df, drop_moldb=drop_moldb)
-        self.on_success(res, f'Created: {moldb}')
+        self.on_success(res, moldb.to_dict())
 
 
 class MolDBItem(BaseResource):
@@ -104,8 +104,8 @@ class MolDBItem(BaseResource):
     def on_get(self, req, res, db_id):
         session = req.context['session']
         try:
-            user_db = MolecularDB.find_by_id(session, db_id)
-            self.on_success(res, user_db.to_dict())
+            moldb = MolecularDB.find_by_id(session, db_id)
+            self.on_success(res, moldb.to_dict())
         except NoResultFound:
             raise ObjectNotExistError('user id: %s' % db_id)
 

--- a/metaspace/mol-db/app/api/molecules.py
+++ b/metaspace/mol-db/app/api/molecules.py
@@ -1,36 +1,9 @@
-import re
-import falcon
-
 from sqlalchemy.orm.exc import NoResultFound
 
-# from cerberus import Validator, ValidationError
-
-from app import log
 from app.api.base import BaseResource
 
-# from app.utils.hooks import auth_required
-# from app.utils.auth import encrypt_token, hash_password, verify_password, uuid
-from app.errors import AppError, InvalidParameterError, ObjectNotExistError, PasswordNotMatch
-from app.model import MolecularDB, Molecule
-
-LOG = log.get_logger()
-
-
-# class MoleculeCollection(BaseResource):
-#     """
-#     Handle for endpoint: /v1/molecules
-#     """
-#
-#     # @falcon.before(auth_required)
-#     def on_get(self, req, res):
-#         db_session = req.context['session']
-#         req.param
-#         mol_db = db_session.query(MolecularDB).filter(MolecularDB.id == db_id).one()
-#         if mol_db:
-#             objs = [mol.to_dict() for mol in mol_db.molecules]
-#             self.on_success(res, objs)
-#         else:
-#             raise AppError()
+from app.errors import ObjectNotExistError
+from app.model import Molecule
 
 
 class MoleculeItem(BaseResource):
@@ -46,36 +19,3 @@ class MoleculeItem(BaseResource):
             self.on_success(res, molecule.to_dict())
         except NoResultFound:
             raise ObjectNotExistError('molecule id: %s' % mol_id)
-
-
-# class Self(BaseResource):
-#     """
-#     Handle for endpoint: /v1/users/self
-#     """
-#     LOGIN = 'login'
-#     RESETPW = 'resetpw'
-#
-#     def on_get(self, req, res):
-#         cmd = re.split('\\W+', req.path)[-1:][0]
-#         if cmd == Self.LOGIN:
-#             self.process_login(req, res)
-#         elif cmd == Self.RESETPW:
-#             self.process_resetpw(req, res)
-#
-#     def process_login(self, req, res):
-#         email = req.params['email']
-#         password = req.params['password']
-#         session = req.context['session']
-#         try:
-#             user_db = User.find_by_email(session, email)
-#             if verify_password(password, user_db.password.encode('utf-8')):
-#                 self.on_success(res, user_db.to_dict())
-#             else:
-#                 raise PasswordNotMatch()
-#
-#         except NoResultFound:
-#             raise UserNotExistsError('User email: %s' % email)
-#
-#     @falcon.before(auth_required)
-#     def process_resetpw(self, req, res):
-#         pass

--- a/metaspace/mol-db/app/database/__init__.py
+++ b/metaspace/mol-db/app/database/__init__.py
@@ -8,7 +8,7 @@ logger = log.get_logger()
 
 
 def get_engine(uri):
-    logger.info('Connecting to database...')
+    logger.info('Connecting to database')
     options = {
         'pool_recycle': 3600,
         'pool_size': 10,

--- a/metaspace/mol-db/app/errors.py
+++ b/metaspace/mol-db/app/errors.py
@@ -13,7 +13,7 @@ ERR_UNKNOWN = {'status': falcon.HTTP_500, 'code': 500, 'title': 'Unknown Error'}
 
 ERR_AUTH_REQUIRED = {'status': falcon.HTTP_401, 'code': 99, 'title': 'Authentication Required'}
 
-ERR_INVALID_PARAMETER = {'status': falcon.HTTP_400, 'code': 88, 'title': 'Invalid Parameter'}
+ERR_BAD_REQUEST = {'status': falcon.HTTP_400, 'code': 88, 'title': 'Bad request'}
 
 ERR_DATABASE_ROLLBACK = {'status': falcon.HTTP_500, 'code': 77, 'title': 'Database Rollback Error'}
 
@@ -56,9 +56,9 @@ class AppError(Exception):
         res.body = json.dumps({'meta': meta})
 
 
-class InvalidParameterError(AppError):
+class BadRequestError(AppError):
     def __init__(self, description=None):
-        super().__init__(ERR_INVALID_PARAMETER)
+        super().__init__(ERR_BAD_REQUEST)
         self.error['description'] = description
 
 

--- a/metaspace/mol-db/app/main.py
+++ b/metaspace/mol-db/app/main.py
@@ -16,7 +16,6 @@ logger = log.get_logger()
 class App(falcon.API):
     def __init__(self, *args, **kwargs):
         super(App, self).__init__(*args, **kwargs)
-        logger.info('API Server is starting')
 
         self.add_route('/', base.BaseResource())
 
@@ -32,9 +31,9 @@ class App(falcon.API):
             isotopic_pattern.IsotopicPatternItem(),
         )
 
-        # self.add_route('/v1/sfs', formulae.SumFormulaCollection())
-        # self.add_route('/v1/sfs/{sf}/molecules', formulae.SumFormulaCollection())
         self.add_error_handler(AppError, AppError.handle)
+
+        logger.info('API server is running')
 
 
 init_session()

--- a/metaspace/mol-db/app/model/molecular_db.py
+++ b/metaspace/mol-db/app/model/molecular_db.py
@@ -30,6 +30,10 @@ class MolecularDB(Base):
     def find_by_name_version(cls, session, name, version):
         return session.query(MolecularDB).filter_by(name=name, version=version).first()
 
+    @classmethod
+    def find_by_id(cls, session, id):
+        return session.query(MolecularDB).filter_by(id=id).first()
+
     FIELDS = {'id': int, 'name': str, 'version': str}
 
     FIELDS.update(Base.FIELDS)

--- a/metaspace/mol-db/app/model/molecular_db.py
+++ b/metaspace/mol-db/app/model/molecular_db.py
@@ -5,7 +5,6 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 
 from app.model.base import Base
-from app.config import UUID_LEN
 
 
 class MolecularDB(Base):

--- a/metaspace/mol-db/app/moldb_import.py
+++ b/metaspace/mol-db/app/moldb_import.py
@@ -11,7 +11,6 @@ logger = logging.getLogger('API')
 
 
 def get_inchikey_gen(mol_db_id):
-
     def get_inchikey(ser):
         try:
             if ser.get('inchikey', None):
@@ -23,27 +22,6 @@ def get_inchikey_gen(mol_db_id):
             return '{}-{}-{}'.format(ser.formula, ser['name'], ser['id'])
 
     return get_inchikey
-
-
-# def get_or_create(session, model, query, **kwargs):
-#     inst = query.first()
-#     if inst:
-#         return inst
-#     else:
-#         inst = model(**kwargs)
-#         session.add(inst)
-#         # session.commit()
-#         return inst
-#
-#
-# def get_or_create_molecule(session, model, **kwargs):
-#     q = session.query(model).filter_by(inchikey=kwargs['inchikey'])
-#     return get_or_create(session, model, query=q, **kwargs)
-#
-#
-# def get_or_create_db_mol_assoc(session, model, **kwargs):
-#     q = session.query(model).filter_by(db_id=kwargs['db_id'], inchikey=kwargs['inchikey'])
-#     return get_or_create(session, model, query=q, **kwargs)
 
 
 def filter_formulas(mol_db_df):

--- a/metaspace/mol-db/app/moldb_import.py
+++ b/metaspace/mol-db/app/moldb_import.py
@@ -1,0 +1,140 @@
+import logging
+
+import pandas as pd
+from pyMSpec.pyisocalc.pyisocalc import parseSumFormula
+
+from app.database import db_session as db
+from app.errors import BadRequestError, ObjectNotExistError
+from app.model import Molecule, MolecularDB
+
+logger = logging.getLogger('API')
+
+
+def get_inchikey_gen(mol_db_id):
+
+    def get_inchikey(ser):
+        try:
+            if ser.get('inchikey', None):
+                return ser.inchikey
+
+            return f"{mol_db_id}:{ser['id']}"
+        except Exception as e:
+            logger.warning(f'{e}\t{ser}')
+            return '{}-{}-{}'.format(ser.formula, ser['name'], ser['id'])
+
+    return get_inchikey
+
+
+# def get_or_create(session, model, query, **kwargs):
+#     inst = query.first()
+#     if inst:
+#         return inst
+#     else:
+#         inst = model(**kwargs)
+#         session.add(inst)
+#         # session.commit()
+#         return inst
+#
+#
+# def get_or_create_molecule(session, model, **kwargs):
+#     q = session.query(model).filter_by(inchikey=kwargs['inchikey'])
+#     return get_or_create(session, model, query=q, **kwargs)
+#
+#
+# def get_or_create_db_mol_assoc(session, model, **kwargs):
+#     q = session.query(model).filter_by(db_id=kwargs['db_id'], inchikey=kwargs['inchikey'])
+#     return get_or_create(session, model, query=q, **kwargs)
+
+
+def filter_formulas(mol_db_df):
+    def is_valid(sf):
+        try:
+            if '.' in sf:
+                logger.warning('"." in formula {}, skipping'.format(sf))
+                return False
+            parseSumFormula(sf)
+        except Exception as e:
+            logger.warning(e)
+            return False
+        else:
+            return True
+
+    formulas = pd.Series(mol_db_df['formula'].unique())
+    valid_formulas = formulas[formulas.map(is_valid)]
+    return mol_db_df[mol_db_df.formula.isin(set(valid_formulas))].copy()
+
+
+def remove_invalid_inchikey_molecules(mol_db_df):
+    invalid_inchikey = mol_db_df.inchikey.isnull()
+    n_invalid = invalid_inchikey.sum()
+    if n_invalid > 0:
+        logger.warning("{} invalid records (InChI key couldn't be generated)".format(n_invalid))
+    return mol_db_df[~invalid_inchikey]
+
+
+def remove_duplicated_inchikey_molecules(mol_db_df):
+    ids_to_insert = set()
+    for inchikey, g in mol_db_df.groupby('inchikey'):
+        if len(g) > 1:
+            logger.warning(
+                "{} molecules have the same InChI key {}: {} - taking only the first one".format(
+                    len(g), inchikey, list(g['id'])
+                )
+            )
+        ids_to_insert.add(g.iloc[0].id)
+    # remove duplicates
+    return mol_db_df[mol_db_df['id'].isin(ids_to_insert)]
+
+
+def save_molecules(mol_db, moldb_df):
+    logger.info('{} new rows to insert into molecule table'.format(moldb_df.shape[0]))
+    new_molecule_df = moldb_df[['inchikey', 'id', 'name', 'formula']].copy()
+    new_molecule_df.rename(
+        {'id': 'mol_id', 'name': 'mol_name', 'formula': 'sf'}, axis='columns', inplace=True
+    )
+    new_molecule_df['inchi'] = ''
+    new_molecule_df['db_id'] = int(mol_db.id)
+
+    db.bulk_insert_mappings(Molecule, new_molecule_df.to_dict(orient='record'))
+    logger.info('Inserted {} new molecules for {}'.format(len(moldb_df), mol_db))
+
+
+def import_molecules_from_df(moldb, moldb_df):
+    logger.info(f'Importing molecules to Mol DB: {moldb}')
+    required_columns = {'id', 'name', 'formula'}
+    if not required_columns.issubset(set(moldb_df.columns)):
+        raise BadRequestError(
+            f'Not all required columns provided: {moldb_df.columns} <= {required_columns}'
+        )
+
+    moldb_df = filter_formulas(moldb_df)
+    moldb_df['inchikey'] = moldb_df.apply(get_inchikey_gen(moldb.id), axis=1)
+    moldb_df = remove_invalid_inchikey_molecules(moldb_df)
+    moldb_df = remove_duplicated_inchikey_molecules(moldb_df)
+
+    if not moldb_df.empty:
+        save_molecules(moldb, moldb_df)
+    else:
+        raise BadRequestError(f'Empty dataframe: {moldb_df}')
+
+
+def import_molecular_database(name, version, moldb_df, drop_moldb=False):
+    moldb = MolecularDB.find_by_name_version(db, name, version)
+    if moldb and not drop_moldb:
+        raise BadRequestError(f'Mol DB already exists: {moldb}')
+
+    if moldb:
+        logger.info(f'Deleting Mol DB: {moldb}')
+        db.delete(moldb)
+        db.commit()
+        moldb = MolecularDB(id=moldb.id, name=name, version=version)
+    else:
+        moldb = MolecularDB(name=name, version=version)
+    db.add(moldb)
+    db.commit()
+    db.refresh(moldb)
+
+    import_molecules_from_df(moldb, moldb_df)
+
+    db.commit()
+    return moldb

--- a/metaspace/mol-db/app/moldb_import.py
+++ b/metaspace/mol-db/app/moldb_import.py
@@ -94,25 +94,3 @@ def import_molecules_from_df(moldb, moldb_df):
         save_molecules(moldb, moldb_df)
     else:
         raise BadRequestError(f'Empty dataframe: {moldb_df}')
-
-
-def import_molecular_database(name, version, moldb_df, drop_moldb=False):
-    moldb = MolecularDB.find_by_name_version(db, name, version)
-    if moldb and not drop_moldb:
-        raise BadRequestError(f'Mol DB already exists: {moldb}')
-
-    if moldb:
-        logger.info(f'Deleting Mol DB: {moldb}')
-        db.delete(moldb)
-        db.commit()
-        moldb = MolecularDB(id=moldb.id, name=name, version=version)
-    else:
-        moldb = MolecularDB(name=name, version=version)
-    db.add(moldb)
-    db.commit()
-    db.refresh(moldb)
-
-    import_molecules_from_df(moldb, moldb_df)
-
-    db.commit()
-    return moldb

--- a/metaspace/mol-db/scripts/import_molecular_db.py
+++ b/metaspace/mol-db/scripts/import_molecular_db.py
@@ -1,6 +1,8 @@
 import sys
 from os.path import dirname
 
+from app.moldb_import import import_molecular_database
+
 sys.path.append(dirname(dirname(__file__)))
 import argparse
 from pyMSpec.pyisocalc.pyisocalc import parseSumFormula
@@ -10,110 +12,6 @@ from app.model.molecular_db import MolecularDB
 from app.model.molecule import Molecule
 from app.database import init_session, db_session
 from app.log import logger
-
-
-def get_inchikey_gen(mol_db_id):
-
-    def get_inchikey(ser):
-        try:
-            if ser.get('inchikey', None):
-                return ser.inchikey
-
-            return f"{mol_db_id}:{ser['id']}"
-        except Exception as e:
-            logger.warning(f'{e}\t{ser}')
-            return '{}-{}-{}'.format(ser.formula, ser['name'], ser['id'])
-
-    return get_inchikey
-
-
-def get_or_create(session, model, query, **kwargs):
-    inst = query.first()
-    if inst:
-        return inst
-    else:
-        inst = model(**kwargs)
-        session.add(inst)
-        # session.commit()
-        return inst
-
-
-def get_or_create_molecule(session, model, **kwargs):
-    q = session.query(model).filter_by(inchikey=kwargs['inchikey'])
-    return get_or_create(session, model, query=q, **kwargs)
-
-
-def get_or_create_db_mol_assoc(session, model, **kwargs):
-    q = session.query(model).filter_by(db_id=kwargs['db_id'], inchikey=kwargs['inchikey'])
-    return get_or_create(session, model, query=q, **kwargs)
-
-
-def remove_invalid_inchikey_molecules(mol_db_df):
-    invalid_inchikey = mol_db_df.inchikey.isnull()
-    n_invalid = invalid_inchikey.sum()
-    if n_invalid > 0:
-        logger.warning("{} invalid records (InChI key couldn't be generated)".format(n_invalid))
-    return mol_db_df[~invalid_inchikey]
-
-
-def remove_duplicated_inchikey_molecules(mol_db_df):
-    ids_to_insert = set()
-    for inchikey, g in mol_db_df.groupby('inchikey'):
-        if len(g) > 1:
-            logger.warning(
-                "{} molecules have the same InChI key {}: {} - taking only the first one".format(
-                    len(g), inchikey, list(g['id'])
-                )
-            )
-        ids_to_insert.add(g.iloc[0].id)
-    # remove duplicates
-    return mol_db_df[mol_db_df['id'].isin(ids_to_insert)]
-
-
-def save_molecules(mol_db, mol_db_df):
-    new_molecule_df = mol_db_df[['inchikey', 'id', 'name', 'formula']].copy()
-    new_molecule_df.rename(
-        {'id': 'mol_id', 'name': 'mol_name', 'formula': 'sf'}, axis='columns', inplace=True
-    )
-    new_molecule_df['inchi'] = ''
-    new_molecule_df['db_id'] = int(mol_db.id)
-
-    if new_molecule_df.shape[0] > 0:
-        db_session.bulk_insert_mappings(Molecule, new_molecule_df.to_dict(orient='record'))
-
-
-def filter_formulas(mol_db_df):
-    def is_valid(sf):
-        if '.' in sf:
-            logger.warning('"." in formula {}, skipping'.format(sf))
-            return False
-        try:
-            parseSumFormula(sf)
-        except Exception as e:
-            logger.warning(e)
-            return False
-        else:
-            return True
-
-    formulas = pd.Series(mol_db_df['formula'].unique())
-    valid_formulas = formulas[formulas.map(is_valid)]
-    return mol_db_df[mol_db_df.formula.isin(set(valid_formulas))].copy()
-
-
-def import_molecules(mol_db, csv_file, delimiter):
-    mol_db_df = pd.read_csv(open(csv_file, encoding='utf8'), sep=delimiter).fillna('')
-    assert {'id', 'name', 'formula'}.issubset(set(mol_db_df.columns))
-
-    mol_db_df = filter_formulas(mol_db_df)
-    mol_db_df['inchikey'] = mol_db_df.apply(get_inchikey_gen(mol_db.id), axis=1)
-    mol_db_df = remove_invalid_inchikey_molecules(mol_db_df)
-    mol_db_df = remove_duplicated_inchikey_molecules(mol_db_df)
-
-    logger.info('{} new rows to insert into molecule table'.format(mol_db_df.shape[0]))
-    if not mol_db_df.empty:
-        save_molecules(mol_db, mol_db_df)
-        db_session.commit()
-    logger.info('Inserted {} new molecules for {}'.format(len(mol_db_df), mol_db))
 
 
 if __name__ == "__main__":
@@ -131,34 +29,13 @@ if __name__ == "__main__":
     )
     parser.add_argument('--sep', dest='sep', type=str, help='CSV file fields delimiter')
     parser.add_argument(
-        '--yes', dest='confirmed', type=bool, help='Don\'t ask for a confirmation'
-    )  # TODO: remove
-    parser.add_argument(
         '--drop',
         action='store_true',
-        help='Drop molecular database before importing? (destructive, use with caution!)',
+        help='Drop molecular database before importing? Use it with caution!',
     )
     parser.set_defaults(sep='\t', confirmed=False)
     args = parser.parse_args()
 
     init_session()
-
-    mol_db = MolecularDB.find_by_name_version(db_session, args.name, args.version)
-    if mol_db and not args.drop:
-        logger.info('Molecular DB already exists: {} {}'.format(args.name, args.version))
-    else:
-        if mol_db:
-            logger.info('Deleting molecular DB: {} {}'.format(args.name, args.version))
-            db_session.delete(mol_db)
-            db_session.commit()
-
-            mol_db = MolecularDB(id=mol_db.id, name=args.name, version=args.version)
-        else:
-            mol_db = MolecularDB(name=args.name, version=args.version)
-
-        db_session.add(mol_db)
-        db_session.commit()
-
-        logger.info('Appending molecules to Mol DB: {} {}'.format(args.name, args.version))
-        import_molecules(mol_db, args.csv_file, args.sep)
-        db_session.commit()
+    moldb_df = pd.read_csv(open(args.csv_file, encoding='utf8'), sep=args.sep).fillna('')
+    import_molecular_database(args.name, args.version, moldb_df, drop_moldb=args.drop)

--- a/metaspace/mol-db/setup.py
+++ b/metaspace/mol-db/setup.py
@@ -15,7 +15,7 @@ setup(
         "sqlalchemy>=1.1.5",
         "gunicorn>=19.1.0",
         "psycopg2>=2.6.2",
-        "pandas>=0.19.2",
+        "pandas>=0.25.3",
         "cpyMSpec>=0.3.4",
         "pyMSpec>=0.1.2",
     ],

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -1111,10 +1111,13 @@ class SMInstance(object):
             ds_id=dsid,
         )
 
-    def update_dataset_dbs(self, datasetID, molDBs, adducts, priority):
+    def update_dataset_dbs(self, datasetID, molDBs, adducts, priority=1):
         return self._gqclient.update_dataset(
             ds_id=datasetID, mol_dbs=molDBs, adducts=adducts, priority=priority
         )
+
+    def reprocess_dataset(self, dataset_id, force=False):
+        return self._gqclient.update_dataset(ds_id=dataset_id, reprocess=True, force=force)
 
     def delete_dataset(self, ds_id, **kwargs):
         return self._gqclient.delete_dataset(ds_id, **kwargs)


### PR DESCRIPTION
In order to avoid repetitive manual steps when importing new molecular databases, this PR implements automation of this process through new mol-db API endpoints that accept new POST and DELETE requests.

* Remove OpenBabel from mol-db as there is no need for it
* Install all dependencies of mol-db using `setup.py`
* Update mol-db names specified in the Ansible host config: list public mol-db names instead of custom ones
* Allow POST, DELETE requests to mol-db API only from `localhost` in the nginx config