### PR TITLE
Add requests package as dependency for python client

### DIFF
--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,2 +1,2 @@
 name = 'metaspace2020'
-__version__ = '1.6.0'
+__version__ = '1.6.1'

--- a/metaspace/python-client/setup.py
+++ b/metaspace/python-client/setup.py
@@ -11,7 +11,15 @@ setup(
     url='https://github.com/metaspace2020/metaspace/tree/master/metaspace/python-client',
     author='Alexandrov Team, EMBL',
     packages=find_packages(),
-    install_requires=['pandas', 'plotly>=1.12', 'numpy', 'matplotlib', 'pyMSpec', 'pillow'],
+    install_requires=[
+        'pandas',
+        'plotly>=1.12',
+        'numpy',
+        'matplotlib',
+        'pyMSpec',
+        'pillow',
+        'requests',
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
When importing the python client in a fresh environment with `from metaspace import sm_annotation_utils`, an error is thrown that the module 'requests' cannot be found because it is missing from the environment.

This change adds `requests` to the dependencies of the python client.