### PR TITLE
Fix "Project not found" error

### DIFF
--- a/metaspace/graphql/src/modules/project/controller/Query.spec.ts
+++ b/metaspace/graphql/src/modules/project/controller/Query.spec.ts
@@ -1,5 +1,10 @@
 import * as _ from 'lodash';
-import {createTestDataset, createTestProject, createTestProjectMember} from '../../../tests/testDataCreation';
+import {
+  createTestDataset,
+  createTestProject,
+  createTestProjectMember,
+  createTestUserProject,
+} from '../../../tests/testDataCreation';
 import {Context} from '../../../context';
 import {Project as ProjectType, UserProjectRole} from '../../../binding';
 import {DatasetProject as DatasetProjectModel} from '../../dataset/model';
@@ -60,11 +65,7 @@ describe('modules/project/controller (queries)', () => {
     const userId = context.user && context.user.id;
 
     if (userId != null) {
-      if (projectRole != null) {
-        await testEntityManager.save(UserProjectModel, { userId, projectId, role: projectRole });
-      } else {
-        await testEntityManager.delete(UserProjectModel, { userId, projectId });
-      }
+      await createTestUserProject(userId, projectId, projectRole);
     }
 
     return {project, projectId, context};

--- a/metaspace/graphql/src/modules/user/__snapshots__/controller.spec.ts.snap
+++ b/metaspace/graphql/src/modules/user/__snapshots__/controller.spec.ts.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`modules/user/controller Query.currentUser should match snapshot 1`] = `
+Object {
+  "email": "MASKED",
+  "groups": Object {
+    "0": Object {
+      "group": Object {
+        "currentUserRole": "MEMBER",
+        "groupDescriptionAsHtml": "",
+        "hasPendingRequest": null,
+        "id": "MASKED",
+        "name": "test group",
+        "numMembers": 1,
+        "shortName": "tstgrp",
+        "urlSlug": null,
+      },
+      "numDatasets": 0,
+      "role": "MEMBER",
+    },
+    "1": Object {
+      "group": Object {
+        "currentUserRole": "MEMBER",
+        "groupDescriptionAsHtml": "",
+        "hasPendingRequest": null,
+        "id": "MASKED",
+        "name": "test group",
+        "numMembers": 1,
+        "shortName": "tstgrp",
+        "urlSlug": null,
+      },
+      "numDatasets": 0,
+      "role": "MEMBER",
+    },
+  },
+  "id": "MASKED",
+  "name": "tester",
+  "primaryGroup": Object {
+    "group": Object {
+      "currentUserRole": "MEMBER",
+      "groupDescriptionAsHtml": "",
+      "hasPendingRequest": null,
+      "id": "MASKED",
+      "name": "test group",
+      "numMembers": 1,
+      "shortName": "tstgrp",
+      "urlSlug": null,
+    },
+    "numDatasets": 0,
+    "role": "MEMBER",
+  },
+  "projects": Object {
+    "0": Object {
+      "numDatasets": 0,
+      "project": Object {
+        "createdDT": "MASKED",
+        "currentUserRole": "MEMBER",
+        "hasPendingRequest": null,
+        "id": "MASKED",
+        "isPublic": false,
+        "latestUploadDT": null,
+        "name": "MEMBER project",
+        "numDatasets": 0,
+        "numMembers": 1,
+        "projectDescriptionAsHtml": "",
+        "publicationStatus": "UNPUBLISHED",
+        "reviewToken": null,
+        "urlSlug": null,
+      },
+      "role": "MEMBER",
+    },
+  },
+  "role": "user",
+}
+`;

--- a/metaspace/graphql/src/modules/user/controller.spec.ts
+++ b/metaspace/graphql/src/modules/user/controller.spec.ts
@@ -1,0 +1,144 @@
+import * as _ from 'lodash';
+import {
+  createTestGroup,
+  createTestProject,
+  createTestUserGroup,
+  createTestUserProject,
+} from '../../tests/testDataCreation';
+import {UserGroupRole, UserProjectRole} from '../../binding';
+import {
+  UserProjectRoleOptions as UPRO,
+} from '../project/model';
+import {
+  UserGroupRoleOptions as UGRO,
+} from '../group/model';
+import {
+  doQuery,
+  onAfterAll,
+  onAfterEach,
+  onBeforeAll,
+  onBeforeEach,
+  setupTestUsers,
+  shallowFieldsOfSchemaType,
+  testEntityManager,
+  testUser, userContext,
+} from '../../tests/graphqlTestEnvironment';
+import {createBackgroundData} from '../../tests/backgroundDataCreation';
+
+
+// ROLE_COMBOS is a list of possible user & project role combinations, for tests that should exhaustively check every possibility
+// When running Jest against a single file, it shows a concise list of all sub-tests, which makes it easy to see patterns
+// of failures across the different combinations
+type UserRole = 'anon' | 'user' | 'admin';
+
+
+describe('modules/user/controller', () => {
+  let userId: string;
+
+  const setupProject = async (projectRole: UserProjectRole | null, isPublic: boolean) => {
+    const project = await createTestProject({isPublic, name: `${projectRole} project`});
+    await createTestUserProject(userContext.user.id!, project.id, projectRole);
+    return project;
+  };
+
+  const setupGroup = async (groupRole: UserGroupRole, primary: boolean) => {
+    const group = await createTestGroup();
+    await createTestUserGroup(userContext.user.id!, group.id, groupRole, primary);
+    return group;
+  };
+
+  beforeAll(onBeforeAll);
+  afterAll(onAfterAll);
+  beforeEach(async () => {
+    await onBeforeEach();
+    await setupTestUsers();
+    userId = testUser.id;
+  });
+  afterEach(onAfterEach);
+
+  describe('Query.currentUser', () => {
+    const query = `query {
+      currentUser {
+        ${shallowFieldsOfSchemaType('User')}
+        groups {
+          ${shallowFieldsOfSchemaType('UserGroup')}
+          group {
+            ${shallowFieldsOfSchemaType('Group')}
+          }
+        }
+        primaryGroup {
+          ${shallowFieldsOfSchemaType('UserGroup')}
+          group {
+            ${shallowFieldsOfSchemaType('Group')}
+          }
+        }
+        projects {
+          ${shallowFieldsOfSchemaType('UserProject')}
+          project {
+            ${shallowFieldsOfSchemaType('Project')}
+          }
+        }
+      }
+    }`;
+
+    describe('should include project in currentUser.projects', () => {
+      const ROLE_COMBOS: [UserProjectRole | null, boolean, boolean][] = [
+        [null, false, false],
+        [UPRO.PENDING, false, false],
+        [UPRO.INVITED, false, true],
+        [UPRO.MEMBER, false, true],
+        [UPRO.MANAGER, false, true],
+        [UPRO.REVIEWER, false, true],
+        [UPRO.PENDING, true, true],
+        [UPRO.INVITED, true, true],
+        [UPRO.MEMBER, true, true],
+        [UPRO.MANAGER, true, true],
+        [UPRO.REVIEWER, true, true],
+      ];
+      it.each(ROLE_COMBOS)('project role: %s, project.isPublic: %s, expected: %s',
+        async (projectRole, isPublic, expected) => {
+          // Arrange
+          const project = await setupProject(projectRole, isPublic);
+
+          // Act
+          const result = await doQuery(query, { }, { context: userContext });
+
+          // Assert
+          expect(result.projects).toEqual(!expected ? [] : [
+            expect.objectContaining({
+              project: expect.objectContaining({id: project.id}),
+              role: projectRole,
+            })
+          ]);
+        });
+    });
+
+    it('should match snapshot', async () => {
+      // Arrange
+      await createBackgroundData({projects: true, users: true});
+      await setupProject(UPRO.MEMBER, false);
+      await setupGroup(UGRO.MEMBER, true);
+      await setupGroup(UGRO.MEMBER, false);
+
+      // Act
+      const result = await doQuery(query, { }, { context: userContext });
+
+      // Assert
+      const maskedFields = ['id', 'userId', 'projectId', 'groupId', 'email', 'createdDT'];
+      const cleanData = (value: any, key?: any): any => {
+        if (_.isObject(value)) {
+          return _.mapValues(value, cleanData);
+        } else if (_.isArray(value)) {
+          return _.map(value, cleanData);
+        } else if (maskedFields.includes(key) && value) {
+          return 'MASKED';
+        } else {
+          return value;
+        }
+      };
+      const currentUser = cleanData(result);
+      expect(currentUser).toMatchSnapshot();
+    });
+
+  });
+});

--- a/metaspace/graphql/src/tests/testDataCreation.ts
+++ b/metaspace/graphql/src/tests/testDataCreation.ts
@@ -3,11 +3,16 @@ import * as moment from 'moment';
 import {User} from '../modules/user/model';
 import {Credentials} from '../modules/auth/model';
 import {testEntityManager, userContext} from './graphqlTestEnvironment';
-import {Project, UserProject, UserProjectRoleOptions as UPRO} from '../modules/project/model';
+import {
+  Project,
+  UserProject as UserProjectModel,
+  UserProjectRoleOptions as UPRO,
+} from '../modules/project/model';
 import {PublicationStatusOptions as PSO} from '../modules/project/PublicationStatusOptions';
-import {PublicationStatus, UserProjectRole} from '../binding';
+import {PublicationStatus, UserGroupRole, UserProjectRole} from '../binding';
 import {Dataset, DatasetProject} from '../modules/dataset/model';
 import {EngineDataset} from '../modules/engine/model';
+import {Group, UserGroup as UserGroupModel} from '../modules/group/model';
 
 
 export const createTestUser = async (user?: Partial<User>): Promise<User> => {
@@ -21,6 +26,25 @@ export const createTestUser = async (user?: Partial<User>): Promise<User> => {
   }) as User;
 };
 
+export const createTestGroup = async (group?: Partial<Group>): Promise<Group> => {
+  const groupDefaultFields = {
+    name: 'test group',
+    shortName: 'tstgrp',
+    isPublic: true,
+  };
+  return await testEntityManager.save(Group, {...groupDefaultFields, ...group}) as Group;
+};
+
+export const createTestUserGroup = async (userId: string, groupId: string, role: UserGroupRole | null,
+                                          primary: boolean): Promise<UserGroupModel | null> => {
+  if (role != null) {
+    return await testEntityManager.save(UserGroupModel, { userId, groupId, role, primary }) as UserGroupModel;
+  } else {
+    await testEntityManager.delete(UserGroupModel, { userId, groupId });
+    return null;
+  }
+};
+
 export const createTestProject = async (project?: Partial<Project>): Promise<Project> => {
   const projectDefaultFields = {
     name: 'test project',
@@ -30,10 +54,20 @@ export const createTestProject = async (project?: Partial<Project>): Promise<Pro
   return await testEntityManager.save(Project, {...projectDefaultFields, ...project}) as Project;
 };
 
+export const createTestUserProject = async (userId: string, projectId: string,
+                                            role: UserProjectRole | null): Promise<UserProjectModel | null> => {
+  if (role != null) {
+    return await testEntityManager.save(UserProjectModel, { userId, projectId, role }) as UserProjectModel;
+  } else {
+    await testEntityManager.delete(UserProjectModel, { userId, projectId });
+    return null;
+  }
+};
+
 export const createTestProjectMember = async (projectOrId: string | {id: string},
                                               role: UserProjectRole = UPRO.MEMBER) => {
   const user = await createTestUser({name: 'project member'}) as User;
-  await testEntityManager.save(UserProject, {
+  await testEntityManager.save(UserProjectModel, {
     userId: user.id,
     projectId: typeof projectOrId === 'string' ? projectOrId : projectOrId.id,
     role,


### PR DESCRIPTION
This error was deployed to production earlier this month. The issue is when a user is a `PENDING` member of a private project, their `currentUser.projects` query contains the project, but `currentUser.projects.project` emits an error because the user shouldn't be able to see the project.

This can only happen if the user requests to join the project before the project is made private. I chose to make the project invisible to the user requesting access, rather than allowing them to continue seeing it, because a project manager may make their project private without first reviewing the members list. It would be surprising to them if their project was still visible to an outsider after setting it to private.

I decided not to make this a hotfix as it's not urgent anymore. There was only 1 case of this error, and it was fixed by changing the data.