### PR TITLE
mol-db falcon fix

### DIFF
--- a/metaspace/mol-db/app/api/molecular_dbs.py
+++ b/metaspace/mol-db/app/api/molecular_dbs.py
@@ -31,7 +31,8 @@ class MoleculeCollection(BaseResource):
             molecules = q.limit(limit).all()
 
         if fields:
-            fields = fields.split(',')
+            if isinstance(fields, str):
+                fields = fields.split(',')
             selector = self.field_selector(fields)
             objs = [selector(mol.to_dict()) for mol in molecules]
         else:

--- a/metaspace/mol-db/environment.yml
+++ b/metaspace/mol-db/environment.yml
@@ -36,7 +36,7 @@ dependencies:
 - pip:
   - cffi==1.10.0
   - cpymspec==0.3.5
-  - falcon==1.1.0
+  - falcon>=2.0,<3.0
   - pycparser==2.17
   - pymspec==0.1.2
   - python-mimeparse==1.6.0

--- a/metaspace/mol-db/setup.py
+++ b/metaspace/mol-db/setup.py
@@ -11,7 +11,7 @@ setup(
     author_email='vitaly.kovalev@embl.de',
     packages=find_packages(),
     install_requires=[
-        "falcon>=1.1.0,<3.0",
+        "falcon>=2.0,<3.0",
         "sqlalchemy>=1.1.5",
         "gunicorn>=19.1.0",
         "psycopg2>=2.6.2",


### PR DESCRIPTION
I got this error, but only in some environments:
```
Error handling request
Traceback (most recent call last):
  File "/opt/dev/miniconda3/envs/mol-db/lib/python3.6/site-packages/gunicorn-19.1.0-py3.6.egg/gunicorn/workers/sync.py", line 93, in handle
    self.handle_request(listener, req, client, addr)
  File "/opt/dev/miniconda3/envs/mol-db/lib/python3.6/site-packages/gunicorn-19.1.0-py3.6.egg/gunicorn/workers/sync.py", line 134, in handle_req
uest
    respiter = self.wsgi(environ, resp.start_response)
  File "/opt/dev/miniconda3/envs/mol-db/lib/python3.6/site-packages/falcon/api.py", line 209, in __call__
    responder(req, resp, **params)
  File "/opt/dev/metaspace/metaspace/mol-db/app/api/molecular_dbs.py", line 34, in on_get
    fields = fields.split(',')
AttributeError: 'list' object has no attribute 'split'
172.31.22.225 - - [05/Dec/2019:13:15:02 +0100] "GET /v1/databases/26/molecules?fields=sf,mol_id,mol_name&limit=10000000 HTTP/1.1" 500 - "-" "-"
```

Depending on version of `falcon`, sometimes `req.params.get('fields')` returns  `'sf,mol_id,mol_name'` and sometimes it returns `['sf','mol_id','mol_name']`. I'd prefer to fix this by using `req.get_param_as_list('fields')`, but that function doesn't handle comma-separated lists, despite the documentation saying that it does.

Also, this bumps the minimum falcon version to 2.0, so that the environments stay in sync.