### PR TITLE
Return empty dataframe if no formula metrics computed

### DIFF
--- a/metaspace/engine/.pylintrc
+++ b/metaspace/engine/.pylintrc
@@ -276,7 +276,7 @@ function-naming-style=snake_case
 #function-rgx=
 
 # Good variable names which should always be accepted, separated by a comma.
-good-names=_,i,j,f,k,n,a,e,m,v,h,w,x,db,df,ds,db,id,es,fn,fp,xs,Run,logger,parser,args,sm_config
+good-names=_,i,j,f,k,n,a,e,m,v,h,w,x,db,df,ds,db,id,es,fn,fp,on,xs,Run,logger,parser,args,sm_config
 
 # Include a hint for the correct naming format with invalid-name.
 include-naming-hint=no

--- a/metaspace/engine/sm/engine/msm_basic/formula_validator.py
+++ b/metaspace/engine/sm/engine/msm_basic/formula_validator.py
@@ -141,6 +141,10 @@ def formula_image_metrics(
         f_ints = formula_ints_buffer[f_i]
         add_metrics(f_i, f_images, f_ints)
 
-    formula_metrics_df = pd.DataFrame.from_dict(formula_metrics, orient='index')
+    if formula_metrics:
+        formula_metrics_df = pd.DataFrame.from_dict(formula_metrics, orient='index')
+    else:
+        formula_metrics_df = pd.DataFrame(columns=list(METRICS.keys()))
     formula_metrics_df.index.name = 'formula_i'
+
     return formula_metrics_df, formula_images


### PR DESCRIPTION
This should prevent engine from failing on the FDR estimation step if there were no annotations found during the search step.

* compute_fdr: fix bug with duplication of 'modifier' field
* simplify pandas left merges

Fixes #491 