### PR TITLE
Isobar tweaks

### DIFF
--- a/metaspace/engine/.pylintrc
+++ b/metaspace/engine/.pylintrc
@@ -276,7 +276,7 @@ function-naming-style=snake_case
 #function-rgx=
 
 # Good variable names which should always be accepted, separated by a comma.
-good-names=_,i,j,f,k,n,a,e,m,v,h,w,x,db,df,ds,db,id,es,fn,fp,on,xs,Run,logger,parser,args,sm_config
+good-names=_,i,j,f,k,n,a,e,m,v,h,w,x,db,df,ds,db,id,es,fn,fp,on,xs,mz,Run,logger,parser,args,sm_config
 
 # Include a hint for the correct naming format with invalid-name.
 include-naming-hint=no

--- a/metaspace/engine/migrations/r1_7_20200122_moldb.py
+++ b/metaspace/engine/migrations/r1_7_20200122_moldb.py
@@ -48,6 +48,7 @@ def import_moldb_tables(db_config):
         conn.commit()
     except Exception:
         conn.rollback()
+        raise
     finally:
         conn.close()
 

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -583,7 +583,11 @@ class ESExporterIsobars:
         for doc in ann_docs:
             doc['isobars'] = []
             for peak_i, mz in enumerate(doc['centroid_mzs']):
-                if mz != 0 and doc['iso_image_ids'][peak_i] is not None:
+                if (
+                    mz != 0
+                    and peak_i < len(doc['iso_image_ids'])
+                    and doc['iso_image_ids'][peak_i] is not None
+                ):
                     peaks.append(
                         (
                             doc['annotation_id'],

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -582,13 +582,13 @@ class ESExporterIsobars:
 
         for doc in ann_docs:
             doc['isobars'] = []
-            for peak_n, mz in enumerate(doc['centroid_mzs'], 1):  # pylint: disable=invalid-name
-                if mz != 0:
+            for peak_i, mz in enumerate(doc['centroid_mzs']):
+                if mz != 0 and doc['iso_image_ids'][peak_i] is not None:
                     peaks.append(
                         (
                             doc['annotation_id'],
                             doc,
-                            peak_n,
+                            peak_i + 1,
                             mz,
                             doc['msm'],
                             doc['ion'],

--- a/metaspace/engine/tests/test_es_exporter.py
+++ b/metaspace/engine/tests/test_es_exporter.py
@@ -264,6 +264,7 @@ def test_add_isobar_fields_to_anns(ds_config):
         {
             'annotation_id': 'Base annotation',
             'centroid_mzs': [100, 101, 102, 103],
+            'iso_image_ids': ['img1', 'img2', 'img3', 'img4'],
             'msm': 0.5,
             'ion': 'H1+',
             'ion_formula': 'H1',
@@ -271,6 +272,7 @@ def test_add_isobar_fields_to_anns(ds_config):
         {
             'annotation_id': "Base's 1st centroid overlaps 1st",
             'centroid_mzs': [100.0002, 101.1, 102.1, 103.1],
+            'iso_image_ids': ['img1', 'img2', 'img3', 'img4'],
             'msm': 0.6,
             'ion': 'H2+',
             'ion_formula': 'H2',
@@ -278,6 +280,7 @@ def test_add_isobar_fields_to_anns(ds_config):
         {
             'annotation_id': "Base's 1st centroid overlaps 2nd (shouldn't be reported)",
             'centroid_mzs': [98, 100.0002, 101.2, 102.2],
+            'iso_image_ids': ['img1', 'img2', 'img3', 'img4'],
             'msm': 0.7,
             'ion': 'H3+',
             'ion_formula': 'H3',
@@ -285,6 +288,7 @@ def test_add_isobar_fields_to_anns(ds_config):
         {
             'annotation_id': "Base's 2nd and 3rd centroid overlap 3rd and 4th",
             'centroid_mzs': [96, 97, 101, 102],
+            'iso_image_ids': ['img1', 'img2', 'img3', 'img4'],
             'msm': 0.8,
             'ion': 'H4+',
             'ion_formula': 'H4',

--- a/metaspace/webapp/src/api/annotation.ts
+++ b/metaspace/webapp/src/api/annotation.ts
@@ -170,6 +170,7 @@ export const relatedMoleculesQuery =
       adduct
       ion
       ionFormula
+      mz
       msmScore
       fdrLevel
       possibleCompounds {

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/AmbiguityAlert.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/AmbiguityAlert.vue
@@ -36,7 +36,7 @@
     </div>
     <div
       slot="reference"
-      class="isomer-warning-icon"
+      class="ambiguity-alert-icon"
     />
   </el-popover>
 </template>
@@ -67,7 +67,7 @@ export default {
     display: inline-block;
     margin: auto 20px;
   }
-  .isomer-warning-icon  {
+  .ambiguity-alert-icon {
     width: 20px;
     height: 20px;
     background-image: url('../../../assets/danger.svg');

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/RelatedMolecules.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/RelatedMolecules.vue
@@ -160,8 +160,14 @@ export default {
         ...(this.isomerAnnotations || []).map(ann => ({ ...ann, isIsomer: true })),
         ...(this.isobarAnnotations || []).map(ann => ({ ...ann, isIsobar: true })),
       ]
-      annotations = sortBy(annotations, a => a.ion === this.annotation.ion ? 0 : 1)
       annotations = uniqBy(annotations, a => a.ion)
+      // Sort order: reference annotation first, then best by FDR, then best by MSM
+      // (consistent with the default sort in AnnotationsTable and RelatedMolecules)
+      annotations = sortBy(annotations,
+        a => a.ion === this.annotation.ion ? 0 : 1,
+        a => a.fdrLevel,
+        a => -a.msmScore,
+      )
 
       return annotations
     },

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/RelatedMolecules.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/RelatedMolecules.vue
@@ -16,7 +16,7 @@
           >
             <div>
               <span v-if="other.isIsomer">Isomer:</span>
-              <span v-else-if="other.isIsobar">Isobar:</span>
+              <span v-else-if="other.isIsobar">Isobar {{ renderMassShift(annotation.mz, other.mz) }}: </span>
               <span
                 class="ion-formula"
                 v-html="renderMolFormulaHtml(other.ion)"
@@ -91,7 +91,7 @@
 
 <script>
 import { omit, sortBy, uniqBy } from 'lodash-es'
-import { renderMolFormulaHtml } from '../../../util'
+import { renderMassShift, renderMolFormulaHtml } from '../../../util'
 import { relatedMoleculesQuery } from '../../../api/annotation'
 import { encodeParams, stripFilteringParams } from '../../Filters'
 import { ANNOTATION_SPECIFIC_FILTERS } from '../../Filters/filterSpecs'
@@ -167,6 +167,7 @@ export default {
     },
   },
   methods: {
+    renderMassShift,
     renderMolFormulaHtml,
     linkToAnnotation(other) {
       const filters = {
@@ -215,6 +216,9 @@ export default {
     color: $--color-text-regular;
 
     .ion-formula {
+      font-weight: bold;
+    }
+    .mass-shift {
       font-weight: bold;
     }
   }

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
@@ -216,7 +216,7 @@ export default class Diagnostics extends Vue {
         const isReference = ionFormula === this.annotation.ionFormula
         const isobars = isobarsByIonFormula[ionFormula]
         const annotations = annotationsByIonFormula[ionFormula]
-        const massShiftText = isReference ? '' : renderMassShift(annotations[0].mz, this.annotation.mz) + ': '
+        const massShiftText = isReference ? '' : renderMassShift(this.annotation.mz, annotations[0].mz) + ': '
         const isomersText = annotations.length < 2 ? '' : ' (isomers)'
         return {
           ionFormula,
@@ -229,10 +229,13 @@ export default class Diagnostics extends Vue {
         }
       })
 
-      return sortBy(groups, [
+      // Sort order: reference annotation first, then best by FDR, then best by MSM
+      // (consistent with the default sort in AnnotationsTable and RelatedMolecules)
+      return sortBy<AnnotationGroup>(groups,
         grp => grp.isReference ? 0 : 1,
-        grp => -grp.annotations[0].msm,
-      ])
+        grp => grp.annotations[0].fdrLevel,
+        grp => -grp.annotations[0].msmScore,
+      )
     }
 
     get nonReferenceGroups() {

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
@@ -31,13 +31,15 @@ exports[`Diagnostics should match snapshot (no isobars) 1`] = `
     <div class="isotope-images-container el-row">
       <div class="el-col el-col-24 el-col-xs-24 el-col-sm-12 el-col-md-12 el-col-lg-6">
         <div class="small-peak-image">
-          100.0000<br>
+          100.0000
+          <!----> <br>
           <imageloader-stub src="/fs/iso_images/img1" colormap="Viridis" image-fit-params="[object Object]" min-intensity="0" max-intensity="100" show-pixel-intensity="" annotimageopacity="1" opacitymode="constant" imageposition="[object Object]" pixelaspectratio="1" style="overflow: hidden;"></imageloader-stub>
         </div>
       </div>
       <div class="el-col el-col-24 el-col-xs-24 el-col-sm-12 el-col-md-12 el-col-lg-6">
         <div class="small-peak-image">
-          101.0000<br>
+          101.0000
+          <!----> <br>
           <imageloader-stub src="/fs/iso_images/img2" colormap="Viridis" image-fit-params="[object Object]" min-intensity="100" max-intensity="200" show-pixel-intensity="" annotimageopacity="1" opacitymode="constant" imageposition="[object Object]" pixelaspectratio="1" style="overflow: hidden;"></imageloader-stub>
         </div>
       </div>
@@ -221,13 +223,20 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
     <div class="isotope-images-container el-row">
       <div class="el-col el-col-24 el-col-xs-24 el-col-sm-12 el-col-md-12 el-col-lg-6">
         <div class="small-peak-image">
-          100.0000<br>
+          100.0000
+          <mock-el-popover trigger="hover" placement="top">
+            <div slot-key="default">
+              This peak's detection window overlaps with the other annotation's 1st peak.
+            </div>
+            <div slot-key="reference"><i class="isobar-alert el-icon-warning"></i></div>
+          </mock-el-popover> <br>
           <imageloader-stub src="/fs/iso_images/img1" colormap="Viridis" image-fit-params="[object Object]" min-intensity="0" max-intensity="100" show-pixel-intensity="" annotimageopacity="1" opacitymode="constant" imageposition="[object Object]" pixelaspectratio="1" style="overflow: hidden;"></imageloader-stub>
         </div>
       </div>
       <div class="el-col el-col-24 el-col-xs-24 el-col-sm-12 el-col-md-12 el-col-lg-6">
         <div class="small-peak-image">
-          101.0000<br>
+          101.0000
+          <!----> <br>
           <imageloader-stub src="/fs/iso_images/img2" colormap="Viridis" image-fit-params="[object Object]" min-intensity="100" max-intensity="200" show-pixel-intensity="" annotimageopacity="1" opacitymode="constant" imageposition="[object Object]" pixelaspectratio="1" style="overflow: hidden;"></imageloader-stub>
         </div>
       </div>
@@ -274,13 +283,20 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
   <div class="isotope-images-container el-row">
     <div class="el-col el-col-24 el-col-xs-24 el-col-sm-12 el-col-md-12 el-col-lg-6">
       <div class="small-peak-image">
-        100.0000<br>
+        100.0000
+        <mock-el-popover trigger="hover" placement="top">
+          <div slot-key="default">
+            This peak's detection window overlaps with the other annotation's 1st peak.
+          </div>
+          <div slot-key="reference"><i class="isobar-alert el-icon-warning"></i></div>
+        </mock-el-popover> <br>
         <imageloader-stub src="/fs/iso_images/img1" colormap="Viridis" image-fit-params="[object Object]" min-intensity="0" max-intensity="100" show-pixel-intensity="" annotimageopacity="1" opacitymode="constant" imageposition="[object Object]" pixelaspectratio="1" style="overflow: hidden;"></imageloader-stub>
       </div>
     </div>
     <div class="el-col el-col-24 el-col-xs-24 el-col-sm-12 el-col-md-12 el-col-lg-6">
       <div class="small-peak-image">
-        101.0000<br>
+        101.0000
+        <!----> <br>
         <imageloader-stub src="/fs/iso_images/img2" colormap="Viridis" image-fit-params="[object Object]" min-intensity="100" max-intensity="200" show-pixel-intensity="" annotimageopacity="1" opacitymode="constant" imageposition="[object Object]" pixelaspectratio="1" style="overflow: hidden;"></imageloader-stub>
       </div>
     </div>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
@@ -228,7 +228,7 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
             <div slot-key="default">
               This peak's detection window overlaps with the other annotation's 1st peak.
             </div>
-            <div slot-key="reference"><i class="isobar-alert el-icon-warning"></i></div>
+            <div slot-key="reference"><i class="el-icon-warning-outline"></i></div>
           </mock-el-popover> <br>
           <imageloader-stub src="/fs/iso_images/img1" colormap="Viridis" image-fit-params="[object Object]" min-intensity="0" max-intensity="100" show-pixel-intensity="" annotimageopacity="1" opacitymode="constant" imageposition="[object Object]" pixelaspectratio="1" style="overflow: hidden;"></imageloader-stub>
         </div>
@@ -288,7 +288,7 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
           <div slot-key="default">
             This peak's detection window overlaps with the other annotation's 1st peak.
           </div>
-          <div slot-key="reference"><i class="isobar-alert el-icon-warning"></i></div>
+          <div slot-key="reference"><i class="el-icon-warning-outline"></i></div>
         </mock-el-popover> <br>
         <imageloader-stub src="/fs/iso_images/img1" colormap="Viridis" image-fit-params="[object Object]" min-intensity="0" max-intensity="100" show-pixel-intensity="" annotimageopacity="1" opacitymode="constant" imageposition="[object Object]" pixelaspectratio="1" style="overflow: hidden;"></imageloader-stub>
       </div>

--- a/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
+++ b/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
@@ -66,39 +66,24 @@ const STORAGE_KEY = 'dismissedFeaturePopups'
 
 const NEW_FEATURES: FeatureSpec[] = [
   {
-    name: 'offSample',
-    title: 'Off-Sample Prediction',
+    name: 'isomersIsobars',
+    title: 'Isomers and isobars',
     contentHtml: `
-<p>We've trained a deep learning model to filter out annotations which represent molecules localized
-in the off-sample area, such as those corresponding to the MALDI matrix. You can now
-hide these annotations from the results, allowing you to find important molecules faster.</p>
-<p>Add the <u style="white-space: nowrap;">Show/hide off-sample annotations</u> filter to try it out.</p>
-<p>Please keep in mind that the accuracy of this model is greatly improved
-in datasets that include some off-sample area. We recommend including off-sample area around your sample
-during data acquisition.</p>
+<p>METASPACE now warns when there are isomeric and isobaric annotations.</p>
+<p>
+When you see this icon <span class='danger-icon'></span>, it means that that there are
+multiple candidate annotations for this set of peaks. Open the Molecules section for more information.
+</p>
+<p>
+If isobaric annotations have been identified, the Diagnostics section allows comparisons
+between overlapping annotations to help you to determine which annotation is more likely.
+The ion formulas of isomers and isobars are also available in the CSV export. </p>
       `,
-    dontShowAfter: new Date('2019-07-22'),
-    placement: 'bottom',
-    getAnchorIfActive(vue: Vue) {
-      if (config.features.off_sample && vue.$route.path === '/annotations') {
-        return document.querySelector('.tf-outer[data-test-key=offSample]')
-            || document.querySelector('.filter-select')
-      }
-      return null
-    },
-  },
-  {
-    name: 'logScale',
-    title: 'Log-scale colormaps',
-    contentHtml: `
-<p>Ion images can now be viewed with a logarithmic-scale colormap.
-The ion image display options can be configured in this menu.</p>
-      `,
-    dontShowAfter: new Date('2019-08-30'),
-    placement: 'bottom',
+    dontShowAfter: new Date('2020-05-30'),
+    placement: 'top',
     getAnchorIfActive(vue: Vue) {
       if (vue.$route.path === '/annotations') {
-        return document.querySelector('[data-feature-anchor="ion-image-settings"]')
+        return document.querySelector('.ambiguity-alert-icon')
       }
       return null
     },
@@ -283,5 +268,11 @@ export default class NewFeaturePopup extends Vue {
     font-weight: bold;
     background-color: orangered;
     color: white;
+  }
+  .danger-icon {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    background-image: url('../../assets/danger.svg');
   }
 </style>

--- a/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
+++ b/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
@@ -69,15 +69,13 @@ const NEW_FEATURES: FeatureSpec[] = [
     name: 'isomersIsobars',
     title: 'Isomers and isobars',
     contentHtml: `
-<p>METASPACE now warns when there are isomeric and isobaric annotations.</p>
-<p>
-When you see this icon <span class='danger-icon'></span>, it means that that there are
-multiple candidate annotations for this set of peaks. Open the Molecules section for more information.
-</p>
-<p>
-If isobaric annotations have been identified, the Diagnostics section allows comparisons
-between overlapping annotations to help you to determine which annotation is more likely.
-The ion formulas of isomers and isobars are also available in the CSV export. </p>
+<p>METASPACE now warns about isomeric and isobaric ambiguity.</p>
+<p>This icon <span class='danger-icon'></span> indicates that for this annotation,
+there are other isomers and/or isobars annotated. These are listed in the <b>Molecules</b> section.</p>
+<p>In case of isobaric annotations, the <b>Diagnostics</b> section allows for comparisons
+between overlapping annotations to help determine which annotation is more likely
+based on their isotopic patterns and images.
+The ion formulas of isomers and isobars are also available in the regular CSV export.</p>
       `,
     dontShowAfter: new Date('2020-05-30'),
     placement: 'top',


### PR DESCRIPTION
### New feature popup (only shows up once you've selected an annotation that shows the warning icon)
![image](https://user-images.githubusercontent.com/26366936/73552714-07a86800-4449-11ea-91b4-a01531f59856.png)

Wording:
> Isomers and isobars
> METASPACE now warns when there are isomeric and isobaric annotations.
>
> When you see this icon , it means that that there are multiple candidate annotations for this set of peaks. Open the Molecules section for more information.
>
> If isobaric annotations have been identified, the Diagnostics section allows comparisons between overlapping annotations to help you to determine which annotation is more likely. The ion formulas of isomers and isobars are also available in the CSV export.

### Isobars how show mass difference in the "Molecules" page
![image](https://user-images.githubusercontent.com/26366936/73552857-463e2280-4449-11ea-9639-b809608ffc94.png)

### Diagnostic ion images now show an indicator against the peak that overlap
![image](https://user-images.githubusercontent.com/26366936/73553071-9e752480-4449-11ea-97a0-67438eaac417.png)

### Behind the scenes
* If an annotation is missing ion images for some of its peaks, those peaks won't count toward isobar detection. In extreme cases it was previously possible for two annotations to be declared as isobars, but not actually have any overlapping signal.
* (Unrelated change) Print the error if something goes wrong during the moldb migration

Resolves #497 