### PR TITLE
Fixes for "Datasets containing molecule" filter

### DIFF
--- a/metaspace/engine/scripts/db_schema.sql
+++ b/metaspace/engine/scripts/db_schema.sql
@@ -170,6 +170,7 @@ CREATE TABLE "public"."dataset" (
   "config" json, 
   "upload_dt" TIMESTAMP, 
   "status" text, 
+  "status_update_dt" TIMESTAMP NOT NULL DEFAULT (now() at time zone 'utc'), 
   "optical_image" text, 
   "transform" double precision array, 
   "is_public" boolean NOT NULL DEFAULT true, 

--- a/metaspace/engine/sm/engine/dataset.py
+++ b/metaspace/engine/sm/engine/dataset.py
@@ -78,7 +78,7 @@ class Dataset:
     IMG_STORAGE_TYPE_SEL = 'SELECT ion_img_storage_type FROM dataset WHERE id = %s'
     IMG_STORAGE_TYPE_UPD = 'UPDATE dataset SET ion_img_storage_type = %s WHERE id = %s'
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         id=None,  # pylint: disable=redefined-builtin
         name=None,

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -113,7 +113,7 @@ class ESIndexManager:
             indices = self._ind_client.get_alias(name=alias)
         except NotFoundError:
             indices = {}
-        logger.warning(f'Could not find ElasticSearch alias "{alias}"')
+            logger.warning(f'Could not find ElasticSearch alias "{alias}"')
 
         index = next(iter(indices.keys()), None)
         if len(indices) > 1:

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -67,6 +67,7 @@ FROM (
     d.input_path AS ds_input_path,
     d.upload_dt AS ds_upload_dt,
     d.status AS ds_status,
+    d.status_update_dt as ds_status_update_dt,
     to_char(max(job.finish), 'YYYY-MM-DD HH24:MI:SS') AS ds_last_finished,
     d.is_public AS ds_is_public,
     d.config #> '{databases}' AS ds_mol_dbs,

--- a/metaspace/engine/sm/engine/tests/util.py
+++ b/metaspace/engine/sm/engine/tests/util.py
@@ -115,7 +115,7 @@ def fill_db(test_db, metadata, ds_config):
     db = DB()
     db.insert(
         'INSERT INTO dataset (id, name, input_path, upload_dt, metadata, config, '
-        'status, is_public) values (%s, %s, %s, %s, %s, %s, %s, %s)',
+        'status, status_update_dt, is_public) values (%s, %s, %s, %s, %s, %s, %s, %s, %s)',
         rows=[
             (
                 ds_id,
@@ -125,6 +125,7 @@ def fill_db(test_db, metadata, ds_config):
                 json.dumps(metadata),
                 json.dumps(ds_config),
                 'FINISHED',
+                upload_dt,
                 True,
             )
         ],

--- a/metaspace/engine/tests/test_colocalization.py
+++ b/metaspace/engine/tests/test_colocalization.py
@@ -44,7 +44,14 @@ def mock_get_ion_images_for_analysis(storage_type, img_ids, **kwargs):
 
 def test_new_ds_saves_to_db(test_db, metadata, ds_config):
     db = DB()
-    ds = Dataset('ds_id', 'ds_name', 'input_path', datetime.now(), metadata, ds_config)
+    ds = Dataset(
+        id='ds_id',
+        name='ds_name',
+        input_path='input_path',
+        upload_dt=datetime.now(),
+        metadata=metadata,
+        config=ds_config,
+    )
     ds.save(db)
 
     ion_metrics_df = pd.DataFrame(

--- a/metaspace/engine/tests/test_dataset.py
+++ b/metaspace/engine/tests/test_dataset.py
@@ -73,7 +73,14 @@ def test_dataset_save_overwrite_ds_works(fill_db, metadata, ds_config):
 
     upload_dt = datetime.now()
     ds_id = '2000-01-01'
-    ds = Dataset(ds_id, 'ds_name', 'input_path', upload_dt, metadata, ds_config)
+    ds = Dataset(
+        id=ds_id,
+        name='ds_name',
+        input_path='input_path',
+        upload_dt=upload_dt,
+        metadata=metadata,
+        config=ds_config,
+    )
 
     ds.save(db, es_mock)
 

--- a/metaspace/engine/tests/test_dataset.py
+++ b/metaspace/engine/tests/test_dataset.py
@@ -19,8 +19,8 @@ def fill_db(test_db, metadata, ds_config):
     db.insert(
         (
             'INSERT INTO dataset (id, name, input_path, upload_dt, metadata, config, status, '
-            'is_public) '
-            'VALUES (%s, %s, %s, %s, %s, %s, %s, %s)'
+            'status_update_dt, is_public) '
+            'VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)'
         ),
         rows=[
             (
@@ -31,6 +31,7 @@ def fill_db(test_db, metadata, ds_config):
                 json.dumps(metadata),
                 json.dumps(ds_config),
                 DatasetStatus.FINISHED,
+                upload_dt,
                 True,
             )
         ],
@@ -62,6 +63,7 @@ def test_dataset_load_existing_ds_works(fill_db, metadata, ds_config):
         metadata=metadata,
         config=ds_config,
         status=DatasetStatus.FINISHED,
+        status_update_dt=upload_dt,
         is_public=True,
         ion_img_storage_type='fs',
     )

--- a/metaspace/engine/tests/test_es_exporter.py
+++ b/metaspace/engine/tests/test_es_exporter.py
@@ -48,10 +48,10 @@ def test_index_ds_works(test_db, es_dsl_search, sm_index, ds_config, metadata):
     db = DB()
     db.insert(
         "INSERT INTO dataset(id, name, input_path, config, metadata, upload_dt, status, "
-        "is_public, ion_img_storage_type, acq_geometry) "
-        "VALUES (%s, 'ds_name', 'ds_input_path', %s, %s, %s, 'ds_status', "
+        "status_update_dt, is_public, ion_img_storage_type, acq_geometry) "
+        "VALUES (%s, 'ds_name', 'ds_input_path', %s, %s, %s, 'ds_status', %s, "
         "true, 'fs', '{}')",
-        [[ds_id, json.dumps(ds_config), json.dumps(metadata), upload_dt]],
+        [[ds_id, json.dumps(ds_config), json.dumps(metadata), upload_dt, upload_dt]],
     )
     db.insert(
         "INSERT INTO molecular_db (id, name, version) VALUES (%s, %s, %s)",
@@ -132,6 +132,7 @@ def test_index_ds_works(test_db, es_dsl_search, sm_index, ds_config, metadata):
         'ds_project_names': [],
         'ds_meta': metadata,
         'ds_status': 'ds_status',
+        'ds_status_update_dt': upload_dt,
         'ds_name': 'ds_name',
         'ds_input_path': 'ds_input_path',
         'ds_id': ds_id,

--- a/metaspace/graphql/esConnector.ts
+++ b/metaspace/graphql/esConnector.ts
@@ -33,6 +33,7 @@ export interface ESDatasetSource {
   ds_config: any;
   ds_meta: any;
   ds_status: string;
+  ds_status_update_dt: string;
   ds_input_path: string;
   ds_ion_img_storage: ImageStorageType;
   ds_is_public: boolean;
@@ -144,7 +145,10 @@ function esSort(orderBy: AnnotationOrderBy | DatasetOrderBy, sortingOrder: Sorti
     return [sortTerm('off_sample_prob', order)];
   // dataset orderings
   else if (orderBy === 'ORDER_BY_DATE')
-    return [sortTerm('ds_last_finished', order)];
+    return [
+      sortTerm('ds_status_update_dt', order),
+      sortTerm('ds_last_finished', order),
+    ];
   else if (orderBy === 'ORDER_BY_NAME')
     return [sortTerm('ds_name', order)];
 }
@@ -417,18 +421,37 @@ export const esCountGroupedResults = async (args: any, docType: DocType, user: C
 
 export const esCountMatchingAnnotationsPerDataset = async (args: any, user: ContextUser): Promise<Record<string, number>> => {
   const body = constructESQuery(args, 'annotation', user, await user.getProjectRoles());
+  if (1) {
+    const aggRequest = {
+      body: {
+        ...body,
+        aggs: { ds_id: { terms: { field: 'ds_id', size: 1000000 } } },
+      },
+      index: esIndex,
+      size: 0,
+    };
+    const resp = await es.search(aggRequest);
+    const counts = resp.aggregations.ds_id.buckets.map(({ key, doc_count }: any) => [key, doc_count]);
+    console.log(resp.took, counts.length);
+    return _.fromPairs(counts);
+  } else {
+    const aggRequest = {
+      body: {
+        ...body,
+        collapse: {
+          field: 'ds_id',
+          inner_hits: {name: 'latest', size: 1},
+        },
+      },
+      index: esIndex,
+      size: 10000,
+    };
+    const resp = await es.search(aggRequest);
+    console.log(resp.took, resp.hits.hits[0]);
+    const counts = resp.hits.hits.map((doc: any) => [doc._source.ds_id, 1]);
+    return _.fromPairs(counts);
 
-  const aggRequest = {
-    body: {
-      ...body,
-      aggs: { ds_id: { terms: { field: 'ds_id' } } },
-    },
-    index: esIndex,
-    size: 0,
-  };
-  const resp = await es.search(aggRequest);
-  const counts = resp.aggregations.ds_id.buckets.map(({key, doc_count}: any) => [key, doc_count]);
-  return _.fromPairs(counts);
+  }
 };
 
 export interface FilterValueCountArgs {

--- a/metaspace/graphql/esConnector.ts
+++ b/metaspace/graphql/esConnector.ts
@@ -359,7 +359,8 @@ const fieldEnumToSchemaPath = {
   DF_ORGANISM_PART: datasetFilters.organismPart.esField,
   DF_CONDITION: datasetFilters.condition.esField,
   DF_GROWTH_CONDITIONS: datasetFilters.growthConditions.esField,
-  DF_MALDI_MATRIX: datasetFilters.maldiMatrix.esField
+  DF_MALDI_MATRIX: datasetFilters.maldiMatrix.esField,
+  DF_STATUS: 'ds_status',
 };
 
 function constructTermAggregations(fields: (keyof typeof fieldEnumToSchemaPath)[]) {

--- a/metaspace/graphql/esConnector.ts
+++ b/metaspace/graphql/esConnector.ts
@@ -422,37 +422,17 @@ export const esCountGroupedResults = async (args: any, docType: DocType, user: C
 
 export const esCountMatchingAnnotationsPerDataset = async (args: any, user: ContextUser): Promise<Record<string, number>> => {
   const body = constructESQuery(args, 'annotation', user, await user.getProjectRoles());
-  if (1) {
-    const aggRequest = {
-      body: {
-        ...body,
-        aggs: { ds_id: { terms: { field: 'ds_id', size: 1000000 } } },
-      },
-      index: esIndex,
-      size: 0,
-    };
-    const resp = await es.search(aggRequest);
-    const counts = resp.aggregations.ds_id.buckets.map(({ key, doc_count }: any) => [key, doc_count]);
-    console.log(resp.took, counts.length);
-    return _.fromPairs(counts);
-  } else {
-    const aggRequest = {
-      body: {
-        ...body,
-        collapse: {
-          field: 'ds_id',
-          inner_hits: {name: 'latest', size: 1},
-        },
-      },
-      index: esIndex,
-      size: 10000,
-    };
-    const resp = await es.search(aggRequest);
-    console.log(resp.took, resp.hits.hits[0]);
-    const counts = resp.hits.hits.map((doc: any) => [doc._source.ds_id, 1]);
-    return _.fromPairs(counts);
-
-  }
+  const aggRequest = {
+    body: {
+      ...body,
+      aggs: { ds_id: { terms: { field: 'ds_id', size: 1000000 } } },
+    },
+    index: esIndex,
+    size: 0,
+  };
+  const resp = await es.search(aggRequest);
+  const counts = resp.aggregations.ds_id.buckets.map(({ key, doc_count }: any) => [key, doc_count]);
+  return _.fromPairs(counts);
 };
 
 export interface FilterValueCountArgs {

--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -98,7 +98,8 @@ enum DatasetAggField {
   DF_ORGANISM_PART,
   DF_CONDITION,
   DF_GROWTH_CONDITIONS,
-  DF_MALDI_MATRIX
+  DF_MALDI_MATRIX,
+  DF_STATUS,
 }
 
 enum JobStatus {

--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -32,6 +32,7 @@ type Dataset {
   metadataType: String!
 
   status: JobStatus
+  statusUpdateDT: String!
   inputPath: String
   uploadDateTime: String
   fdrCounts(inpFdrLvls: [Int!]! = [10], checkLvl: Int! = 10): FdrCounts

--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -252,7 +252,7 @@ type DatasetStatusUpdate {
   relationship: DatasetRelationship
   action: DatasetAction!
   stage: DatasetActionStage!
-  is_new: Boolean
+  isNew: Boolean
 }
 
 type DatasetDeletion {

--- a/metaspace/graphql/src/migrations/1575383804034-DatasetStatusDT.ts
+++ b/metaspace/graphql/src/migrations/1575383804034-DatasetStatusDT.ts
@@ -1,0 +1,28 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class DatasetStatusDT1575383804034 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "public"."dataset" ADD "status_update_dt" TIMESTAMP NOT NULL DEFAULT (now() at time zone 'utc')`);
+        await queryRunner.query(`
+            UPDATE dataset SET status_update_dt = COALESCE(
+                (SELECT MAX(finish) FROM job WHERE job.ds_id = dataset.id),
+                dataset.upload_dt,
+                (now() at time zone 'utc')
+            )
+        `);
+        // await queryRunner.query(`ALTER TABLE "graphql"."project" ALTER COLUMN "created_dt" SET DEFAULT (now() at time zone 'utc')`);
+        // await queryRunner.query(`ALTER TABLE "graphql"."project" ALTER COLUMN "review_token_created_dt" SET DEFAULT null`);
+        // await queryRunner.query(`ALTER TABLE "graphql"."coloc_job" ALTER COLUMN "start" SET DEFAULT (now() at time zone 'utc')`);
+        // await queryRunner.query(`ALTER TABLE "graphql"."coloc_job" ALTER COLUMN "finish" SET DEFAULT (now() at time zone 'utc')`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        // await queryRunner.query(`ALTER TABLE "graphql"."coloc_job" ALTER COLUMN "finish" SET DEFAULT timezone('utc'`);
+        // await queryRunner.query(`ALTER TABLE "graphql"."coloc_job" ALTER COLUMN "start" SET DEFAULT timezone('utc'`);
+        // await queryRunner.query(`ALTER TABLE "graphql"."project" ALTER COLUMN "review_token_created_dt" DROP DEFAULT`);
+        // await queryRunner.query(`ALTER TABLE "graphql"."project" ALTER COLUMN "created_dt" SET DEFAULT timezone('utc'`);
+        await queryRunner.query(`ALTER TABLE "public"."dataset" DROP COLUMN "status_update_dt"`);
+    }
+
+}

--- a/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
+++ b/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
@@ -153,7 +153,7 @@ const Annotation: FieldResolversFor<Annotation, ESAnnotation | ESAnnotationWithC
     return isobars.map(({ion, ion_formula, peak_ns,  msm}) =>
       ({
         ion,
-        ionFormula: ion_formula,
+        ionFormula: ion_formula || '',
         peakNs: peak_ns,
         msmScore: msm,
         shouldWarn: msm > hit._source.msm - 0.5,

--- a/metaspace/graphql/src/modules/annotation/queryFilters/hasAnnotationMatching.ts
+++ b/metaspace/graphql/src/modules/annotation/queryFilters/hasAnnotationMatching.ts
@@ -17,16 +17,19 @@ export const applyHasAnnotationMatchingFilter =
       }, context.user);
 
       const datasetIds = Object.keys(result);
-      const ids = otherDatasetFilters.ids
-        ? _.intersection(datasetIds, otherDatasetFilters.ids.split('|')).join('|')
-        : datasetIds.join('|');
+      let ids = otherDatasetFilters.ids
+        ? _.intersection(datasetIds, otherDatasetFilters.ids.split('|'))
+        : datasetIds;
+      if (ids.length === 0) {
+        ids = ['DONT_MATCH_ANYTHING']
+      }
 
       return {
         args: {
           ...otherArgs,
           datasetFilter: {
             ...otherDatasetFilters,
-            ids,
+            ids: ids.join('|'),
           }
         },
       };

--- a/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
@@ -91,6 +91,10 @@ const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
     return ds._source.ds_upload_dt;
   },
 
+  statusUpdateDT(ds) {
+    return ds._source.ds_status_update_dt;
+  },
+
   configJson(ds) {
     return JSON.stringify(ds._source.ds_config);
   },

--- a/metaspace/graphql/src/modules/engine/model.ts
+++ b/metaspace/graphql/src/modules/engine/model.ts
@@ -32,6 +32,9 @@ export class EngineDataset {
   uploadDt: Date | null;
   @Column({ type: 'text', nullable: true })
   status: DatasetStatus | null;
+  @Column({ type: 'timestamp without time zone', default: () => "(now() at time zone 'utc')",
+    transformer: new MomentValueTransformer() })
+  statusUpdateDt: Date | null;
   @Column({ type: 'text', nullable: true })
   opticalImage: string | null;
   @Column({ type: 'double precision', array: true, nullable: true })

--- a/metaspace/graphql/src/utils/pubsub.ts
+++ b/metaspace/graphql/src/utils/pubsub.ts
@@ -10,7 +10,7 @@ interface DatasetStatusUpdatedPayload {
   dataset: ESDataset;
   action: DatasetAction;
   stage: DatasetActionStage;
-  is_new?: boolean;
+  isNew?: boolean;
 }
 
 type SystemHealthPayload = SystemHealth;

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -91,7 +91,7 @@ export const datasetDetailItemsQuery =
   ${datasetDetailItemFragment}
   `
 
-export const datasetCountQuery =
+export const countDatasetsByStatusQuery =
   gql`query CountDatasets($dFilter: DatasetFilter, $query: String) {
     countDatasetsPerGroup(query: {filter: $dFilter, simpleQuery: $query, fields: [DF_STATUS]}) {
       counts {
@@ -99,6 +99,11 @@ export const datasetCountQuery =
         count
       }
     }
+  }`
+
+export const countDatasetsQuery =
+  gql`query CountDatasets($dFilter: DatasetFilter, $query: String) {
+    countDatasets(filter: $dFilter, simpleQuery: $query)
   }`
 
 export interface DatasetListItem {

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -71,6 +71,7 @@ export const datasetDetailItemFragment =
     isPublic
     molDBs
     status
+    statusUpdateDT
     metadataType
     fdrCounts(inpFdrLvls: $inpFdrLvls, checkLvl: $checkLvl) {
       dbName
@@ -92,7 +93,7 @@ export const datasetDetailItemsQuery =
 
 export const datasetCountQuery =
   gql`query CountDatasets($dFilter: DatasetFilter, $query: String) {
-    countDatasets(filter: $dFilter, simpleQuery: $query)
+    countDatasetsPerGroup(query: {filter: $dFilter, simpleQuery: $query, fields: ["ds_status"]})
   }`
 
 export interface DatasetListItem {

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -208,7 +208,7 @@ export const datasetStatusUpdatedQuery = gql`subscription datasetStatusUpdated(
     }
     action
     stage
-    is_new
+    isNew
   }
 }
 ${datasetDetailItemFragment}`

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -93,7 +93,12 @@ export const datasetDetailItemsQuery =
 
 export const datasetCountQuery =
   gql`query CountDatasets($dFilter: DatasetFilter, $query: String) {
-    countDatasetsPerGroup(query: {filter: $dFilter, simpleQuery: $query, fields: ["ds_status"]})
+    countDatasetsPerGroup(query: {filter: $dFilter, simpleQuery: $query, fields: [DF_STATUS]}) {
+      counts {
+        fieldValues
+        count
+      }
+    }
   }`
 
 export interface DatasetListItem {

--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
@@ -437,7 +437,7 @@ export default {
         return this.queryVariables
       },
       update: data => data.allAnnotations,
-      debounce: 200,
+      throttle: 200,
       result({ data }) {
         // For whatever reason (could be a bug), vue-apollo seems to first refetch
         // data for the current page and only then fetch the updated data.

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
@@ -156,6 +156,7 @@ interface AnnotationGroup {
         return {
           datasetId: this.annotation.dataset.id,
           ionFormula: this.annotation.ionFormula,
+          database: this.annotation.database,
         }
       },
       update(data) {

--- a/metaspace/webapp/src/modules/App/MetaspaceHeader.vue
+++ b/metaspace/webapp/src/modules/App/MetaspaceHeader.vue
@@ -289,7 +289,7 @@ const MetaspaceHeader = {
       datasetStatusUpdated: {
         query: datasetStatusUpdatedQuery,
         result(data) {
-          const { dataset, relationship, action, stage, is_new: isNew } = data.data.datasetStatusUpdated
+          const { dataset, relationship, action, stage, isNew } = data.data.datasetStatusUpdated
           if (dataset != null && relationship != null) {
             const { name, submitter } = dataset
 

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.spec.ts
@@ -50,10 +50,20 @@ describe('DatasetTable', () => {
   it('should match snapshot', async() => {
     initMockGraphqlClient({
       Query: () => ({
-        allDatasets: (_: any, { filter: { status } }: any) => {
-          return [{ ...mockDataset, id: `${status}1`, status }]
+        allDatasets: () => {
+          return [
+            { ...mockDataset, id: 'ANNOTATING1', status: 'ANNOTATING' },
+            { ...mockDataset, id: 'QUEUED1', status: 'QUEUED' },
+            { ...mockDataset, id: 'FINISHED1', status: 'FINISHED' },
+          ]
         },
-        countDatasets: () => 1,
+        countDatasetsPerGroup: () => ({
+          counts: [
+            { fieldValues: ['QUEUED'], count: 2},
+            { fieldValues: ['ANNOTATING'], count: 1},
+            { fieldValues: ['FINISHED'], count: 20},
+          ],
+        }),
       }),
     })
     const wrapper = mount(DatasetTable, { store, router, apolloProvider, sync: false })

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
@@ -164,7 +164,7 @@ export default {
       datasetStatusUpdated: {
         query: datasetStatusUpdatedQuery,
         async result({ data }) {
-          const { dataset, action, stage, is_new: isNew } = data.datasetStatusUpdated
+          const { dataset, action, stage, isNew } = data.datasetStatusUpdated
           if (this.noFilters && dataset != null) {
             if (action === 'ANNOTATE' && stage === 'QUEUED' && isNew) {
               updateApolloCache(this, 'allDatasets', oldVal => {

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
@@ -81,7 +81,7 @@ import delay from '../../../lib/delay'
 import formatCsvRow, { csvExportHeader, formatCsvTextArray } from '../../../lib/formatCsvRow'
 import { currentUserRoleQuery } from '../../../api/user'
 import { removeDatasetFromAllDatasetsQuery } from '../../../lib/updateApolloCache'
-import { sortBy, uniqBy } from 'lodash-es'
+import { orderBy } from 'lodash-es'
 import updateApolloCache from '../../../lib/updateApolloCache'
 
 const extractGroupedStatusCounts = (data) => {
@@ -145,7 +145,7 @@ export default {
            || (ds.status === 'ANNOTATING' && this.categories.includes('started'))
            || (ds.status === 'QUEUED' && this.categories.includes('queued'))
            || (ds.status === 'FINISHED' && this.categories.includes('finished')))
-      datasets = sortBy(datasets, ['ds_status_update_dt'], ['desc'])
+      datasets = orderBy(datasets, ['ds_status_update_dt'], ['desc'])
       return datasets
     },
 

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
@@ -123,7 +123,6 @@ export default {
       }
       return true
     },
-
     queryVariables() {
       return {
         dFilter: this.$store.getters.gqlDatasetFilter,
@@ -132,11 +131,9 @@ export default {
         checkLvl: 10,
       }
     },
-
     nonEmpty() {
       return this.datasets.length > 0
     },
-
     datasets() {
       const statusOrder = ['QUEUED', 'ANNOTATING']
       let datasets = (this.allDatasets || [])
@@ -147,7 +144,6 @@ export default {
       ], ['asc', 'desc'])
       return datasets
     },
-
     canSeeFailed() {
       return this.currentUser != null && this.currentUser.role === 'admin'
     },
@@ -197,13 +193,11 @@ export default {
         },
       },
     },
-
     currentUser: {
       loadingKey: 'loading',
       query: currentUserRoleQuery,
       fetchPolicy: 'cache-first',
     },
-
     allDatasets: {
       loadingKey: 'loading',
       fetchPolicy: 'cache-and-network',
@@ -213,7 +207,6 @@ export default {
         return this.queryVariables
       },
     },
-
     datasetCounts: {
       loadingKey: 'countLoading',
       fetchPolicy: 'cache-and-network',
@@ -239,12 +232,11 @@ export default {
       (row.analyzer.resolvingPower / 1000).toFixed(0) * 1000,
 
     count(status) {
-      let count = null
       if (this.datasetCounts != null) {
-        count = this.datasetCounts[status]
+        return `(${this.datasetCounts[status] || 0})`
+      } else {
+        return ''
       }
-
-      return count != null && !isNaN(count) ? `(${count})` : ''
     },
 
     async startExport() {

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
@@ -1,4 +1,4 @@
-\<template>
+<template>
   <div>
     <filter-panel level="dataset" />
 
@@ -18,9 +18,7 @@
 
         <el-checkbox-group
           v-model="categories"
-          :min="1"
-          class="dataset-status-checkboxes"
-        >
+          :min="1" class="dataset-status-checkboxes" v-loading="countLoading">
           <el-checkbox
             class="cb-started"
             label="started"
@@ -57,8 +55,7 @@
       </el-form>
     </div>
 
-    <dataset-list
-      :datasets="datasets"
+    <dataset-list v-loading="loading" :datasets="datasets"
       allow-double-column
     />
   </div>
@@ -82,7 +79,18 @@ import { removeDatasetFromAllDatasetsQuery } from '../../../lib/updateApolloCach
 import { sortBy, uniqBy } from 'lodash-es'
 import updateApolloCache from '../../../lib/updateApolloCache'
 
-const processingStages = ['started', 'queued', 'failed', 'finished']
+ const extractGroupedStatusCounts = (data) => {
+   const counts = {
+     QUEUED: 0,
+     ANNOTATING: 0,
+     FINISHED: 0,
+     FAILED: 0,
+   };
+   (data.countDatasetsPerGroup.counts || []).forEach(({fieldValues: [status], count}) => {
+     counts[status] = count;
+   });
+   return counts;
+ };
 
 export default {
   name: 'DatasetTable',
@@ -96,8 +104,11 @@ export default {
       csvChunkSize: 1000,
       categories: ['started', 'queued', 'finished'],
       isExporting: false,
-    }
-  },
+       loading: 0,
+       countLoading: 0,
+     }
+   },
+
 
   computed: {
     noFilters() {
@@ -108,118 +119,110 @@ export default {
       return true
     },
 
-    nonEmpty() {
-      return this.datasets.length > 0
+    queryVariables() {
+       return {
+         dFilter: this.$store.getters.gqlDatasetFilter,
+         query: this.$store.getters.ftsQuery,
+         inpFdrLvls: [10],
+         checkLvl: 10
+       };
+     },
+
+     nonEmpty() {
+       return this.datasets.length > 0
     },
 
-    allDatasets() {
-      let list = []
-      for (const category of processingStages) {
-        if (this[category]) {
-          list = list.concat(this[category])
-        }
-      }
-      // Sort again in case any datasets have had their status changed and are now in the wrong list
-      const sortOrder = ['FAILED', 'ANNOTATING', 'QUEUED', 'FINISHED']
-      list = uniqBy(list, 'id')
-      list = sortBy(list, dataset => sortOrder.indexOf(dataset.status))
-      return list
-    },
-
-    datasets() {
-      return this.allDatasets
-        .filter(ds =>
-          (ds.status === 'FAILED' && this.categories.includes('failed'))
+     datasets() {
+       let datasets = (this.allDatasets || []);
+       datasets = datasets.filter(ds =>
+           (ds.status === 'FAILED' && this.categories.includes('failed'))
            || (ds.status === 'ANNOTATING' && this.categories.includes('started'))
            || (ds.status === 'QUEUED' && this.categories.includes('queued'))
            || (ds.status === 'FINISHED' && this.categories.includes('finished')))
-    },
+       datasets = sortBy(datasets, ['ds_status_update_dt'], ['desc']);
+       return datasets;
+     },
 
     canSeeFailed() {
       return this.currentUser != null && this.currentUser.role === 'admin'
     },
   },
 
-  apollo: {
-    $subscribe: {
-      datasetDeleted: {
-        query: datasetDeletedQuery,
-        result({ data }) {
-          const datasetId = data.datasetDeleted.id;
-          ['failed', 'finished', 'queued', 'started'].forEach(queryName => {
-            removeDatasetFromAllDatasetsQuery(this, queryName, datasetId)
-          })
-        },
-      },
-      datasetStatusUpdated: {
-        query: datasetStatusUpdatedQuery,
-        async result({ data }) {
-          const { dataset, action, stage, is_new: isNew } = data.datasetStatusUpdated
-          if (dataset != null && action === 'ANNOTATE' && stage === 'QUEUED' && isNew) {
-            updateApolloCache(this, 'queued', oldVal => {
-              return {
-                ...oldVal,
-                allDatasets: oldVal.allDatasets && [dataset, ...oldVal.allDatasets],
-              }
-            })
-          }
-        },
-      },
-    },
+   apollo: {
+     $subscribe: {
+       datasetDeleted: {
+         query: datasetDeletedQuery,
+         result({data}) {
+           const datasetId = data.datasetDeleted.id;
+           removeDatasetFromAllDatasetsQuery(this, 'allDatasets', datasetId);
+         }
+       },
+       datasetStatusUpdated: {
+         query: datasetStatusUpdatedQuery,
+         async result({ data }) {
+           const { dataset, action, stage, is_new } = data.datasetStatusUpdated;
+           if (this.noFilters && dataset != null) {
+             if (action === 'ANNOTATE' && stage === 'QUEUED' && is_new) {
+               updateApolloCache(this, 'allDatasets', oldVal => {
+                 return {
+                   ...oldVal,
+                   allDatasets: oldVal.allDatasets && [dataset, ...oldVal.allDatasets],
+                 };
+               });
+             }
+             if (this.allDatasets != null) {
+               // Make a best effort to update counts.
+               const oldDataset = this.allDatasets.find(ds => ds.id === dataset.id);
+               const oldStatus = oldDataset && oldDataset.status;
+               const newStatus = dataset.status;
+               updateApolloCache(this, 'countDatasets', oldVal => {
+                 const oldCounts = extractGroupedStatusCounts(oldVal);
+                 return {
+                   ...oldVal,
+                   counts: Object.entries(oldCounts).map(([status, count]) => ({
+                     fields: [status],
+                     count: count
+                       - (status === oldStatus ? 1 : 0)
+                       + (status === newStatus ? 1 : 0),
+                   })),
+                 };
+               });
+
+             }
+           }
+         }
+       },
+     },
 
     currentUser: {
-      query: currentUserRoleQuery,
-      fetchPolicy: 'cache-first',
-    },
+      loadingKey: 'loading',
+       query: currentUserRoleQuery,
+       fetchPolicy: 'cache-first',
+     },
 
-    failed: {
-      fetchPolicy: 'cache-and-network',
-      query: datasetDetailItemsQuery,
-      update: data => data.allDatasets,
-      skip() {
-        return !this.canSeeFailed
-      },
-      variables() {
-        return this.queryVariables('FAILED')
-      },
-    },
+     allDatasets: {
+       loadingKey: 'loading',
+       fetchPolicy: 'cache-and-network',
+       query: datasetDetailItemsQuery,
+       throttle: 1000,
+       variables () {
+         return this.queryVariables;
+       }
+     },
 
-    started: {
-      fetchPolicy: 'cache-and-network',
-      query: datasetDetailItemsQuery,
-      update: data => data.allDatasets,
-      variables() {
-        return this.queryVariables('ANNOTATING')
-      },
-    },
-
-    queued: {
-      fetchPolicy: 'cache-and-network',
-      query: datasetDetailItemsQuery,
-      update: data => data.allDatasets,
-      variables() {
-        return this.queryVariables('QUEUED')
-      },
-    },
-
-    finished: {
-      fetchPolicy: 'cache-and-network',
-      query: datasetDetailItemsQuery,
-      update: data => data.allDatasets,
-      variables() {
-        return this.queryVariables('FINISHED')
-      },
-    },
-
-    finishedCount: {
-      fetchPolicy: 'cache-and-network',
-      query: datasetCountQuery,
-      update: data => data.countDatasets,
-      variables() {
-        return this.queryVariables('FINISHED')
-      },
-    },
-  },
+     datasetCounts: {
+       loadingKey: 'countLoading',
+       fetchPolicy: 'cache-and-network',
+       query: datasetCountQuery,
+       throttle: 1000,
+       update(data) {
+         return extractGroupedStatusCounts(data);
+       },
+       variables () {
+         return this.queryVariables;
+       }
+     },
+   },
 
   methods: {
     formatSubmitter: (row, col) =>
@@ -229,35 +232,23 @@ export default {
     formatResolvingPower: (row, col) =>
       (row.analyzer.resolvingPower / 1000).toFixed(0) * 1000,
 
-    queryVariables(status) {
-      const body = {
-        dFilter: Object.assign({ status }, this.$store.getters.gqlDatasetFilter),
-        query: this.$store.getters.ftsQuery,
-        inpFdrLvls: [],
-        checkLvl: 10,
-      }
-      if (status === 'FINISHED') { body.inpFdrLvls = [10] }
-      return body
-    },
-
-    count(stage) {
-      let count = null
-      // assume not too many items are failed/queued/annotating so they are all visible in the web app,
-      // but check all lists because they may be in the wrong list due to status updates after they were loaded
-      if (stage === 'failed') {
-        count = this.allDatasets.filter(ds => ds.status === 'FAILED').length
-      }
-      if (stage === 'queued') {
-        count = this.allDatasets.filter(ds => ds.status === 'QUEUED').length
-      }
-      if (stage === 'started') {
-        count = this.allDatasets.filter(ds => ds.status === 'ANNOTATING').length
-      }
-      if (stage === 'finished') {
-        const inOtherLists = this.allDatasets.filter(ds => ds.status === 'FINISHED').length
-           - (this.finished && this.finished.length || 0)
-        count = this.finishedCount == null ? null : this.finishedCount + inOtherLists
-      }
+     count(stage) {
+       let count = null;
+       if (this.allDatasets != null) {
+         // assume not too many items are failed/queued/annotating so they are all visible in the web app,
+         // but check all lists because they may be in the wrong list due to status updates after they were loaded
+         if (stage === 'failed')
+           count = this.allDatasets.filter(ds => ds.status === 'FAILED').length;
+         if (stage === 'queued')
+           count = this.allDatasets.filter(ds => ds.status === 'QUEUED').length;
+         if (stage === 'started')
+           count = this.allDatasets.filter(ds => ds.status === 'ANNOTATING').length;
+         if (stage === 'finished') {
+           const inOtherLists = this.allDatasets.filter(ds => ds.status === 'FINISHED').length
+             - (this.finished && this.finished.length || 0);
+           count = this.finishedCount == null ? null : this.finishedCount + inOtherLists;
+         }
+       }
 
       return count != null && !isNaN(count) ? `(${count})` : ''
     },
@@ -308,7 +299,7 @@ export default {
       this.isExporting = true
       const self = this
 
-      const v = this.queryVariables('FINISHED')
+      const v = {...this.queryVariables, status:'FINISHED'}
       const chunks = []
       let offset = 0
 

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -18,6 +18,7 @@ exports[`DatasetTable should match snapshot 1`] = `
       <mock-el-option value="project" label="Select project"></mock-el-option>
       <mock-el-option value="submitter" label="Select submitter"></mock-el-option>
       <mock-el-option value="datasetIds" label="Select dataset"></mock-el-option>
+      <mock-el-option value="compoundName" label="Search molecule"></mock-el-option>
       <mock-el-option value="polarity" label="Select polarity"></mock-el-option>
       <mock-el-option value="organism" label="Select organism"></mock-el-option>
       <mock-el-option value="organismPart" label="Select organism part"></mock-el-option>
@@ -33,12 +34,12 @@ exports[`DatasetTable should match snapshot 1`] = `
   <div>
     <form class="el-form el-form--inline" id="dataset-list-header">
       <div role="radiogroup" class="el-radio-group"><label role="radio" aria-checked="true" tabindex="0" class="el-radio-button el-radio-button--small is-active"><input type="radio" tabindex="-1" class="el-radio-button__orig-radio" value="List"><span class="el-radio-button__inner">List</span></label> <label role="radio" tabindex="-1" class="el-radio-button el-radio-button--small"><input type="radio" tabindex="-1" class="el-radio-button__orig-radio" value="Summary"><span class="el-radio-button__inner">Summary</span></label></div>
-      <div role="group" aria-label="checkbox-group" class="el-checkbox-group dataset-status-checkboxes"><label class="el-checkbox cb-started is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="started"></span><span class="el-checkbox__label">
+      <div role="group" aria-label="checkbox-group" class="el-checkbox-group dataset-status-checkboxes" mock-v-loading="0"><label class="el-checkbox cb-annotating is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="ANNOTATING"></span><span class="el-checkbox__label">
           Processing (1)
-        <!----></span></label> <label class="el-checkbox cb-queued is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="queued"></span><span class="el-checkbox__label">
-          Queued (1)
-        <!----></span></label> <label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="finished"></span><span class="el-checkbox__label">
-          Finished (1)
+        <!----></span></label> <label class="el-checkbox cb-queued is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="QUEUED"></span><span class="el-checkbox__label">
+          Queued (2)
+        <!----></span></label> <label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="FINISHED"></span><span class="el-checkbox__label">
+          Finished (20)
         <!----></span></label>
         <!---->
       </div>
@@ -49,7 +50,7 @@ exports[`DatasetTable should match snapshot 1`] = `
       </span></button>
     </form>
   </div>
-  <div class="dataset-list allow-double-column">
+  <div class="dataset-list allow-double-column" mock-v-loading="0">
     <div class="dataset-item">
       <mock-el-dialog title="Provided metadata">
         <div class="el-row">
@@ -57,21 +58,21 @@ exports[`DatasetTable should match snapshot 1`] = `
         </div>
       </mock-el-dialog>
       <div class="opt-image--container">
-        <div class="thumb"><img src="allDatasets.0.thumbnailOpticalImageUrl" alt="Optical image" class="thumb--img" style="transform: scaleY(1) translateY(0%); height: 100px;"> <img src="allDatasets.0.ionThumbnailUrl" alt="Ion image thumbnail" class="thumb--img thumb--img__ion" style="transform: scaleY(1) translateY(0%); height: 100px;">
+        <div class="thumb"><img src="allDatasets.1.thumbnailOpticalImageUrl" alt="Optical image" class="thumb--img" style="transform: scaleY(1) translateY(0%); height: 100px;"> <img src="allDatasets.1.ionThumbnailUrl" alt="Ion image thumbnail" class="thumb--img thumb--img__ion" style="transform: scaleY(1) translateY(0%); height: 100px;">
           <!---->
         </div>
       </div>
       <div class="ds-info">
-        <div class="ds-item-line"><b title="allDatasets.0.name">allDatasets.0.name</b></div>
+        <div class="ds-item-line"><b title="allDatasets.1.name">allDatasets.1.name</b></div>
         <div class="ds-item-line" style="color: darkblue;"><span title="Filter by species" class="ds-add-filter">
-          allDatasets.0.organism</span>,
+          allDatasets.1.organism</span>,
           <span title="Filter by organism part" class="ds-add-filter">
-          alldatasets.0.organismpart</span> <span title="Filter by condition" class="ds-add-filter">
-          (alldatasets.0.condition)</span></div>
+          alldatasets.1.organismpart</span> <span title="Filter by condition" class="ds-add-filter">
+          (alldatasets.1.condition)</span></div>
         <div class="ds-item-line"><span title="Filter by ionisation source" class="ds-add-filter">
-          allDatasets.0.ionisationSource</span> +
+          allDatasets.1.ionisationSource</span> +
           <span title="Filter by analyzer type" class="ds-add-filter">
-          allDatasets.0.analyzer.type</span>,
+          allDatasets.1.analyzer.type</span>,
           <span title="Filter by polarity" class="ds-add-filter">
           positive mode</span>,
           RP 123k @ 1234
@@ -80,9 +81,9 @@ exports[`DatasetTable should match snapshot 1`] = `
           Submitted <span class="s-bold">????-??-??</span>
           at ??:?? by
           <span title="Filter by submitter" class="ds-add-filter">
-          allDatasets.0.submitter.name</span><span>,
+          allDatasets.1.submitter.name</span><span>,
           <mock-el-dropdown show-timeout="50" placement="bottom" trigger="hover"><div slot-key="default"><span class="s-group ds-add-filter">
-              allDatasets.0.group.shortName
+              allDatasets.1.group.shortName
             </span> </div>
         <div slot-key="dropdown">
           <mock-el-dropdown-menu>
@@ -95,12 +96,19 @@ exports[`DatasetTable should match snapshot 1`] = `
       <!---->
     </div>
     <div class="ds-actions">
-      <!----> <span><div title="Processing is under way" class="striped-progressbar processing"></div></span>
-      <!----> <i class="el-icon-view"></i> <a class="metadata-link">Show full metadata</a>
+      <!---->
+      <!----> <span><div title="Waiting in the queue" class="striped-progressbar queued"></div></span> <i class="el-icon-view"></i> <a class="metadata-link">Show full metadata</a>
       <!---->
       <!---->
       <!---->
-      <!---->
+      <mock-el-popover trigger="hover" placement="top">
+        <div slot-key="default">
+          <div mock-v-loading="true">
+
+          </div>
+        </div>
+        <div slot-key="reference"><img src="../../../assets/padlock-icon.svg" class="ds-item-private-icon"></div>
+      </mock-el-popover>
     </div>
   </div>
   <div class="dataset-item odd">
@@ -148,8 +156,8 @@ exports[`DatasetTable should match snapshot 1`] = `
     <!---->
   </div>
   <div class="ds-actions">
-    <!---->
-    <!----> <span><div title="Waiting in the queue" class="striped-progressbar queued"></div></span> <i class="el-icon-view"></i> <a class="metadata-link">Show full metadata</a>
+    <!----> <span><div title="Processing is under way" class="striped-progressbar processing"></div></span>
+    <!----> <i class="el-icon-view"></i> <a class="metadata-link">Show full metadata</a>
     <!---->
     <!---->
     <!---->
@@ -163,21 +171,21 @@ exports[`DatasetTable should match snapshot 1`] = `
     </div>
   </mock-el-dialog>
   <div class="opt-image--container">
-    <div class="thumb"><img src="allDatasets.0.thumbnailOpticalImageUrl" alt="Optical image" class="thumb--img" style="transform: scaleY(1) translateY(0%); height: 100px;"> <img src="allDatasets.0.ionThumbnailUrl" alt="Ion image thumbnail" class="thumb--img thumb--img__ion" style="transform: scaleY(1) translateY(0%); height: 100px;">
+    <div class="thumb"><img src="allDatasets.2.thumbnailOpticalImageUrl" alt="Optical image" class="thumb--img" style="transform: scaleY(1) translateY(0%); height: 100px;"> <img src="allDatasets.2.ionThumbnailUrl" alt="Ion image thumbnail" class="thumb--img thumb--img__ion" style="transform: scaleY(1) translateY(0%); height: 100px;">
       <!---->
     </div>
   </div>
   <div class="ds-info">
-    <div class="ds-item-line"><b title="allDatasets.0.name">allDatasets.0.name</b></div>
+    <div class="ds-item-line"><b title="allDatasets.2.name">allDatasets.2.name</b></div>
     <div class="ds-item-line" style="color: darkblue;"><span title="Filter by species" class="ds-add-filter">
-          allDatasets.0.organism</span>,
+          allDatasets.2.organism</span>,
       <span title="Filter by organism part" class="ds-add-filter">
-          alldatasets.0.organismpart</span> <span title="Filter by condition" class="ds-add-filter">
-          (alldatasets.0.condition)</span></div>
+          alldatasets.2.organismpart</span> <span title="Filter by condition" class="ds-add-filter">
+          (alldatasets.2.condition)</span></div>
     <div class="ds-item-line"><span title="Filter by ionisation source" class="ds-add-filter">
-          allDatasets.0.ionisationSource</span> +
+          allDatasets.2.ionisationSource</span> +
       <span title="Filter by analyzer type" class="ds-add-filter">
-          allDatasets.0.analyzer.type</span>,
+          allDatasets.2.analyzer.type</span>,
       <span title="Filter by polarity" class="ds-add-filter">
           positive mode</span>,
       RP 123k @ 1234
@@ -186,9 +194,9 @@ exports[`DatasetTable should match snapshot 1`] = `
       Submitted <span class="s-bold">????-??-??</span>
       at ??:?? by
       <span title="Filter by submitter" class="ds-add-filter">
-          allDatasets.0.submitter.name</span><span>,
+          allDatasets.2.submitter.name</span><span>,
           <mock-el-dropdown show-timeout="50" placement="bottom" trigger="hover"><div slot-key="default"><span class="s-group ds-add-filter">
-              allDatasets.0.group.shortName
+              allDatasets.2.group.shortName
             </span> </div>
     <div slot-key="dropdown">
       <mock-el-dropdown-menu>
@@ -198,17 +206,17 @@ exports[`DatasetTable should match snapshot 1`] = `
     </div>
     </mock-el-dropdown></span>
   </div>
-  <div class="ds-item-line"><span><a href="/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">20 annotations</a>
+  <div class="ds-item-line"><span><a href="/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.2.metadataType" class="">20 annotations</a>
           @ FDR 10% (HMDB-v2.5)
         </span></div>
 </div>
 <div class="ds-actions"><span><i class="el-icon-picture"></i> <mock-el-popover trigger="hover" placement="top"><div slot-key="default"><div class="db-link-list">
             Select a database:
-            <div><a href="/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
+            <div><a href="/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.2.metadataType" class="">
                 HMDB-v2.5
-              </a></div><div><a href="/annotations?db=HMDB-v4&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
+              </a></div><div><a href="/annotations?db=HMDB-v4&amp;ds=FINISHED1&amp;mdtype=allDatasets.2.metadataType" class="">
                 HMDB-v4
-              </a></div><div><a href="/annotations?db=CHEBI&amp;ds=FINISHED1&amp;mdtype=allDatasets.0.metadataType" class="">
+              </a></div><div><a href="/annotations?db=CHEBI&amp;ds=FINISHED1&amp;mdtype=allDatasets.2.metadataType" class="">
                 CHEBI
               </a></div></div> </div><div slot-key="reference"><a>Browse annotations</a></div></mock-el-popover> <br></span>
   <!---->

--- a/metaspace/webapp/src/modules/Datasets/summary/MSSetupSummaryPlot.vue
+++ b/metaspace/webapp/src/modules/Datasets/summary/MSSetupSummaryPlot.vue
@@ -20,7 +20,6 @@ function matrixName(matrix) {
   if (matrix !== OTHER_MATRIX) {
     const match = matrix.replace('_', ' ').match(/\(([A-Z0-9]{2,10})\)/i)
     if (match) {
-      console.log(`${matrix} => ${match[1]}`)
       return match[1]
     }
   }
@@ -238,25 +237,6 @@ export default {
       elem.selectAll('*').remove()
       const svg = configureSvg(elem, geometry)
 
-      // const xData =
-      //   d3.nest().key(d => d.sourceType + '@@' + d.source)
-      //     .entries(this.data)
-      //     .map(({ key, values }) => ({
-      //       key: key.split('@@')[1],
-      //       sourceType: key.split('@@')[0],
-      //       count: values.map(d => d.totalCount).reduce((x, y) => x + y),
-      //     }))
-      //     .sort((a, b) => {
-      //       if (a.sourceType !== b.sourceType && !(isMaldi(a.sourceType) && isMaldi(b.sourceType))) {
-      //         if (isMaldi(a.sourceType)) {
-      //           return 1
-      //         }
-      //         if (isMaldi(b.sourceType)) {
-      //           return -1
-      //         }
-      //       }
-      //       return b.count - a.count
-      //     })
       let xData = map(groupBy(this.data, d => d.isMaldi + '@@' + d.sourceType), (items) => ({
         key: items[0].sourceType,
         count: sumBy(items, 'totalCount'),
@@ -270,8 +250,6 @@ export default {
         isOther: analyzer === OTHER_ANALYZER,
       }))
       yData = orderBy(yData, ['isOther', 'count'], ['desc', 'desc'])
-
-      console.log({ xData, yData })
 
       const { scales } = pieScatterPlot(svg, this.data, config, xData, yData)
 

--- a/metaspace/webapp/src/modules/Datasets/summary/OrganismSummaryPlot.vue
+++ b/metaspace/webapp/src/modules/Datasets/summary/OrganismSummaryPlot.vue
@@ -25,7 +25,7 @@ const query =
       }
   }`
 
-const OTHER = '(Other)'
+const OTHER = '(other)'
 
 const geometry = {
   margin: {

--- a/metaspace/webapp/src/modules/Datasets/summary/SubmitterSummaryPlot.vue
+++ b/metaspace/webapp/src/modules/Datasets/summary/SubmitterSummaryPlot.vue
@@ -7,6 +7,7 @@
 <script>
 
 import { configureSvg, addMainTitle } from './utils'
+import { sortBy } from 'lodash-es'
 import * as d3 from 'd3'
 import gql from 'graphql-tag'
 
@@ -68,7 +69,7 @@ export default {
         return []
       }
 
-      const result = []
+      let result = []
 
       const OTHER = '(Other)'
       const submitters = {}
@@ -110,8 +111,10 @@ export default {
         numDatasets: numDatasets[OTHER],
         numSubmitters: numSubmitters[OTHER],
       })
-
-      result.sort((a, b) => b.numDatasets - a.numDatasets)
+      result = sortBy(result,
+        a => a.lab === OTHER,
+        a => -a.numDatasets,
+      )
       return result.filter(a => a.numDatasets > 0)
     },
   },

--- a/metaspace/webapp/src/modules/Filters/filter-components/InputFilter.vue
+++ b/metaspace/webapp/src/modules/Filters/filter-components/InputFilter.vue
@@ -20,7 +20,8 @@
 
 <script lang="ts">
 import TagFilterInputBox from './TagFilterInputBox.vue'
-import Vue, { ComponentOptions } from 'vue'
+import Vue from 'vue'
+import { debounce } from 'lodash-es'
 
  interface InputFilter extends Vue {
    name: string
@@ -32,8 +33,8 @@ import Vue, { ComponentOptions } from 'vue'
    destroy(): void
  }
 
-export default {
-  name: 'input-filter',
+export default Vue.extend({
+  name: 'InputFilter',
   components: {
     'tf-input-box': TagFilterInputBox,
   },
@@ -42,9 +43,15 @@ export default {
     value: [String, Number],
     removable: { type: Boolean, default: true },
     mode: { type: String, default: 'text' },
+    debounce: Boolean,
+  },
+  created() {
+    if (this.debounce) {
+      this.onChange = debounce(this.onChange, 500)
+    }
   },
   methods: {
-    onChange(val) {
+    onChange(val: any) {
       this.$emit('input', val)
       this.$emit('change', val)
     },
@@ -52,5 +59,5 @@ export default {
       this.$emit('destroy', this.name)
     },
   },
-} as ComponentOptions<InputFilter>
+})
 </script>

--- a/metaspace/webapp/src/modules/Filters/filterSpecs.ts
+++ b/metaspace/webapp/src/modules/Filters/filterSpecs.ts
@@ -97,7 +97,7 @@ export const FILTER_SPECIFICATIONS: Record<FilterKey, FilterSpecification> = {
     type: SingleSelectFilter,
     name: 'Database',
     description: 'Select database',
-    levels: ['annotation', 'dataset'],
+    levels: ['annotation'],
     defaultInLevels: ['annotation'],
     initialValue: lists => lists.molecularDatabases
       .filter(d => d.default)

--- a/metaspace/webapp/src/modules/Filters/filterSpecs.ts
+++ b/metaspace/webapp/src/modules/Filters/filterSpecs.ts
@@ -128,7 +128,7 @@ export const FILTER_SPECIFICATIONS: Record<FilterKey, FilterSpecification> = {
     type: InputFilter,
     name: 'Molecule',
     description: 'Search molecule',
-    levels: ['annotation'], // ['dataset', 'annotation'],
+    levels: ['dataset', 'annotation'],
     initialValue: undefined,
   },
 

--- a/metaspace/webapp/src/modules/Filters/filterSpecs.ts
+++ b/metaspace/webapp/src/modules/Filters/filterSpecs.ts
@@ -67,6 +67,7 @@ export interface FilterSpecification {
   filterable?: boolean;
   multiple?: boolean;
   hidden?: boolean | (() => boolean);
+  debounce?: boolean;
   /** How to encode/decode this filter from the URL */
   encoding?: 'list' | 'json' | 'bool' | 'number';
   /** Callback to format options for display. "options" parameter may be an empty array while the page is loading */
@@ -88,6 +89,7 @@ export const FILTER_COMPONENT_PROPS: (keyof FilterSpecification)[] = [
   'name', 'helpComponent',
   'removable', 'filterable', 'multiple',
   'optionFormatter', 'valueGetter',
+  'debounce',
 ]
 
 export const FILTER_SPECIFICATIONS: Record<FilterKey, FilterSpecification> = {
@@ -95,7 +97,7 @@ export const FILTER_SPECIFICATIONS: Record<FilterKey, FilterSpecification> = {
     type: SingleSelectFilter,
     name: 'Database',
     description: 'Select database',
-    levels: ['annotation'],
+    levels: ['annotation', 'dataset'],
     defaultInLevels: ['annotation'],
     initialValue: lists => lists.molecularDatabases
       .filter(d => d.default)
@@ -130,6 +132,7 @@ export const FILTER_SPECIFICATIONS: Record<FilterKey, FilterSpecification> = {
     description: 'Search molecule',
     levels: ['dataset', 'annotation'],
     initialValue: undefined,
+    debounce: true,
   },
 
   chemMod: {

--- a/metaspace/webapp/vue.config.js
+++ b/metaspace/webapp/vue.config.js
@@ -25,6 +25,10 @@ module.exports = {
           whitespace: 'preserve',
         }
       }))
+
+    config.module.rule('eslint').use('eslint-loader').options({
+      fix: true
+    })
   },
 
   configureWebpack: (config) => {
@@ -62,4 +66,5 @@ module.exports = {
       lintGQL: true,
     },
   },
+  lintOnSave: 'warning'
 }

--- a/metaspace/webapp/vue.config.js
+++ b/metaspace/webapp/vue.config.js
@@ -25,10 +25,6 @@ module.exports = {
           whitespace: 'preserve',
         }
       }))
-
-    config.module.rule('eslint').use('eslint-loader').options({
-      fix: true
-    })
   },
 
   configureWebpack: (config) => {


### PR DESCRIPTION
Resolves #432 

This is a collection of tweaks around the datasets list to improve performance/UX. The biggest cause of performance problems with the "datasets containing molecule" filter was that typing into the filter box would trigger ~6 graphql requests per keystroke, each taking about 400ms. These would queue up, meaning it would sometimes take 5+ seconds for the datasets list to update. During this time there was no indicator that anything was happening.

Changes:

* Consolidate the API calls into a single pair of `allDatasets` and `countDatasetsPerGroup` calls instead of having a call to `allDatasets` and `countDatasets` with filters for each of the 3/4 visible statuses.
    * In order to replicate the original status-based ordering, I've added a new column to the database: `Dataset.status_update_dt` - the datetime of the last status update for the dataset.
* Debounce & throttle filter changes so that requests are less likely to stack up
* Add a loading spinner to the datasets list
* Tidy up the summary plots, mainly the one for instrument types & MALDI matrices so that it can be used for checking "which instruments/matrices can detect this molecule".
* Change the structure of the ElasticSearch aggregation query so that it wouldn't limit itself to 10 results