### PR TITLE
Add median-thresholded colocalization algorithm

### DIFF
--- a/metaspace/engine/scripts/run_colocalization.py
+++ b/metaspace/engine/scripts/run_colocalization.py
@@ -98,7 +98,7 @@ def run_coloc_jobs(sm_config, ds_id_str, sql_where, fix_missing, fix_corrupt, sk
         ]
         mol_db_ids, mol_db_names = map(list, zip(*mol_dbs))
         fdrs = [0.05, 0.1, 0.2, 0.5]
-        algorithms = ['cosine', 'pca_cosine', 'pca_pearson', 'pca_spearman']
+        algorithms = ['median_thresholded_cosine', 'cosine']
 
         if fix_missing:
             logger.info('Checking for missing colocalization jobs...')
@@ -166,7 +166,7 @@ if __name__ == '__main__':
         args.config,
         partial(
             run_coloc_jobs,
-            ds_id=args.ds_id,
+            ds_id_str=args.ds_id,
             sql_where=args.sql_where,
             fix_missing=args.fix_missing,
             fix_corrupt=args.fix_corrupt,

--- a/metaspace/engine/sm/engine/colocalization.py
+++ b/metaspace/engine/sm/engine/colocalization.py
@@ -5,7 +5,7 @@ from traceback import format_exc
 import numpy as np
 from sklearn.metrics.pairwise import pairwise_kernels
 from sklearn.cluster import spectral_clustering
-from scipy.ndimage import zoom
+from scipy.ndimage import zoom, median_filter
 
 from sm.engine.dataset import Dataset
 from sm.engine.ion_mapping import get_ion_id_mapping
@@ -208,8 +208,15 @@ def _downscale_image_if_required(img, num_annotations):
         return zoom(img, zoom_factor)
 
 
+def _median_thresholded_cosine(images, h, w):
+    cnt = images.shape[0]
+    images[images < np.quantile(images, 0.5, axis=1, keepdims=True)] = 0
+    images = median_filter(images.reshape((cnt, h, w)), (1, 3, 3)).reshape((cnt, h * w))
+    return pairwise_kernels(images, metric='cosine')
+
+
 # pylint: disable=cell-var-from-loop
-def analyze_colocalization(ds_id, mol_db, images, ion_ids, fdrs, cluster_max_images=5000):
+def analyze_colocalization(ds_id, mol_db, images, ion_ids, fdrs, h, w, cluster_max_images=5000):
     """ Calculate co-localization of ion images for all algorithms and yield results
 
     Args
@@ -240,6 +247,7 @@ def analyze_colocalization(ds_id, mol_db, images, ion_ids, fdrs, cluster_max_ima
 
     logger.debug('Calculating colocalization metrics')
     cos_scores = pairwise_kernels(images.ref, metric='cosine')
+    med_cos_scores = _median_thresholded_cosine(images.ref, h, w)
     images.free()
 
     trunc_ion_ids = ion_ids[:cluster_max_images]
@@ -300,7 +308,8 @@ def analyze_colocalization(ds_id, mol_db, images, ion_ids, fdrs, cluster_max_ima
                     coloc_annotations=coloc_annotations,
                 )
 
-            yield run_alg('cosine', cos_scores, True)
+            yield run_alg('median_thresholded_cosine', med_cos_scores, True)
+            yield run_alg('cosine', cos_scores, False)
         else:
             logger.debug(
                 f'Skipping FDR {fdr} as there are only {len(masked_ion_ids)} annotation(s)'
@@ -335,13 +344,13 @@ class Colocalization:
         annotations = [(job_id, *ann) for ann in job.coloc_annotations]
         self._db.insert(COLOC_ANN_INS, annotations)
 
-    def _analyze_and_save(self, ds_id, mol_db, images, ion_ids, fdrs):
+    def _analyze_and_save(self, ds_id, mol_db, images, ion_ids, fdrs, h, w):
         try:
             # Clear old jobs from DB
             self._db.alter(COLOC_JOB_DEL, [ds_id, mol_db])
 
             if len(ion_ids) > 2:
-                for job in analyze_colocalization(ds_id, mol_db, images, ion_ids, fdrs):
+                for job in analyze_colocalization(ds_id, mol_db, images, ion_ids, fdrs, h, w):
                     self._save_job_to_db(job)
             else:
                 # Technically `len(ion_ids) == 2` is enough,
@@ -376,10 +385,11 @@ class Colocalization:
             )
         else:
             images = np.zeros((0, 0), dtype=np.float32)
+            h, w = 1, 1
             ion_ids = np.zeros((0,), dtype=np.int64)
             fdrs = np.zeros((0,), dtype=np.float32)
 
-        return FreeableRef(images), ion_ids, fdrs
+        return FreeableRef(images), ion_ids, fdrs, h, w
 
     def run_coloc_job(self, ds_id, reprocess=False):
         """ Analyze colocalization for a previously annotated dataset,
@@ -399,9 +409,9 @@ class Colocalization:
         for mol_db_name in mol_dbs:
             if reprocess or mol_db_name not in existing_mol_dbs:
                 logger.info(f'Running colocalization job for {ds_id} on {mol_db_name}')
-                images, ion_ids, fdrs = self._get_existing_ds_annotations(
+                images, ion_ids, fdrs, h, w = self._get_existing_ds_annotations(
                     ds_id, mol_db_name, image_storage_type, charge
                 )
-                self._analyze_and_save(ds_id, mol_db_name, images, ion_ids, fdrs)
+                self._analyze_and_save(ds_id, mol_db_name, images, ion_ids, fdrs, h, w)
             else:
                 logger.info(f'Skipping colocalization job for {ds_id} on {mol_db_name}')

--- a/metaspace/engine/tests/test_colocalization.py
+++ b/metaspace/engine/tests/test_colocalization.py
@@ -18,7 +18,7 @@ def test_valid_colocalization_jobs_generated():
     ion_ids = np.array(range(20)) * 4
     fdrs = np.array([[0.05, 0.1, 0.2, 0.5][i % 4] for i in range(20)])
 
-    jobs = list(analyze_colocalization('ds_id', 'HMDB_v4', ion_images, ion_ids, fdrs))
+    jobs = list(analyze_colocalization('ds_id', 'HMDB_v4', ion_images, ion_ids, fdrs, 5, 10))
 
     assert len(jobs) > 1
     assert not any(job.error for job in jobs)

--- a/metaspace/graphql/config/default.js
+++ b/metaspace/graphql/config/default.js
@@ -128,11 +128,9 @@ module.exports = {
 
   metadataLookups: {
     colocalizationAlgos: [
+      ['median_thresholded_cosine', 'Median-thresholded cosine distance'],
       ['cosine', 'Cosine distance'],
-      ['pca_cosine', 'PCA + Cosine distance'],
-      ['pca_pearson', 'PCA + Pearson correlation'],
-      ['pca_spearman', 'PCA + Spearman correlation'],
     ],
-    defaultColocalizationAlgo: 'cosine',
+    defaultColocalizationAlgo: 'median_thresholded_cosine',
   },
 };

--- a/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
+++ b/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
@@ -164,7 +164,7 @@ const Annotation: FieldResolversFor<Annotation, ESAnnotation | ESAnnotationWithC
     // Actual implementation is in src/modules/annotation/queryFilters.ts
     if ('getColocalizationCoeff' in hit && args.colocalizationCoeffFilter != null) {
       const {colocalizedWith, colocalizationAlgo, database, fdrLevel} = args.colocalizationCoeffFilter;
-      return await hit.getColocalizationCoeff(colocalizedWith, colocalizationAlgo || 'cosine',
+      return await hit.getColocalizationCoeff(colocalizedWith, colocalizationAlgo || config.metadataLookups.defaultColocalizationAlgo,
         database || config.defaults.moldb_names[0], fdrLevel);
     } else {
       return null;

--- a/metaspace/webapp/.eslintrc.js
+++ b/metaspace/webapp/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
   'rules': {
     'vue/require-default-prop': ['off'], // Will props even be relevant if we shift to the Composition API?
     'vue/require-prop-types': ['off'], // Will props even be relevant if we shift to the Composition API?
+    'vue/html-self-closing': ['off'], // Unnecessarily forces template style to differ from TSX
     'vue/no-v-html': ['off'],
     'no-mixed-operators': ['off'], // TODO?
 

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.vue
@@ -143,6 +143,7 @@
                 @click.stop=""
               >
                 <i
+                  id="colocalization-settings-icon"
                   class="el-icon-setting"
                   style="font-size: 20px; vertical-align: middle;"
                 />

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/ColocalizationSettings.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/ColocalizationSettings.vue
@@ -1,6 +1,6 @@
 <template>
   <span id="colocalization-settings">
-    <el-form>
+    <el-form label-position="top">
       <el-form-item>
         <span slot="label">
           Colocalization algorithm
@@ -10,16 +10,18 @@
           >
             <div style="max-width: 500px;">
               <p>
-                <u>Median-thresholded cosine distance</u> is the best choice for exploring most biological datasets.
-                It was found to outperform other traditional co-localization measures when compared
-                to expert rankings of imaging-MS images.
-                Its description and evaluation can be found in:
+                <b>Median-thresholded cosine distance</b> is the best choice for exploring most biological datasets.
+                It was found to outperform other traditional colocalization measures when compared
+                to expert rankings of imaging mass spectrometry ion images. <br/>
+                Its description and evaluation can be found in: <a href="https://doi.org/10.1101/758425">
+                ColocAI: artificial intelligence approach to quantify colocalization between mass spectrometry images,
+                Ovchinnikova et al.</a>
               </p>
               <p>
-                <a href="https://doi.org/10.1101/758425">ColocAI: artificial intelligence approach to quantify co-localization between mass spectrometry images</a>, Ovchinnikova <i>et al.</i>
+
               </p>
               <p>
-                <u>Cosine distance</u> was previously used as the default colocalization measure.  It has been
+                <b>Cosine distance</b> was previously used as the default colocalization measure.  It has been
                 preserved so that historical data remains consistent, and is comparable against new datasets.
               </p>
             </div>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/ColocalizationSettings.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/ColocalizationSettings.vue
@@ -15,7 +15,7 @@
                 It was found to highly reproduce expert rankings of mass spectrometry ion images
                 and performed better than other traditional colocalization measures. <br/>
                 Its description and evaluation can be found in:
-                <a href=“https://doi.org/10.1093/bioinformatics/btaa085”>Ovchinnikova et al. (2020) ColocML</a>.
+                <a href="https://doi.org/10.1093/bioinformatics/btaa085">Ovchinnikova et al. (2020) ColocML</a>.
               </p>
               <p>
 

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/ColocalizationSettings.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/ColocalizationSettings.vue
@@ -13,15 +13,12 @@
                 The <b>median-thresholded cosine distance</b> algorithm is the best choice for
                 exploring most datasets in METASPACE.
                 It was found to highly reproduce expert rankings of mass spectrometry ion images
-                and performed better than other traditional colocalization measures. <br/>
+                and performed better than other traditional colocalization measures. <br />
                 Its description and evaluation can be found in:
-                <a href="https://doi.org/10.1093/bioinformatics/btaa085">Ovchinnikova et al. (2020) ColocML</a>.
-              </p>
-              <p>
-
-              </p>
-              <p>
-
+                <a
+                  href="https://doi.org/10.1093/bioinformatics/btaa085"
+                  target="blank"
+                >Ovchinnikova et al. (2020) ColocML</a>.
               </p>
               <p>
                 The <b>cosine distance</b> was previously used as the default colocalization measure.

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/ColocalizationSettings.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/ColocalizationSettings.vue
@@ -8,21 +8,24 @@
             trigger="hover"
             placement="top"
           >
-            <div style="max-width: 500px;">
+            <div style="max-width: 550px;">
               <p>
-                <b>Median-thresholded cosine distance</b> is the best choice for exploring most biological datasets.
-                It was found to outperform other traditional colocalization measures when compared
-                to expert rankings of imaging mass spectrometry ion images. <br/>
-                Its description and evaluation can be found in: <a href="https://doi.org/10.1101/758425">
-                ColocAI: artificial intelligence approach to quantify colocalization between mass spectrometry images,
-                Ovchinnikova et al.</a>
+                The <b>median-thresholded cosine distance</b> algorithm is the best choice for
+                exploring most datasets in METASPACE.
+                It was found to highly reproduce expert rankings of mass spectrometry ion images
+                and performed better than other traditional colocalization measures. <br/>
+                Its description and evaluation can be found in:
+                <a href=“https://doi.org/10.1093/bioinformatics/btaa085”>Ovchinnikova et al. (2020) ColocML</a>.
               </p>
               <p>
 
               </p>
               <p>
-                <b>Cosine distance</b> was previously used as the default colocalization measure.  It has been
-                preserved so that historical data remains consistent, and is comparable against new datasets.
+
+              </p>
+              <p>
+                The <b>cosine distance</b> was previously used as the default colocalization measure.
+                It is still available and can be selected from the list.
               </p>
             </div>
             <i
@@ -52,7 +55,6 @@
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
 import { colocalizationAlgosQuery } from '../../../api/metadata'
-import { omit } from 'lodash-es'
 
  interface ColocalizationAlgoOption {
    id: string;

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/ColocalizationSettings.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/ColocalizationSettings.vue
@@ -1,11 +1,38 @@
 <template>
-  <span id="ion-image-settings">
+  <span id="colocalization-settings">
     <el-form>
-      <el-form-item label="Colocalization Algorithm">
+      <el-form-item>
+        <span slot="label">
+          Colocalization algorithm
+          <el-popover
+            trigger="hover"
+            placement="top"
+          >
+            <div style="max-width: 500px;">
+              <p>
+                <u>Median-thresholded cosine distance</u> is the best choice for exploring most biological datasets.
+                It was found to outperform other traditional co-localization measures when compared
+                to expert rankings of imaging-MS images.
+                Its description and evaluation can be found in:
+              </p>
+              <p>
+                <a href="https://doi.org/10.1101/758425">ColocAI: artificial intelligence approach to quantify co-localization between mass spectrometry images</a>, Ovchinnikova <i>et al.</i>
+              </p>
+              <p>
+                <u>Cosine distance</u> was previously used as the default colocalization measure.  It has been
+                preserved so that historical data remains consistent, and is comparable against new datasets.
+              </p>
+            </div>
+            <i
+              slot="reference"
+              class="el-icon-question help-icon"
+            />
+          </el-popover>
+        </span>
         <el-select
           v-model="colocalizationAlgo"
           style="width: 300px;"
-          title="Colocalization Algorithm"
+          title="Colocalization algorithm"
         >
           <el-option
             v-for="{id, name} in colocalizationAlgoOptions"
@@ -58,13 +85,13 @@ export default class ColocalizationSettings extends Vue {
 </script>
 
 <style>
- #ion-image-settings {
+ #colocalization-settings {
    display: inline-flex;
    flex-direction: column;
    justify-content: center;
  }
 
- #ion-image-settings > .el-select {
+ #colocalization-settings > .el-select {
    display: inline-flex;
  }
 </style>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/RelatedAnnotations.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/RelatedAnnotations.vue
@@ -79,7 +79,10 @@
       No annotations found.
     </p>
 
-    <div id="new-feature-popup-coloc" v-if="query === 'colocalized'" />
+    <div
+      v-if="query === 'colocalized'"
+      id="new-feature-popup-coloc"
+    />
   </div>
 </template>
 

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/RelatedAnnotations.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/RelatedAnnotations.vue
@@ -78,6 +78,8 @@
     >
       No annotations found.
     </p>
+
+    <div id="new-feature-popup-coloc" v-if="query === 'colocalized'" />
   </div>
 </template>
 

--- a/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
+++ b/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
@@ -86,6 +86,25 @@ The ion formulas of isomers and isobars are also available in the regular CSV ex
       return null
     },
   },
+  {
+    name: 'medianCosineColoc',
+    title: 'New Colocalization Algorithm',
+    contentHtml: `
+<p>METASPACE has an improved colocalization algorithm for ion images!</p>
+<p><b>Median-thresholded cosine distance</b> gives better results than plain cosine distance when compared to
+expert judgements. See <a href="https://doi.org/10.1101/758425">our paper</a> for more information.</p>
+<p>This new algorithm is now used by default for ranking colocalized annotations.
+If you wish to go back to the old behavior, <b>cosine distance</b> can be selected in this menu.</p>
+      `,
+    dontShowAfter: new Date('2020-05-30'),
+    placement: 'bottom',
+    getAnchorIfActive(vue: Vue) {
+      if (vue.$route.path === '/annotations' && document.querySelector('#new-feature-popup-coloc') != null) {
+        return document.querySelector('#colocalization-settings-icon')
+      }
+      return null
+    },
+  },
 ]
 
   @Component({})
@@ -196,7 +215,7 @@ export default class NewFeaturePopup extends Vue {
   .nf-container {
     background: $popper-background-color;
     color: black;
-    width: 400px;
+    width: 500px;
     padding: 10px;
     border-radius: 3px;
     margin: 5px;

--- a/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
+++ b/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
@@ -92,7 +92,7 @@ The ion formulas of isomers and isobars are also available in the regular CSV ex
     contentHtml: `
 <p>METASPACE has an improved colocalization algorithm for ion images!</p>
 <p>The <b>median-thresholded cosine distance</b> gives better results than the plain cosine distance when compared to
-expert judgements. See <a href=“https://doi.org/10.1093/bioinformatics/btaa085”>Ovchinnikova et al. (2020) ColocML</a>
+expert judgements. See <a href="https://doi.org/10.1093/bioinformatics/btaa085">Ovchinnikova et al. (2020) ColocML</a>
 for more information.</p>
 <p>This new algorithm is now used by default for ranking colocalized annotations.
 If you wish to go back to the old behavior, <b>cosine distance</b> can be selected in this menu.</p>

--- a/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
+++ b/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
@@ -92,7 +92,8 @@ The ion formulas of isomers and isobars are also available in the regular CSV ex
     contentHtml: `
 <p>METASPACE has an improved colocalization algorithm for ion images!</p>
 <p>The <b>median-thresholded cosine distance</b> gives better results than the plain cosine distance when compared to
-expert judgements. See <a href="https://doi.org/10.1093/bioinformatics/btaa085">Ovchinnikova et al. (2020) ColocML</a>
+expert judgements.
+See <a href="https://doi.org/10.1093/bioinformatics/btaa085" target="blank">Ovchinnikova et al. (2020) ColocML</a>
 for more information.</p>
 <p>This new algorithm is now used by default for ranking colocalized annotations.
 If you wish to go back to the old behavior, <b>cosine distance</b> can be selected in this menu.</p>

--- a/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
+++ b/metaspace/webapp/src/modules/App/NewFeaturePopup.vue
@@ -91,8 +91,9 @@ The ion formulas of isomers and isobars are also available in the regular CSV ex
     title: 'New Colocalization Algorithm',
     contentHtml: `
 <p>METASPACE has an improved colocalization algorithm for ion images!</p>
-<p><b>Median-thresholded cosine distance</b> gives better results than plain cosine distance when compared to
-expert judgements. See <a href="https://doi.org/10.1101/758425">our paper</a> for more information.</p>
+<p>The <b>median-thresholded cosine distance</b> gives better results than the plain cosine distance when compared to
+expert judgements. See <a href=“https://doi.org/10.1093/bioinformatics/btaa085”>Ovchinnikova et al. (2020) ColocML</a>
+for more information.</p>
 <p>This new algorithm is now used by default for ranking colocalized annotations.
 If you wish to go back to the old behavior, <b>cosine distance</b> can be selected in this menu.</p>
       `,
@@ -215,7 +216,7 @@ export default class NewFeaturePopup extends Vue {
   .nf-container {
     background: $popper-background-color;
     color: black;
-    width: 500px;
+    width: 450px;
     padding: 10px;
     border-radius: 3px;
     margin: 5px;

--- a/metaspace/webapp/src/store/getters.js
+++ b/metaspace/webapp/src/store/getters.js
@@ -34,7 +34,9 @@ export default {
       adduct: filter.adduct,
       fdrLevel: filter.fdrLevel,
       colocalizedWith: filter.colocalizedWith,
-      colocalizationAlgo,
+      // Only include colocalizationAlgo if there is another filter that uses it. Otherwise the annotations list
+      // refreshes unnecessarily when changing algorithm.
+      colocalizationAlgo: filter.colocalizedWith || filter.colocalizationSamples ? colocalizationAlgo : null,
       colocalizationSamples: filter.colocalizationSamples,
       offSample: filter.offSample == null ? undefined : !!filter.offSample,
     };


### PR DESCRIPTION
## Webapp side

#### New Feature popup
![image](https://user-images.githubusercontent.com/26366936/74917756-52722b80-53c8-11ea-8e95-4574abb80513.png)

> New Colocalization Algorithm
> METASPACE has an improved colocalization algorithm for ion images!
>
> The median-thresholded cosine distance gives better results than the plain cosine distance when compared to expert judgements. See [Ovchinnikova et al. (2020) ColocML](https://doi.org/10.1093/bioinformatics/btaa085) for more information.
> 
> This new algorithm is now used by default for ranking colocalized annotations. If you wish to go back to the old behavior, cosine distance can be selected in this menu.

#### Colocalization Algorithm popup

![image](https://user-images.githubusercontent.com/26366936/74919273-a2ea8880-53ca-11ea-9245-83ab80dc5cdc.png)


> The median-thresholded cosine distance algorithm is the best choice for exploring most datasets in METASPACE. It was found to highly reproduce expert rankings of mass spectrometry ion images and performed better than other traditional colocalization measures. 
> Its description and evaluation can be found in: [Ovchinnikova et al. (2020) ColocML.](https://academic.oup.com/bioinformatics/advance-article/doi/10.1093/bioinformatics/btaa085/5734647)
>
> The cosine distance was previously used as the default colocalization measure. It is still available and can be selected from the list.


## Python side
Please double-check that I've faithfully reproduced the reference implementation's "cosine" output: https://github.com/metaspace2020/coloc/blob/master/measures/NoLearning/ion_intensity_coloc_measures.ipynb

As far as I can tell `sklearn.metrics.pairwise.pairwise_kernels(metric='cosine')` is an acceptable substitute for `gensim.similarities.Similarity` as it generates virtually identical output. I used this script to confirm it:
```python
from sklearn.metrics.pairwise import pairwise_kernels
from gensim.similarities import Similarity
pixels = np.random.rand(1000, 1000)
pixels[pixels < 0.5] = 0 # Make them sparse, because if the two algorithms differed, it would most likely be in the way that sparse elements are handled
docs = [list(zip(px.nonzero()[0], px[px.nonzero()[0]])) for px in pixels]
scipy_result = pairwise_kernels(pixels, metric='cosine')
gensim_result = Similarity(None, docs, pixels.shape[0])[docs]
error = np.abs(scipy_result - gensim_result)
print(f'Max error: {np.max(error)}') # Output: Max error: 3.5762786954052217e-07
```

To minimize time/complexity, clustering is only done with the new algorithm, and the same results are saved for both algorithms. I checked the quality of the results - I think it was slightly improved, but that could just be the effects of a small sample size. 

This needs a two-step deployment - first deploy the sm-engine code, then run `do_colocalization` to recalculate it for all datasets, then do a second deployment with the graphql/ansible config updated to show the new algorithm. As before, I'll run `do_colocalization` on staging to minimize load on prod for the week or so that it takes.

Resolves #530 