### PR TITLE
Build webapp with lower CPU priority

### DIFF
--- a/ansible/roles/sm_web_app/tasks/main.yml
+++ b/ansible/roles/sm_web_app/tasks/main.yml
@@ -23,7 +23,7 @@
     executable: /bin/bash
 
 - name: Run build app
-  shell: yarn run build
+  shell: nice yarn run build
   args:
     chdir: "{{ sm_webapp_home }}"
     executable: /bin/bash


### PR DESCRIPTION
During today's deployment I found that graphql takes a very long time to start because it has to compete with webapp's multi-threaded build. This change should give graphql more CPU time so that it's not down for as long.