### PR TITLE
Fix "colocalizationCoeff" error on SMDataset.results()

### DIFF
--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,2 +1,2 @@
 name = 'metaspace2020'
-__version__ = '1.7.1'
+__version__ = '1.7.2'

--- a/metaspace/python-client/metaspace/tests/test_projects_client.py
+++ b/metaspace/python-client/metaspace/tests/test_projects_client.py
@@ -1,13 +1,6 @@
-from os import path
-from pathlib import Path
-
 import pytest
-from metaspace.sm_annotation_utils import SMInstance
 
-
-@pytest.fixture()
-def sm():
-    return SMInstance(config_path=path.join(path.dirname(__file__), '../../test_config'))
+from metaspace.tests.utils import sm
 
 
 def test_get_all_projects(sm):

--- a/metaspace/python-client/metaspace/tests/test_sm_dataset.py
+++ b/metaspace/python-client/metaspace/tests/test_sm_dataset.py
@@ -1,0 +1,64 @@
+import pytest
+import numpy as np
+
+from metaspace.sm_annotation_utils import IsotopeImages, SMDataset
+from metaspace.tests.utils import sm, my_ds_id
+
+
+EXPECTED_RESULTS_COLS = [
+    'msm',
+    'moc',
+    'rhoSpatial',
+    'rhoSpectral',
+    'fdr',
+    'mz',
+    'moleculeNames',
+    'moleculeIds',
+    'intensity',
+    'colocCoeff',
+]
+
+
+@pytest.fixture()
+def dataset(sm, my_ds_id):
+    return sm.dataset(id=my_ds_id)
+
+
+def test_annotations(dataset: SMDataset):
+    annotations = dataset.annotations()
+
+    assert len(annotations) > 0
+    assert len(annotations[0]) == 2  # sf, adduct tuple
+
+
+def test_results(dataset: SMDataset):
+    # Test normal config
+    annotations = dataset.results('HMDB-v4', fdr=0.5)
+
+    assert len(annotations) > 0
+    assert all(col in annotations.columns for col in EXPECTED_RESULTS_COLS)
+
+    # Test with colocalization
+    coloc_with = annotations.ion[0]
+    coloc_annotations = dataset.results('HMDB-v4', fdr=0.5, coloc_with=coloc_with)
+
+    assert len(coloc_annotations) > 0
+    assert coloc_annotations.colocCoeff.all()
+
+
+def test_isotope_images(dataset: SMDataset):
+    sf, adduct = dataset.annotations()[0]
+
+    images = dataset.isotope_images(sf, adduct)
+
+    assert len(images) > 1
+    assert isinstance(images[0], np.ndarray)
+
+
+def test_all_annotation_images(dataset: SMDataset):
+    image_list = dataset.all_annotation_images(only_first_isotope=True)
+
+    assert isinstance(image_list[0], IsotopeImages)
+    assert len(image_list) > 0
+    assert all(len(isotope_images) == 1 for isotope_images in image_list)
+    assert isinstance(image_list[0][0], np.ndarray)

--- a/metaspace/python-client/metaspace/tests/test_sm_instance.py
+++ b/metaspace/python-client/metaspace/tests/test_sm_instance.py
@@ -1,20 +1,5 @@
-from os import path
-from pathlib import Path
-
 import pytest
-from metaspace.sm_annotation_utils import SMInstance
-
-
-@pytest.fixture()
-def sm():
-    return SMInstance(config_path=path.join(path.dirname(__file__), '../../test_config'))
-
-
-@pytest.fixture()
-def my_ds_id(sm):
-    user_id = sm.current_user_id()
-    datasets = sm.get_metadata({'submitter': user_id})
-    return datasets.index[0]
+from metaspace.tests.utils import sm, my_ds_id
 
 
 def test_add_dataset_external_link(sm, my_ds_id):

--- a/metaspace/python-client/metaspace/tests/utils.py
+++ b/metaspace/python-client/metaspace/tests/utils.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import pytest
+
+from metaspace.sm_annotation_utils import SMInstance
+
+
+@pytest.fixture()
+def sm():
+    return SMInstance(config_path=(Path(__file__).parent / '../../test_config').resolve())
+
+
+@pytest.fixture()
+def my_ds_id(sm):
+    user_id = sm.current_user_id()
+    datasets = sm.get_metadata({'submitter': user_id, 'status': 'FINISHED'})
+    return datasets.index[0]


### PR DESCRIPTION
Resolves #524 

The issue was that `colocalizationCoeff` was only added to the queried fields in `GraphQLClient.getAnnotations` if there was a `colocFilter` supplied, but `SMDataset.results` would always try to read that `colocalizationCoeff` even when it was missing. I changed `GraphQLClient.getAnnotations` to always include the `colocalizationCoeff` field - it will just be `None` when no `colocFilter` is included.

Other changes:
* Refactor SMDataset.results dataframe to include any extra fields returned by GraphQLClient.getAnnotations, so that `ion` would be included, because it's used for `coloc_with` values
* Add tests for SMDataset class
* Consolidate common test fixtures