### PR TITLE
CircleCI fix & other tweaks

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,8 +15,12 @@ coverage:
         threshold: 0.2
         flags: engine
       webapp:
-        range: 40...100
-        threshold: 0.2
+        range: 45...100
+        threshold: 0.5
         flags: webapp
+      graphql:
+        range: 55...100
+        threshold: 0.5
+        flags: graphql
     patch: no
     changes: no

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,7 +15,7 @@ coverage:
         threshold: 0.2
         flags: engine
       webapp:
-        range: 45...100
+        range: 50...100
         threshold: 0.5
         flags: webapp
       graphql:

--- a/docker/nginx/config/sites-enabled/default
+++ b/docker/nginx/config/sites-enabled/default
@@ -45,36 +45,44 @@ server {
 #    }
 
     location /fs/iso_images/ {
-        proxy_pass http://sm-graphql:4201/fs/iso_images/;
+        set $graphql_storage sm-graphql:4201;
+        proxy_pass http://$graphql_storage$request_uri;
         limit_except GET {deny all;}
     }
     location /db/iso_images/ {
-        proxy_pass http://sm-graphql:4201/db/iso_images/;
+        set $graphql_storage sm-graphql:4201;
+        proxy_pass http://$graphql_storage$request_uri;
         limit_except GET {deny all;}
     }
     location /fs/optical_images/ {
-        proxy_pass http://sm-graphql:4201/fs/optical_images/;
+        set $graphql_storage sm-graphql:4201;
+        proxy_pass http://$graphql_storage$request_uri;
         limit_except GET {deny all;}
     }
     location /fs/raw_optical_images/ {
-        proxy_pass http://sm-graphql:4201/fs/raw_optical_images/;
+        set $graphql_storage sm-graphql:4201;
+        proxy_pass http://$graphql_storage$request_uri;
         client_max_body_size 50M;
     }
     location /fs/ion_thumbnails/ {
-        proxy_pass http://sm-graphql:4201/fs/ion_thumbnails/;
+        set $graphql_storage sm-graphql:4201;
+        proxy_pass http://$graphql_storage$request_uri;
         client_max_body_size 50M;
     }
     location /dataset_upload {
-        proxy_pass http://sm-graphql:4201/dataset_upload;
+        set $graphql_storage sm-graphql:4201;
+        proxy_pass http://$graphql_storage$request_uri;
         # include proxy-params.conf;
         client_max_body_size 5M;
     }
     location /graphql {
-        proxy_pass http://sm-graphql:3010/graphql;
+        set $graphql sm-graphql:3010;
+        proxy_pass http://$graphql$request_uri;
         include proxy-params.conf;
     }
     location /api_auth {
-        proxy_pass http://sm-graphql:3010/api_auth;
+        set $graphql sm-graphql:3010;
+        proxy_pass http://$graphql$request_uri;
         include proxy-params.conf;
     }
     location /ws {
@@ -83,11 +91,6 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        include proxy-params.conf;
-    }
-    location /app/kibana {
-        set $kibana_server kibana:5601;
-        proxy_pass http://$kibana_server/;
         include proxy-params.conf;
     }
 }

--- a/metaspace/webapp/src/lib/apolloCache.ts
+++ b/metaspace/webapp/src/lib/apolloCache.ts
@@ -1,0 +1,28 @@
+import {defaultDataIdFromObject, InMemoryCache} from 'apollo-client-preset'
+
+const nonNormalizableTypes: any[] = ['User', 'DatasetUser', 'DatasetGroup', 'DatasetProject']
+export const makeApolloCache = () => new InMemoryCache({
+  cacheRedirects: {
+    Query: {
+      // Allow get-by-id queries to use cached data that originated from other kinds of queries
+      dataset: (_, args, { getCacheKey }) => getCacheKey({ __typename: 'Dataset', id: args.id }),
+      annotation: (_, args, { getCacheKey }) => getCacheKey({ __typename: 'Annotation', id: args.id }),
+      group: (_, args, { getCacheKey }) => getCacheKey({ __typename: 'Group', id: args.groupId }),
+      project: (_, args, { getCacheKey }) => getCacheKey({ __typename: 'Project', id: args.projectId }),
+    },
+  },
+  dataIdFromObject(object: any) {
+    // WORKAROUND: Because of Apollo's aggressive caching, often the current User will be overwritten with results
+    // from other queries. The server side often strips fields based on how they're accessed (the "ScopeRole" logic),
+    // which means these query paths will often return different data with the same IDs:
+    // currentUser -> primaryGroup (always present)
+    // dataset -> submitter -> primaryGroup (null unless admin)
+    // To protect against this, don't allow Users (and possibly other types in the future) to have a dataId,
+    // so that InMemoryCache cannot share data between different queries.
+    if (nonNormalizableTypes.includes(object.__typename)) {
+      return null
+    } else {
+      return defaultDataIdFromObject(object)
+    }
+  },
+})

--- a/metaspace/webapp/src/modules/App/__snapshots__/MetaspaceHeader.spec.ts.snap
+++ b/metaspace/webapp/src/modules/App/__snapshots__/MetaspaceHeader.spec.ts.snap
@@ -41,8 +41,8 @@ exports[`MetaspaceHeader should match snapshot (logged in) 1`] = `
     </div>
   </div>
   <div class="alert el-row">
-    <div role="alert" class="el-alert el-alert--warning is-light" name="el-alert-fade"><i class="el-alert__icon el-icon-warning"></i>
-      <div class="el-alert__content"><span class="el-alert__title">systemHealthUpdated.message</span>
+    <div role="alert" class="el-alert el-alert--info is-light" name="el-alert-fade"><i class="el-alert__icon el-icon-info"></i>
+      <div class="el-alert__content"><span class="el-alert__title">systemHealth.message</span>
         <!---->
         <!----><i class="el-alert__closebtn el-icon-close" style="display: none;"></i></div>
     </div>
@@ -80,8 +80,8 @@ exports[`MetaspaceHeader should match snapshot (logged out) 1`] = `
     </div>
   </div>
   <div class="alert el-row">
-    <div role="alert" class="el-alert el-alert--warning is-light" name="el-alert-fade"><i class="el-alert__icon el-icon-warning"></i>
-      <div class="el-alert__content"><span class="el-alert__title">systemHealthUpdated.message</span>
+    <div role="alert" class="el-alert el-alert--info is-light" name="el-alert-fade"><i class="el-alert__icon el-icon-info"></i>
+      <div class="el-alert__content"><span class="el-alert__title">systemHealth.message</span>
         <!---->
         <!----><i class="el-alert__closebtn el-icon-close" style="display: none;"></i></div>
     </div>

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -309,6 +309,7 @@ export default {
         Group: this.dataset.groupApproved ? this.dataset.group : null,
         Projects: this.dataset.projects,
       }
+      console.warn(this.dataset.metadataJson)
       return Object.assign(safeJsonParse(this.dataset.metadataJson), datasetMetadataExternals)
     },
 

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -309,7 +309,6 @@ export default {
         Group: this.dataset.groupApproved ? this.dataset.group : null,
         Projects: this.dataset.projects,
       }
-      console.warn(this.dataset.metadataJson)
       return Object.assign(safeJsonParse(this.dataset.metadataJson), datasetMetadataExternals)
     },
 


### PR DESCRIPTION
* Fix intermittent error on CircleCI by removing the auto-mocked resolver for graphql Subscriptions. The previous behavior was that the subscriptions would seem to receive some mock data at a random time point during the DatasetList tests, which sometimes caused the snapshots to fail depending on whether the data came before or after the snapshot rendered. With the resolvers removed they now don't get data at all. 
    * Some more work here will be needed if we want to test the subscription resolvers, but we don't currently test them so I just left it as-is.
* Change unit tests to use the same GraphQL client cache configuration as the production code. 
* Adds graphql to codecov so that we can track the stats more easily
* Bumps webapp's minimum coverage up to 50% (it's currently sitting on 50.17%), but increased the allowable amount of coverage drop to 0.5% so that codecov is less complainey.
* Change the development docker nginx config to use variables for `proxy_pass`. When explicit hosts are used, nginx caches connection failures and won't attempt reconnect. This can result in getting `502 Bad Gateway` errors against graphql, even after restarting & successfully compiling it, forcing you to restart nginx to clear the cache. Using variables prevents nginx from caching server status.