### PR TITLE
Fix API key access for users with no group

### DIFF
--- a/metaspace/graphql/src/modules/auth/operation.ts
+++ b/metaspace/graphql/src/modules/auth/operation.ts
@@ -69,7 +69,7 @@ export const findUserByApiKey = async (apiKey: string, groups: boolean = false) 
     .where(`api_key = :apiKey`, { apiKey: apiKey });
 
   if (groups) {
-    query = query.innerJoinAndSelect('user.groups', 'groups');
+    query = query.leftJoinAndSelect('user.groups', 'groups');
   }
   return (await query.getOne()) || null;
 };


### PR DESCRIPTION
Fixes a bug where `findUserByApiKey(..., true)` would return null for users if they weren't members of any group, causing Invalid API Key errors even under valid attempts.