### PR TITLE
Validate custom URLs

### DIFF
--- a/metaspace/graphql/schemas/group.graphql
+++ b/metaspace/graphql/schemas/group.graphql
@@ -47,6 +47,8 @@ type Query {
   group(groupId: ID!): Group
   groupByUrlSlug(urlSlug: String!): Group
   allGroups(query: String, limit: Int = 10): [Group!]!
+
+  groupUrlSlugIsValid(urlSlug: String!, existingGroupId: ID): Boolean! # Throws error if invalid, consistent with updateGroup
 }
 
 type Mutation {

--- a/metaspace/graphql/schemas/project.graphql
+++ b/metaspace/graphql/schemas/project.graphql
@@ -65,6 +65,8 @@ type Query {
   projectByUrlSlug(urlSlug: String!): Project
   allProjects(query: String, offset: Int = 0, limit: Int = 10): [Project!]!
   projectsCount(query: String): Int!
+
+  projectUrlSlugIsValid(urlSlug: String!, existingProjectId: ID): Boolean! # Throws error if invalid, consistent with updateProject
 }
 
 type Mutation {

--- a/metaspace/graphql/src/modules/group/controller.ts
+++ b/metaspace/graphql/src/modules/group/controller.ts
@@ -16,6 +16,7 @@ import {createInactiveUser} from '../auth/operation';
 import {smAPIUpdateDataset} from '../../utils/smAPI';
 import {getDatasetForEditing} from '../dataset/operation/getDatasetForEditing';
 import {resolveGroupScopeRole} from './util/resolveGroupScopeRole';
+import {urlSlugMatchesClause, validateUrlSlugChange} from "../groupOrProject/urlSlug";
 
 const assertCanCreateGroup = (user: ContextUser) => {
   if (!user.id || user.role !== 'admin')
@@ -153,22 +154,26 @@ export const Resolvers = {
   },
 
   Query: {
-    async group(_: any, {groupId}: any, ctx: Context): Promise<LooselyCompatible<Group & Scope>> {
-      const scopeRole = await resolveGroupScopeRole(ctx, groupId);
-
-      const group = await ctx.entityManager.getRepository(GroupModel).findOneOrFail(groupId);
-      return {
-        ...group,
-        scopeRole
-      };
+    async group(_: any, {groupId}: any, ctx: Context): Promise<LooselyCompatible<Group & Scope> | null> {
+      const group = await ctx.entityManager.getRepository(GroupModel).findOne(groupId);
+      if (group != null) {
+        const scopeRole = await resolveGroupScopeRole(ctx, groupId);
+        return {...group, scopeRole};
+      } else {
+        return null;
+      }
     },
 
-    async groupByUrlSlug(_: any, {urlSlug}: any, ctx: Context): Promise<LooselyCompatible<Group & Scope>> {
-      const group = await ctx.entityManager.getRepository(GroupModel).findOneOrFail({
-        where: { urlSlug }
-      });
-      const scopeRole = await resolveGroupScopeRole(ctx, group.id);
-      return {...group, scopeRole};
+    async groupByUrlSlug(_: any, {urlSlug}: any, ctx: Context): Promise<LooselyCompatible<Group & Scope> | null> {
+      const group = await ctx.entityManager.createQueryBuilder(GroupModel, 'grp')
+          .where(urlSlugMatchesClause('grp', urlSlug))
+          .getOne();
+      if (group != null) {
+        const scopeRole = await resolveGroupScopeRole(ctx, group.id);
+        return {...group, scopeRole};
+      } else {
+        return null;
+      }
     },
 
     async allGroups(_: any, {query}: any, ctx: Context): Promise<LooselyCompatible<Group & Scope>[]|null> {
@@ -180,6 +185,11 @@ export const Resolvers = {
       .getMany();
       return groups.map(g => ({...g, scopeRole}));
     },
+
+    async groupUrlSlugIsValid(source: any, {urlSlug, existingGroupId}: any, ctx: Context): Promise<boolean> {
+      await validateUrlSlugChange(ctx.entityManager, GroupModel, existingGroupId, urlSlug)
+      return true
+    },
   },
 
   Mutation: {
@@ -187,6 +197,10 @@ export const Resolvers = {
       const {groupAdminEmail, ...groupInput} = groupDetails;
       assertCanCreateGroup(user);
       logger.info(`Creating ${groupInput.name} group by '${user!.id}' user...`);
+
+      if (groupDetails.urlSlug != null) {
+        await validateUrlSlugChange(entityManager, GroupModel, null, groupDetails.urlSlug)
+      }
 
       const group = await entityManager.getRepository(GroupModel).save(groupInput) as GroupModel;
 
@@ -206,6 +220,9 @@ export const Resolvers = {
 
     async updateGroup(_: any, {groupId, groupDetails}: any, {user, entityManager}: Context): Promise<Group> {
       await assertCanEditGroup(entityManager, user, groupId);
+      if (groupDetails.urlSlug != null) {
+        await validateUrlSlugChange(entityManager, GroupModel, groupId, groupDetails.urlSlug)
+      }
       logger.info(`Updating '${groupId}' group by '${user!.id}' user...`);
       const groupRepo = entityManager.getRepository(GroupModel);
       const group = {...(await groupRepo.findOneOrFail(groupId)), ...groupDetails};

--- a/metaspace/graphql/src/modules/groupOrProject/urlSlug.spec.ts
+++ b/metaspace/graphql/src/modules/groupOrProject/urlSlug.spec.ts
@@ -8,6 +8,7 @@ import {
     testEntityManager,
 } from "../../tests/graphqlTestEnvironment";
 import {createTestProject} from "../../tests/testDataCreation";
+import {FormValidationErrorsType} from "../../utils/FormValidationErrors";
 
 describe('modules/groupOrProject/urlSlug validateUrlSlugChange', () => {
     beforeAll(onBeforeAll);
@@ -26,14 +27,14 @@ describe('modules/groupOrProject/urlSlug validateUrlSlugChange', () => {
     })
     it.each(INVALID_URL_SLUGS)('should throw on invalid urlSlug', async (urlSlug) => {
         await expect(validateUrlSlugChange(testEntityManager, ProjectModel, null, urlSlug))
-            .rejects.toThrow(expect.objectContaining({type: 'failed_validation'}))
+            .rejects.toThrow(expect.objectContaining({type: FormValidationErrorsType}))
     })
     it('should prevent duplicate urlSlugs', async () => {
         const testProject = await createTestProject({urlSlug: EQUIVALENT_SLUG_1})
         const testProject2 = await createTestProject({})
 
         await expect(validateUrlSlugChange(testEntityManager, ProjectModel, testProject2.id, EQUIVALENT_SLUG_2))
-            .rejects.toThrow(expect.objectContaining({type: 'failed_validation'}))
+            .rejects.toThrow(expect.objectContaining({type: FormValidationErrorsType}))
     })
     it('should allow a project to be saved its existing urlSlug', async () => {
         const testProject = await createTestProject({urlSlug: 'foo_bar_baz'})

--- a/metaspace/graphql/src/modules/groupOrProject/urlSlug.spec.ts
+++ b/metaspace/graphql/src/modules/groupOrProject/urlSlug.spec.ts
@@ -1,0 +1,44 @@
+import {validateUrlSlugChange} from "./urlSlug";
+import {Project as ProjectModel} from '../project/model';
+import {
+    onAfterAll,
+    onAfterEach,
+    onBeforeAll,
+    onBeforeEach,
+    testEntityManager,
+} from "../../tests/graphqlTestEnvironment";
+import {createTestProject} from "../../tests/testDataCreation";
+
+describe('modules/groupOrProject/urlSlug validateUrlSlugChange', () => {
+    beforeAll(onBeforeAll);
+    afterAll(onAfterAll);
+    beforeEach(onBeforeEach);
+    afterEach(onAfterEach);
+
+    const VALID_URL_SLUGS = ['abcdef', 'FOO_bar-baz']
+    const INVALID_URL_SLUGS = ['', 'a', 'äbdcëf', 'too_long__too_long__too_long__too_long__too_long__t']
+    const EQUIVALENT_SLUG_1 = 'foo_bar_baz'
+    const EQUIVALENT_SLUG_2 = 'FOO-BAR-BAZ'
+
+    it.each(VALID_URL_SLUGS)('should successfully validate valid urlSlug', async (urlSlug) => {
+        await expect(validateUrlSlugChange(testEntityManager, ProjectModel, null, urlSlug))
+            .resolves.toBeUndefined()
+    })
+    it.each(INVALID_URL_SLUGS)('should throw on invalid urlSlug', async (urlSlug) => {
+        await expect(validateUrlSlugChange(testEntityManager, ProjectModel, null, urlSlug))
+            .rejects.toThrow(expect.objectContaining({type: 'failed_validation'}))
+    })
+    it('should prevent duplicate urlSlugs', async () => {
+        const testProject = await createTestProject({urlSlug: EQUIVALENT_SLUG_1})
+        const testProject2 = await createTestProject({})
+
+        await expect(validateUrlSlugChange(testEntityManager, ProjectModel, testProject2.id, EQUIVALENT_SLUG_2))
+            .rejects.toThrow(expect.objectContaining({type: 'failed_validation'}))
+    })
+    it('should allow a project to be saved its existing urlSlug', async () => {
+        const testProject = await createTestProject({urlSlug: 'foo_bar_baz'})
+
+        await expect(validateUrlSlugChange(testEntityManager, ProjectModel, testProject.id, EQUIVALENT_SLUG_2))
+            .resolves.toBeUndefined()
+    })
+})

--- a/metaspace/graphql/src/modules/groupOrProject/urlSlug.ts
+++ b/metaspace/graphql/src/modules/groupOrProject/urlSlug.ts
@@ -1,0 +1,35 @@
+import {Brackets, EntityManager, ObjectType} from "typeorm";
+import FormValidationErrors from "../../utils/FormValidationErrors";
+
+
+interface EntityWithUrlSlug {
+    id: string;
+    urlSlug: string;
+}
+
+export const validateUrlSlugChange = async <EntityType extends ObjectType<EntityWithUrlSlug>>
+    (entityManager: EntityManager, model: EntityType, existingId: string | null, urlSlug: string) => {
+
+    if (/[^a-zA-Z0-9_-]/.test(urlSlug)) {
+        throw new FormValidationErrors('urlSlug',
+            'Invalid character in custom URL. Only English letters, numbers, underscore and minus are allowed.')
+    }
+    if (urlSlug.length < 4 || urlSlug.length > 50) {
+        throw new FormValidationErrors('urlSlug', 'Custom URL must be between 4 and 50 characters.')
+    }
+
+    const existing = await entityManager.createQueryBuilder(model, 'entity')
+        .where(urlSlugMatchesClause('entity', urlSlug))
+        .getMany();
+
+    if (existing.some(({id}) => existingId != null && id != existingId)) {
+        throw new FormValidationErrors('urlSlug', 'This custom URL has already been used.')
+    }
+}
+
+export const urlSlugMatchesClause = (relationName: string, urlSlug: string) => {
+    return new Brackets(qb =>
+        qb.where(`LOWER(REPLACE(${relationName}.urlSlug, '-', '_')) = LOWER(REPLACE(:urlSlug, '-', '_'))`,
+            {urlSlug})
+    )
+}

--- a/metaspace/graphql/src/modules/project/ProjectSourceRepository.ts
+++ b/metaspace/graphql/src/modules/project/ProjectSourceRepository.ts
@@ -4,6 +4,7 @@ import {Project as ProjectModel, UserProjectRoleOptions, UserProjectRoleOptions 
 import {ProjectSource} from '../../bindingTypes';
 import * as _ from 'lodash';
 import * as DataLoader from 'dataloader';
+import {urlSlugMatchesClause} from "../groupOrProject/urlSlug";
 
 type SortBy = 'name' | 'popularity';
 
@@ -12,7 +13,8 @@ export class ProjectSourceRepository {
   constructor(private manager: EntityManager) {
   }
 
-  private async queryProjectsWhere(user: ContextUser, whereClause?: string, parameters?: object, sortBy: SortBy = 'name') {
+  private async queryProjectsWhere(user: ContextUser, whereClause?: string | Brackets,
+                                   parameters?: object, sortBy: SortBy = 'name') {
     const columnMap = this.manager.connection
       .getMetadata(ProjectModel)
       .columns
@@ -79,7 +81,7 @@ export class ProjectSourceRepository {
   }
 
   async findProjectByUrlSlug(user: ContextUser, urlSlug: string): Promise<ProjectSource | null> {
-    return await (await this.queryProjectsWhere(user, 'project.urlSlug = :urlSlug', {urlSlug}))
+    return await (await this.queryProjectsWhere(user, urlSlugMatchesClause('project', urlSlug)))
       .getRawOne() || null;
   }
 

--- a/metaspace/graphql/src/modules/project/controller/Mutation.crud.spec.ts
+++ b/metaspace/graphql/src/modules/project/controller/Mutation.crud.spec.ts
@@ -37,7 +37,7 @@ describe('modules/project/controller (CRUD mutations)', () => {
     };
     const projectDetailsWithSlug = {
       ...projectDetails,
-      urlSlug: 'foo',
+      urlSlug: 'foo_bar',
     };
     const createProject = `mutation ($projectDetails: CreateProjectInput!) {
       createProject(projectDetails: $projectDetails) { ${projectFields} }
@@ -73,17 +73,9 @@ describe('modules/project/controller (CRUD mutations)', () => {
       // Assert
       await expect(promise).rejects.toThrow('Unauthenticated');
     });
-    it('should reject a urlSlug from a user', async () => {
+    it('should not reject a urlSlug from a user', async () => {
       // Act
-      const promise = doQuery<ProjectType>(createProject, { projectDetails: projectDetailsWithSlug });
-
-      // Assert
-      await expect(promise).rejects.toThrow();
-    });
-    it('should not reject a urlSlug from an admin', async () => {
-      // Act
-      const result = await doQuery<ProjectType>(createProject,
-        { projectDetails: projectDetailsWithSlug }, { context: adminContext });
+      const result = await doQuery<ProjectType>(createProject, { projectDetails: projectDetailsWithSlug });
 
       // Assert
       const project = await testEntityManager.findOneOrFail(ProjectModel, result.id);
@@ -101,7 +93,7 @@ describe('modules/project/controller (CRUD mutations)', () => {
     };
     const projectDetailsWithSlug = {
       ...projectDetails,
-      urlSlug: 'bar',
+      urlSlug: 'foo_bar',
     };
     const updateProject = `mutation ($projectId: ID!, $projectDetails: UpdateProjectInput!) {
       updateProject(projectId: $projectId, projectDetails: $projectDetails) { ${projectFields} }
@@ -111,7 +103,7 @@ describe('modules/project/controller (CRUD mutations)', () => {
       initialProject = await createTestProject({
         name: 'foo',
         isPublic: true,
-        urlSlug: 'foo',
+        urlSlug: 'bar_baz',
       });
       projectId = initialProject.id;
     });

--- a/metaspace/graphql/src/modules/project/controller/Mutation.ts
+++ b/metaspace/graphql/src/modules/project/controller/Mutation.ts
@@ -89,7 +89,7 @@ const MutationResolvers: FieldResolversFor<Mutation, void> = {
       await txn.update(ProjectModel, projectId, projectDetails);
     });
 
-    if (projectDetails.name || projectDetails.urlSlug || projectDetails.isPublic) {
+    if (projectDetails.name || projectDetails.isPublic) {
       const affectedDatasets = await ctx.entityManager.find(DatasetProjectModel,
           {where: { projectId }, relations: ['dataset', 'dataset.datasetProjects']});
       await Promise.all(affectedDatasets.map(async dp => {

--- a/metaspace/graphql/src/modules/project/controller/Query.spec.ts
+++ b/metaspace/graphql/src/modules/project/controller/Query.spec.ts
@@ -166,15 +166,16 @@ describe('modules/project/controller (queries)', () => {
 
     it('should find a project by URL slug', async () => {
       // Create several projects so that we can be sure it's finding the right one, not just the first one
-      const projectPromises = ['abc','def','ghi','jkl','mno']
+      const projectPromises = ['abc','def','foo_bar','jkl','mno']
         .map(async urlSlug => await createTestProject({urlSlug}));
       const projects = await Promise.all(projectPromises);
-      const urlSlugToFind = 'ghi';
-      const matchingProject = projects.find(p => p.urlSlug === urlSlugToFind)!;
 
-      const result = await doQuery<ProjectType>(query, {urlSlug: urlSlugToFind});
+      const result1 = await doQuery<ProjectType>(query, {urlSlug: 'foo_bar'})
+      const result2 = await doQuery<ProjectType>(query, {urlSlug: 'FOO_BAR'})
+      const result3 = await doQuery<ProjectType>(query, {urlSlug: 'foo-BAR'})
 
-      expect(result.id).toEqual(matchingProject.id);
+      expect([result1.id, result2.id, result3.id])
+          .toEqual([projects[2].id, projects[2].id, projects[2].id]);
     });
   });
 

--- a/metaspace/graphql/src/modules/project/controller/Query.ts
+++ b/metaspace/graphql/src/modules/project/controller/Query.ts
@@ -22,7 +22,7 @@ const QueryResolvers: FieldResolversFor<Query, void> = {
       .countProjectsByQuery(ctx.user, query);
   },
   async projectUrlSlugIsValid(source, {urlSlug, existingProjectId}, ctx): Promise<boolean> {
-    await validateUrlSlugChange(ctx.entityManager, ProjectModel, existingProjectId, urlSlug)
+    await validateUrlSlugChange(ctx.entityManager, ProjectModel, existingProjectId || null, urlSlug)
     return true
   },
 };

--- a/metaspace/graphql/src/modules/project/controller/Query.ts
+++ b/metaspace/graphql/src/modules/project/controller/Query.ts
@@ -1,6 +1,8 @@
 import {FieldResolversFor, ProjectSource} from '../../../bindingTypes';
 import {Query} from '../../../binding';
 import {ProjectSourceRepository} from '../ProjectSourceRepository';
+import {validateUrlSlugChange} from "../../groupOrProject/urlSlug";
+import {Project as ProjectModel} from '../model';
 
 const QueryResolvers: FieldResolversFor<Query, void> = {
   async project(source, { projectId }, ctx): Promise<ProjectSource | null> {
@@ -18,6 +20,10 @@ const QueryResolvers: FieldResolversFor<Query, void> = {
   async projectsCount(source, { query }, ctx): Promise<number> {
     return await ctx.entityManager.getCustomRepository(ProjectSourceRepository)
       .countProjectsByQuery(ctx.user, query);
+  },
+  async projectUrlSlugIsValid(source, {urlSlug, existingProjectId}, ctx): Promise<boolean> {
+    await validateUrlSlugChange(ctx.entityManager, ProjectModel, existingProjectId, urlSlug)
+    return true
   },
 };
 

--- a/metaspace/graphql/src/utils/FormValidationErrors.ts
+++ b/metaspace/graphql/src/utils/FormValidationErrors.ts
@@ -1,0 +1,30 @@
+import {UserError} from "graphql-errors";
+import * as _ from "lodash";
+
+export interface FieldValidationError {
+    field?: string | null
+    message: string
+}
+
+export default class FormValidationErrors extends UserError {
+    type: 'failed_validation'
+    errors: FieldValidationError[]
+
+    constructor(message: string)
+    constructor(field: string, message: string)
+    constructor(errors: FieldValidationError[])
+    constructor(arg1: FieldValidationError[] | string, arg2?: string ){
+        const errors: FieldValidationError[] = _.isArray(arg1) ? arg1
+            : arg2 !== undefined ? [{field: arg1, message: arg2}]
+            : [{message: arg1}]
+
+        super(JSON.stringify({
+            type: 'failed_validation',
+            errors,
+        }))
+
+        this.type = 'failed_validation'
+        this.errors = errors
+        Error.captureStackTrace(this, FormValidationErrors);
+    }
+}

--- a/metaspace/graphql/src/utils/FormValidationErrors.ts
+++ b/metaspace/graphql/src/utils/FormValidationErrors.ts
@@ -6,8 +6,10 @@ export interface FieldValidationError {
     message: string
 }
 
+export const FormValidationErrorsType = 'failed_validation' as const
+
 export default class FormValidationErrors extends UserError {
-    type: 'failed_validation'
+    type: string
     errors: FieldValidationError[]
 
     constructor(message: string)
@@ -19,11 +21,11 @@ export default class FormValidationErrors extends UserError {
             : [{message: arg1}]
 
         super(JSON.stringify({
-            type: 'failed_validation',
+            type: FormValidationErrorsType,
             errors,
         }))
 
-        this.type = 'failed_validation'
+        this.type = FormValidationErrorsType
         this.errors = errors
         Error.captureStackTrace(this, FormValidationErrors);
     }

--- a/metaspace/graphql/yarn.lock
+++ b/metaspace/graphql/yarn.lock
@@ -2955,9 +2955,9 @@ growly@^1.3.0:
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 handlebars@^4.1.2:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
-  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.3.tgz#8ece2797826886cf8082d1726ff21d2a022550ee"
+  integrity sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -4537,15 +4537,10 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 minimist@~0.0.1:
   version "0.0.10"
@@ -4576,11 +4571,11 @@ mixin-deep@^1.2.0:
     is-extendable "^1.0.1"
 
 mkdirp@^0.5.0, mkdirp@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.3.tgz#5a514b7179259287952881e94410ec5465659f8c"
+  integrity sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==
   dependencies:
-    minimist "0.0.8"
+    minimist "^1.2.5"
 
 moment-timezone@^0.5.x:
   version "0.5.27"

--- a/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.vue
@@ -332,7 +332,9 @@ export default class ViewGroupPage extends Vue {
     @Watch('$route.params.groupIdOrSlug')
     @Watch('group.urlSlug')
     canonicalizeUrl() {
-      if (isUuid(this.$route.params.groupIdOrSlug) && this.group != null && this.group.urlSlug) {
+      if (this.group != null
+              && this.group.urlSlug != null
+              && this.$route.params.groupIdOrSlug !== this.group.urlSlug) {
         this.$router.replace({
           params: { groupIdOrSlug: this.group.urlSlug },
           query: this.$route.query,

--- a/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
+++ b/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
@@ -312,7 +312,9 @@ export default class ViewProjectPage extends Vue {
     @Watch('$route.params.projectIdOrSlug')
     @Watch('project.urlSlug')
     canonicalizeUrl() {
-      if (isUuid(this.$route.params.projectIdOrSlug) && this.project != null && this.project.urlSlug) {
+      if (this.project != null
+          && this.project.urlSlug != null
+          && this.$route.params.projectIdOrSlug !== this.project.urlSlug) {
         this.$router.replace({
           params: { projectIdOrSlug: this.project.urlSlug },
           query: this.$route.query,


### PR DESCRIPTION
Resolves #556 

Adds new validation rules to `Project.urlSlug` and `Group.urlSlug`:
* Must be between 4 and 50 characters long
* Can only contain characters `a-z`, `A-Z`, `0-9`, `-` or `_`
* Must be unique (case-insensitive, and treating `-` and `_` as the same character)

Logic changes:
* Validate the `urlSlug` when creating/updating groups/projects, and throw a `FormValidationErrors` exception (which gets JSON-stringified into the GraphQL error message)
    * With the `FormValidationErrors` class, I tried to make something that would be reusable. In previous cases (e.g. the metadata editor form) we've handled this completely ad-hoc.
* Allow non-admins to update `Project.urlSlug` through the API. I haven't changed the permissions on `Group.urlSlug` though - Groups can only be created by admins
* Use case-insensitive, `-`/`_`-insensitive comparison when looking up groups/projects 
* Update the URL if it doesn't exactly match the `urlSlug`
* Add `projectUrlSlugIsValid` and `groupUrlSlugIsValid` queries in case we decide to validate these on the fly
* Unrelated: Updated some dependencies to reduce links to the vulnerable `minimist` package. Unfortunately `handlebars` still depends on the vulnerable version of `minimist`...