### PR TITLE
Fixes for release

### DIFF
--- a/ansible/roles/sm_graphql/templates/sm-graphql.supervisor.j2
+++ b/ansible/roles/sm_graphql/templates/sm-graphql.supervisor.j2
@@ -11,4 +11,4 @@ numprocs = 1
 numprocs_start = 8000
 autorestart = false
 startsecs = 10
-
+stopasgroup = true

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -491,6 +491,8 @@ class ESExporter:
                 ds_doc_upd.update(ds_meta_flat_doc)
             elif f'ds_{field}' in ds_doc:
                 ds_doc_upd[f'ds_{field}'] = ds_doc[f'ds_{field}']
+            else:
+                logger.warning(f'Field ds_{field} not found in ds_doc')
         return ds_doc_upd
 
     @retry_on_conflict()

--- a/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
@@ -92,7 +92,7 @@ const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
   },
 
   statusUpdateDT(ds) {
-    return ds._source.ds_status_update_dt;
+    return ds._source.ds_status_update_dt || ds._source.ds_upload_dt;
   },
 
   configJson(ds) {


### PR DESCRIPTION
This release added a `status_update_dt` field to both the DB and ES. It's needed for ordering the Datasets list. Unfortunately I didn't plan for it being initially unpopulated during deployment.

* Add a fallback value to `statusUpdateDT` for graphql, so that it doesn't error when this field isn't present. This will still cause the sort order to be messed up, but IMO it's fine for a short time.
* Add option for doing bulk, field-specific updates in `scripts.update_es_index`, which runs MUCH faster.

Also, I found that supervisorctl didn't kill `sm-graphql` properly, causing the new instance to fail to open its ports and die. The cause is that when supervisorctl runs a task through yarn, it only seems to kill yarn when stopping the service. Adding the `stopasgroup` flag means that all child processes are sent the `TERM` signal.