### PR TITLE
Hotfix: Add +NH4 adduct, only auto-select default adducts

### DIFF
--- a/metaspace/graphql/config/default.js
+++ b/metaspace/graphql/config/default.js
@@ -19,6 +19,7 @@ module.exports = {
     {adduct: "+Na", name: "[M + Na]⁺", charge: 1, hidden: false, default: true},
     {adduct: "+K", name: "[M + K]⁺", charge: 1, hidden: false, default: true},
     {adduct: "[M]+", name: "[M]⁺", charge: 1, hidden: true, default: false},
+    {adduct: "+NH4", name: "[M + NH₄]⁺", charge: 1, hidden: true, default: false},
     // Negative mode
     {adduct: "-H", name: "[M - H]⁻", charge: -1, hidden: false, default: true},
     {adduct: "+Cl", name: "[M + Cl]⁻", charge: -1, hidden: false, default: true},

--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -156,9 +156,11 @@ export default {
     },
     adductOptions() {
       const polarity = get(this.value, ['MS_Analysis', 'Polarity']) || 'Positive'
-      return this.possibleAdducts[polarity].map(({ adduct, name }) => ({
+      return this.possibleAdducts[polarity].map(({ adduct, name, ...ad }) => ({
+        ...ad,
         value: adduct,
-        label: name,
+        // Without the feature flag, keep old-style names e.g. +H instead of [M+H]⁺
+        label: config.features.all_adducts ? name : adduct,
       }))
     },
   },
@@ -259,10 +261,7 @@ export default {
         ...data,
         adducts: config.features.all_adducts
           ? data.adducts
-          : data.adducts
-            .filter(ad => !ad.hidden)
-          // Also use this as a feature flag to keep old-style names e.g. +H instead of [M+H]⁺
-            .map(ad => ({ ...ad, name: ad.adduct })),
+          : data.adducts.filter(ad => !ad.hidden),
         molecularDatabases: config.features.all_dbs
           ? data.molecularDatabases
           : data.molecularDatabases.filter(db => !db.hidden),
@@ -423,9 +422,11 @@ export default {
     updateCurrentAdductOptions() {
       const selectedAdducts = this.metaspaceOptions.adducts
       let newAdducts = selectedAdducts.filter(adduct => this.adductOptions.some(option => option.value === adduct))
-      // Default to selecting all valid adducts (at least until the less common adducts are added)
+      // If no selected adducts are still valid, reset to the default adducts
       if (newAdducts.length === 0) {
-        newAdducts = this.adductOptions.map(option => option.value)
+        newAdducts = this.adductOptions
+          .filter(option => option.default)
+          .map(option => option.value)
       }
       this.metaspaceOptions.adducts = newAdducts
     },


### PR DESCRIPTION
A user has found a use for running [M + NH₄]⁺ searches against their datasets. This adds it as a hidden adduct so that they can use it via the all_adducts feature flag.

I also added a fix for the metadata editor, because it was auto-selecting all valid adducts, not just the defaults.