### PR TITLE
Python client & Graphql schema fixes

### DIFF
--- a/metaspace/graphql/schemas/annotation.graphql
+++ b/metaspace/graphql/schemas/annotation.graphql
@@ -3,8 +3,8 @@ type Annotation {
 
   dataset: Dataset!
   sumFormula: String!
-  chemMod: String
-  neutralLoss: String
+  chemMod: String!      # Empty string means no chem mod
+  neutralLoss: String!  # Empty string means no neutral loss
   adduct: String!
   ion: String!          # Formula+adducts+polarity
   ionFormula: String!   # "Compiled" formula, such that there are no +/-s, each element is only included once, in CHNOPS order
@@ -45,7 +45,7 @@ type CompoundInfoEntry {
 type Compound {
   name: String!
   imageURL: String
-  information: [CompoundInfoEntry]
+  information: [CompoundInfoEntry!]!
   # TODO: InChi/SMILES, ClassyFire results
 }
 
@@ -103,8 +103,8 @@ input AnnotationFilter {
   compoundQuery: String
   fdrLevel: Float
   sumFormula: String
-  chemMod: String
-  neutralLoss: String
+  chemMod: String                 # Empty string for 'no chem mod'
+  neutralLoss: String             # Empty string for 'no neutral loss'
   adduct: String
   ion: String
   ionFormula: String

--- a/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
+++ b/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
@@ -42,7 +42,7 @@ const Annotation: FieldResolversFor<Annotation, ESAnnotation | ESAnnotationWithC
       let dbName = hit._source.db_name,
         dbBaseName = dbName.split('-')[0];
 
-      let infoURL;
+      let infoURL: string | null = null;
       if (dbBaseName === 'HMDB') {
         infoURL = `http://www.hmdb.ca/metabolites/${id}`;
       } else if (dbBaseName === 'ChEBI') {
@@ -72,9 +72,9 @@ const Annotation: FieldResolversFor<Annotation, ESAnnotation | ESAnnotationWithC
 
   adduct: (hit) => hit._source.adduct,
 
-  neutralLoss: (hit) => hit._source.neutral_loss,
+  neutralLoss: (hit) => hit._source.neutral_loss || '',
 
-  chemMod: (hit) => hit._source.chem_mod,
+  chemMod: (hit) => hit._source.chem_mod || '',
 
   ion: (hit) => hit._source.ion,
 

--- a/metaspace/python-client/example/iso_img_retrieval.ipynb
+++ b/metaspace/python-client/example/iso_img_retrieval.ipynb
@@ -51,7 +51,7 @@
     "# This will prompt you to enter your API key. \n",
     "# Note that API keys should be kept secret like passwords. \n",
     "# You can alternatively save your API key in a config file - see config.template for more details.\n",
-    "if not sm.logged_in:\n",
+    "if not sm.logged_in():\n",
     "    # Using getpass here prevents the API key from being accidentally saved with this notebook.\n",
     "    api_key = getpass.getpass(prompt='API key: ', stream=None)\n",
     "    sm.login(api_key=api_key)"

--- a/metaspace/python-client/example/simple_database_queries.ipynb
+++ b/metaspace/python-client/example/simple_database_queries.ipynb
@@ -54,7 +54,7 @@
     "# This will prompt you to enter your API key. \n",
     "# Note that API keys should be kept secret like passwords. \n",
     "# You can alternatively save your API key in a config file - see config.template for more details.\n",
-    "if not sm.logged_in:\n",
+    "if not sm.logged_in():\n",
     "    # Using getpass here prevents the API key from being accidentally saved with this notebook.\n",
     "    api_key = getpass.getpass(prompt='API key: ', stream=None)\n",
     "    sm.login(api_key=api_key)"

--- a/metaspace/python-client/example/upload_dataset_api.ipynb
+++ b/metaspace/python-client/example/upload_dataset_api.ipynb
@@ -52,7 +52,7 @@
     "# This will prompt you to enter your API key. \n",
     "# Note that API keys should be kept secret like passwords. \n",
     "# You can alternatively save your API key in a config file - see config.template for more details.\n",
-    "if not sm.logged_in:\n",
+    "if not sm.logged_in():\n",
     "    # Using getpass here prevents the API key from being accidentally saved with this notebook.\n",
     "    api_key = getpass.getpass(prompt='API key: ', stream=None)\n",
     "    sm.login(api_key=api_key)"

--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,2 +1,2 @@
 name = 'metaspace2020'
-__version__ = '1.7.2'
+__version__ = '1.7.3'

--- a/metaspace/python-client/metaspace/tests/utils.py
+++ b/metaspace/python-client/metaspace/tests/utils.py
@@ -14,3 +14,18 @@ def my_ds_id(sm):
     user_id = sm.current_user_id()
     datasets = sm.get_metadata({'submitter': user_id, 'status': 'FINISHED'})
     return datasets.index[0]
+
+
+@pytest.fixture()
+def advanced_ds_id(sm):
+    annotations = sm._gqclient.getAnnotations(
+        annotationFilter={
+            'hasNeutralLoss': None,
+            'neutralLoss': '-H2O',
+            'hasChemMod': None,
+            'chemMod': '-H+C',
+        },
+        limit=100,
+    )
+    assert annotations, 'TEST SETUP: Process a dataset with a -H2O neutral loss and -H+C chem mod'
+    return annotations[0]['dataset']['id']


### PR DESCRIPTION
Python client changes & fixes:
* Removed default annotation filters that exclude neutral losses, chem mods, hidden adducts.
    The hidden adduct filter in particular was causing a lot of issues with Chris's data analysis.
* Added opt-in support for chem mods & neutral losses in `SMDataset.results()` and `SMDataset.all_annotation_images()`.
    This implementation differs to how it was previously discussed, where I said I would merge these fields into the `adduct` field. The problem with merging them into one field is that it would require changes in the esExport so that it would be possible to also search annotations by the combined field value. Searching directly for a specific annotation is needed for `SMDataset.isotope_images`. Also, `[M]+` adducts would make the combined field very ugly.
* Mark `SMInstance.get_annotations` as deprecated, because it's confusing having so many ways to get annotations, and this function's description doesn't even match its return value.
* Added `limit` to `GraphQLClient.get_annotations`, so that the tests can find annotations matching some criteria without downloading millions of extra matching annotations.

GraphQL schema fixes:
* Make chemMod/neutralLoss officially non-nullable, using empty string for no-value. This was the previous behavior anyway. I added fallback code just in case ElasticSearch has any missing values, but I'm pretty sure they're all `''` by now.
* Made possibleCompounds.information non-nullable, as it's always present (though an empty list is theoretically still valid)
* Made "infoURL" have a null default, so that it doesn't get auto-mocked if not assigned.

I haven't pushed the new version to PyPI yet. Will do so after merge.