### PR TITLE
Update @vue/test-utils 1.0.0-beta.29 -> 1.0.2

### DIFF
--- a/metaspace/webapp/package.json
+++ b/metaspace/webapp/package.json
@@ -92,7 +92,7 @@
     "@vue/cli-service": "^4.1.2",
     "@vue/eslint-config-standard": "^5.1.0",
     "@vue/eslint-config-typescript": "^5.0.1",
-    "@vue/test-utils": "1.0.0-beta.29",
+    "@vue/test-utils": "^1.0.2",
     "apollo-link-schema": "^1.2.3",
     "babel-jest": "24.9.0",
     "babel-loader": "^8.0.6",

--- a/metaspace/webapp/src/components/ImageLoader.spec.ts
+++ b/metaspace/webapp/src/components/ImageLoader.spec.ts
@@ -56,14 +56,14 @@ describe('ImageLoader', () => {
   })
 
   it('should match snapshot (minimal)', async() => {
-    const wrapper = mount(ImageLoader, { propsData: baseProps, sync: false })
+    const wrapper = mount(ImageLoader, { propsData: baseProps })
     await Vue.nextTick()
 
     expect(wrapper.element).toMatchSnapshot()
   })
 
   it('should match snapshot (with everything turned on)', async() => {
-    const wrapper = mount(ImageLoader, { propsData: fullProps, sync: false })
+    const wrapper = mount(ImageLoader, { propsData: fullProps })
     await Vue.nextTick()
 
     // Trigger mouseover to show the intensity popup.

--- a/metaspace/webapp/src/components/NewFeatureBadge/NewFeatureBadge.spec.ts
+++ b/metaspace/webapp/src/components/NewFeatureBadge/NewFeatureBadge.spec.ts
@@ -18,7 +18,7 @@ describe('NewFeatureBadge', () => {
   it('should hide the badge', async() => {
     const wrapper = mount(TestNewFeatureBadge, { propsData: { featureKey } })
     hideFeatureBadge(featureKey)
-    wrapper.vm.$forceUpdate() // hacking this for now, works IRL
+    await Vue.nextTick()
     expect(wrapper.classes()).toMatchSnapshot()
   })
 

--- a/metaspace/webapp/src/components/NewFeatureBadge/NewFeatureBadge.tsx
+++ b/metaspace/webapp/src/components/NewFeatureBadge/NewFeatureBadge.tsx
@@ -1,5 +1,6 @@
 import './NewFeatureBadge.css'
 
+import Vue from 'vue'
 import { createComponent, reactive } from '@vue/composition-api'
 
 import { getLocalStorage, setLocalStorage } from '../../lib/localStorage'
@@ -14,7 +15,7 @@ export function hideFeatureBadge(featureKey: string) {
   if (store[featureKey]) {
     return
   }
-  store[featureKey] = true
+  Vue.set(store, featureKey, true)
   setLocalStorage(storageKey, store)
 }
 
@@ -25,6 +26,9 @@ const NewFeatureBadge = createComponent({
   },
   setup(props, { slots }) {
     const isStale = props.showUntil && props.showUntil.valueOf() < Date.now()
+    if (!(props.featureKey in store)) {
+      Vue.set(store, props.featureKey, false)
+    }
     if (store[props.featureKey] || isStale) {
       return () => slots.default()
     }

--- a/metaspace/webapp/src/modules/Account/components/CreateAccountDialog.spec.ts
+++ b/metaspace/webapp/src/modules/Account/components/CreateAccountDialog.spec.ts
@@ -15,7 +15,7 @@ Vue.use(Vuex)
 
 const setFormField = (wrapper: Wrapper<Vue>, fieldName: string, value: string) => {
   wrapper
-    .findAll<ElementUI.FormItem>(ElementUI.FormItem)
+    .findAllComponents<ElementUI.FormItem>(ElementUI.FormItem)
     .filter((fi: Wrapper<ElementUI.FormItem>) => fi.props().prop === fieldName)
     .at(0)
     .find('input')
@@ -49,14 +49,14 @@ describe('CreateAccountDialog', () => {
     const lastName = 'bar'
     const email = 'test@example.com'
     const password = 'abcd1234'
-    const wrapper = mount(CreateAccountDialog, { store, router, sync: false }) as Wrapper<CreateAccountDialog>
+    const wrapper = mount(CreateAccountDialog, { store, router }) as Wrapper<CreateAccountDialog>
 
     // Act
     setFormField(wrapper, 'firstName', firstName)
     setFormField(wrapper, 'lastName', lastName)
     setFormField(wrapper, 'email', email)
     setFormField(wrapper, 'password', password)
-    wrapper.find(ElementUI.Button).trigger('click')
+    wrapper.findComponent(ElementUI.Button).trigger('click')
     await Vue.nextTick()
 
     // Assert
@@ -66,14 +66,14 @@ describe('CreateAccountDialog', () => {
 
   it('should not submit an invalid form', async() => {
     // Arrange
-    const wrapper = mount(CreateAccountDialog, { store, router, sync: false }) as Wrapper<CreateAccountDialog>
+    const wrapper = mount(CreateAccountDialog, { store, router }) as Wrapper<CreateAccountDialog>
 
     // Act
     setFormField(wrapper, 'firstName', 'foo')
     setFormField(wrapper, 'lastName', 'bar')
     setFormField(wrapper, 'email', 'test@email.com')
     setFormField(wrapper, 'password', '') // Intentionally left empty
-    wrapper.find(ElementUI.Button).trigger('click')
+    wrapper.findComponent(ElementUI.Button).trigger('click')
     await Vue.nextTick()
 
     // Assert

--- a/metaspace/webapp/src/modules/Account/components/SignInDialog.spec.ts
+++ b/metaspace/webapp/src/modules/Account/components/SignInDialog.spec.ts
@@ -19,7 +19,7 @@ Vue.use(Vuex)
 
 const setFormField = (wrapper: Wrapper<Vue>, fieldName: string, value: string) => {
   wrapper
-    .findAll<ElementUI.FormItem>(ElementUI.FormItem)
+    .findAllComponents<ElementUI.FormItem>(ElementUI.FormItem)
     .filter((fi: Wrapper<ElementUI.FormItem>) => fi.props().prop === fieldName)
     .at(0)
     .find('input')
@@ -51,14 +51,14 @@ describe('SignInDialog', () => {
     // Arrange
     const email = 'test@example.com'
     const password = 'baz'
-    const wrapper = mount(SignInDialog, { store, router, sync: false }) as Wrapper<SignInDialog>
+    const wrapper = mount(SignInDialog, { store, router }) as Wrapper<SignInDialog>
     mockAuthApi.signInByEmail.mockImplementation(() => Promise.resolve(true))
     store.commit('account/showDialog', 'signIn')
 
     // Act
     setFormField(wrapper, 'email', email)
     setFormField(wrapper, 'password', password)
-    wrapper.find(ElementUI.Button).trigger('click')
+    wrapper.findComponent(ElementUI.Button).trigger('click')
     await Vue.nextTick()
 
     // Assert

--- a/metaspace/webapp/src/modules/Account/components/__snapshots__/CreateAccountDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Account/components/__snapshots__/CreateAccountDialog.spec.ts.snap
@@ -18,7 +18,9 @@ exports[`CreateAccountDialog should match snapshot 1`] = `
                     <!---->
                     <!---->
                   </div>
-                  <!---->
+                  <transition-stub name="el-zoom-in-top">
+                    <!---->
+                  </transition-stub>
                 </div>
               </div>
             </div>
@@ -35,7 +37,9 @@ exports[`CreateAccountDialog should match snapshot 1`] = `
                     <!---->
                     <!---->
                   </div>
-                  <!---->
+                  <transition-stub name="el-zoom-in-top">
+                    <!---->
+                  </transition-stub>
                 </div>
               </div>
             </div>
@@ -50,7 +54,9 @@ exports[`CreateAccountDialog should match snapshot 1`] = `
                 <!---->
                 <!---->
               </div>
-              <!---->
+              <transition-stub name="el-zoom-in-top">
+                <!---->
+              </transition-stub>
             </div>
           </div>
           <div class="el-form-item is-required">
@@ -63,7 +69,9 @@ exports[`CreateAccountDialog should match snapshot 1`] = `
                 <!---->
                 <!---->
               </div>
-              <!---->
+              <transition-stub name="el-zoom-in-top">
+                <!---->
+              </transition-stub>
             </div>
           </div> <button type="button" class="el-button el-button--primary">
             <!---->

--- a/metaspace/webapp/src/modules/Account/components/__snapshots__/SignInDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Account/components/__snapshots__/SignInDialog.spec.ts.snap
@@ -15,7 +15,9 @@ exports[`SignInDialog should match snapshot 1`] = `
               <!---->
               <!---->
             </div>
-            <!---->
+            <transition-stub name="el-zoom-in-top">
+              <!---->
+            </transition-stub>
           </div>
         </div>
         <div class="el-form-item is-required">
@@ -28,7 +30,9 @@ exports[`SignInDialog should match snapshot 1`] = `
               <!---->
               <!---->
             </div>
-            <!---->
+            <transition-stub name="el-zoom-in-top">
+              <!---->
+            </transition-stub>
           </div>
         </div>
         <div style="overflow: hidden; transition-property: height; height: auto; transition-duration: 500ms;">

--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.spec.ts
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.spec.ts
@@ -64,7 +64,7 @@ describe('AnnotationTable', () => {
         countAnnotations: () => 1,
       }),
     })
-    const wrapper = mount(AnnotationTable, { store, router, apolloProvider, propsData, sync: false })
+    const wrapper = mount(AnnotationTable, { store, router, apolloProvider, propsData })
     await Vue.nextTick()
 
     expect(wrapper).toMatchSnapshot()
@@ -86,7 +86,7 @@ describe('AnnotationTable', () => {
         countAnnotations: () => 4,
       }),
     })
-    const wrapper = mount(AnnotationTable, { store, router, apolloProvider, propsData, sync: false })
+    const wrapper = mount(AnnotationTable, { store, router, apolloProvider, propsData })
     wrapper.setData({ csvChunkSize: 2 })
     await new Promise(resolve => setTimeout(resolve, 1))
 

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/RelatedMolecules.spec.ts
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/RelatedMolecules.spec.ts
@@ -53,7 +53,7 @@ describe('RelatedMolecules', () => {
         ]),
       }),
     })
-    const wrapper = mount(RelatedMolecules, { store, router, apolloProvider, propsData, sync: false })
+    const wrapper = mount(RelatedMolecules, { store, router, apolloProvider, propsData })
     await Vue.nextTick()
 
     expect(wrapper).toMatchSnapshot()
@@ -80,7 +80,7 @@ describe('RelatedMolecules', () => {
         ]),
       }),
     })
-    const wrapper = mount(RelatedMolecules, { store, router, apolloProvider, propsData, sync: false })
+    const wrapper = mount(RelatedMolecules, { store, router, apolloProvider, propsData })
     await Vue.nextTick()
 
     expect(wrapper.find('.ion-link').exists()).toBe(false)

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.spec.ts
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.spec.ts
@@ -106,7 +106,7 @@ describe('Diagnostics', () => {
         isobars: [],
       },
     }
-    const wrapper = mount(Diagnostics, { store, router, apolloProvider, stubs, propsData, sync: false })
+    const wrapper = mount(Diagnostics, { store, router, apolloProvider, stubs, propsData })
     await Vue.nextTick()
 
     expect(wrapper).toMatchSnapshot()
@@ -120,7 +120,7 @@ describe('Diagnostics', () => {
     })
     console.error = (...args: any[]) => { throw new Error(...args) }
 
-    const wrapper = mount(Diagnostics, { store, router, apolloProvider, stubs, propsData: props, sync: false })
+    const wrapper = mount(Diagnostics, { store, router, apolloProvider, stubs, propsData: props })
     await Vue.nextTick()
     wrapper.setData({ comparisonIonFormula: isobarAnnotation.ionFormula })
     await Vue.nextTick()

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
@@ -163,17 +163,19 @@ exports[`Diagnostics should match snapshot (no isobars) 1`] = `
 
 exports[`Diagnostics should match snapshot (with isobar) 1`] = `
 <div mock-v-loading="0">
-  <div role="alert" class="el-alert isobar-alert el-alert--warning is-light" name="el-alert-fade"><i class="el-alert__icon el-icon-warning is-big"></i>
-    <div class="el-alert__content">
-      <!---->
-      <p class="el-alert__description">
-        Another ion was annotated that is isobaric to the selected annotation.
+  <transition-stub name="el-alert-fade" class="isobar-alert">
+    <div role="alert" class="el-alert el-alert--warning is-light"><i class="el-alert__icon el-icon-warning is-big"></i>
+      <div class="el-alert__content">
         <!---->
-        Select an isobaric annotation below to compare against.
-      </p>
-      <!----><i class="el-alert__closebtn el-icon-close" style="display: none;"></i>
+        <p class="el-alert__description">
+          Another ion was annotated that is isobaric to the selected annotation.
+          <!---->
+          Select an isobaric annotation below to compare against.
+        </p>
+        <!----><i class="el-alert__closebtn el-icon-close" style="display: none;"></i>
+      </div>
     </div>
-  </div>
+  </transition-stub>
   <div class="compare-container">
     Compare selected annotation to:
     <mock-el-select placeholder="None" clearable="" class="compare-select" value="C8H9S2">

--- a/metaspace/webapp/src/modules/App/MetaspaceHeader.spec.ts
+++ b/metaspace/webapp/src/modules/App/MetaspaceHeader.spec.ts
@@ -17,7 +17,7 @@ describe('MetaspaceHeader', () => {
         currentUser: () => null, // Prevent automatic mocking
       }),
     })
-    const wrapper = mount(MetaspaceHeader, { store, router, apolloProvider, sync: false })
+    const wrapper = mount(MetaspaceHeader, { store, router, apolloProvider })
     await Vue.nextTick()
 
     expect(wrapper).toMatchSnapshot()
@@ -48,7 +48,7 @@ describe('MetaspaceHeader', () => {
         }),
       }),
     })
-    const wrapper = mount(MetaspaceHeader, { store, router, apolloProvider, sync: false })
+    const wrapper = mount(MetaspaceHeader, { store, router, apolloProvider })
     await Vue.nextTick()
 
     expect(wrapper).toMatchSnapshot()
@@ -57,7 +57,7 @@ describe('MetaspaceHeader', () => {
   it('should include current filters in annotations & dataset links', async() => {
     initMockGraphqlClient({})
     router.push({ path: '/annotations', query: { db: 'HMDB', organism: 'human' } })
-    const wrapper = mount(MetaspaceHeader, { store, router, apolloProvider, sync: false })
+    const wrapper = mount(MetaspaceHeader, { store, router, apolloProvider })
     await Vue.nextTick()
 
     expect(wrapper.find('#annotations-link').attributes().href).toEqual('/annotations?db=HMDB&organism=human')

--- a/metaspace/webapp/src/modules/App/__snapshots__/MetaspaceHeader.spec.ts.snap
+++ b/metaspace/webapp/src/modules/App/__snapshots__/MetaspaceHeader.spec.ts.snap
@@ -40,11 +40,13 @@ exports[`MetaspaceHeader should match snapshot (logged in) 1`] = `
     </div>
   </div>
   <div class="alert el-row">
-    <div role="alert" class="el-alert el-alert--info is-light" name="el-alert-fade"><i class="el-alert__icon el-icon-info"></i>
-      <div class="el-alert__content"><span class="el-alert__title">systemHealth.message</span>
-        <!---->
-        <!----><i class="el-alert__closebtn el-icon-close" style="display: none;"></i></div>
-    </div>
+    <transition-stub name="el-alert-fade">
+      <div role="alert" class="el-alert el-alert--info is-light"><i class="el-alert__icon el-icon-info"></i>
+        <div class="el-alert__content"><span class="el-alert__title">systemHealth.message</span>
+          <!---->
+          <!----><i class="el-alert__closebtn el-icon-close" style="display: none;"></i></div>
+      </div>
+    </transition-stub>
   </div>
 </div>
 `;
@@ -79,11 +81,13 @@ exports[`MetaspaceHeader should match snapshot (logged out) 1`] = `
     </div>
   </div>
   <div class="alert el-row">
-    <div role="alert" class="el-alert el-alert--info is-light" name="el-alert-fade"><i class="el-alert__icon el-icon-info"></i>
-      <div class="el-alert__content"><span class="el-alert__title">systemHealth.message</span>
-        <!---->
-        <!----><i class="el-alert__closebtn el-icon-close" style="display: none;"></i></div>
-    </div>
+    <transition-stub name="el-alert-fade">
+      <div role="alert" class="el-alert el-alert--info is-light"><i class="el-alert__icon el-icon-info"></i>
+        <div class="el-alert__content"><span class="el-alert__title">systemHealth.message</span>
+          <!---->
+          <!----><i class="el-alert__closebtn el-icon-close" style="display: none;"></i></div>
+      </div>
+    </transition-stub>
   </div>
 </div>
 `;

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.spec.ts
@@ -66,7 +66,7 @@ describe('DatasetTable', () => {
         }),
       }),
     })
-    const wrapper = mount(DatasetTable, { store, router, apolloProvider, sync: false })
+    const wrapper = mount(DatasetTable, { store, router, apolloProvider })
     await Vue.nextTick()
 
     expect(wrapper).toMatchSnapshot()
@@ -95,7 +95,7 @@ describe('DatasetTable', () => {
         countDatasets: () => 4,
       }),
     })
-    const wrapper = mount(DatasetTable, { store, router, apolloProvider, sync: false })
+    const wrapper = mount(DatasetTable, { store, router, apolloProvider })
     wrapper.setData({ csvChunkSize: 2 })
     await Vue.nextTick()
 

--- a/metaspace/webapp/src/modules/Datasets/list/DownloadDialog.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/list/DownloadDialog.spec.ts
@@ -45,7 +45,7 @@ describe('Datasets/DownloadDialog', () => {
       datasetId: '2020-01-02_03h04m05s',
       datasetName: 'Mouse whole body DHB',
     }
-    const wrapper = mount(TestDownloadDialog, { router, apolloProvider, propsData, sync: false })
+    const wrapper = mount(TestDownloadDialog, { router, apolloProvider, propsData })
     await Vue.nextTick()
 
     expect(wrapper.element).toMatchSnapshot()

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DownloadDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DownloadDialog.spec.ts.snap
@@ -1,305 +1,308 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Datasets/DownloadDialog should match snapshot 1`] = `
-<div
-  class="el-dialog__wrapper"
+<transition-stub
   name="dialog-fade"
   style="z-index: 2001;"
 >
   <div
-    aria-label="Download Mouse whole body DHB"
-    aria-modal="true"
-    class="el-dialog el-dialog-lean max-w-xl"
-    role="dialog"
-    style="margin-top: 15vh;"
+    class="el-dialog__wrapper"
   >
     <div
-      class="el-dialog__header"
+      aria-label="Download Mouse whole body DHB"
+      aria-modal="true"
+      class="el-dialog el-dialog-lean max-w-xl"
+      role="dialog"
+      style="margin-top: 15vh;"
     >
-      <span
-        class="el-dialog__title"
-      >
-        Download Mouse whole body DHB
-      </span>
-      <button
-        aria-label="Close"
-        class="el-dialog__headerbtn"
-        type="button"
-      >
-        <i
-          class="el-dialog__close el-icon el-icon-close"
-        />
-      </button>
-    </div>
-    <div
-      class="el-dialog__body"
-    >
-      <p>
-        <p>
-          This dataset is distributed under the 
-          <a
-            href="https://creativecommons.org/licenses/by/4.0/"
-          >
-            CC BY 4.0
-          </a>
-           license. Make sure to credit the author of this dataset:
-        </p>
-      </p>
-      <ul>
-        <li
-          class="list-none"
-        >
-          Foo Bar, EMBL
-        </li>
-      </ul>
-      <h4>
-        Files
-      </h4>
       <div
-        class="flex my-1 flex-wrap"
+        class="el-dialog__header"
       >
-        <div
-          class="flex items-center p-1 w-1/2 box-border"
+        <span
+          class="el-dialog__title"
         >
-          <a
-            href="https://sm-engine-upload.s3.eu-west-1.amazonaws.com/test/Image5.ibd?AWSAccessKeyId=test&Expires=1585569522&Signature=test%3D"
-          >
-            <svg
-              style="width: 32px; height: 50px;"
-              viewBox="0 0 72 100"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <lineargradient
-                gradientUnits="userSpaceOnUse"
-                id="a"
-                x1="36"
-                x2="36"
-                y1="99"
-                y2="1"
-              >
-                <stop
-                  offset="0"
-                  stop-color="#c8d4db"
-                />
-                <stop
-                  offset=".139"
-                  stop-color="#d8e1e6"
-                />
-                <stop
-                  offset=".359"
-                  stop-color="#ebf0f3"
-                />
-                <stop
-                  offset=".617"
-                  stop-color="#f9fafb"
-                />
-                <stop
-                  offset="1"
-                  stop-color="#fff"
-                />
-              </lineargradient>
-              <path
-                d="M45 1L71 27.7V99H1V1H45Z"
-                fill="url(#a)"
-                stroke="#7191a1"
-                stroke-width="2"
-              />
-              <lineargradient
-                gradientUnits="userSpaceOnUse"
-                id="b"
-                x1="45.068"
-                x2="58.568"
-                y1="27.796"
-                y2="14.395"
-              >
-                <stop
-                  offset="0"
-                  stop-color="#fff"
-                />
-                <stop
-                  offset=".35"
-                  stop-color="#fafbfb"
-                />
-                <stop
-                  offset=".532"
-                  stop-color="#edf1f4"
-                />
-                <stop
-                  offset=".675"
-                  stop-color="#dde5e9"
-                />
-                <stop
-                  offset=".799"
-                  stop-color="#c7d3da"
-                />
-                <stop
-                  offset=".908"
-                  stop-color="#adbdc7"
-                />
-                <stop
-                  offset="1"
-                  stop-color="#92a5b0"
-                />
-              </lineargradient>
-              <path
-                d="M45 1L71 27.7H45V1z"
-                fill="url(#b)"
-                stroke="#7191a1"
-                stroke-linejoin="bevel"
-                stroke-width="2"
-              />
-              <text
-                fill="#7191a1"
-                font-size="20px"
-                font-weight="bold"
-                text-anchor="middle"
-                text-length="64"
-                x="36"
-                y="60"
-              >
-                .ibd
-              </text>
-            </svg>
-          </a>
-          <a
-            class="flex mx-3 my-1 overflow-hidden"
-            href="https://sm-engine-upload.s3.eu-west-1.amazonaws.com/test/Image5.ibd?AWSAccessKeyId=test&Expires=1585569522&Signature=test%3D"
-          >
-            <span
-              class="flex-shrink truncate"
-            >
-              Image5
-            </span>
-            <span>
-              .ibd
-            </span>
-          </a>
-        </div>
-        <div
-          class="flex items-center p-1 w-1/2 box-border"
+          Download Mouse whole body DHB
+        </span>
+        <button
+          aria-label="Close"
+          class="el-dialog__headerbtn"
+          type="button"
         >
-          <a
-            href="https://sm-engine-upload.s3.eu-west-1.amazonaws.com/test/Image5.imzML?AWSAccessKeyId=test&Expires=1585569522&Signature=test%3D"
-          >
-            <svg
-              style="width: 32px; height: 50px;"
-              viewBox="0 0 72 100"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <lineargradient
-                gradientUnits="userSpaceOnUse"
-                id="a"
-                x1="36"
-                x2="36"
-                y1="99"
-                y2="1"
-              >
-                <stop
-                  offset="0"
-                  stop-color="#c8d4db"
-                />
-                <stop
-                  offset=".139"
-                  stop-color="#d8e1e6"
-                />
-                <stop
-                  offset=".359"
-                  stop-color="#ebf0f3"
-                />
-                <stop
-                  offset=".617"
-                  stop-color="#f9fafb"
-                />
-                <stop
-                  offset="1"
-                  stop-color="#fff"
-                />
-              </lineargradient>
-              <path
-                d="M45 1L71 27.7V99H1V1H45Z"
-                fill="url(#a)"
-                stroke="#7191a1"
-                stroke-width="2"
-              />
-              <lineargradient
-                gradientUnits="userSpaceOnUse"
-                id="b"
-                x1="45.068"
-                x2="58.568"
-                y1="27.796"
-                y2="14.395"
-              >
-                <stop
-                  offset="0"
-                  stop-color="#fff"
-                />
-                <stop
-                  offset=".35"
-                  stop-color="#fafbfb"
-                />
-                <stop
-                  offset=".532"
-                  stop-color="#edf1f4"
-                />
-                <stop
-                  offset=".675"
-                  stop-color="#dde5e9"
-                />
-                <stop
-                  offset=".799"
-                  stop-color="#c7d3da"
-                />
-                <stop
-                  offset=".908"
-                  stop-color="#adbdc7"
-                />
-                <stop
-                  offset="1"
-                  stop-color="#92a5b0"
-                />
-              </lineargradient>
-              <path
-                d="M45 1L71 27.7H45V1z"
-                fill="url(#b)"
-                stroke="#7191a1"
-                stroke-linejoin="bevel"
-                stroke-width="2"
-              />
-              <text
-                fill="#7191a1"
-                font-size="20px"
-                font-weight="bold"
-                text-anchor="middle"
-                text-length="64"
-                x="36"
-                y="60"
-              >
-                .imzML
-              </text>
-            </svg>
-          </a>
-          <a
-            class="flex mx-3 my-1 overflow-hidden"
-            href="https://sm-engine-upload.s3.eu-west-1.amazonaws.com/test/Image5.imzML?AWSAccessKeyId=test&Expires=1585569522&Signature=test%3D"
-          >
-            <span
-              class="flex-shrink truncate"
-            >
-              Image5
-            </span>
-            <span>
-              .imzML
-            </span>
-          </a>
-        </div>
+          <i
+            class="el-dialog__close el-icon el-icon-close"
+          />
+        </button>
       </div>
-      <p>
-        <i>
-          These download links expire after 30 minutes.
-        </i>
-      </p>
+      <div
+        class="el-dialog__body"
+      >
+        <p>
+          <p>
+            This dataset is distributed under the 
+            <a
+              href="https://creativecommons.org/licenses/by/4.0/"
+            >
+              CC BY 4.0
+            </a>
+             license. Make sure to credit the author of this dataset:
+          </p>
+        </p>
+        <ul>
+          <li
+            class="list-none"
+          >
+            Foo Bar, EMBL
+          </li>
+        </ul>
+        <h4>
+          Files
+        </h4>
+        <div
+          class="flex my-1 flex-wrap"
+        >
+          <div
+            class="flex items-center p-1 w-1/2 box-border"
+          >
+            <a
+              href="https://sm-engine-upload.s3.eu-west-1.amazonaws.com/test/Image5.ibd?AWSAccessKeyId=test&Expires=1585569522&Signature=test%3D"
+            >
+              <svg
+                style="width: 32px; height: 50px;"
+                viewBox="0 0 72 100"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <lineargradient
+                  gradientUnits="userSpaceOnUse"
+                  id="a"
+                  x1="36"
+                  x2="36"
+                  y1="99"
+                  y2="1"
+                >
+                  <stop
+                    offset="0"
+                    stop-color="#c8d4db"
+                  />
+                  <stop
+                    offset=".139"
+                    stop-color="#d8e1e6"
+                  />
+                  <stop
+                    offset=".359"
+                    stop-color="#ebf0f3"
+                  />
+                  <stop
+                    offset=".617"
+                    stop-color="#f9fafb"
+                  />
+                  <stop
+                    offset="1"
+                    stop-color="#fff"
+                  />
+                </lineargradient>
+                <path
+                  d="M45 1L71 27.7V99H1V1H45Z"
+                  fill="url(#a)"
+                  stroke="#7191a1"
+                  stroke-width="2"
+                />
+                <lineargradient
+                  gradientUnits="userSpaceOnUse"
+                  id="b"
+                  x1="45.068"
+                  x2="58.568"
+                  y1="27.796"
+                  y2="14.395"
+                >
+                  <stop
+                    offset="0"
+                    stop-color="#fff"
+                  />
+                  <stop
+                    offset=".35"
+                    stop-color="#fafbfb"
+                  />
+                  <stop
+                    offset=".532"
+                    stop-color="#edf1f4"
+                  />
+                  <stop
+                    offset=".675"
+                    stop-color="#dde5e9"
+                  />
+                  <stop
+                    offset=".799"
+                    stop-color="#c7d3da"
+                  />
+                  <stop
+                    offset=".908"
+                    stop-color="#adbdc7"
+                  />
+                  <stop
+                    offset="1"
+                    stop-color="#92a5b0"
+                  />
+                </lineargradient>
+                <path
+                  d="M45 1L71 27.7H45V1z"
+                  fill="url(#b)"
+                  stroke="#7191a1"
+                  stroke-linejoin="bevel"
+                  stroke-width="2"
+                />
+                <text
+                  fill="#7191a1"
+                  font-size="20px"
+                  font-weight="bold"
+                  text-anchor="middle"
+                  text-length="64"
+                  x="36"
+                  y="60"
+                >
+                  .ibd
+                </text>
+              </svg>
+            </a>
+            <a
+              class="flex mx-3 my-1 overflow-hidden"
+              href="https://sm-engine-upload.s3.eu-west-1.amazonaws.com/test/Image5.ibd?AWSAccessKeyId=test&Expires=1585569522&Signature=test%3D"
+            >
+              <span
+                class="flex-shrink truncate"
+              >
+                Image5
+              </span>
+              <span>
+                .ibd
+              </span>
+            </a>
+          </div>
+          <div
+            class="flex items-center p-1 w-1/2 box-border"
+          >
+            <a
+              href="https://sm-engine-upload.s3.eu-west-1.amazonaws.com/test/Image5.imzML?AWSAccessKeyId=test&Expires=1585569522&Signature=test%3D"
+            >
+              <svg
+                style="width: 32px; height: 50px;"
+                viewBox="0 0 72 100"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <lineargradient
+                  gradientUnits="userSpaceOnUse"
+                  id="a"
+                  x1="36"
+                  x2="36"
+                  y1="99"
+                  y2="1"
+                >
+                  <stop
+                    offset="0"
+                    stop-color="#c8d4db"
+                  />
+                  <stop
+                    offset=".139"
+                    stop-color="#d8e1e6"
+                  />
+                  <stop
+                    offset=".359"
+                    stop-color="#ebf0f3"
+                  />
+                  <stop
+                    offset=".617"
+                    stop-color="#f9fafb"
+                  />
+                  <stop
+                    offset="1"
+                    stop-color="#fff"
+                  />
+                </lineargradient>
+                <path
+                  d="M45 1L71 27.7V99H1V1H45Z"
+                  fill="url(#a)"
+                  stroke="#7191a1"
+                  stroke-width="2"
+                />
+                <lineargradient
+                  gradientUnits="userSpaceOnUse"
+                  id="b"
+                  x1="45.068"
+                  x2="58.568"
+                  y1="27.796"
+                  y2="14.395"
+                >
+                  <stop
+                    offset="0"
+                    stop-color="#fff"
+                  />
+                  <stop
+                    offset=".35"
+                    stop-color="#fafbfb"
+                  />
+                  <stop
+                    offset=".532"
+                    stop-color="#edf1f4"
+                  />
+                  <stop
+                    offset=".675"
+                    stop-color="#dde5e9"
+                  />
+                  <stop
+                    offset=".799"
+                    stop-color="#c7d3da"
+                  />
+                  <stop
+                    offset=".908"
+                    stop-color="#adbdc7"
+                  />
+                  <stop
+                    offset="1"
+                    stop-color="#92a5b0"
+                  />
+                </lineargradient>
+                <path
+                  d="M45 1L71 27.7H45V1z"
+                  fill="url(#b)"
+                  stroke="#7191a1"
+                  stroke-linejoin="bevel"
+                  stroke-width="2"
+                />
+                <text
+                  fill="#7191a1"
+                  font-size="20px"
+                  font-weight="bold"
+                  text-anchor="middle"
+                  text-length="64"
+                  x="36"
+                  y="60"
+                >
+                  .imzML
+                </text>
+              </svg>
+            </a>
+            <a
+              class="flex mx-3 my-1 overflow-hidden"
+              href="https://sm-engine-upload.s3.eu-west-1.amazonaws.com/test/Image5.imzML?AWSAccessKeyId=test&Expires=1585569522&Signature=test%3D"
+            >
+              <span
+                class="flex-shrink truncate"
+              >
+                Image5
+              </span>
+              <span>
+                .imzML
+              </span>
+            </a>
+          </div>
+        </div>
+        <p>
+          <i>
+            These download links expire after 30 minutes.
+          </i>
+        </p>
+      </div>
+      <!---->
     </div>
-    <!---->
   </div>
-</div>
+</transition-stub>
 `;

--- a/metaspace/webapp/src/modules/Filters/FilterPanel.spec.ts
+++ b/metaspace/webapp/src/modules/Filters/FilterPanel.spec.ts
@@ -56,7 +56,7 @@ describe('FilterPanel', () => {
   it('should match snapshot (no filters)', async() => {
     await updateFilter({})
     const propsData = { level: 'annotation' }
-    const wrapper = mount(FilterPanel, { router, apolloProvider, store, propsData, sync: false })
+    const wrapper = mount(FilterPanel, { router, apolloProvider, store, propsData })
     await Vue.nextTick()
 
     expect(wrapper).toMatchSnapshot()
@@ -65,7 +65,7 @@ describe('FilterPanel', () => {
   it('should match snapshot (all annotation filters)', async() => {
     await updateFilter(allFilters)
     const propsData = { level: 'annotation' }
-    const wrapper = mount(FilterPanel, { router, apolloProvider, store, propsData, sync: false })
+    const wrapper = mount(FilterPanel, { router, apolloProvider, store, propsData })
     await Vue.nextTick()
 
     expect(wrapper).toMatchSnapshot()
@@ -74,7 +74,7 @@ describe('FilterPanel', () => {
   it('should update the route when filters change', async() => {
     await updateFilter(allFilters)
     const propsData = { level: 'annotation' }
-    const wrapper = mount(FilterPanel, { router, apolloProvider, store, propsData, sync: false })
+    const wrapper = mount(FilterPanel, { router, apolloProvider, store, propsData })
     const newFilters = {
       simpleQuery: 'lorem ipsum',
       database: 'CHEBI',
@@ -111,7 +111,7 @@ describe('FilterPanel', () => {
   it('should be able to add a filter', async() => {
     await updateFilter({})
     const propsData = { level: 'annotation' }
-    const wrapper = mount(FilterPanel, { router, apolloProvider, store, propsData, sync: false })
+    const wrapper = mount(FilterPanel, { router, apolloProvider, store, propsData })
     await Vue.nextTick()
     expect(wrapper.find('[data-test-key="project"]').exists()).toEqual(false)
 
@@ -124,7 +124,7 @@ describe('FilterPanel', () => {
   it('should be able to remove a filter', async() => {
     await updateFilter(allFilters)
     const propsData = { level: 'annotation' }
-    const wrapper = mount(FilterPanel, { router, apolloProvider, store, propsData, sync: false })
+    const wrapper = mount(FilterPanel, { router, apolloProvider, store, propsData })
     await Vue.nextTick()
     expect(wrapper.find('[data-test-key="project"]').exists()).toEqual(true)
 

--- a/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.spec.ts
+++ b/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.spec.ts
@@ -25,7 +25,7 @@ describe('TransferDatasetsDialog', () => {
         + `${hasDatasets ? 'datasets to import' : 'no datasets'}, `
         + `${isInvited ? 'invited' : 'requesting access'})`, () => {
         const propsData = { ...mockProps, isInvited }
-        const wrapper = mount(TransferDatasetsDialog, { router, propsData, stubs, sync: false })
+        const wrapper = mount(TransferDatasetsDialog, { router, propsData, stubs })
         wrapper.setData({ allDatasets: hasDatasets ? mockDatasets : [] })
 
         expect(wrapper).toMatchSnapshot()
@@ -34,12 +34,12 @@ describe('TransferDatasetsDialog', () => {
   })
 
   it('should call back on success when some datasets are selected', async() => {
-    const wrapper = mount(TransferDatasetsDialog, { router, propsData: mockProps, stubs, sync: false })
+    const wrapper = mount(TransferDatasetsDialog, { router, propsData: mockProps, stubs })
     wrapper.setData({ allDatasets: mockDatasets })
     await Vue.nextTick()
 
-    wrapper.find(ElementUI.Checkbox).trigger('click')
-    wrapper.findAll<ElementUI.Button>(ElementUI.Button)
+    wrapper.findComponent(ElementUI.Checkbox).trigger('click')
+    wrapper.findAllComponents<ElementUI.Button>(ElementUI.Button)
       .filter((b: Wrapper<ElementUI.Button>) => b.props().type === 'primary')
       .at(0)
       .trigger('click')

--- a/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.spec.ts
+++ b/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.spec.ts
@@ -76,7 +76,7 @@ describe('ViewGroupPage', () => {
     it('should match snapshot (non-member)', async() => {
       initMockGraphqlClient(graphqlMocks)
       const maxVisibleDatasets = 3
-      const wrapper = mount(ViewGroupPage, { router, stubs, apolloProvider, sync: false })
+      const wrapper = mount(ViewGroupPage, { router, stubs, apolloProvider })
       wrapper.setData({ maxVisibleDatasets }) // Also test that the datasets list is correctly clipped
       await Vue.nextTick()
 
@@ -97,7 +97,7 @@ describe('ViewGroupPage', () => {
 
     it('should match snapshot (non-member)', async() => {
       initMockGraphqlClient(graphqlMocks)
-      const wrapper = mount(ViewGroupPage, { router, stubs: stubsWithMembersList, apolloProvider, sync: false })
+      const wrapper = mount(ViewGroupPage, { router, stubs: stubsWithMembersList, apolloProvider })
       await Vue.nextTick()
 
       expect(wrapper).toMatchSnapshot()
@@ -106,7 +106,7 @@ describe('ViewGroupPage', () => {
     it('should match snapshot (invited)', async() => {
       mockGroupFn.mockImplementation(() => ({ ...mockGroup, currentUserRole: 'INVITED' }))
       initMockGraphqlClient(graphqlMocks)
-      const wrapper = mount(ViewGroupPage, { router, stubs: stubsWithMembersList, apolloProvider, sync: false })
+      const wrapper = mount(ViewGroupPage, { router, stubs: stubsWithMembersList, apolloProvider })
       await Vue.nextTick()
 
       expect(wrapper).toMatchSnapshot()
@@ -116,7 +116,7 @@ describe('ViewGroupPage', () => {
       mockGroupFn.mockImplementation(() =>
         ({ ...mockGroup, currentUserRole: 'MEMBER', members: mockMembersForMembers }))
       initMockGraphqlClient(graphqlMocks)
-      const wrapper = mount(ViewGroupPage, { router, stubs: stubsWithMembersList, apolloProvider, sync: false })
+      const wrapper = mount(ViewGroupPage, { router, stubs: stubsWithMembersList, apolloProvider })
       await Vue.nextTick()
 
       expect(wrapper).toMatchSnapshot()
@@ -126,7 +126,7 @@ describe('ViewGroupPage', () => {
       mockGroupFn.mockImplementation(() =>
         ({ ...mockGroup, currentUserRole: 'GROUP_ADMIN', members: mockMembersForAdmins }))
       initMockGraphqlClient(graphqlMocks)
-      const wrapper = mount(ViewGroupPage, { router, stubs, apolloProvider, sync: false })
+      const wrapper = mount(ViewGroupPage, { router, stubs, apolloProvider })
       await Vue.nextTick()
 
       expect(wrapper).toMatchSnapshot()
@@ -141,7 +141,7 @@ describe('ViewGroupPage', () => {
     it('should match snapshot', async() => {
       mockGroupFn.mockImplementation(() => ({ ...mockGroup, currentUserRole: 'GROUP_ADMIN' }))
       initMockGraphqlClient(graphqlMocks)
-      const wrapper = mount(ViewGroupPage, { router, stubs, apolloProvider, sync: false })
+      const wrapper = mount(ViewGroupPage, { router, stubs, apolloProvider })
       await Vue.nextTick()
 
       expect(wrapper).toMatchSnapshot()
@@ -153,7 +153,7 @@ describe('ViewGroupPage', () => {
     mockGroupFn.mockImplementation(() => ({ ...mockGroup, urlSlug }))
     initMockGraphqlClient(graphqlMocks)
 
-    const wrapper = mount(ViewGroupPage, { router, stubs, apolloProvider, sync: false })
+    const wrapper = mount(ViewGroupPage, { router, stubs, apolloProvider })
     await Vue.nextTick()
 
     expect(router.currentRoute.params.groupIdOrSlug).toEqual(urlSlug)

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupPage.spec.ts.snap
@@ -71,28 +71,30 @@ exports[`ViewGroupPage members tab should match snapshot (invited) 1`] = `
         <!---->
         <!---->
       </div>
-      <div role="alert" class="el-alert el-alert--info is-light" name="el-alert-fade"><i class="el-alert__icon el-icon-info is-big"></i>
-        <div class="el-alert__content">
-          <!---->
-          <p class="el-alert__description">
-            <div style="padding: 0px 0px 20px 20px;">
-              <p>
-                You have been invited to join group name.
-              </p>
-              <div><button type="button" class="el-button el-button--danger">
-                  <!---->
-                  <!----><span>
+      <transition-stub name="el-alert-fade">
+        <div role="alert" class="el-alert el-alert--info is-light"><i class="el-alert__icon el-icon-info is-big"></i>
+          <div class="el-alert__content">
+            <!---->
+            <p class="el-alert__description">
+              <div style="padding: 0px 0px 20px 20px;">
+                <p>
+                  You have been invited to join group name.
+                </p>
+                <div><button type="button" class="el-button el-button--danger">
+                    <!---->
+                    <!----><span>
               Decline invitation
             </span></button> <button type="button" class="el-button el-button--primary">
-                  <!---->
-                  <!----><span>
+                    <!---->
+                    <!----><span>
               Join group
             </span></button></div>
-            </div>
-          </p>
-          <!----><i class="el-alert__closebtn el-icon-close" style="display: none;"></i>
+              </div>
+            </p>
+            <!----><i class="el-alert__closebtn el-icon-close" style="display: none;"></i>
+          </div>
         </div>
-      </div>
+      </transition-stub>
     </div>
     <div class="el-tabs el-tabs--top">
       <div class="el-tabs__header is-top">
@@ -537,7 +539,9 @@ exports[`ViewGroupPage settings tab should match snapshot 1`] = `
                       <!---->
                       <!---->
                     </div>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
                 <div class="el-form-item shortName is-required"><label for="shortName" class="el-form-item__label"><span>
@@ -551,7 +555,9 @@ exports[`ViewGroupPage settings tab should match snapshot 1`] = `
                       <!---->
                       <!---->
                     </div>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>

--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.spec.ts
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.spec.ts
@@ -22,7 +22,6 @@ describe('MetadataEditor', () => {
   }
 
   beforeAll(async() => {
-    testConfig.logModifiedComponents = false
     store.replaceState({
       ...store.state,
       // @ts-ignore
@@ -46,7 +45,7 @@ describe('MetadataEditor', () => {
         adductSuggestions: mockAdductSuggestions,
       }),
     })
-    const wrapper = mount(MetadataEditor, { store, router, apolloProvider, sync: false })
+    const wrapper = mount(MetadataEditor, { store, router, apolloProvider })
     await wrapper.vm.$data.loadingPromise
 
     expect(wrapper).toMatchSnapshot()
@@ -59,7 +58,7 @@ describe('MetadataEditor', () => {
       }),
     })
     const propsData = { datasetId: '123' }
-    const wrapper = mount(MetadataEditor, { store, router, apolloProvider, propsData, sync: false })
+    const wrapper = mount(MetadataEditor, { store, router, apolloProvider, propsData })
     await wrapper.vm.$data.loadingPromise
 
     expect(wrapper.vm.$data.value).toMatchSnapshot('metadata')
@@ -73,11 +72,11 @@ describe('MetadataEditor', () => {
       }),
     })
 
-    const wrapper = mount(MetadataEditor, { store, router, apolloProvider, sync: false })
+    const wrapper = mount(MetadataEditor, { store, router, apolloProvider })
     await wrapper.vm.$data.loadingPromise
 
     const fieldValues: Record<string, string> = {}
-    wrapper.findAll({ name: 'FormField' }).wrappers
+    wrapper.findAllComponents({ name: 'FormField' }).wrappers
       .forEach(field => { fieldValues[field.vm.$props.name] = field.vm.$props.value })
 
     expect(fieldValues.Organism).toEqual(mockMetadata.Sample_Information.Organism)
@@ -101,7 +100,7 @@ describe('MetadataEditor', () => {
       }),
     })
     const propsData = { datasetId: '123' }
-    const wrapper = mount(MetadataEditor, { store, router, apolloProvider, propsData, sync: false })
+    const wrapper = mount(MetadataEditor, { store, router, apolloProvider, propsData })
     await wrapper.vm.$data.loadingPromise
 
     expect(mockUserFn).toHaveBeenCalledTimes(1)

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -106,7 +106,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
         }
         return result;
       }" class="md-ac"></mock-el-autocomplete>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>
@@ -138,7 +140,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
         }
         return result;
       }" class="md-ac"></mock-el-autocomplete>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>
@@ -170,7 +174,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
         }
         return result;
       }" class="md-ac"></mock-el-autocomplete>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>
@@ -203,7 +209,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
         }
         return result;
       }" class="md-ac"></mock-el-autocomplete>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>
@@ -249,7 +257,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
         }
         return result;
       }" class="md-ac"></mock-el-autocomplete>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>
@@ -281,7 +291,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
         }
         return result;
       }" class="md-ac"></mock-el-autocomplete>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>
@@ -313,7 +325,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
         }
         return result;
       }" class="md-ac"></mock-el-autocomplete>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>
@@ -345,7 +359,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
         }
         return result;
       }" class="md-ac"></mock-el-autocomplete>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>
@@ -378,7 +394,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
         }
         return result;
       }" class="md-ac"></mock-el-autocomplete>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>
@@ -409,7 +427,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
                       <mock-el-option value="Positive" label="Positive"></mock-el-option>
                       <mock-el-option value="Negative" label="Negative"></mock-el-option>
                     </mock-el-select>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>
@@ -441,7 +461,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
         }
         return result;
       }" class="md-ac"></mock-el-autocomplete>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>
@@ -473,7 +495,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
         }
         return result;
       }" class="md-ac"></mock-el-autocomplete>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>
@@ -501,7 +525,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
                               m/z
                             </div>
                             <!---->
-                            <!---->
+                            <transition-stub name="el-zoom-in-top">
+                              <!---->
+                            </transition-stub>
                           </div>
                         </div>
                       </div>
@@ -524,12 +550,16 @@ exports[`MetadataEditor should match snapshot 1`] = `
                               resolving power
                             </div>
                             <!---->
-                            <!---->
+                            <transition-stub name="el-zoom-in-top">
+                              <!---->
+                            </transition-stub>
                           </div>
                         </div>
                       </div>
                     </div>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>
@@ -557,7 +587,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
                               horizontal
                             </div>
                             <!---->
-                            <!---->
+                            <transition-stub name="el-zoom-in-top">
+                              <!---->
+                            </transition-stub>
                           </div>
                         </div>
                       </div>
@@ -580,12 +612,16 @@ exports[`MetadataEditor should match snapshot 1`] = `
                               vertical
                             </div>
                             <!---->
-                            <!---->
+                            <transition-stub name="el-zoom-in-top">
+                              <!---->
+                            </transition-stub>
                           </div>
                         </div>
                       </div>
                     </div>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>
@@ -606,7 +642,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
                 <div class="el-row">
                   <mock-el-select filterable="" remote="" remote-method="function () { [native code] }" placeholder="Enter group name"></mock-el-select>
                 </div>
-                <!---->
+                <transition-stub name="el-zoom-in-top">
+                  <!---->
+                </transition-stub>
               </div>
             </div>
           </form>
@@ -641,7 +679,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
                 <div class="el-form-item__content"><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
       Allow other users to see this project
     <!----></span></label>
-                  <!---->
+                  <transition-stub name="el-zoom-in-top">
+                    <!---->
+                  </transition-stub>
                 </div>
               </div>
             </form>
@@ -698,7 +738,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
                         <!---->
                         <!---->
                       </div>
-                      <!---->
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
                     </div>
                   </div>
                 </div>
@@ -712,7 +754,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
                         <mock-el-option value="FIND_GROUP" label="Find my group..."></mock-el-option>
                         <mock-el-option value="NO_GROUP" label="No group (Enter PI instead)"></mock-el-option>
                       </mock-el-select>
-                      <!---->
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
                     </div>
                   </div>
                 </div>
@@ -726,7 +770,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
                         <mock-el-option value="currentUser.projects.1.project.id" label="currentUser.projects.1.project.name"></mock-el-option>
                         <mock-el-option value="CREATE_PROJECT" label="Create a new project..."></mock-el-option>
                       </mock-el-select>
-                      <!---->
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
                     </div>
                   </div>
                 </div>
@@ -734,7 +780,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
             </div>
           </div>
         </div>
-        <!---->
+        <transition-stub>
+          <!---->
+        </transition-stub>
       </div>
       <div class="metadata-section">
         <div class="el-row">
@@ -884,7 +932,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
                       <mock-el-select value="molecularDatabases.0.name" required="true" multiple="" multiple-limit="3">
                         <mock-el-option value="molecularDatabases.0.name" label="molecularDatabases.0.name"></mock-el-option>
                       </mock-el-select>
-                      <!---->
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
                     </div>
                   </div>
                 </div>
@@ -897,7 +947,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
                         <mock-el-option value="+Na" label="+Na"></mock-el-option>
                         <mock-el-option value="+K" label="+K"></mock-el-option>
                       </mock-el-select>
-                      <!---->
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
                     </div>
                   </div>
                 </div>
@@ -912,7 +964,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
                         <!---->
                         <!---->
                       </div>
-                      <!---->
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
                     </div>
                   </div>
                 </div>
@@ -941,7 +995,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
                     <div class="el-textarea el-input--medium"><textarea autocomplete="off" class="el-textarea__inner" style="min-height: -6px; height: -20px;"></textarea>
                       <!---->
                     </div>
-                    <!---->
+                    <transition-stub name="el-zoom-in-top">
+                      <!---->
+                    </transition-stub>
                   </div>
                 </div>
               </div>

--- a/metaspace/webapp/src/modules/Project/ProjectsListPage.spec.ts
+++ b/metaspace/webapp/src/modules/Project/ProjectsListPage.spec.ts
@@ -80,7 +80,9 @@ describe('ProjectsListPage', () => {
     await Vue.nextTick()
 
     expect(wrapper).toMatchSnapshot()
-    const projectIds = wrapper.findAllComponents({ name: 'ProjectsListItem' }).wrappers.map(item => item.props().project.id)
+    const projectIds = wrapper.findAllComponents({ name: 'ProjectsListItem' })
+      .wrappers
+      .map(item => item.props().project.id)
     expect(projectIds).toEqual(['project 1', 'project 2'])
   })
 
@@ -96,7 +98,9 @@ describe('ProjectsListPage', () => {
     store.commit('updateFilter', { simpleFilter: 'my-projects' })
     await Vue.nextTick()
 
-    const projectIds = wrapper.findAllComponents({ name: 'ProjectsListItem' }).wrappers.map(item => item.props().project.id)
+    const projectIds = wrapper.findAllComponents({ name: 'ProjectsListItem' })
+      .wrappers
+      .map(item => item.props().project.id)
     expect(projectIds).toEqual(['project 3', 'project 1'])
   })
 
@@ -114,7 +118,9 @@ describe('ProjectsListPage', () => {
     store.commit('updateFilter', { simpleFilter: 'my-projects', simpleQuery: 'ww' })
     await Vue.nextTick()
 
-    const projectIds = wrapper.findAllComponents({ name: 'ProjectsListItem' }).wrappers.map(item => item.props().project.id)
+    const projectIds = wrapper.findAllComponents({ name: 'ProjectsListItem' })
+      .wrappers
+      .map(item => item.props().project.id)
     expect(projectIds).toEqual(['ID W'])
   })
 

--- a/metaspace/webapp/src/modules/Project/ProjectsListPage.spec.ts
+++ b/metaspace/webapp/src/modules/Project/ProjectsListPage.spec.ts
@@ -75,12 +75,12 @@ describe('ProjectsListPage', () => {
         countProjects: () => 3,
       }),
     })
-    const wrapper = mount(ProjectsListPage, { router, apolloProvider, store, sync: false })
+    const wrapper = mount(ProjectsListPage, { router, apolloProvider, store })
     await Vue.nextTick()
     await Vue.nextTick()
 
     expect(wrapper).toMatchSnapshot()
-    const projectIds = wrapper.findAll({ name: 'ProjectsListItem' }).wrappers.map(item => item.props().project.id)
+    const projectIds = wrapper.findAllComponents({ name: 'ProjectsListItem' }).wrappers.map(item => item.props().project.id)
     expect(projectIds).toEqual(['project 1', 'project 2'])
   })
 
@@ -92,11 +92,11 @@ describe('ProjectsListPage', () => {
       }),
     })
 
-    const wrapper = mount(ProjectsListPage, { router, apolloProvider, store, sync: false })
+    const wrapper = mount(ProjectsListPage, { router, apolloProvider, store })
     store.commit('updateFilter', { simpleFilter: 'my-projects' })
     await Vue.nextTick()
 
-    const projectIds = wrapper.findAll({ name: 'ProjectsListItem' }).wrappers.map(item => item.props().project.id)
+    const projectIds = wrapper.findAllComponents({ name: 'ProjectsListItem' }).wrappers.map(item => item.props().project.id)
     expect(projectIds).toEqual(['project 3', 'project 1'])
   })
 
@@ -110,11 +110,11 @@ describe('ProjectsListPage', () => {
       }),
     })
 
-    const wrapper = mount(ProjectsListPage, { router, apolloProvider, store, sync: false })
+    const wrapper = mount(ProjectsListPage, { router, apolloProvider, store })
     store.commit('updateFilter', { simpleFilter: 'my-projects', simpleQuery: 'ww' })
     await Vue.nextTick()
 
-    const projectIds = wrapper.findAll({ name: 'ProjectsListItem' }).wrappers.map(item => item.props().project.id)
+    const projectIds = wrapper.findAllComponents({ name: 'ProjectsListItem' }).wrappers.map(item => item.props().project.id)
     expect(projectIds).toEqual(['ID W'])
   })
 
@@ -127,7 +127,7 @@ describe('ProjectsListPage', () => {
         ],
       }),
     })
-    const wrapper = mount(ProjectsListPage, { router, apolloProvider, store, sync: false })
+    const wrapper = mount(ProjectsListPage, { router, apolloProvider, store })
     await Vue.nextTick()
 
     expect(wrapper).toMatchSnapshot()
@@ -142,7 +142,7 @@ describe('ProjectsListPage', () => {
         ],
       }),
     })
-    const wrapper = mount(ProjectsListPage, { router, apolloProvider, store, sync: false })
+    const wrapper = mount(ProjectsListPage, { router, apolloProvider, store })
     await Vue.nextTick()
 
     expect(wrapper).toMatchSnapshot()

--- a/metaspace/webapp/src/modules/Project/ViewProjectPage.spec.ts
+++ b/metaspace/webapp/src/modules/Project/ViewProjectPage.spec.ts
@@ -79,7 +79,7 @@ describe('ViewProjectPage', () => {
     it('should match snapshot (non-member)', async() => {
       initMockGraphqlClient(graphqlMocks)
       const maxVisibleDatasets = 3
-      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider, sync: false })
+      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider })
       wrapper.setData({ maxVisibleDatasets }) // Also test that the datasets list is correctly clipped
       await Vue.nextTick()
 
@@ -100,7 +100,7 @@ describe('ViewProjectPage', () => {
 
     it('should match snapshot (non-member)', async() => {
       initMockGraphqlClient(graphqlMocks)
-      const wrapper = mount(ViewProjectPage, { router, stubs: stubsWithMembersList, apolloProvider, sync: false })
+      const wrapper = mount(ViewProjectPage, { router, stubs: stubsWithMembersList, apolloProvider })
       await Vue.nextTick()
 
       expect(wrapper).toMatchSnapshot()
@@ -109,7 +109,7 @@ describe('ViewProjectPage', () => {
     it('should match snapshot (invited)', async() => {
       mockProjectFn.mockImplementation(() => ({ ...mockProject, currentUserRole: 'INVITED' }))
       initMockGraphqlClient(graphqlMocks)
-      const wrapper = mount(ViewProjectPage, { router, stubs: stubsWithMembersList, apolloProvider, sync: false })
+      const wrapper = mount(ViewProjectPage, { router, stubs: stubsWithMembersList, apolloProvider })
       await Vue.nextTick()
 
       expect(wrapper).toMatchSnapshot()
@@ -119,7 +119,7 @@ describe('ViewProjectPage', () => {
       mockProjectFn.mockImplementation(() =>
         ({ ...mockProject, currentUserRole: 'MEMBER', members: mockMembersForMembers }))
       initMockGraphqlClient(graphqlMocks)
-      const wrapper = mount(ViewProjectPage, { router, stubs: stubsWithMembersList, apolloProvider, sync: false })
+      const wrapper = mount(ViewProjectPage, { router, stubs: stubsWithMembersList, apolloProvider })
       await Vue.nextTick()
 
       expect(wrapper).toMatchSnapshot()
@@ -129,7 +129,7 @@ describe('ViewProjectPage', () => {
       mockProjectFn.mockImplementation(() =>
         ({ ...mockProject, currentUserRole: 'MANAGER', members: mockMembersForManagers }))
       initMockGraphqlClient(graphqlMocks)
-      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider, sync: false })
+      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider })
       await Vue.nextTick()
 
       expect(wrapper).toMatchSnapshot()
@@ -144,7 +144,7 @@ describe('ViewProjectPage', () => {
     it('should match snapshot', async() => {
       mockProjectFn.mockImplementation(() => ({ ...mockProject, currentUserRole: 'MANAGER' }))
       initMockGraphqlClient(graphqlMocks)
-      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider, sync: false })
+      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider })
       await Vue.nextTick()
 
       expect(wrapper).toMatchSnapshot()
@@ -155,7 +155,7 @@ describe('ViewProjectPage', () => {
         ...mockProject, currentUserRole: 'MANAGER', publicationStatus: 'UNDER_REVIEW',
       }))
       initMockGraphqlClient(graphqlMocks)
-      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider, sync: false })
+      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider })
       await Vue.nextTick()
 
       expect(wrapper).toMatchSnapshot()
@@ -166,7 +166,7 @@ describe('ViewProjectPage', () => {
         ...mockProject, currentUserRole: 'MANAGER', publicationStatus: 'PUBLISHED',
       }))
       initMockGraphqlClient(graphqlMocks)
-      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider, sync: false })
+      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider })
       await Vue.nextTick()
 
       expect(wrapper).toMatchSnapshot()
@@ -178,7 +178,7 @@ describe('ViewProjectPage', () => {
     mockProjectFn.mockImplementation(() => ({ ...mockProject, urlSlug }))
     initMockGraphqlClient(graphqlMocks)
 
-    const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider, sync: false })
+    const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider })
     await Vue.nextTick()
 
     expect(router.currentRoute.params.projectIdOrSlug).toEqual(urlSlug)
@@ -200,7 +200,7 @@ describe('ViewProjectPage', () => {
       mockGenerateId(123)
       mockProjectFn.mockImplementation(() => ({ ...mockProject, currentUserRole: 'MANAGER' }))
       initMockGraphqlClient(graphqlMocks)
-      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider, sync: false })
+      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider })
       await Vue.nextTick()
 
       expect(wrapper).toMatchSnapshot()
@@ -211,7 +211,7 @@ describe('ViewProjectPage', () => {
         ...mockProject, currentUserRole: 'MANAGER', publicationStatus: 'UNDER_REVIEW',
       }))
       initMockGraphqlClient(graphqlMocks)
-      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider, sync: false })
+      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider })
       await Vue.nextTick()
 
       expect(wrapper).toMatchSnapshot()
@@ -222,7 +222,7 @@ describe('ViewProjectPage', () => {
         ...mockProject, currentUserRole: 'MANAGER', publicationStatus: 'PUBLISHED',
       }))
       initMockGraphqlClient(graphqlMocks)
-      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider, sync: false })
+      const wrapper = mount(ViewProjectPage, { router, stubs, apolloProvider })
       await Vue.nextTick()
 
       expect(wrapper).toMatchSnapshot()

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -18,7 +18,9 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
           <div class="el-form-item__content"><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
       Allow other users to see this project
     <!----></span></label>
-            <!---->
+            <transition-stub name="el-zoom-in-top">
+              <!---->
+            </transition-stub>
           </div>
         </div>
       </form>
@@ -168,7 +170,9 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
           <div class="el-form-item__content"><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
       Allow other users to see this project
     <!----></span></label>
-            <!---->
+            <transition-stub name="el-zoom-in-top">
+              <!---->
+            </transition-stub>
           </div>
         </div>
       </form>
@@ -317,7 +321,9 @@ exports[`ProjectsListPage should match snapshot 1`] = `
           <div class="el-form-item__content"><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
       Allow other users to see this project
     <!----></span></label>
-            <!---->
+            <transition-stub name="el-zoom-in-top">
+              <!---->
+            </transition-stub>
           </div>
         </div>
       </form>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
@@ -70,28 +70,30 @@ exports[`ViewProjectPage members tab should match snapshot (invited) 1`] = `
         <!---->
         <!---->
       </div>
-      <div role="alert" class="el-alert el-alert--info is-light" name="el-alert-fade"><i class="el-alert__icon el-icon-info is-big"></i>
-        <div class="el-alert__content">
-          <!---->
-          <p class="el-alert__description">
-            <div style="padding: 0px 0px 20px 20px;">
-              <p>
-                You have been invited to join project name.
-              </p>
-              <div><button type="button" class="el-button el-button--danger">
-                  <!---->
-                  <!----><span>
+      <transition-stub name="el-alert-fade">
+        <div role="alert" class="el-alert el-alert--info is-light"><i class="el-alert__icon el-icon-info is-big"></i>
+          <div class="el-alert__content">
+            <!---->
+            <p class="el-alert__description">
+              <div style="padding: 0px 0px 20px 20px;">
+                <p>
+                  You have been invited to join project name.
+                </p>
+                <div><button type="button" class="el-button el-button--danger">
+                    <!---->
+                    <!----><span>
               Decline invitation
             </span></button> <button type="button" class="el-button el-button--primary">
-                  <!---->
-                  <!----><span>
+                    <!---->
+                    <!----><span>
               Join project
             </span></button></div>
-            </div>
-          </p>
-          <!----><i class="el-alert__closebtn el-icon-close" style="display: none;"></i>
+              </div>
+            </p>
+            <!----><i class="el-alert__closebtn el-icon-close" style="display: none;"></i>
+          </div>
         </div>
-      </div>
+      </transition-stub>
     </div>
     <div class="with-badges el-tabs el-tabs--top">
       <div class="el-tabs__header is-top">
@@ -156,7 +158,7 @@ exports[`ViewProjectPage members tab should match snapshot (manager, including t
           <span class="notification"></span></span></div>
               <div id="tab-publishing" aria-controls="pane-publishing" role="tab" tabindex="-1" class="el-tabs__item is-top"><span><div class="el-badge sm-feature-badge">
             Publishing
-          <sup class="el-badge__content el-badge__content--undefined is-fixed" name="el-zoom-in-center">New</sup></div></span></div>
+          <transition-stub name="el-zoom-in-center"><sup class="el-badge__content el-badge__content--undefined is-fixed">New</sup></transition-stub></div></span></div>
               <div id="tab-settings" aria-controls="pane-settings" role="tab" tabindex="-1" class="el-tabs__item is-top">Settings</div>
             </div>
           </div>
@@ -522,13 +524,15 @@ exports[`ViewProjectPage publishing tab should match snapshot (published) 1`] = 
         <!---->
         <!---->
         <div role="tabpanel" id="pane-publishing" aria-labelledby="tab-publishing" class="el-tab-pane tab-with-badge sm-publishing-tab">
-          <div class="leading-6 text-center mt-12" mode="out-in" enter-class="opacity-0" leave-to-class="opacity-0" enter-active-class="duration-150 transition-opacity ease-in-out" leave-active-class="duration-150 transition-opacity ease-in-out"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-6 w-6 block w-8 h-8 p-2 rounded-full bg-blue-100 mx-auto">
-              <circle cx="12" cy="12" r="10" class="fill-current text-blue-800"></circle>
-              <path d="M2.05 11A10 10 0 0 1 15 2.46V6a2 2 0 0 1-2 2h-1v1a2 2 0 0 1-1 1.73V12h2a2 2 0 0 1 2 2v1h2a2 2 0 0 1 2 2v2.14A9.97 9.97 0 0 1 12 22v-4h-1a2 2 0 0 1-2-2v-2a2 2 0 0 1-2-2v-1H2.05z" class="fill-current text-blue-300"></path>
-            </svg>
-            <h2 class="leading-10 py-1 m-0">Project is published</h2>
-            <p class="m-0">The project and its datasets are now public.<br>Thank you for your contribution.</p>
-          </div>
+          <transition-stub mode="out-in" enter-class="opacity-0" leave-to-class="opacity-0" enter-active-class="duration-150 transition-opacity ease-in-out" leave-active-class="duration-150 transition-opacity ease-in-out">
+            <div class="leading-6 text-center mt-12"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-6 w-6 block w-8 h-8 p-2 rounded-full bg-blue-100 mx-auto">
+                <circle cx="12" cy="12" r="10" class="fill-current text-blue-800"></circle>
+                <path d="M2.05 11A10 10 0 0 1 15 2.46V6a2 2 0 0 1-2 2h-1v1a2 2 0 0 1-1 1.73V12h2a2 2 0 0 1 2 2v1h2a2 2 0 0 1 2 2v2.14A9.97 9.97 0 0 1 12 22v-4h-1a2 2 0 0 1-2-2v-2a2 2 0 0 1-2-2v-1H2.05z" class="fill-current text-blue-300"></path>
+              </svg>
+              <h2 class="leading-10 py-1 m-0">Project is published</h2>
+              <p class="m-0">The project and its datasets are now public.<br>Thank you for your contribution.</p>
+            </div>
+          </transition-stub>
         </div>
         <!---->
       </div>
@@ -578,61 +582,65 @@ exports[`ViewProjectPage publishing tab should match snapshot (under review) 1`]
         <!---->
         <!---->
         <div role="tabpanel" id="pane-publishing" aria-labelledby="tab-publishing" class="el-tab-pane tab-with-badge sm-publishing-tab">
-          <ol class="sm-workflow leading-6 m-0 p-0 sm-scientific-publishing" mode="out-in" enter-class="opacity-0" leave-to-class="opacity-0" enter-active-class="duration-150 transition-opacity ease-in-out" leave-active-class="duration-150 transition-opacity ease-in-out">
-            <li class="sm-workflow-step flex flex-col relative text-gray-600 max-w-measure-3 ml-8 pl-12 border-solid border-0 border-l-2 border-gray-300 transition-colors ease-in-out duration-300 done border-blue-200">
-              <h2 class="sm-workflow-header">Update project details</h2>
-              <form action="#" mode="out-in" enter-class="opacity-0" leave-to-class="opacity-0" enter-active-class="duration-150 transition-opacity ease-in-out" leave-active-class="duration-150 transition-opacity ease-in-out"><label><span class="font-medium text-primary">Reference the project in the manuscript using this link:</span>
-                  <div class="el-input el-input-group el-input-group--append py-1">
-                    <!----><input type="text" readonly="readonly" autocomplete="off" class="el-input__inner">
+          <transition-stub mode="out-in" enter-class="opacity-0" leave-to-class="opacity-0" enter-active-class="duration-150 transition-opacity ease-in-out" leave-active-class="duration-150 transition-opacity ease-in-out">
+            <ol class="sm-workflow leading-6 m-0 p-0 sm-scientific-publishing">
+              <li class="sm-workflow-step flex flex-col relative text-gray-600 max-w-measure-3 ml-8 pl-12 border-solid border-0 border-l-2 border-gray-300 transition-colors ease-in-out duration-300 done border-blue-200">
+                <h2 class="sm-workflow-header">Update project details</h2>
+                <transition-stub mode="out-in" enter-class="opacity-0" leave-to-class="opacity-0" enter-active-class="duration-150 transition-opacity ease-in-out" leave-active-class="duration-150 transition-opacity ease-in-out">
+                  <form action="#"><label><span class="font-medium text-primary">Reference the project in the manuscript using this link:</span>
+                      <div class="el-input el-input-group el-input-group--append py-1">
+                        <!----><input type="text" readonly="readonly" autocomplete="off" class="el-input__inner">
+                        <!---->
+                        <!---->
+                        <div class="el-input-group__append">
+                          <mock-el-tooltip manual="true" content="Copied!" placement="right"><button type="button" class="el-button el-button--default" title="Copy to clipboard">
+                              <!----><i class="el-icon-document-copy"></i>
+                              <!----></button></mock-el-tooltip>
+                        </div>
+                        <!---->
+                      </div></label><button type="button" class="el-button el-button--default">
+                      <!---->
+                      <!----><span>Edit details</span></button></form>
+                </transition-stub>
+              </li>
+              <li class="sm-workflow-step flex flex-col relative text-gray-600 max-w-measure-3 ml-8 pl-12 border-solid border-0 border-l-2 border-gray-300 transition-colors ease-in-out duration-300 done border-blue-200">
+                <h2 class="sm-workflow-header">Create link for reviewers</h2>
+                <form>
+                  <p class="pb-3"><em>Review links are temporary and will not work after the project is published.</em></p><label><span class="font-medium text-primary">Reviewers can access the project using this link:</span>
+                    <div class="el-input el-input-group el-input-group--append py-1">
+                      <!----><input type="text" readonly="readonly" autocomplete="off" class="el-input__inner">
+                      <!---->
+                      <!---->
+                      <div class="el-input-group__append">
+                        <mock-el-tooltip manual="true" content="Copied!" placement="right"><button type="button" class="el-button el-button--default" title="Copy to clipboard">
+                            <!----><i class="el-icon-document-copy"></i>
+                            <!----></button></mock-el-tooltip>
+                      </div>
+                      <!---->
+                    </div></label><button type="button" class="el-button el-button--default">
                     <!---->
-                    <!---->
-                    <div class="el-input-group__append">
-                      <mock-el-tooltip manual="true" content="Copied!" placement="right"><button type="button" class="el-button el-button--default" title="Copy to clipboard">
-                          <!----><i class="el-icon-document-copy"></i>
-                          <!----></button></mock-el-tooltip>
+                    <!----><span>Remove link</span></button>
+                </form>
+              </li>
+              <li class="sm-workflow-step flex flex-col relative text-gray-600 max-w-measure-3 ml-8 pl-12 border-solid border-0 border-l-2 border-gray-300 transition-colors ease-in-out duration-300 active">
+                <h2 class="sm-workflow-header">Publish the data</h2>
+                <form class="sm-form">
+                  <p class="italic">Complete this step after the DOI for your paper has been issued.<br>You will receive a reminder by email.</p>
+                  <div><label for="scientific-publishing-doi"><span class="text-base font-medium">Publication DOI</span><span class="block text-sm text-gray-800">Should link to the published paper</span></label>
+                    <div class="el-input el-input-group el-input-group--append el-input-group--prepend">
+                      <div class="el-input-group__prepend"><span>https://doi.org/</span></div><input type="text" autocomplete="off" id="scientific-publishing-doi" class="el-input__inner">
+                      <!---->
+                      <!---->
+                      <div class="el-input-group__append"><span><a target="_blank" rel="noopener" class="text-inherit">Test link</a></span></div>
+                      <!---->
                     </div>
+                  </div><button type="button" class="el-button el-button--primary">
                     <!---->
-                  </div></label><button type="button" class="el-button el-button--default">
-                  <!---->
-                  <!----><span>Edit details</span></button></form>
-            </li>
-            <li class="sm-workflow-step flex flex-col relative text-gray-600 max-w-measure-3 ml-8 pl-12 border-solid border-0 border-l-2 border-gray-300 transition-colors ease-in-out duration-300 done border-blue-200">
-              <h2 class="sm-workflow-header">Create link for reviewers</h2>
-              <form>
-                <p class="pb-3"><em>Review links are temporary and will not work after the project is published.</em></p><label><span class="font-medium text-primary">Reviewers can access the project using this link:</span>
-                  <div class="el-input el-input-group el-input-group--append py-1">
-                    <!----><input type="text" readonly="readonly" autocomplete="off" class="el-input__inner">
-                    <!---->
-                    <!---->
-                    <div class="el-input-group__append">
-                      <mock-el-tooltip manual="true" content="Copied!" placement="right"><button type="button" class="el-button el-button--default" title="Copy to clipboard">
-                          <!----><i class="el-icon-document-copy"></i>
-                          <!----></button></mock-el-tooltip>
-                    </div>
-                    <!---->
-                  </div></label><button type="button" class="el-button el-button--default">
-                  <!---->
-                  <!----><span>Remove link</span></button>
-              </form>
-            </li>
-            <li class="sm-workflow-step flex flex-col relative text-gray-600 max-w-measure-3 ml-8 pl-12 border-solid border-0 border-l-2 border-gray-300 transition-colors ease-in-out duration-300 active">
-              <h2 class="sm-workflow-header">Publish the data</h2>
-              <form class="sm-form">
-                <p class="italic">Complete this step after the DOI for your paper has been issued.<br>You will receive a reminder by email.</p>
-                <div><label for="scientific-publishing-doi"><span class="text-base font-medium">Publication DOI</span><span class="block text-sm text-gray-800">Should link to the published paper</span></label>
-                  <div class="el-input el-input-group el-input-group--append el-input-group--prepend">
-                    <div class="el-input-group__prepend"><span>https://doi.org/</span></div><input type="text" autocomplete="off" id="scientific-publishing-doi" class="el-input__inner">
-                    <!---->
-                    <!---->
-                    <div class="el-input-group__append"><span><a target="_blank" rel="noopener" class="text-inherit">Test link</a></span></div>
-                    <!---->
-                  </div>
-                </div><button type="button" class="el-button el-button--primary">
-                  <!---->
-                  <!----><span>Publish project</span></button>
-              </form>
-            </li>
-          </ol>
+                    <!----><span>Publish project</span></button>
+                </form>
+              </li>
+            </ol>
+          </transition-stub>
         </div>
         <!---->
       </div>
@@ -682,48 +690,52 @@ exports[`ViewProjectPage publishing tab should match snapshot (unpublished) 1`] 
         <!---->
         <!---->
         <div role="tabpanel" id="pane-publishing" aria-labelledby="tab-publishing" class="el-tab-pane tab-with-badge sm-publishing-tab">
-          <ol class="sm-workflow leading-6 m-0 p-0 sm-scientific-publishing" mode="out-in" enter-class="opacity-0" leave-to-class="opacity-0" enter-active-class="duration-150 transition-opacity ease-in-out" leave-active-class="duration-150 transition-opacity ease-in-out">
-            <li class="sm-workflow-step flex flex-col relative text-gray-600 max-w-measure-3 ml-8 pl-12 border-solid border-0 border-l-2 border-gray-300 transition-colors ease-in-out duration-300 active">
-              <h2 class="sm-workflow-header">Update project details</h2>
-              <form action="#" class="sm-form" mode="out-in" enter-class="opacity-0" leave-to-class="opacity-0" enter-active-class="duration-150 transition-opacity ease-in-out" leave-active-class="duration-150 transition-opacity ease-in-out">
-                <p>Create a short project link to use in the manuscript. We also suggest updating the project title and adding an abstract to the project description.</p>
-                <div><label for="publishing-project-link"><span class="text-base font-medium">Link to be used in the manuscript</span><span class="block text-sm text-gray-800">Must be unique, min. 4 characters, using a–z, 0–9, hyphen or underscore</span></label>
-                  <div class="el-input el-input-group el-input-group--prepend">
-                    <div class="el-input-group__prepend"><span>http://localhost/project/</span></div><input type="text" autocomplete="off" id="publishing-project-link" maxlength="50" minlength="4" pattern="[a-zA-Z0-9_-]+" title="min. 4 characters, a–z, 0–9, hyphen or underscore" class="el-input__inner">
-                    <!---->
-                    <!---->
-                    <!---->
-                    <!---->
-                  </div>
-                </div>
-                <div><label for="project-review-title"><span class="text-base font-medium">Project title</span><span class="block text-sm text-gray-800">Suggested format: Author et al. (year) title</span></label>
-                  <div class="el-input">
-                    <!----><input type="text" autocomplete="off" id="project-review-title" class="el-input__inner">
-                    <!---->
-                    <!---->
-                    <!---->
-                    <!---->
-                  </div>
-                </div>
-                <div class="sm-RichText sm-RichTextArea relative"><label><span class="text-base font-medium">Abstract</span><span class="block text-sm text-gray-800">Copy and paste here, will be displayed in the About section</span></label>
-                  <div class="h-40 w-full box-border overflow-y-auto cursor-text text-gray-800 text-sm rounded border border-solid transition-colors ease-in-out duration-200 border-gray-300 hover:border-gray-500 focus-within:border-primary mt-1">
-                    <div contenteditable="true" tabindex="0" class="ProseMirror">
-                      <p><br></p>
+          <transition-stub mode="out-in" enter-class="opacity-0" leave-to-class="opacity-0" enter-active-class="duration-150 transition-opacity ease-in-out" leave-active-class="duration-150 transition-opacity ease-in-out">
+            <ol class="sm-workflow leading-6 m-0 p-0 sm-scientific-publishing">
+              <li class="sm-workflow-step flex flex-col relative text-gray-600 max-w-measure-3 ml-8 pl-12 border-solid border-0 border-l-2 border-gray-300 transition-colors ease-in-out duration-300 active">
+                <h2 class="sm-workflow-header">Update project details</h2>
+                <transition-stub mode="out-in" enter-class="opacity-0" leave-to-class="opacity-0" enter-active-class="duration-150 transition-opacity ease-in-out" leave-active-class="duration-150 transition-opacity ease-in-out">
+                  <form action="#" class="sm-form">
+                    <p>Create a short project link to use in the manuscript. We also suggest updating the project title and adding an abstract to the project description.</p>
+                    <div><label for="publishing-project-link"><span class="text-base font-medium">Link to be used in the manuscript</span><span class="block text-sm text-gray-800">Must be unique, min. 4 characters, using a–z, 0–9, hyphen or underscore</span></label>
+                      <div class="el-input el-input-group el-input-group--prepend">
+                        <div class="el-input-group__prepend"><span>http://localhost/project/</span></div><input type="text" autocomplete="off" id="publishing-project-link" maxlength="50" minlength="4" pattern="[a-zA-Z0-9_-]+" title="min. 4 characters, a–z, 0–9, hyphen or underscore" class="el-input__inner">
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                      </div>
                     </div>
-                  </div>
-                  <div class="absolute bg-white rounded p-1 border border-solid border-gray-100 shadow mb-2 transform -translate-x-1/2 transition-fade ease-in-out duration-150 invisible opacity-0" style="left: 0px; bottom: 0px;"><span class="flex items-start justify-center"><button title="Bold (Ctrl+B)" class="button-reset mr-1 last:mr-0 h-8 w-8 inline-flex items-center justify-center rounded-sm text-gray-600 hover:bg-gray-100 focus:bg-gray-100"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" class="fill-current"><path d="M0 0h24v24H0V0z" fill="none"></path><path d="M15.6 10.79c.97-.67 1.65-1.77 1.65-2.79 0-2.26-1.75-4-4-4H8c-.55 0-1 .45-1 1v12c0 .55.45 1 1 1h5.78c2.07 0 3.96-1.69 3.97-3.77.01-1.53-.85-2.84-2.15-3.44zM10 6.5h3c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5h-3v-3zm3.5 9H10v-3h3.5c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5z"></path></svg></button><button title="Italic (Ctrl+I)" class="button-reset mr-1 last:mr-0 h-8 w-8 inline-flex items-center justify-center rounded-sm text-gray-600 hover:bg-gray-100 focus:bg-gray-100"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" class="fill-current"><path d="M0 0h24v24H0V0z" fill="none"></path><path d="M10 5.5c0 .83.67 1.5 1.5 1.5h.71l-3.42 8H7.5c-.83 0-1.5.67-1.5 1.5S6.67 18 7.5 18h5c.83 0 1.5-.67 1.5-1.5s-.67-1.5-1.5-1.5h-.71l3.42-8h1.29c.83 0 1.5-.67 1.5-1.5S17.33 4 16.5 4h-5c-.83 0-1.5.67-1.5 1.5z"></path></svg></button><button title="Underline (Ctrl+U)" class="button-reset mr-1 last:mr-0 h-8 w-8 inline-flex items-center justify-center rounded-sm text-gray-600 hover:bg-gray-100 focus:bg-gray-100"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" class="fill-current"><path d="M0 0h24v24H0V0z" fill="none"></path><path d="M12.79 16.95c3.03-.39 5.21-3.11 5.21-6.16V4.25C18 3.56 17.44 3 16.75 3s-1.25.56-1.25 1.25v6.65c0 1.67-1.13 3.19-2.77 3.52-2.25.47-4.23-1.25-4.23-3.42V4.25C8.5 3.56 7.94 3 7.25 3S6 3.56 6 4.25V11c0 3.57 3.13 6.42 6.79 5.95zM5 20c0 .55.45 1 1 1h12c.55 0 1-.45 1-1s-.45-1-1-1H6c-.55 0-1 .45-1 1z"></path></svg></button><button title="Title" class="button-reset mr-1 last:mr-0 h-8 w-8 inline-flex items-center justify-center rounded-sm text-gray-600 hover:bg-gray-100 focus:bg-gray-100"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" class="fill-current"><path d="M0 0h24v24H0V0z" fill="none"></path><path d="M5 5.5C5 6.33 5.67 7 6.5 7h4v10.5c0 .83.67 1.5 1.5 1.5s1.5-.67 1.5-1.5V7h4c.83 0 1.5-.67 1.5-1.5S18.33 4 17.5 4h-11C5.67 4 5 4.67 5 5.5z"></path></svg></button><button title="Bullet list" class="button-reset mr-1 last:mr-0 h-8 w-8 inline-flex items-center justify-center rounded-sm text-gray-600 hover:bg-gray-100 focus:bg-gray-100"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" class="fill-current"><path d="M0 0h24v24H0V0z" fill="none"></path><path d="M4 10.5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5 1.5-.67 1.5-1.5-.67-1.5-1.5-1.5zm0-6c-.83 0-1.5.67-1.5 1.5S3.17 7.5 4 7.5 5.5 6.83 5.5 6 4.83 4.5 4 4.5zm0 12c-.83 0-1.5.68-1.5 1.5s.68 1.5 1.5 1.5 1.5-.68 1.5-1.5-.67-1.5-1.5-1.5zM8 19h12c.55 0 1-.45 1-1s-.45-1-1-1H8c-.55 0-1 .45-1 1s.45 1 1 1zm0-6h12c.55 0 1-.45 1-1s-.45-1-1-1H8c-.55 0-1 .45-1 1s.45 1 1 1zM7 6c0 .55.45 1 1 1h12c.55 0 1-.45 1-1s-.45-1-1-1H8c-.55 0-1 .45-1 1z"></path></svg></button><button title="Subscript" class="button-reset mr-1 last:mr-0 h-8 w-8 inline-flex items-center justify-center rounded-sm text-gray-600 hover:bg-gray-100 focus:bg-gray-100"><span class="text-lg font-bold tracking-wider">H<sub class="text-xs leading-none">2</sub></span></button><button title="Superscript" class="button-reset mr-1 last:mr-0 h-8 w-8 inline-flex items-center justify-center rounded-sm text-gray-600 hover:bg-gray-100 focus:bg-gray-100"><span class="text-lg font-bold">x<sup class="text-xs leading-none">2</sup></span></button></span></div>
-                </div><button class="el-button el-button--primary"><span>Update</span></button>
-              </form>
-            </li>
-            <li class="sm-workflow-step flex flex-col relative text-gray-600 max-w-measure-3 ml-8 pl-12 border-solid border-0 border-l-2 border-gray-300 transition-colors ease-in-out duration-300">
-              <h2 class="sm-workflow-header">Create link for reviewers</h2>
-              <p>A review link allows reviewers to access this project and its datasets without making the project available to everyone.</p>
-            </li>
-            <li class="sm-workflow-step flex flex-col relative text-gray-600 max-w-measure-3 ml-8 pl-12 border-solid border-0 border-l-2 border-gray-300 transition-colors ease-in-out duration-300">
-              <h2 class="sm-workflow-header">Publish the data</h2>
-              <p>This project and its datasets will be made public.</p>
-            </li>
-          </ol>
+                    <div><label for="project-review-title"><span class="text-base font-medium">Project title</span><span class="block text-sm text-gray-800">Suggested format: Author et al. (year) title</span></label>
+                      <div class="el-input">
+                        <!----><input type="text" autocomplete="off" id="project-review-title" class="el-input__inner">
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                      </div>
+                    </div>
+                    <div class="sm-RichText sm-RichTextArea relative"><label><span class="text-base font-medium">Abstract</span><span class="block text-sm text-gray-800">Copy and paste here, will be displayed in the About section</span></label>
+                      <div class="h-40 w-full box-border overflow-y-auto cursor-text text-gray-800 text-sm rounded border border-solid transition-colors ease-in-out duration-200 border-gray-300 hover:border-gray-500 focus-within:border-primary mt-1">
+                        <div contenteditable="true" tabindex="0" class="ProseMirror">
+                          <p><br></p>
+                        </div>
+                      </div>
+                      <div class="absolute bg-white rounded p-1 border border-solid border-gray-100 shadow mb-2 transform -translate-x-1/2 transition-fade ease-in-out duration-150 invisible opacity-0" style="left: 0px; bottom: 0px;"><span class="flex items-start justify-center"><button title="Bold (Ctrl+B)" class="button-reset mr-1 last:mr-0 h-8 w-8 inline-flex items-center justify-center rounded-sm text-gray-600 hover:bg-gray-100 focus:bg-gray-100"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" class="fill-current"><path d="M0 0h24v24H0V0z" fill="none"></path><path d="M15.6 10.79c.97-.67 1.65-1.77 1.65-2.79 0-2.26-1.75-4-4-4H8c-.55 0-1 .45-1 1v12c0 .55.45 1 1 1h5.78c2.07 0 3.96-1.69 3.97-3.77.01-1.53-.85-2.84-2.15-3.44zM10 6.5h3c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5h-3v-3zm3.5 9H10v-3h3.5c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5z"></path></svg></button><button title="Italic (Ctrl+I)" class="button-reset mr-1 last:mr-0 h-8 w-8 inline-flex items-center justify-center rounded-sm text-gray-600 hover:bg-gray-100 focus:bg-gray-100"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" class="fill-current"><path d="M0 0h24v24H0V0z" fill="none"></path><path d="M10 5.5c0 .83.67 1.5 1.5 1.5h.71l-3.42 8H7.5c-.83 0-1.5.67-1.5 1.5S6.67 18 7.5 18h5c.83 0 1.5-.67 1.5-1.5s-.67-1.5-1.5-1.5h-.71l3.42-8h1.29c.83 0 1.5-.67 1.5-1.5S17.33 4 16.5 4h-5c-.83 0-1.5.67-1.5 1.5z"></path></svg></button><button title="Underline (Ctrl+U)" class="button-reset mr-1 last:mr-0 h-8 w-8 inline-flex items-center justify-center rounded-sm text-gray-600 hover:bg-gray-100 focus:bg-gray-100"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" class="fill-current"><path d="M0 0h24v24H0V0z" fill="none"></path><path d="M12.79 16.95c3.03-.39 5.21-3.11 5.21-6.16V4.25C18 3.56 17.44 3 16.75 3s-1.25.56-1.25 1.25v6.65c0 1.67-1.13 3.19-2.77 3.52-2.25.47-4.23-1.25-4.23-3.42V4.25C8.5 3.56 7.94 3 7.25 3S6 3.56 6 4.25V11c0 3.57 3.13 6.42 6.79 5.95zM5 20c0 .55.45 1 1 1h12c.55 0 1-.45 1-1s-.45-1-1-1H6c-.55 0-1 .45-1 1z"></path></svg></button><button title="Title" class="button-reset mr-1 last:mr-0 h-8 w-8 inline-flex items-center justify-center rounded-sm text-gray-600 hover:bg-gray-100 focus:bg-gray-100"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" class="fill-current"><path d="M0 0h24v24H0V0z" fill="none"></path><path d="M5 5.5C5 6.33 5.67 7 6.5 7h4v10.5c0 .83.67 1.5 1.5 1.5s1.5-.67 1.5-1.5V7h4c.83 0 1.5-.67 1.5-1.5S18.33 4 17.5 4h-11C5.67 4 5 4.67 5 5.5z"></path></svg></button><button title="Bullet list" class="button-reset mr-1 last:mr-0 h-8 w-8 inline-flex items-center justify-center rounded-sm text-gray-600 hover:bg-gray-100 focus:bg-gray-100"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" class="fill-current"><path d="M0 0h24v24H0V0z" fill="none"></path><path d="M4 10.5c-.83 0-1.5.67-1.5 1.5s.67 1.5 1.5 1.5 1.5-.67 1.5-1.5-.67-1.5-1.5-1.5zm0-6c-.83 0-1.5.67-1.5 1.5S3.17 7.5 4 7.5 5.5 6.83 5.5 6 4.83 4.5 4 4.5zm0 12c-.83 0-1.5.68-1.5 1.5s.68 1.5 1.5 1.5 1.5-.68 1.5-1.5-.67-1.5-1.5-1.5zM8 19h12c.55 0 1-.45 1-1s-.45-1-1-1H8c-.55 0-1 .45-1 1s.45 1 1 1zm0-6h12c.55 0 1-.45 1-1s-.45-1-1-1H8c-.55 0-1 .45-1 1s.45 1 1 1zM7 6c0 .55.45 1 1 1h12c.55 0 1-.45 1-1s-.45-1-1-1H8c-.55 0-1 .45-1 1z"></path></svg></button><button title="Subscript" class="button-reset mr-1 last:mr-0 h-8 w-8 inline-flex items-center justify-center rounded-sm text-gray-600 hover:bg-gray-100 focus:bg-gray-100"><span class="text-lg font-bold tracking-wider">H<sub class="text-xs leading-none">2</sub></span></button><button title="Superscript" class="button-reset mr-1 last:mr-0 h-8 w-8 inline-flex items-center justify-center rounded-sm text-gray-600 hover:bg-gray-100 focus:bg-gray-100"><span class="text-lg font-bold">x<sup class="text-xs leading-none">2</sup></span></button></span></div>
+                    </div><button class="el-button el-button--primary"><span>Update</span></button>
+                  </form>
+                </transition-stub>
+              </li>
+              <li class="sm-workflow-step flex flex-col relative text-gray-600 max-w-measure-3 ml-8 pl-12 border-solid border-0 border-l-2 border-gray-300 transition-colors ease-in-out duration-300">
+                <h2 class="sm-workflow-header">Create link for reviewers</h2>
+                <p>A review link allows reviewers to access this project and its datasets without making the project available to everyone.</p>
+              </li>
+              <li class="sm-workflow-step flex flex-col relative text-gray-600 max-w-measure-3 ml-8 pl-12 border-solid border-0 border-l-2 border-gray-300 transition-colors ease-in-out duration-300">
+                <h2 class="sm-workflow-header">Publish the data</h2>
+                <p>This project and its datasets will be made public.</p>
+              </li>
+            </ol>
+          </transition-stub>
         </div>
         <!---->
       </div>
@@ -762,7 +774,7 @@ exports[`ViewProjectPage settings tab should disable actions when published 1`] 
           <!----></span></div>
               <div id="tab-publishing" aria-controls="pane-publishing" role="tab" tabindex="-1" class="el-tabs__item is-top"><span><div class="el-badge sm-feature-badge">
             Publishing
-          <sup class="el-badge__content el-badge__content--undefined is-fixed" name="el-zoom-in-center">New</sup></div></span></div>
+          <transition-stub name="el-zoom-in-center"><sup class="el-badge__content el-badge__content--undefined is-fixed">New</sup></transition-stub></div></span></div>
               <div id="tab-settings" aria-controls="pane-settings" role="tab" aria-selected="true" tabindex="0" class="el-tabs__item is-top is-active">Settings</div>
             </div>
           </div>
@@ -792,7 +804,9 @@ exports[`ViewProjectPage settings tab should disable actions when published 1`] 
                     <div class="el-form-item__content"><label class="el-checkbox is-disabled"><span class="el-checkbox__input is-disabled"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" disabled="disabled" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
       Published projects must be visible
     <!----></span></label>
-                      <!---->
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
                     </div>
                   </div>
                 </form>
@@ -861,7 +875,7 @@ exports[`ViewProjectPage settings tab should disable actions when under review 1
           <!----></span></div>
               <div id="tab-publishing" aria-controls="pane-publishing" role="tab" tabindex="-1" class="el-tabs__item is-top"><span><div class="el-badge sm-feature-badge">
             Publishing
-          <sup class="el-badge__content el-badge__content--undefined is-fixed" name="el-zoom-in-center">New</sup></div></span></div>
+          <transition-stub name="el-zoom-in-center"><sup class="el-badge__content el-badge__content--undefined is-fixed">New</sup></transition-stub></div></span></div>
               <div id="tab-settings" aria-controls="pane-settings" role="tab" aria-selected="true" tabindex="0" class="el-tabs__item is-top is-active">Settings</div>
             </div>
           </div>
@@ -891,7 +905,9 @@ exports[`ViewProjectPage settings tab should disable actions when under review 1
                     <div class="el-form-item__content"><label class="el-checkbox"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
       Allow other users to see this project
     <!----></span></label>
-                      <!---->
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
                     </div>
                   </div>
                 </form>
@@ -955,7 +971,7 @@ exports[`ViewProjectPage settings tab should match snapshot 1`] = `
           <!----></span></div>
               <div id="tab-publishing" aria-controls="pane-publishing" role="tab" tabindex="-1" class="el-tabs__item is-top"><span><div class="el-badge sm-feature-badge">
             Publishing
-          <sup class="el-badge__content el-badge__content--undefined is-fixed" name="el-zoom-in-center">New</sup></div></span></div>
+          <transition-stub name="el-zoom-in-center"><sup class="el-badge__content el-badge__content--undefined is-fixed">New</sup></transition-stub></div></span></div>
               <div id="tab-settings" aria-controls="pane-settings" role="tab" aria-selected="true" tabindex="0" class="el-tabs__item is-top is-active">Settings</div>
             </div>
           </div>
@@ -985,7 +1001,9 @@ exports[`ViewProjectPage settings tab should match snapshot 1`] = `
                     <div class="el-form-item__content"><label class="el-checkbox"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
       Allow other users to see this project
     <!----></span></label>
-                      <!---->
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
                     </div>
                   </div>
                 </form>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
@@ -524,7 +524,7 @@ exports[`ViewProjectPage publishing tab should match snapshot (published) 1`] = 
         <!---->
         <!---->
         <div role="tabpanel" id="pane-publishing" aria-labelledby="tab-publishing" class="el-tab-pane tab-with-badge sm-publishing-tab">
-          <transition-stub mode="out-in" enter-class="opacity-0" leave-to-class="opacity-0" enter-active-class="duration-150 transition-opacity ease-in-out" leave-active-class="duration-150 transition-opacity ease-in-out">
+          <transition-stub mode="out-in" enterclass="opacity-0" leavetoclass="opacity-0" enteractiveclass="duration-150 transition-opacity ease-in-out" leaveactiveclass="duration-150 transition-opacity ease-in-out">
             <div class="leading-6 text-center mt-12"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-6 w-6 block w-8 h-8 p-2 rounded-full bg-blue-100 mx-auto">
                 <circle cx="12" cy="12" r="10" class="fill-current text-blue-800"></circle>
                 <path d="M2.05 11A10 10 0 0 1 15 2.46V6a2 2 0 0 1-2 2h-1v1a2 2 0 0 1-1 1.73V12h2a2 2 0 0 1 2 2v1h2a2 2 0 0 1 2 2v2.14A9.97 9.97 0 0 1 12 22v-4h-1a2 2 0 0 1-2-2v-2a2 2 0 0 1-2-2v-1H2.05z" class="fill-current text-blue-300"></path>
@@ -582,11 +582,11 @@ exports[`ViewProjectPage publishing tab should match snapshot (under review) 1`]
         <!---->
         <!---->
         <div role="tabpanel" id="pane-publishing" aria-labelledby="tab-publishing" class="el-tab-pane tab-with-badge sm-publishing-tab">
-          <transition-stub mode="out-in" enter-class="opacity-0" leave-to-class="opacity-0" enter-active-class="duration-150 transition-opacity ease-in-out" leave-active-class="duration-150 transition-opacity ease-in-out">
+          <transition-stub mode="out-in" enterclass="opacity-0" leavetoclass="opacity-0" enteractiveclass="duration-150 transition-opacity ease-in-out" leaveactiveclass="duration-150 transition-opacity ease-in-out">
             <ol class="sm-workflow leading-6 m-0 p-0 sm-scientific-publishing">
               <li class="sm-workflow-step flex flex-col relative text-gray-600 max-w-measure-3 ml-8 pl-12 border-solid border-0 border-l-2 border-gray-300 transition-colors ease-in-out duration-300 done border-blue-200">
                 <h2 class="sm-workflow-header">Update project details</h2>
-                <transition-stub mode="out-in" enter-class="opacity-0" leave-to-class="opacity-0" enter-active-class="duration-150 transition-opacity ease-in-out" leave-active-class="duration-150 transition-opacity ease-in-out">
+                <transition-stub mode="out-in" enterclass="opacity-0" leavetoclass="opacity-0" enteractiveclass="duration-150 transition-opacity ease-in-out" leaveactiveclass="duration-150 transition-opacity ease-in-out">
                   <form action="#"><label><span class="font-medium text-primary">Reference the project in the manuscript using this link:</span>
                       <div class="el-input el-input-group el-input-group--append py-1">
                         <!----><input type="text" readonly="readonly" autocomplete="off" class="el-input__inner">
@@ -690,11 +690,11 @@ exports[`ViewProjectPage publishing tab should match snapshot (unpublished) 1`] 
         <!---->
         <!---->
         <div role="tabpanel" id="pane-publishing" aria-labelledby="tab-publishing" class="el-tab-pane tab-with-badge sm-publishing-tab">
-          <transition-stub mode="out-in" enter-class="opacity-0" leave-to-class="opacity-0" enter-active-class="duration-150 transition-opacity ease-in-out" leave-active-class="duration-150 transition-opacity ease-in-out">
+          <transition-stub mode="out-in" enterclass="opacity-0" leavetoclass="opacity-0" enteractiveclass="duration-150 transition-opacity ease-in-out" leaveactiveclass="duration-150 transition-opacity ease-in-out">
             <ol class="sm-workflow leading-6 m-0 p-0 sm-scientific-publishing">
               <li class="sm-workflow-step flex flex-col relative text-gray-600 max-w-measure-3 ml-8 pl-12 border-solid border-0 border-l-2 border-gray-300 transition-colors ease-in-out duration-300 active">
                 <h2 class="sm-workflow-header">Update project details</h2>
-                <transition-stub mode="out-in" enter-class="opacity-0" leave-to-class="opacity-0" enter-active-class="duration-150 transition-opacity ease-in-out" leave-active-class="duration-150 transition-opacity ease-in-out">
+                <transition-stub mode="out-in" enterclass="opacity-0" leavetoclass="opacity-0" enteractiveclass="duration-150 transition-opacity ease-in-out" leaveactiveclass="duration-150 transition-opacity ease-in-out">
                   <form action="#" class="sm-form">
                     <p>Create a short project link to use in the manuscript. We also suggest updating the project title and adding an abstract to the project description.</p>
                     <div><label for="publishing-project-link"><span class="text-base font-medium">Link to be used in the manuscript</span><span class="block text-sm text-gray-800">Must be unique, min. 4 characters, using a–z, 0–9, hyphen or underscore</span></label>

--- a/metaspace/webapp/src/modules/UserProfile/EditUserPage.spec.ts
+++ b/metaspace/webapp/src/modules/UserProfile/EditUserPage.spec.ts
@@ -49,14 +49,14 @@ describe('EditUserPage', () => {
   })
 
   it('should match snapshot', async() => {
-    const wrapper = mount(EditUserPage, { router, apolloProvider, sync: false })
+    const wrapper = mount(EditUserPage, { router, apolloProvider })
     await Vue.nextTick()
 
     expect(wrapper).toMatchSnapshot()
   })
 
   it('should be able to submit changes to the user', async() => {
-    const wrapper = mount(EditUserPage, { router, apolloProvider, sync: false })
+    const wrapper = mount(EditUserPage, { router, apolloProvider })
     await Vue.nextTick()
     const nameInput = wrapper.find('input[name="name"]')
     const emailInput = wrapper.find('input[name="email"]')
@@ -85,7 +85,7 @@ describe('EditUserPage', () => {
   })
 
   it('should not include unchanged fields in the update payload', async() => {
-    const wrapper = mount(EditUserPage, { router, apolloProvider, sync: false })
+    const wrapper = mount(EditUserPage, { router, apolloProvider })
     await Vue.nextTick()
     const nameInput = wrapper.find('input[name="name"]')
     const saveButton = wrapper.find('.saveButton')

--- a/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
@@ -48,7 +48,9 @@ exports[`EditUserPage should match snapshot 1`] = `
                   <!---->
                   <!---->
                 </div>
-                <!---->
+                <transition-stub name="el-zoom-in-top">
+                  <!---->
+                </transition-stub>
               </div>
             </div>
           </div>
@@ -62,7 +64,9 @@ exports[`EditUserPage should match snapshot 1`] = `
                   <!---->
                   <!---->
                 </div>
-                <!---->
+                <transition-stub name="el-zoom-in-top">
+                  <!---->
+                </transition-stub>
               </div>
             </div>
             <!---->
@@ -74,7 +78,9 @@ exports[`EditUserPage should match snapshot 1`] = `
                   <!----><span>
                 Click to change...
               </span></button>
-                <!---->
+                <transition-stub name="el-zoom-in-top">
+                  <!---->
+                </transition-stub>
               </div>
             </div>
           </div>
@@ -170,7 +176,9 @@ exports[`EditUserPage should match snapshot 1`] = `
                 <div class="el-form-item__content"><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
       Allow other users to see this project
     <!----></span></label>
-                  <!---->
+                  <transition-stub name="el-zoom-in-top">
+                    <!---->
+                  </transition-stub>
                 </div>
               </div>
             </form>

--- a/metaspace/webapp/tests/utils/setupTestFramework.ts
+++ b/metaspace/webapp/tests/utils/setupTestFramework.ts
@@ -36,10 +36,6 @@ jest.mock('../../src/lib/reportError', () => jest.fn(console.error))
 // Prevent JWT requests
 jest.mock('../../src/api/graphqlClient', () => require('./mockGraphqlClient'))
 
-// Transitions throw errors because cssstyle doesn't support transition styles
-registerMockComponent('transition', { abstract: true }) //  ElTreeNode relies on Transition being abstract
-registerMockComponent('transition-group')
-
 // Ignore delay duration
 jest.mock('../../src/lib/delay', () => jest.fn(() => Promise.resolve()))
 

--- a/metaspace/webapp/tests/utils/setupTestFramework.ts
+++ b/metaspace/webapp/tests/utils/setupTestFramework.ts
@@ -3,14 +3,12 @@ import ElementUI from 'element-ui'
 import registerMockComponent from './registerMockComponent'
 import VueRouter from 'vue-router'
 import registerMockDirective from './registerMockDirective'
-import { Wrapper, config as vueTestConfig } from '@vue/test-utils'
+import * as vueTestUtils from '@vue/test-utils'
 import { replaceConfigWithDefaultForTests } from '../../src/lib/config'
 import VueCompositionApi from '@vue/composition-api'
 import './mockGenerateId'
 
 window.fetch = jest.fn()
-
-vueTestConfig.logModifiedComponents = false
 
 Vue.use(VueRouter)
 Vue.use(ElementUI)
@@ -48,29 +46,9 @@ jest.mock('../../src/lib/delay', () => jest.fn(() => Promise.resolve()))
 // Mock elapsed time as it relies on variables such as current time and locale
 registerMockComponent('elapsed-time', { path: '../../src/components/ElapsedTime' })
 
-// Track all components mounted by vue-test-utils and automatically clean them up after each test to prevent stale
-// components from updating due to e.g. route changes
-const mockWrappers: Wrapper<Vue>[] = []
-jest.mock('@vue/test-utils', () => {
-  const wrapVueTestToolsFunction = (originalFunc: ((...args: any[]) => Wrapper<Vue>)) => {
-    return function(...args: any[]) {
-      const wrapper = originalFunc(...args)
-      mockWrappers.push(wrapper)
-      return wrapper
-    }
-  }
-  const actual = require.requireActual('@vue/test-utils')
-  return Object.assign({}, actual, {
-    mount: wrapVueTestToolsFunction(actual.mount),
-    shallowMount: wrapVueTestToolsFunction(actual.shallowMount),
-  })
-})
-
-afterEach(() => {
-  while (mockWrappers.length > 0) {
-    mockWrappers.pop()!.destroy()
-  }
-})
+// Automatically clean up components after each test to prevent stale components from updating due to e.g. route changes
+// @ts-ignore
+vueTestUtils.enableAutoDestroy(afterEach)
 
 // Use consistent config
 // TODO: Change metadata to always ship with all available types, but filter at runtime based on config

--- a/metaspace/webapp/yarn.lock
+++ b/metaspace/webapp/yarn.lock
@@ -2408,13 +2408,14 @@
   resolved "https://registry.yarnpkg.com/@vue/preload-webpack-plugin/-/preload-webpack-plugin-1.1.1.tgz#18723530d304f443021da2292d6ec9502826104a"
   integrity sha512-8VCoJeeH8tCkzhkpfOkt+abALQkS11OIHhte5MBzYaKMTqK0A3ZAKEUVAffsOklhEv7t0yrQt696Opnu9oAx+w==
 
-"@vue/test-utils@1.0.0-beta.29":
-  version "1.0.0-beta.29"
-  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.0-beta.29.tgz#c942cf25e891cf081b6a03332b4ae1ef430726f0"
-  integrity sha512-yX4sxEIHh4M9yAbLA/ikpEnGKMNBCnoX98xE1RwxfhQVcn0MaXNSj1Qmac+ZydTj6VBSEVukchBogXBTwc+9iA==
+"@vue/test-utils@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.2.tgz#68134747cb88d996e4c9703ca4b103b4d23fda14"
+  integrity sha512-pnRWJbb0cLqjSJIKRpqoSISeYtufEn8D16VmhlCrDWIVt4iAY4Og4JpOPmFytvtQVz96p6n7T6ERI55ue6n0Ew==
   dependencies:
     dom-event-types "^1.0.0"
-    lodash "^4.17.4"
+    lodash "^4.17.15"
+    pretty "^2.0.0"
 
 "@vue/web-component-wrapper@^1.2.0":
   version "1.2.0"
@@ -13686,7 +13687,7 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
-pretty@2.0.0:
+pretty@2.0.0, pretty@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pretty/-/pretty-2.0.0.tgz#adbc7960b7bbfe289a557dc5f737619a220d06a5"
   integrity sha1-rbx5YLe7/iiaVX3F9zdhmiINBqU=


### PR DESCRIPTION
[Changelog](https://github.com/vuejs/vue-test-utils/blob/dev/packages/test-utils/CHANGELOG.md)

Notable changes:
* `<transition-stub>` is now visible in snapshots because it's now stubbed by @vue/test-utils by default. I removed our global mock as it the stub was taking precedence.
* `sync: false` is now the default and only way to mount components. Sync mode was apparently a failed experiment, so they removed it completely.
* `wrapper.find` and `wrapper.findAll` were split into two separate sets of functions: `wrapper.find`/`wrapper.findAll`, which take a string argument, and `wrapper.findComponent`/`wrapper.findAllComponents`, which take Component or object arguments.
* They added a convenience function `enableAutoDestroy`, allowing me to remove a big chunk of hacky code to do this in `setupTestFramework`. They didn't include type definitions for that function, so I had to `@ts-ignore` the call :(
* I made a fix to the `NewFeatureBadge` & its test. The issue is that [Vue2 reactive objects can't trigger observers when properties are added/deleted from the object.](https://vuejs.org/v2/guide/reactivity.html#For-Objects) Vue3 fixes this by using `Proxy` objects, which can hook property addition/deletion.