### PR TITLE
Refactor DatasetItem.vue

### DIFF
--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -20,6 +20,11 @@ export interface DatasetDetailItem {
     name: string;
     shortName: string;
   };
+  projects: {
+    id: string;
+    name: string;
+    publicationStatus: String;
+  }[],
   groupApproved: boolean;
   polarity: GqlPolarity;
   ionisationSource: string;
@@ -42,6 +47,7 @@ export interface DatasetDetailItem {
     counts: number[];
   };
   rawOpticalImageUrl: string;
+  canDownload: boolean;
   uploadDT: string;
 }
 
@@ -197,8 +203,12 @@ export const datasetVisibilityQuery =
        group { id name }
        projects { id name }
      }
+     currentUser { id }
    }`
-
+export interface DatasetVisibilityQuery {
+  datasetVisibility: DatasetVisibilityResult | null
+  currentUser: { id: string } | null
+}
 export interface DatasetVisibilityResult {
   id: string;
   submitter: { id: string, name: string };

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -42,6 +42,7 @@ export interface DatasetDetailItem {
     counts: number[];
   };
   rawOpticalImageUrl: string;
+  uploadDT: string;
 }
 
 export const datasetDetailItemFragment =

--- a/metaspace/webapp/src/components/DatasetInfo.vue
+++ b/metaspace/webapp/src/components/DatasetInfo.vue
@@ -12,12 +12,13 @@
 </template>
 
 <script>
+import Vue from 'vue'
 import { defaultMetadataType, metadataSchemas } from '../lib/metadataRegistry'
 import { get, flatMap } from 'lodash-es'
 import { optionalSuffixInParens } from '../lib/vueFilters'
 import { getLocalStorage, setLocalStorage } from '../lib/localStorage'
 
-export default {
+export default Vue.extend({
   name: 'DatasetInfo',
   props: ['metadata', 'expandedKeys', 'currentUser'],
   data() {
@@ -147,7 +148,7 @@ export default {
       }
     },
   },
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/metaspace/webapp/src/modules/Datasets/common/VisibilityBadge.tsx
+++ b/metaspace/webapp/src/modules/Datasets/common/VisibilityBadge.tsx
@@ -1,0 +1,51 @@
+import { computed, createComponent, reactive } from '@vue/composition-api'
+import { useQuery } from '@vue/apollo-composable'
+import { datasetVisibilityQuery, DatasetVisibilityQuery } from '../../../api/dataset'
+import { Popover } from 'element-ui'
+
+const VisibilityBadge = createComponent({
+  props: {
+    datasetId: { type: String, required: true },
+  },
+  setup(props) {
+    const queryOptions = reactive({ enabled: false })
+    const queryVars = computed(() => ({ id: props.datasetId }))
+    const query = useQuery<DatasetVisibilityQuery>(datasetVisibilityQuery, queryVars, queryOptions)
+    const loadVisibility = () => { queryOptions.enabled = true }
+
+    const visibilityText = computed(() => {
+      if (query.result.value != null) {
+        const { datasetVisibility, currentUser } = query.result.value
+        if (datasetVisibility != null) {
+          const { submitter, group, projects } = datasetVisibility
+          const submitterName = currentUser && submitter.id === currentUser.id ? 'you' : submitter.name
+          const all = [
+            submitterName,
+            ...(group ? [group.name] : []),
+            ...(projects || []).map(p => p.name),
+          ]
+          return 'These annotation results are not publicly visible. '
+            + `They are visible to ${all.join(', ')} and METASPACE Administrators.`
+        }
+      }
+      return null
+    })
+
+    return () => (
+      <Popover
+        class="ml-1"
+        trigger="hover"
+        placement="top"
+        onShow={loadVisibility}
+      >
+        <div v-loading={visibilityText.value == null}>{visibilityText.value || ''}</div>
+        <i
+          slot="reference"
+          class="el-icon-lock"
+        />
+      </Popover>
+    )
+  },
+})
+
+export default VisibilityBadge

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.spec.js
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.spec.js
@@ -9,8 +9,7 @@ import { mockGenerateId, resetGenerateId } from '../../../../tests/utils/mockGen
 
 Vue.use(Vuex)
 sync(store, router)
-Vue.options.router = router
-Vue.options.store = store
+
 
 describe('DatasetItem', () => {
   const user = { id: 'user' }
@@ -57,7 +56,7 @@ describe('DatasetItem', () => {
       currentUser: submitter,
       dataset,
     }
-    const wrapper = mount(DatasetItem, { router, store, propsData })
+    const wrapper = mount(DatasetItem, { parentComponent: { store, router }, propsData })
     expect(wrapper.element).toMatchSnapshot()
   })
 
@@ -69,7 +68,7 @@ describe('DatasetItem', () => {
         projects: [unpublished]
       },
     }
-    const wrapper = mount(DatasetItem, { router, store, propsData })
+    const wrapper = mount(DatasetItem, { parentComponent: { store, router }, propsData })
     expect(wrapper.find('.ds-delete').exists()).toBe(true)
   })
 
@@ -81,7 +80,7 @@ describe('DatasetItem', () => {
         projects: [published]
       },
     }
-    const wrapper = mount(DatasetItem, { router, store, propsData })
+    const wrapper = mount(DatasetItem, { parentComponent: { store, router }, propsData })
     expect(wrapper.find('.test-publication-status').exists()).toBe(false)
   })
 
@@ -94,7 +93,7 @@ describe('DatasetItem', () => {
         status: 'ANNOTATING'
       }
     }
-    const wrapper = mount(DatasetItem, { router, store, propsData })
+    const wrapper = mount(DatasetItem, { parentComponent: { store, router }, propsData })
     expect(wrapper.find('.test-publication-status').exists()).toBe(false)
   })
 
@@ -106,7 +105,7 @@ describe('DatasetItem', () => {
         projects: [underReview]
       }
     }
-    const wrapper = mount(DatasetItem, { router, store, propsData })
+    const wrapper = mount(DatasetItem, { parentComponent: { store, router }, propsData })
     expect(wrapper.find('.test-publication-status').text()).toBe('Under review')
   })
 
@@ -118,7 +117,7 @@ describe('DatasetItem', () => {
         projects: [published]
       }
     }
-    const wrapper = mount(DatasetItem, { router, store, propsData })
+    const wrapper = mount(DatasetItem, { parentComponent: { store, router }, propsData })
     expect(wrapper.find('.test-publication-status').text()).toBe('Published')
   })
 
@@ -130,7 +129,7 @@ describe('DatasetItem', () => {
         projects: [published, underReview]
       }
     }
-    const wrapper = mount(DatasetItem, { router, store, propsData })
+    const wrapper = mount(DatasetItem, { parentComponent: { store, router }, propsData })
     expect(wrapper.find('.test-publication-status').text()).toBe('Published')
   })
 
@@ -142,7 +141,7 @@ describe('DatasetItem', () => {
         projects: [published]
       }
     }
-    const wrapper = mount(DatasetItem, { router, store, propsData })
+    const wrapper = mount(DatasetItem, { parentComponent: { store, router }, propsData })
     expect(wrapper.find('.ds-delete').exists()).toBe(true)
     expect(wrapper.find('.ds-reprocess').exists()).toBe(true)
   })

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.spec.js
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.spec.js
@@ -5,9 +5,12 @@ import router from '../../../router'
 import store from '../../../store'
 import { sync } from 'vuex-router-sync'
 import DatasetItem from './DatasetItem.vue'
+import { mockGenerateId, resetGenerateId } from '../../../../tests/utils/mockGenerateId'
 
 Vue.use(Vuex)
 sync(store, router)
+Vue.options.router = router
+Vue.options.store = store
 
 describe('DatasetItem', () => {
   const user = { id: 'user' }
@@ -44,13 +47,18 @@ describe('DatasetItem', () => {
   const underReview = { name: 'project', publicationStatus: 'UNDER_REVIEW' }
   const published = { name: 'project', publicationStatus: 'PUBLISHED' }
 
+  beforeEach(() => {
+    resetGenerateId()
+  })
+
   it('should match snapshot', () => {
+    mockGenerateId(123)
     const propsData = {
       currentUser: submitter,
       dataset,
     }
     const wrapper = mount(DatasetItem, { router, store, propsData })
-    expect(wrapper).toMatchSnapshot()
+    expect(wrapper.element).toMatchSnapshot()
   })
 
   it('should be able to delete if unpublished', () => {

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -2,19 +2,7 @@
   <div
     v-if="!deferRender"
     class="dataset-item border border-solid border-gray-200 leading-5"
-    :class="disabledClass"
   >
-    <el-dialog
-      title="Provided metadata"
-      :lock-scroll="false"
-      :visible.sync="showMetadataDialog"
-    >
-      <dataset-info
-        :metadata="metadata"
-        :current-user="currentUser"
-      />
-    </el-dialog>
-
     <div
       v-if="isOpticalImageSupported"
       class="opt-image--container"
@@ -31,134 +19,30 @@
       :hide-group-menu="hideGroupMenu"
     />
 
-    <div class="ds-actions">
-      <span v-if="dataset.status == 'FINISHED'">
-        <i class="el-icon-picture" />
-        <el-popover
-          trigger="hover"
-          placement="top"
-        >
-          <div class="db-link-list">
-            Select a database:
-            <div
-              v-for="database in metaboliteDatabases"
-              :key="database"
-            >
-              <FilterLink :filter="{database, datasetIds: [dataset.id]}">
-                {{ database }}
-              </FilterLink>
-            </div>
-          </div>
-          <a slot="reference">Browse annotations</a>
-        </el-popover>
-        <br>
-      </span>
-
-      <span v-if="dataset.status === 'ANNOTATING'">
-        <div
-          class="striped-progressbar processing"
-          title="Processing is under way"
-        />
-      </span>
-
-      <span v-if="dataset.status === 'QUEUED'">
-        <div
-          class="striped-progressbar queued"
-          title="Waiting in the queue"
-        />
-      </span>
-
-      <div>
-        <i class="el-icon-view" />
-        <a
-          href="#"
-          @click="showMetadata"
-        >Show full metadata</a>
-      </div>
-
-      <div v-if="canEdit">
-        <i class="el-icon-edit" />
-        <router-link :to="editHref">
-          Edit metadata
-        </router-link>
-      </div>
-
-      <div
-        v-if="dataset.canDownload"
-        class="ds-download"
-      >
-        <i class="el-icon-download" />
-        <a
-          href="#"
-          @click.prevent="() => { showDownloadDialog = true }"
-        >Download</a>
-      </div>
-
-      <div
-        v-if="canDelete"
-        class="ds-delete"
-      >
-        <i class="el-icon-delete" />
-        <a
-          href="#"
-          class="text-danger"
-          @click.prevent="openDeleteDialog"
-        >Delete dataset</a>
-      </div>
-
-      <div
-        v-if="canReprocess"
-        class="ds-reprocess"
-      >
-        <i class="el-icon-refresh" />
-        <a
-          href="#"
-          class="text-danger"
-          @click.prevent="handleReprocess"
-        >Reprocess dataset</a>
-      </div>
-
-      <div
-        v-else-if="canViewPublicationStatus"
-        class="mt-auto text-right text-gray-700 text-sm test-publication-status"
-      >
-        {{ publicationStatus }}
-      </div>
-    </div>
-    <DownloadDialog
-      v-if="showDownloadDialog"
-      :dataset-id="dataset.id"
-      :dataset-name="dataset.name"
-      @close="() => { showDownloadDialog = false }"
+    <DatasetItemActions
+      :dataset="dataset"
+      :metadata="metadata"
+      :current-user="currentUser"
     />
   </div>
 </template>
 
 <script>
-import DatasetInfo from '../../../components/DatasetInfo.vue'
 import DatasetThumbnail from './DatasetThumbnail.vue'
 import { get } from 'lodash-es'
-import {
-  deleteDatasetQuery,
-  reprocessDatasetQuery,
-} from '../../../api/dataset'
 import { mdTypeSupportsOpticalImages } from '../../../lib/util'
-import reportError from '../../../lib/reportError'
 import safeJsonParse from '../../../lib/safeJsonParse'
 import { plural } from '../../../lib/vueFilters'
-import DownloadDialog from './DownloadDialog'
 import { defaultMetadataType } from '../../../lib/metadataRegistry'
 import DatasetItemMetadata from './DatasetItemMetadata'
-import FilterLink from './FilterLink'
+import DatasetItemActions from './DatasetItemActions'
 
 export default {
   name: 'DatasetItem',
   components: {
-    DatasetInfo,
     DatasetThumbnail,
-    DownloadDialog,
     DatasetItemMetadata,
-    FilterLink,
+    DatasetItemActions,
   },
   filters: {
     plural,
@@ -166,21 +50,11 @@ export default {
   props: ['dataset', 'currentUser', 'idx', 'hideGroupMenu'],
   data() {
     return {
-      showMetadataDialog: false,
-      disabled: false,
       deferRender: this.idx >= 20,
-      showDownloadDialog: false,
     }
   },
 
   computed: {
-    opticalImageAlignmentHref() {
-      return {
-        name: 'add-optical-image',
-        params: { dataset_id: this.dataset.id },
-      }
-    },
-
     isOpticalImageSupported() {
       return mdTypeSupportsOpticalImages(get(this.metadata, 'Data_Type') || defaultMetadataType)
     },
@@ -195,77 +69,9 @@ export default {
       return Object.assign(safeJsonParse(this.dataset.metadataJson), datasetMetadataExternals)
     },
 
-    metaboliteDatabases() {
-      const dbs = this.dataset.molDBs
-      if (typeof dbs === 'string') {
-        return [dbs]
-      } else {
-        return dbs
-      }
-    },
-
-    canEdit() {
-      if (this.currentUser != null) {
-        if (this.currentUser.role === 'admin') {
-          return true
-        }
-        if (
-          this.currentUser.id === this.dataset.submitter.id
-          && !['QUEUED', 'ANNOTATING'].includes(this.dataset.status)
-        ) {
-          return true
-        }
-      }
-      return false
-    },
-
-    canDelete() {
-      return (
-        (this.currentUser && this.currentUser.role === 'admin')
-        || (this.canEdit && this.publicationStatus === null)
-      )
-    },
-
     canEditOpticalImage() {
-      return this.canEdit && this.dataset.status === 'FINISHED'
-    },
-
-    canReprocess() {
-      return this.currentUser != null
-         && this.currentUser.role === 'admin'
-    },
-
-    editHref() {
-      return {
-        name: 'edit-metadata',
-        params: { dataset_id: this.dataset.id },
-      }
-    },
-
-    disabledClass() {
-      return this.disabled ? 'ds-item-disabled' : ''
-    },
-
-    canViewPublicationStatus() {
-      return (
-        this.dataset.status === 'FINISHED'
-        && this.canEdit
-        && this.publicationStatus !== null
-      )
-    },
-
-    publicationStatus() {
-      let status = null
-      for (const project of this.dataset.projects) {
-        if (project.publicationStatus === 'PUBLISHED') {
-          status = 'Published'
-          break
-        }
-        if (project.publicationStatus === 'UNDER_REVIEW') {
-          status = 'Under review'
-        }
-      }
-      return status
+      return this.currentUser?.role === 'admin'
+        || (this.currentUser?.id === this.dataset.submitter.id && this.dataset.status === 'FINISHED')
     },
   },
   async created() {
@@ -277,63 +83,6 @@ export default {
       }
     } catch (err) { /* Browser/test doesn't support requestAnimationFrame? */ }
     this.deferRender = false
-  },
-
-  methods: {
-    showMetadata(e) {
-      e.preventDefault()
-      this.showMetadataDialog = true
-    },
-
-    async openDeleteDialog() {
-      const force = this.currentUser != null
-         && this.currentUser.role === 'admin'
-         && this.dataset.status !== 'FINISHED'
-      try {
-        const msg = `Are you sure you want to ${force ? 'FORCE-DELETE' : 'delete'} ${this.formatDatasetName}?`
-        await this.$confirm(msg, {
-          type: force ? 'warning' : null,
-          lockScroll: false,
-        })
-      } catch (cancel) {
-        return
-      }
-
-      try {
-        this.disabled = true
-        const resp = await this.$apollo.mutate({
-          mutation: deleteDatasetQuery,
-          variables: {
-            id: this.dataset.id,
-            force,
-          },
-        })
-        this.$emit('datasetMutated')
-      } catch (err) {
-        this.disabled = false
-        reportError(err, 'Deletion failed :( Please contact us at contact@metaspace2020.eu')
-      }
-    },
-
-    async handleReprocess() {
-      try {
-        this.disabled = true
-        await this.$apollo.mutate({
-          mutation: reprocessDatasetQuery,
-          variables: {
-            id: this.dataset.id,
-            force: true,
-          },
-        })
-        this.$notify.success('Dataset sent for reprocessing')
-        this.$emit('datasetMutated')
-      } catch (err) {
-        reportError(err)
-      } finally {
-        this.disabled = false
-      }
-    },
-
   },
 }
 </script>

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
@@ -6,6 +6,7 @@ import DownloadDialog from './DownloadDialog'
 import reportError from '../../../lib/reportError'
 
 const DatasetItemActions = createComponent({
+  name: 'DatasetItemActions',
   props: {
     dataset: { type: Object as () => DatasetDetailItem, required: true },
     metadata: { type: Object as () => any, required: true },

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
@@ -1,0 +1,239 @@
+import FilterLink from './FilterLink'
+import { computed, createComponent, reactive } from '@vue/composition-api'
+import { DatasetDetailItem, deleteDatasetQuery, reprocessDatasetQuery } from '../../../api/dataset'
+import DatasetInfo from '../../../components/DatasetInfo.vue'
+import DownloadDialog from './DownloadDialog'
+import reportError from '../../../lib/reportError'
+
+const DatasetItemActions = createComponent({
+  props: {
+    dataset: { type: Object as () => DatasetDetailItem, required: true },
+    metadata: { type: Object as () => any, required: true },
+    currentUser: { type: Object as () => any, required: true },
+  },
+  setup(props, { emit, root: { $apollo, $confirm, $notify } }) {
+    const state = reactive({
+      disabled: false,
+      showMetadataDialog: false,
+      showDownloadDialog: false,
+    })
+
+    const openDeleteDialog = async(e: Event) => {
+      e.preventDefault()
+      const force = props.currentUser != null
+        && props.currentUser.role === 'admin'
+        && props.dataset.status !== 'FINISHED'
+      try {
+        const msg = `Are you sure you want to ${force ? 'FORCE-DELETE' : 'delete'} ${props.dataset.name}?`
+        await $confirm(msg, {
+          type: force ? 'warning' : undefined,
+          lockScroll: false,
+        })
+      } catch (cancel) {
+        return
+      }
+
+      try {
+        state.disabled = true
+        const resp = await $apollo.mutate({
+          mutation: deleteDatasetQuery,
+          variables: {
+            id: props.dataset.id,
+            force,
+          },
+        })
+        emit('datasetMutated')
+      } catch (err) {
+        state.disabled = false
+        reportError(err, 'Deletion failed :( Please contact us at contact@metaspace2020.eu')
+      }
+    }
+
+    const handleReprocess = async(e: Event) => {
+      e.preventDefault()
+      try {
+        state.disabled = true
+        await $apollo.mutate({
+          mutation: reprocessDatasetQuery,
+          variables: {
+            id: props.dataset.id,
+            force: true,
+          },
+        })
+        $notify.success('Dataset sent for reprocessing')
+        emit('datasetMutated')
+      } catch (err) {
+        reportError(err)
+      } finally {
+        state.disabled = false
+      }
+    }
+
+    const openMetadataDialog = (e: Event) => {
+      e.preventDefault()
+      state.showMetadataDialog = true
+    }
+
+    const closeMetadataDialog = () => {
+      state.showMetadataDialog = false
+    }
+
+    const openDownloadDialog = (e: Event) => {
+      e.preventDefault()
+      state.showDownloadDialog = true
+    }
+
+    const closeDownloadDialog = () => {
+      state.showDownloadDialog = false
+    }
+
+    const publicationStatus = computed(() => {
+      if (props.dataset.projects.some(({ publicationStatus }) => publicationStatus === 'PUBLISHED')) {
+        return 'Published'
+      }
+      if (props.dataset.projects.some(({ publicationStatus }) => publicationStatus === 'UNDER_REVIEW')) {
+        return 'Under review'
+      }
+      return null
+    })
+
+    const canEdit = computed(() =>
+      props.currentUser?.role === 'admin'
+      || (props.currentUser?.id === props.dataset.submitter.id
+      && (props.dataset.status !== 'QUEUED' && props.dataset.status !== 'ANNOTATING')),
+    )
+
+    const canDelete = computed(() =>
+      props.currentUser?.role === 'admin'
+      || (canEdit.value && publicationStatus.value === null),
+    )
+
+    const canReprocess = computed(() => props.currentUser?.role === 'admin')
+
+    const canViewPublicationStatus = computed(() =>
+      props.dataset.status === 'FINISHED'
+      && canEdit.value
+      && publicationStatus.value != null,
+    )
+
+    return () => {
+      const { dataset, metadata, currentUser } = props
+
+      return (
+        <div class="ds-actions">
+          <el-dialog
+            title="Provided metadata"
+            lock-scroll={false}
+            visible={state.showMetadataDialog}
+            onClose={closeMetadataDialog}
+          >
+            <DatasetInfo
+              metadata={metadata}
+              currentUser={currentUser}
+            />
+          </el-dialog>
+
+          {state.showDownloadDialog
+          && <DownloadDialog
+            datasetId={dataset.id}
+            datasetName={dataset.name}
+            onClose={closeDownloadDialog}
+          />}
+
+          {dataset.status === 'FINISHED'
+          && <span>
+            <i class="el-icon-picture" />
+            <el-popover
+              trigger="hover"
+              placement="top"
+            >
+              <div class="db-link-list">
+              Select a database:
+                {dataset.molDBs.map(database => (
+                  <div key={database}>
+                    <FilterLink filter={{ database, datasetIds: [dataset.id] }}>
+                      {database}
+                    </FilterLink>
+                  </div>
+                ))}
+              </div>
+              <a slot="reference">Browse annotations</a>
+            </el-popover>
+            <br />
+          </span>}
+
+          {dataset.status === 'ANNOTATING'
+          && <span>
+            <div
+              class="striped-progressbar processing"
+              title="Processing is under way"
+            />
+          </span>}
+
+          {dataset.status === 'QUEUED'
+          && <span>
+            <div
+              class="striped-progressbar queued"
+              title="Waiting in the queue"
+            />
+          </span>}
+
+          <div>
+            <i class="el-icon-view" />
+            <a
+              href="#"
+              onClick={openMetadataDialog}
+            >Show full metadata</a>
+          </div>
+
+          {canEdit.value
+          && <div>
+            <i class="el-icon-edit" />
+            <router-link to={{
+              name: 'edit-metadata',
+              params: { dataset_id: props.dataset.id },
+            }}>
+              Edit metadata
+            </router-link>
+          </div>}
+
+          {dataset.canDownload
+          && <div class="ds-download">
+            <i class="el-icon-download" />
+            <a
+              href="#"
+              onClick={openDownloadDialog}
+            >Download</a>
+          </div>}
+
+          {canDelete.value
+          && <div class="ds-delete">
+            <i class="el-icon-delete" />
+            <a
+              href="#"
+              class="text-danger"
+              onClick={openDeleteDialog}
+            >Delete dataset</a>
+          </div>}
+
+          {canReprocess.value
+          && <div class="ds-reprocess">
+            <i class="el-icon-refresh" />
+            <a
+              href="#"
+              class="text-danger"
+              onClick={handleReprocess}
+            >Reprocess dataset</a>
+          </div>}
+
+          {!canReprocess.value && canViewPublicationStatus.value
+          && <div class="mt-auto text-right text-gray-700 text-sm test-publication-status">
+            {publicationStatus.value}
+          </div>}
+        </div>
+      )
+    }
+  },
+})
+
+export default DatasetItemActions

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItemMetadata.tsx
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItemMetadata.tsx
@@ -9,6 +9,7 @@ import FilterLink from './FilterLink'
 type FilterField = keyof DatasetDetailItem | 'analyzerType';
 
 const DatasetItemMetadata = createComponent({
+  name: 'DatasetItemMetadata',
   props: {
     dataset: { type: Object as () => DatasetDetailItem, required: true },
     metadata: { type: Object as () => any, required: true },

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItemMetadata.tsx
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItemMetadata.tsx
@@ -1,0 +1,137 @@
+import { createComponent } from '@vue/composition-api'
+import VisibilityBadge from '../common/VisibilityBadge'
+import ElapsedTime from '../../../components/ElapsedTime'
+import { plural } from '../../../lib/vueFilters'
+import { DatasetDetailItem } from '../../../api/dataset'
+import { capitalize, get } from 'lodash-es'
+import FilterLink from './FilterLink'
+
+type FilterField = keyof DatasetDetailItem | 'analyzerType';
+
+function removeUnderscores(str: string) {
+  return str.replace(/_/g, ' ')
+}
+
+const DatasetItemMetadata = createComponent({
+  props: {
+    dataset: { type: Object as () => DatasetDetailItem, required: true },
+    metadata: { type: Object as () => any, required: true },
+    hideGroupMenu: { type: Boolean, default: false },
+  },
+  setup(props, ctx) {
+    const { $router, $store } = ctx.root
+
+    const addFilter = (field: FilterField) => {
+      const filter = Object.assign({}, $store.getters.filter)
+      if (field === 'polarity') {
+        filter.polarity = capitalize(props.dataset.polarity)
+      } else if (field === 'submitter') {
+        filter[field] = props.dataset.submitter.id
+      } else if (field === 'group') {
+        filter[field] = props.dataset.group.id
+      } else if (field === 'analyzerType') {
+        filter[field] = props.dataset.analyzer.type
+      } else {
+        filter[field] = props.dataset[field]
+      }
+      $store.commit('updateFilter', filter)
+      ctx.emit('filterUpdate', filter)
+    }
+
+    const handleDropdownCommand = (command: string) => {
+      if (command === 'filter_group') {
+        addFilter('group')
+      } else if (command === 'view_group') {
+        $router.push({
+          name: 'group',
+          params: {
+            groupIdOrSlug: props.dataset.group.id,
+          },
+        })
+      }
+    }
+
+    return () => {
+      const { dataset, metadata, hideGroupMenu } = props
+      const { mz: rpAtMz = 0, Resolving_Power: rp = 0 } = get(metadata, ['MS_Analysis', 'Detector_Resolving_Power']) || {}
+
+      const filterableItem = (field: FilterField, name: string, text: string) => (
+        <span
+          class="ds-add-filter"
+          title={`Filter by ${name}`}
+          onClick={() => addFilter(field)}
+        >
+          {text}
+        </span>
+      )
+
+      return (
+        <div class="ds-info">
+          <div class="ds-item-line flex">
+            <span
+              title={dataset.name}
+              class="font-bold truncate"
+            >{dataset.name}</span>
+            {!dataset.isPublic && <VisibilityBadge datasetId={dataset.id} />}
+          </div>
+
+          <div class="ds-item-line text-gray-700">
+            {filterableItem('organism', 'species', dataset.organism || '')}
+            {', '}
+            {filterableItem('organismPart', 'organism part', (dataset.organismPart || '').toLowerCase())}
+            {' '}
+            {filterableItem('condition', 'condition', `(${(dataset.condition || '').toLowerCase()})`)}
+          </div>
+          <div class="ds-item-line">
+            {filterableItem('ionisationSource', 'ionisation source', dataset.ionisationSource)}
+            {' + '}
+            {filterableItem('analyzerType', 'analyzer type', dataset.analyzer.type)}
+            {', '}
+            {filterableItem('polarity', 'polarity', `${dataset.polarity.toLowerCase()} mode`)}
+            {', RP '}
+            {(rp / 1000).toFixed(0)}
+            {'k @ '}
+            {rpAtMz}
+          </div>
+
+          <div class="ds-item-line">
+            Submitted <ElapsedTime date={dataset.uploadDT} />
+            {' by '}
+            {filterableItem('submitter', 'submitter', dataset.submitter.name)}
+            {dataset.groupApproved && dataset.group && <span>
+              {', '}
+              <el-dropdown
+                show-timeout={50}
+                placement="bottom"
+                trigger={hideGroupMenu ? 'never' : 'hover'}
+                onCommand={handleDropdownCommand}
+              >
+                <span
+                  class="text-base text-primary cursor-pointer"
+                  onClick={() => addFilter('group')}
+                >
+                  {dataset.group.shortName}
+                </span>
+                <el-dropdown-menu slot="dropdown">
+                  <el-dropdown-item command="filter_group">Filter by this group</el-dropdown-item>
+                  <el-dropdown-item command="view_group">View group</el-dropdown-item>
+                </el-dropdown-menu>
+              </el-dropdown>
+            </span>}
+          </div>
+          {dataset.status === 'FINISHED' && dataset.fdrCounts && <div class="ds-item-line">
+            <span>
+              <FilterLink filter={{ database: dataset.fdrCounts.dbName, datasetIds: [dataset.id] }}>
+                {plural(dataset.fdrCounts.counts.join(', '), 'annotation', 'annotations')}
+              </FilterLink>
+              {' @ FDR '}
+              {dataset.fdrCounts.levels.join(', ')}
+              % ({dataset.fdrCounts.dbName})
+            </span>
+          </div>}
+        </div>
+      )
+    }
+  },
+})
+export default DatasetItemMetadata

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItemMetadata.tsx
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItemMetadata.tsx
@@ -8,10 +8,6 @@ import FilterLink from './FilterLink'
 
 type FilterField = keyof DatasetDetailItem | 'analyzerType';
 
-function removeUnderscores(str: string) {
-  return str.replace(/_/g, ' ')
-}
-
 const DatasetItemMetadata = createComponent({
   props: {
     dataset: { type: Object as () => DatasetDetailItem, required: true },
@@ -53,7 +49,8 @@ const DatasetItemMetadata = createComponent({
 
     return () => {
       const { dataset, metadata, hideGroupMenu } = props
-      const { mz: rpAtMz = 0, Resolving_Power: rp = 0 } = get(metadata, ['MS_Analysis', 'Detector_Resolving_Power']) || {}
+      const { mz: rpAtMz = 0, Resolving_Power: rp = 0 } =
+        get(metadata, ['MS_Analysis', 'Detector_Resolving_Power']) || {}
 
       const filterableItem = (field: FilterField, name: string, text: string) => (
         <span

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.spec.ts
@@ -69,7 +69,7 @@ describe('DatasetTable', () => {
     const wrapper = mount(DatasetTable, { store, router, apolloProvider })
     await Vue.nextTick()
 
-    expect(wrapper).toMatchSnapshot()
+    expect(wrapper.element).toMatchSnapshot()
   })
 
   it('should be able to export a CSV', async() => {

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.spec.ts
@@ -1,4 +1,4 @@
-import { mount, config as testConfig } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
 import DatasetTable from './DatasetTable.vue'
 import router from '../../../router'
 import { initMockGraphqlClient, apolloProvider } from '../../../../tests/utils/mockGraphqlClient'
@@ -8,11 +8,16 @@ import Vuex from 'vuex'
 import { sync } from 'vuex-router-sync'
 import * as FileSaver from 'file-saver'
 import { merge } from 'lodash-es'
+import { mockGenerateId, resetGenerateId } from '../../../../tests/utils/mockGenerateId'
 jest.mock('file-saver')
 const mockFileSaver = FileSaver as jest.Mocked<typeof FileSaver>
 
 Vue.use(Vuex)
 sync(store, router)
+// @ts-ignore
+Vue.options.router = router
+// @ts-ignore
+Vue.options.store = store
 
 const blobToText = (blob: Blob) => new Promise<string>((resolve, reject) => {
   const reader = new FileReader()
@@ -45,9 +50,11 @@ describe('DatasetTable', () => {
 
   afterEach(() => {
     jest.useRealTimers()
+    resetGenerateId()
   })
 
   it('should match snapshot', async() => {
+    mockGenerateId(123)
     initMockGraphqlClient({
       Query: () => ({
         allDatasets: () => {

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.spec.ts
@@ -14,10 +14,6 @@ const mockFileSaver = FileSaver as jest.Mocked<typeof FileSaver>
 
 Vue.use(Vuex)
 sync(store, router)
-// @ts-ignore
-Vue.options.router = router
-// @ts-ignore
-Vue.options.store = store
 
 const blobToText = (blob: Blob) => new Promise<string>((resolve, reject) => {
   const reader = new FileReader()
@@ -73,7 +69,7 @@ describe('DatasetTable', () => {
         }),
       }),
     })
-    const wrapper = mount(DatasetTable, { store, router, apolloProvider })
+    const wrapper = mount(DatasetTable, { parentComponent: { store, router }, apolloProvider })
     await Vue.nextTick()
 
     expect(wrapper.element).toMatchSnapshot()
@@ -102,7 +98,7 @@ describe('DatasetTable', () => {
         countDatasets: () => 4,
       }),
     })
-    const wrapper = mount(DatasetTable, { store, router, apolloProvider })
+    const wrapper = mount(DatasetTable, { parentComponent: { store, router }, apolloProvider })
     wrapper.setData({ csvChunkSize: 2 })
     await Vue.nextTick()
 

--- a/metaspace/webapp/src/modules/Datasets/list/DownloadDialog.tsx
+++ b/metaspace/webapp/src/modules/Datasets/list/DownloadDialog.tsx
@@ -85,6 +85,7 @@ export default createComponent({
   props: {
     datasetName: { type: String, required: true },
     datasetId: { type: String, required: true },
+    onClose: Function,
   },
   setup(props, { emit }) {
     const { datasetId } = toRefs(props)

--- a/metaspace/webapp/src/modules/Datasets/list/FilterLink.tsx
+++ b/metaspace/webapp/src/modules/Datasets/list/FilterLink.tsx
@@ -1,0 +1,29 @@
+import { createComponent } from '@vue/composition-api'
+import { encodeParams } from '../../Filters'
+
+const FilterLink = createComponent({
+  name: 'FilterLink',
+  props: {
+    path: { type: String, default: '/annotations' },
+    filter: { type: Object, required: true },
+  },
+  setup(props, { slots, root }) {
+    return () => {
+      const filter = {
+        ...root.$store.getters.filter,
+        ...props.filter,
+      }
+      const to = {
+        path: props.path,
+        query: encodeParams(filter, props.path, root.$store.state.filterLists),
+      }
+      return (
+        <router-link to={to}>
+          {slots.default?.()}
+        </router-link>
+      )
+    }
+  },
+})
+
+export default FilterLink

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetItem.spec.js.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetItem.spec.js.snap
@@ -55,37 +55,31 @@ exports[`DatasetItem should match snapshot 1`] = `
     >
       <span
         class="font-bold truncate"
-      >
-        
-      </span>
-       
-      <mock-el-popover
+      />
+      <span
         class="ml-1"
-        placement="top"
-        trigger="hover"
       >
         <div
-          slot-key="default"
+          aria-hidden="true"
+          class="el-popover el-popper"
+          id="el-popover-4000"
+          name="fade-in-linear"
+          role="tooltip"
+          style="display: none;"
+          tabindex="0"
         >
+          <!---->
           <div
             mock-v-loading="true"
-          >
-            
-          
-        
-          </div>
-           
-        </div>
-        <div
-          slot-key="reference"
-        >
-          <i
-            class="el-icon-lock"
           />
         </div>
-      </mock-el-popover>
+        <i
+          aria-describedby="el-popover-4000"
+          class="el-icon-lock el-popover__reference"
+          tabindex="0"
+        />
+      </span>
     </div>
-     
     <div
       class="ds-item-line text-gray-700"
     >
@@ -93,16 +87,13 @@ exports[`DatasetItem should match snapshot 1`] = `
         class="ds-add-filter"
         title="Filter by species"
       >
-        
         organism
       </span>
-      ,
-      
+      , 
       <span
         class="ds-add-filter"
         title="Filter by organism part"
       >
-        
         organismpart
       </span>
        
@@ -110,64 +101,45 @@ exports[`DatasetItem should match snapshot 1`] = `
         class="ds-add-filter"
         title="Filter by condition"
       >
-        
         (condition)
       </span>
     </div>
-     
     <div
       class="ds-item-line"
     >
       <span
         class="ds-add-filter"
         title="Filter by ionisation source"
-      >
-        
-        
-      </span>
-       +
-      
+      />
+       + 
       <span
         class="ds-add-filter"
         title="Filter by analyzer type"
       >
-        
         type
       </span>
-      ,
-      
+      , 
       <span
         class="ds-add-filter"
         title="Filter by polarity"
       >
-        
         positive mode
       </span>
-      ,
-      RP 123k @ 1234
-    
+      , RP 123k @ 1234
     </div>
-     
     <div
       class="ds-item-line"
     >
-      
       Submitted 
       <mock-elapsed-time
         date="2020-04-17T11:37:50.318667"
       />
-       by
-      
+       by 
       <span
         class="ds-add-filter"
         title="Filter by submitter"
-      >
-        
-        
-      </span>
-      <!---->
+      />
     </div>
-     
     <div
       class="ds-item-line"
     >
@@ -178,9 +150,7 @@ exports[`DatasetItem should match snapshot 1`] = `
         >
           20 annotations
         </a>
-        
-        @ FDR 10% (HMDB-v2.5)
-      
+         @ FDR 10% (HMDB-v2.5)
       </span>
     </div>
   </div>

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetItem.spec.js.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetItem.spec.js.snap
@@ -4,21 +4,6 @@ exports[`DatasetItem should match snapshot 1`] = `
 <div
   class="dataset-item border border-solid border-gray-200 leading-5"
 >
-  <mock-el-dialog
-    title="Provided metadata"
-  >
-    <div
-      class="el-row"
-    >
-      <mock-el-tree
-        data="[object Object],[object Object]"
-        default-expanded-keys="MS analysis,Detector resolving power,Data Management"
-        id="metadata-tree"
-        node-key="id"
-      />
-    </div>
-  </mock-el-dialog>
-   
   <div
     class="opt-image--container"
   >
@@ -62,7 +47,7 @@ exports[`DatasetItem should match snapshot 1`] = `
         <div
           aria-hidden="true"
           class="el-popover el-popper"
-          id="el-popover-4000"
+          id="el-popover-123"
           name="fade-in-linear"
           role="tooltip"
           style="display: none;"
@@ -74,7 +59,7 @@ exports[`DatasetItem should match snapshot 1`] = `
           />
         </div>
         <i
-          aria-describedby="el-popover-4000"
+          aria-describedby="el-popover-123"
           class="el-icon-lock el-popover__reference"
           tabindex="0"
         />
@@ -158,11 +143,24 @@ exports[`DatasetItem should match snapshot 1`] = `
   <div
     class="ds-actions"
   >
+    <mock-el-dialog
+      title="Provided metadata"
+    >
+      <div
+        class="el-row"
+      >
+        <mock-el-tree
+          data="[object Object],[object Object]"
+          default-expanded-keys="MS analysis,Detector resolving power,Data Management"
+          id="metadata-tree"
+          node-key="id"
+        />
+      </div>
+    </mock-el-dialog>
     <span>
       <i
         class="el-icon-picture"
       />
-       
       <mock-el-popover
         placement="top"
         trigger="hover"
@@ -173,17 +171,13 @@ exports[`DatasetItem should match snapshot 1`] = `
           <div
             class="db-link-list"
           >
-            
-          Select a database:
-          
+            Select a database:
             <div>
               <a
                 class=""
                 href="/annotations?db=HMDB-v2.5&ds=mockdataset"
               >
-                
-              HMDB-v2.5
-            
+                HMDB-v2.5
               </a>
             </div>
             <div>
@@ -191,9 +185,7 @@ exports[`DatasetItem should match snapshot 1`] = `
                 class=""
                 href="/annotations?db=HMDB-v4&ds=mockdataset"
               >
-                
-              HMDB-v4
-            
+                HMDB-v4
               </a>
             </div>
             <div>
@@ -201,13 +193,10 @@ exports[`DatasetItem should match snapshot 1`] = `
                 class=""
                 href="/annotations?db=CHEBI&ds=mockdataset"
               >
-                
-              CHEBI
-            
+                CHEBI
               </a>
             </div>
           </div>
-           
         </div>
         <div
           slot-key="reference"
@@ -217,50 +206,35 @@ exports[`DatasetItem should match snapshot 1`] = `
           </a>
         </div>
       </mock-el-popover>
-       
       <br />
     </span>
-     
-    <!---->
-     
-    <!---->
-     
     <div>
       <i
         class="el-icon-view"
       />
-       
       <a
         href="#"
       >
         Show full metadata
       </a>
     </div>
-     
     <div>
       <i
         class="el-icon-edit"
       />
-       
       <a
         class=""
         href="/datasets/edit/mockdataset"
       >
-        
         Edit metadata
-      
       </a>
     </div>
-     
-    <!---->
-     
     <div
       class="ds-delete"
     >
       <i
         class="el-icon-delete"
       />
-       
       <a
         class="text-danger"
         href="#"
@@ -268,10 +242,6 @@ exports[`DatasetItem should match snapshot 1`] = `
         Delete dataset
       </a>
     </div>
-     
-    <!---->
   </div>
-   
-  <!---->
 </div>
 `;

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetItem.spec.js.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetItem.spec.js.snap
@@ -1,72 +1,307 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DatasetItem should match snapshot 1`] = `
-<div class="dataset-item border border-solid border-gray-200 leading-5">
-  <mock-el-dialog title="Provided metadata">
-    <div class="el-row">
-      <mock-el-tree id="metadata-tree" data="[object Object],[object Object]" node-key="id" default-expanded-keys="MS analysis,Detector resolving power,Data Management"></mock-el-tree>
+<div
+  class="dataset-item border border-solid border-gray-200 leading-5"
+>
+  <mock-el-dialog
+    title="Provided metadata"
+  >
+    <div
+      class="el-row"
+    >
+      <mock-el-tree
+        data="[object Object],[object Object]"
+        default-expanded-keys="MS analysis,Detector resolving power,Data Management"
+        id="metadata-tree"
+        node-key="id"
+      />
     </div>
   </mock-el-dialog>
-  <div class="opt-image--container"><a href="/datasets/mockdataset/add-optical-image" class="">
-      <div title="Add Optical Image" class="thumb thumb__editable thumb__empty">
+   
+  <div
+    class="opt-image--container"
+  >
+    <a
+      class=""
+      href="/datasets/mockdataset/add-optical-image"
+    >
+      <div
+        class="thumb thumb__editable thumb__empty"
+        title="Add Optical Image"
+      >
         <!---->
-        <!----> <img src="../../../assets/no_opt_image.png" alt="Add optical image" class="thumb--img">
-        <div class="thumb--overlay el-icon-edit el-icon-plus"></div>
+         
+        <!---->
+         
+        <img
+          alt="Add optical image"
+          class="thumb--img"
+          src="../../../assets/no_opt_image.png"
+        />
+         
+        <div
+          class="thumb--overlay el-icon-edit el-icon-plus"
+        />
       </div>
-    </a></div>
-  <div class="ds-info">
-    <div class="ds-item-line flex"><span class="font-bold truncate"></span>
-      <mock-el-popover trigger="hover" placement="top" class="ml-1">
-        <div slot-key="default">
-          <div mock-v-loading="true">
-
+    </a>
+  </div>
+   
+  <div
+    class="ds-info"
+  >
+    <div
+      class="ds-item-line flex"
+    >
+      <span
+        class="font-bold truncate"
+      >
+        
+      </span>
+       
+      <mock-el-popover
+        class="ml-1"
+        placement="top"
+        trigger="hover"
+      >
+        <div
+          slot-key="default"
+        >
+          <div
+            mock-v-loading="true"
+          >
+            
+          
+        
           </div>
+           
         </div>
-        <div slot-key="reference"><i class="el-icon-lock"></i></div>
+        <div
+          slot-key="reference"
+        >
+          <i
+            class="el-icon-lock"
+          />
+        </div>
       </mock-el-popover>
     </div>
-    <div class="ds-item-line text-gray-700"><span title="Filter by species" class="ds-add-filter">
-        organism</span>,
-      <span title="Filter by organism part" class="ds-add-filter">
-        organismpart</span> <span title="Filter by condition" class="ds-add-filter">
-        (condition)</span></div>
-    <div class="ds-item-line"><span title="Filter by ionisation source" class="ds-add-filter">
-        </span> +
-      <span title="Filter by analyzer type" class="ds-add-filter">
-        type</span>,
-      <span title="Filter by polarity" class="ds-add-filter">
-        positive mode</span>,
-      RP 123k @ 1234
+     
+    <div
+      class="ds-item-line text-gray-700"
+    >
+      <span
+        class="ds-add-filter"
+        title="Filter by species"
+      >
+        
+        organism
+      </span>
+      ,
+      
+      <span
+        class="ds-add-filter"
+        title="Filter by organism part"
+      >
+        
+        organismpart
+      </span>
+       
+      <span
+        class="ds-add-filter"
+        title="Filter by condition"
+      >
+        
+        (condition)
+      </span>
     </div>
-    <div class="ds-item-line">
-      Submitted <mock-elapsed-time date="2020-04-17T11:37:50.318667"></mock-elapsed-time> by
-      <span title="Filter by submitter" class="ds-add-filter">
-        </span>
+     
+    <div
+      class="ds-item-line"
+    >
+      <span
+        class="ds-add-filter"
+        title="Filter by ionisation source"
+      >
+        
+        
+      </span>
+       +
+      
+      <span
+        class="ds-add-filter"
+        title="Filter by analyzer type"
+      >
+        
+        type
+      </span>
+      ,
+      
+      <span
+        class="ds-add-filter"
+        title="Filter by polarity"
+      >
+        
+        positive mode
+      </span>
+      ,
+      RP 123k @ 1234
+    
+    </div>
+     
+    <div
+      class="ds-item-line"
+    >
+      
+      Submitted 
+      <mock-elapsed-time
+        date="2020-04-17T11:37:50.318667"
+      />
+       by
+      
+      <span
+        class="ds-add-filter"
+        title="Filter by submitter"
+      >
+        
+        
+      </span>
       <!---->
     </div>
-    <div class="ds-item-line"><span><a href="/annotations?db=HMDB-v2.5&amp;ds=mockdataset" class="">20 annotations</a>
+     
+    <div
+      class="ds-item-line"
+    >
+      <span>
+        <a
+          class=""
+          href="/annotations?db=HMDB-v2.5&ds=mockdataset"
+        >
+          20 annotations
+        </a>
+        
         @ FDR 10% (HMDB-v2.5)
-      </span></div>
+      
+      </span>
+    </div>
   </div>
-  <div class="ds-actions"><span><i class="el-icon-picture"></i> <mock-el-popover trigger="hover" placement="top"><div slot-key="default"><div class="db-link-list">
+   
+  <div
+    class="ds-actions"
+  >
+    <span>
+      <i
+        class="el-icon-picture"
+      />
+       
+      <mock-el-popover
+        placement="top"
+        trigger="hover"
+      >
+        <div
+          slot-key="default"
+        >
+          <div
+            class="db-link-list"
+          >
+            
           Select a database:
-          <div><a href="/annotations?db=HMDB-v2.5&amp;ds=mockdataset" class="">
+          
+            <div>
+              <a
+                class=""
+                href="/annotations?db=HMDB-v2.5&ds=mockdataset"
+              >
+                
               HMDB-v2.5
-            </a></div><div><a href="/annotations?db=HMDB-v4&amp;ds=mockdataset" class="">
+            
+              </a>
+            </div>
+            <div>
+              <a
+                class=""
+                href="/annotations?db=HMDB-v4&ds=mockdataset"
+              >
+                
               HMDB-v4
-            </a></div><div><a href="/annotations?db=CHEBI&amp;ds=mockdataset" class="">
+            
+              </a>
+            </div>
+            <div>
+              <a
+                class=""
+                href="/annotations?db=CHEBI&ds=mockdataset"
+              >
+                
               CHEBI
-            </a></div></div> </div><div slot-key="reference"><a>Browse annotations</a></div></mock-el-popover> <br></span>
+            
+              </a>
+            </div>
+          </div>
+           
+        </div>
+        <div
+          slot-key="reference"
+        >
+          <a>
+            Browse annotations
+          </a>
+        </div>
+      </mock-el-popover>
+       
+      <br />
+    </span>
+     
     <!---->
+     
     <!---->
-    <div><i class="el-icon-view"></i> <a href="#">Show full metadata</a></div>
-    <div><i class="el-icon-edit"></i> <a href="/datasets/edit/mockdataset" class="">
+     
+    <div>
+      <i
+        class="el-icon-view"
+      />
+       
+      <a
+        href="#"
+      >
+        Show full metadata
+      </a>
+    </div>
+     
+    <div>
+      <i
+        class="el-icon-edit"
+      />
+       
+      <a
+        class=""
+        href="/datasets/edit/mockdataset"
+      >
+        
         Edit metadata
-      </a></div>
+      
+      </a>
+    </div>
+     
     <!---->
-    <div class="ds-delete"><i class="el-icon-delete"></i> <a href="#" class="text-danger">Delete dataset</a></div>
+     
+    <div
+      class="ds-delete"
+    >
+      <i
+        class="el-icon-delete"
+      />
+       
+      <a
+        class="text-danger"
+        href="#"
+      >
+        Delete dataset
+      </a>
+    </div>
+     
     <!---->
   </div>
+   
   <!---->
 </div>
 `;

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetItem.spec.js.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetItem.spec.js.snap
@@ -44,20 +44,23 @@ exports[`DatasetItem should match snapshot 1`] = `
       <span
         class="ml-1"
       >
-        <div
-          aria-hidden="true"
-          class="el-popover el-popper"
-          id="el-popover-123"
+        <transition-stub
           name="fade-in-linear"
-          role="tooltip"
-          style="display: none;"
-          tabindex="0"
         >
-          <!---->
           <div
-            mock-v-loading="true"
-          />
-        </div>
+            aria-hidden="true"
+            class="el-popover el-popper"
+            id="el-popover-123"
+            role="tooltip"
+            style="display: none;"
+            tabindex="0"
+          >
+            <!---->
+            <div
+              mock-v-loading="true"
+            />
+          </div>
+        </transition-stub>
         <i
           aria-describedby="el-popover-123"
           class="el-icon-lock el-popover__reference"

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -243,21 +243,6 @@ exports[`DatasetTable should match snapshot 1`] = `
     <div
       class="dataset-item border border-solid border-gray-200 leading-5"
     >
-      <mock-el-dialog
-        title="Provided metadata"
-      >
-        <div
-          class="el-row"
-        >
-          <mock-el-tree
-            data="[object Object],[object Object]"
-            default-expanded-keys="MS analysis,Detector resolving power,Data Management"
-            id="metadata-tree"
-            node-key="id"
-          />
-        </div>
-      </mock-el-dialog>
-       
       <div
         class="opt-image--container"
       >
@@ -294,34 +279,33 @@ exports[`DatasetTable should match snapshot 1`] = `
           >
             allDatasets.1.name
           </span>
-           
-          <mock-el-popover
+          <span
             class="ml-1"
-            placement="top"
-            trigger="hover"
           >
-            <div
-              slot-key="default"
+            <transition-stub
+              name="fade-in-linear"
             >
               <div
-                mock-v-loading="true"
+                aria-hidden="true"
+                class="el-popover el-popper"
+                id="el-popover-123"
+                role="tooltip"
+                style="display: none;"
+                tabindex="0"
               >
-                
-          
-        
+                <!---->
+                <div
+                  mock-v-loading="true"
+                />
               </div>
-               
-            </div>
-            <div
-              slot-key="reference"
-            >
-              <i
-                class="el-icon-lock"
-              />
-            </div>
-          </mock-el-popover>
+            </transition-stub>
+            <i
+              aria-describedby="el-popover-123"
+              class="el-icon-lock el-popover__reference"
+              tabindex="0"
+            />
+          </span>
         </div>
-         
         <div
           class="ds-item-line text-gray-700"
         >
@@ -329,28 +313,23 @@ exports[`DatasetTable should match snapshot 1`] = `
             class="ds-add-filter"
             title="Filter by species"
           >
-            
-        allDatasets.1.organism
+            allDatasets.1.organism
           </span>
-          ,
-      
+          , 
           <span
             class="ds-add-filter"
             title="Filter by organism part"
           >
-            
-        alldatasets.1.organismpart
+            alldatasets.1.organismpart
           </span>
            
           <span
             class="ds-add-filter"
             title="Filter by condition"
           >
-            
-        (alldatasets.1.condition)
+            (alldatasets.1.condition)
           </span>
         </div>
-         
         <div
           class="ds-item-line"
         >
@@ -358,52 +337,40 @@ exports[`DatasetTable should match snapshot 1`] = `
             class="ds-add-filter"
             title="Filter by ionisation source"
           >
-            
-        allDatasets.1.ionisationSource
+            allDatasets.1.ionisationSource
           </span>
-           +
-      
+           + 
           <span
             class="ds-add-filter"
             title="Filter by analyzer type"
           >
-            
-        allDatasets.1.analyzer.type
+            allDatasets.1.analyzer.type
           </span>
-          ,
-      
+          , 
           <span
             class="ds-add-filter"
             title="Filter by polarity"
           >
-            
-        positive mode
+            positive mode
           </span>
-          ,
-      RP 123k @ 1234
-    
+          , RP 123k @ 1234
         </div>
-         
         <div
           class="ds-item-line"
         >
-          
-      Submitted 
+          Submitted 
           <mock-elapsed-time
             date="allDatasets.1.uploadDT"
           />
-           by
-      
+           by 
           <span
             class="ds-add-filter"
             title="Filter by submitter"
           >
-            
-        allDatasets.1.submitter.name
+            allDatasets.1.submitter.name
           </span>
           <span>
-            ,
-        
+            , 
             <mock-el-dropdown
               placement="bottom"
               show-timeout="50"
@@ -415,11 +382,8 @@ exports[`DatasetTable should match snapshot 1`] = `
                 <span
                   class="text-base text-primary cursor-pointer"
                 >
-                  
-            allDatasets.1.group.shortName
-          
+                  allDatasets.1.group.shortName
                 </span>
-                 
               </div>
               <div
                 slot-key="dropdown"
@@ -430,7 +394,6 @@ exports[`DatasetTable should match snapshot 1`] = `
                   >
                     Filter by this group
                   </mock-el-dropdown-item>
-                   
                   <mock-el-dropdown-item
                     command="view_group"
                   >
@@ -441,77 +404,58 @@ exports[`DatasetTable should match snapshot 1`] = `
             </mock-el-dropdown>
           </span>
         </div>
-         
-        <!---->
       </div>
        
       <div
         class="ds-actions"
       >
-        <!---->
-         
-        <!---->
-         
+        <mock-el-dialog
+          title="Provided metadata"
+        >
+          <div
+            class="el-row"
+          >
+            <mock-el-tree
+              data="[object Object],[object Object]"
+              default-expanded-keys="MS analysis,Detector resolving power,Data Management"
+              id="metadata-tree"
+              node-key="id"
+            />
+          </div>
+        </mock-el-dialog>
         <span>
           <div
             class="striped-progressbar queued"
             title="Waiting in the queue"
           />
         </span>
-         
         <div>
           <i
             class="el-icon-view"
           />
-           
           <a
             href="#"
           >
             Show full metadata
           </a>
         </div>
-         
-        <!---->
-         
         <div
           class="ds-download"
         >
           <i
             class="el-icon-download"
           />
-           
           <a
             href="#"
           >
             Download
           </a>
         </div>
-         
-        <!---->
-         
-        <!---->
       </div>
-       
-      <!---->
     </div>
     <div
       class="dataset-item border border-solid border-gray-200 leading-5"
     >
-      <mock-el-dialog
-        title="Provided metadata"
-      >
-        <div
-          class="el-row"
-        >
-          <mock-el-tree
-            data="[object Object],[object Object]"
-            default-expanded-keys="MS analysis,Detector resolving power,Data Management"
-            id="metadata-tree"
-            node-key="id"
-          />
-        </div>
-      </mock-el-dialog>
-       
       <div
         class="opt-image--container"
       >
@@ -548,10 +492,7 @@ exports[`DatasetTable should match snapshot 1`] = `
           >
             allDatasets.0.name
           </span>
-           
-          <!---->
         </div>
-         
         <div
           class="ds-item-line text-gray-700"
         >
@@ -559,28 +500,23 @@ exports[`DatasetTable should match snapshot 1`] = `
             class="ds-add-filter"
             title="Filter by species"
           >
-            
-        allDatasets.0.organism
+            allDatasets.0.organism
           </span>
-          ,
-      
+          , 
           <span
             class="ds-add-filter"
             title="Filter by organism part"
           >
-            
-        alldatasets.0.organismpart
+            alldatasets.0.organismpart
           </span>
            
           <span
             class="ds-add-filter"
             title="Filter by condition"
           >
-            
-        (alldatasets.0.condition)
+            (alldatasets.0.condition)
           </span>
         </div>
-         
         <div
           class="ds-item-line"
         >
@@ -588,52 +524,40 @@ exports[`DatasetTable should match snapshot 1`] = `
             class="ds-add-filter"
             title="Filter by ionisation source"
           >
-            
-        allDatasets.0.ionisationSource
+            allDatasets.0.ionisationSource
           </span>
-           +
-      
+           + 
           <span
             class="ds-add-filter"
             title="Filter by analyzer type"
           >
-            
-        allDatasets.0.analyzer.type
+            allDatasets.0.analyzer.type
           </span>
-          ,
-      
+          , 
           <span
             class="ds-add-filter"
             title="Filter by polarity"
           >
-            
-        positive mode
+            positive mode
           </span>
-          ,
-      RP 123k @ 1234
-    
+          , RP 123k @ 1234
         </div>
-         
         <div
           class="ds-item-line"
         >
-          
-      Submitted 
+          Submitted 
           <mock-elapsed-time
             date="allDatasets.0.uploadDT"
           />
-           by
-      
+           by 
           <span
             class="ds-add-filter"
             title="Filter by submitter"
           >
-            
-        allDatasets.0.submitter.name
+            allDatasets.0.submitter.name
           </span>
           <span>
-            ,
-        
+            , 
             <mock-el-dropdown
               placement="bottom"
               show-timeout="50"
@@ -645,11 +569,8 @@ exports[`DatasetTable should match snapshot 1`] = `
                 <span
                   class="text-base text-primary cursor-pointer"
                 >
-                  
-            allDatasets.0.group.shortName
-          
+                  allDatasets.0.group.shortName
                 </span>
-                 
               </div>
               <div
                 slot-key="dropdown"
@@ -660,7 +581,6 @@ exports[`DatasetTable should match snapshot 1`] = `
                   >
                     Filter by this group
                   </mock-el-dropdown-item>
-                   
                   <mock-el-dropdown-item
                     command="view_group"
                   >
@@ -671,65 +591,46 @@ exports[`DatasetTable should match snapshot 1`] = `
             </mock-el-dropdown>
           </span>
         </div>
-         
-        <!---->
       </div>
        
       <div
         class="ds-actions"
       >
-        <!---->
-         
+        <mock-el-dialog
+          title="Provided metadata"
+        >
+          <div
+            class="el-row"
+          >
+            <mock-el-tree
+              data="[object Object],[object Object]"
+              default-expanded-keys="MS analysis,Detector resolving power,Data Management"
+              id="metadata-tree"
+              node-key="id"
+            />
+          </div>
+        </mock-el-dialog>
         <span>
           <div
             class="striped-progressbar processing"
             title="Processing is under way"
           />
         </span>
-         
-        <!---->
-         
         <div>
           <i
             class="el-icon-view"
           />
-           
           <a
             href="#"
           >
             Show full metadata
           </a>
         </div>
-         
-        <!---->
-         
-        <!---->
-         
-        <!---->
-         
-        <!---->
       </div>
-       
-      <!---->
     </div>
     <div
       class="dataset-item border border-solid border-gray-200 leading-5"
     >
-      <mock-el-dialog
-        title="Provided metadata"
-      >
-        <div
-          class="el-row"
-        >
-          <mock-el-tree
-            data="[object Object],[object Object]"
-            default-expanded-keys="MS analysis,Detector resolving power,Data Management"
-            id="metadata-tree"
-            node-key="id"
-          />
-        </div>
-      </mock-el-dialog>
-       
       <div
         class="opt-image--container"
       >
@@ -766,10 +667,7 @@ exports[`DatasetTable should match snapshot 1`] = `
           >
             allDatasets.2.name
           </span>
-           
-          <!---->
         </div>
-         
         <div
           class="ds-item-line text-gray-700"
         >
@@ -777,28 +675,23 @@ exports[`DatasetTable should match snapshot 1`] = `
             class="ds-add-filter"
             title="Filter by species"
           >
-            
-        allDatasets.2.organism
+            allDatasets.2.organism
           </span>
-          ,
-      
+          , 
           <span
             class="ds-add-filter"
             title="Filter by organism part"
           >
-            
-        alldatasets.2.organismpart
+            alldatasets.2.organismpart
           </span>
            
           <span
             class="ds-add-filter"
             title="Filter by condition"
           >
-            
-        (alldatasets.2.condition)
+            (alldatasets.2.condition)
           </span>
         </div>
-         
         <div
           class="ds-item-line"
         >
@@ -806,52 +699,40 @@ exports[`DatasetTable should match snapshot 1`] = `
             class="ds-add-filter"
             title="Filter by ionisation source"
           >
-            
-        allDatasets.2.ionisationSource
+            allDatasets.2.ionisationSource
           </span>
-           +
-      
+           + 
           <span
             class="ds-add-filter"
             title="Filter by analyzer type"
           >
-            
-        allDatasets.2.analyzer.type
+            allDatasets.2.analyzer.type
           </span>
-          ,
-      
+          , 
           <span
             class="ds-add-filter"
             title="Filter by polarity"
           >
-            
-        positive mode
+            positive mode
           </span>
-          ,
-      RP 123k @ 1234
-    
+          , RP 123k @ 1234
         </div>
-         
         <div
           class="ds-item-line"
         >
-          
-      Submitted 
+          Submitted 
           <mock-elapsed-time
             date="allDatasets.2.uploadDT"
           />
-           by
-      
+           by 
           <span
             class="ds-add-filter"
             title="Filter by submitter"
           >
-            
-        allDatasets.2.submitter.name
+            allDatasets.2.submitter.name
           </span>
           <span>
-            ,
-        
+            , 
             <mock-el-dropdown
               placement="bottom"
               show-timeout="50"
@@ -863,11 +744,8 @@ exports[`DatasetTable should match snapshot 1`] = `
                 <span
                   class="text-base text-primary cursor-pointer"
                 >
-                  
-            allDatasets.2.group.shortName
-          
+                  allDatasets.2.group.shortName
                 </span>
-                 
               </div>
               <div
                 slot-key="dropdown"
@@ -878,7 +756,6 @@ exports[`DatasetTable should match snapshot 1`] = `
                   >
                     Filter by this group
                   </mock-el-dropdown-item>
-                   
                   <mock-el-dropdown-item
                     command="view_group"
                   >
@@ -889,20 +766,17 @@ exports[`DatasetTable should match snapshot 1`] = `
             </mock-el-dropdown>
           </span>
         </div>
-         
         <div
           class="ds-item-line"
         >
           <span>
             <a
               class=""
-              href="/annotations?db=HMDB-v2.5&ds=FINISHED1&mdtype=allDatasets.2.metadataType"
+              href="/annotations?db=HMDB-v2.5&ds=FINISHED1"
             >
               20 annotations
             </a>
-            
-        @ FDR 10% (HMDB-v2.5)
-      
+             @ FDR 10% (HMDB-v2.5)
           </span>
         </div>
       </div>
@@ -910,11 +784,24 @@ exports[`DatasetTable should match snapshot 1`] = `
       <div
         class="ds-actions"
       >
+        <mock-el-dialog
+          title="Provided metadata"
+        >
+          <div
+            class="el-row"
+          >
+            <mock-el-tree
+              data="[object Object],[object Object]"
+              default-expanded-keys="MS analysis,Detector resolving power,Data Management"
+              id="metadata-tree"
+              node-key="id"
+            />
+          </div>
+        </mock-el-dialog>
         <span>
           <i
             class="el-icon-picture"
           />
-           
           <mock-el-popover
             placement="top"
             trigger="hover"
@@ -925,41 +812,32 @@ exports[`DatasetTable should match snapshot 1`] = `
               <div
                 class="db-link-list"
               >
-                
-          Select a database:
-          
+                Select a database:
                 <div>
                   <a
                     class=""
-                    href="/annotations?db=HMDB-v2.5&ds=FINISHED1&mdtype=allDatasets.2.metadataType"
+                    href="/annotations?db=HMDB-v2.5&ds=FINISHED1"
                   >
-                    
-              HMDB-v2.5
-            
+                    HMDB-v2.5
                   </a>
                 </div>
                 <div>
                   <a
                     class=""
-                    href="/annotations?db=HMDB-v4&ds=FINISHED1&mdtype=allDatasets.2.metadataType"
+                    href="/annotations?db=HMDB-v4&ds=FINISHED1"
                   >
-                    
-              HMDB-v4
-            
+                    HMDB-v4
                   </a>
                 </div>
                 <div>
                   <a
                     class=""
-                    href="/annotations?db=CHEBI&ds=FINISHED1&mdtype=allDatasets.2.metadataType"
+                    href="/annotations?db=CHEBI&ds=FINISHED1"
                   >
-                    
-              CHEBI
-            
+                    CHEBI
                   </a>
                 </div>
               </div>
-               
             </div>
             <div
               slot-key="reference"
@@ -969,36 +847,19 @@ exports[`DatasetTable should match snapshot 1`] = `
               </a>
             </div>
           </mock-el-popover>
-           
           <br />
         </span>
-         
-        <!---->
-         
-        <!---->
-         
         <div>
           <i
             class="el-icon-view"
           />
-           
           <a
             href="#"
           >
             Show full metadata
           </a>
         </div>
-         
-        <!---->
-         
-        <!---->
-         
-        <!---->
-         
-        <!---->
       </div>
-       
-      <!---->
     </div>
      
     <!---->

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -12,231 +12,996 @@ exports[`DatasetTable should be able to export a CSV 1`] = `
 
 exports[`DatasetTable should match snapshot 1`] = `
 <div>
-  <div class="filter-panel">
-    <mock-el-select placeholder="Add filter" class="filter-select">
-      <mock-el-option value="group" label="Select group"></mock-el-option>
-      <mock-el-option value="project" label="Select project"></mock-el-option>
-      <mock-el-option value="submitter" label="Select submitter"></mock-el-option>
-      <mock-el-option value="datasetIds" label="Select dataset"></mock-el-option>
-      <mock-el-option value="compoundName" label="Search molecule"></mock-el-option>
-      <mock-el-option value="polarity" label="Select polarity"></mock-el-option>
-      <mock-el-option value="organism" label="Select organism"></mock-el-option>
-      <mock-el-option value="organismPart" label="Select organism part"></mock-el-option>
-      <mock-el-option value="condition" label="Select organism condition"></mock-el-option>
-      <mock-el-option value="growthConditions" label="Select sample growth conditions"></mock-el-option>
-      <mock-el-option value="analyzerType" label="Select analyzer"></mock-el-option>
-      <mock-el-option value="ionisationSource" label="Select ionisation source"></mock-el-option>
-      <mock-el-option value="maldiMatrix" label="Select MALDI matrix"></mock-el-option>
-      <mock-el-option value="simpleQuery" label="Search anything"></mock-el-option>
-      <mock-el-option value="metadataType" label="Select data type"></mock-el-option>
+  <div
+    class="filter-panel"
+  >
+    <mock-el-select
+      class="filter-select"
+      placeholder="Add filter"
+    >
+      <mock-el-option
+        label="Select group"
+        value="group"
+      />
+      <mock-el-option
+        label="Select project"
+        value="project"
+      />
+      <mock-el-option
+        label="Select submitter"
+        value="submitter"
+      />
+      <mock-el-option
+        label="Select dataset"
+        value="datasetIds"
+      />
+      <mock-el-option
+        label="Search molecule"
+        value="compoundName"
+      />
+      <mock-el-option
+        label="Select polarity"
+        value="polarity"
+      />
+      <mock-el-option
+        label="Select organism"
+        value="organism"
+      />
+      <mock-el-option
+        label="Select organism part"
+        value="organismPart"
+      />
+      <mock-el-option
+        label="Select organism condition"
+        value="condition"
+      />
+      <mock-el-option
+        label="Select sample growth conditions"
+        value="growthConditions"
+      />
+      <mock-el-option
+        label="Select analyzer"
+        value="analyzerType"
+      />
+      <mock-el-option
+        label="Select ionisation source"
+        value="ionisationSource"
+      />
+      <mock-el-option
+        label="Select MALDI matrix"
+        value="maldiMatrix"
+      />
+      <mock-el-option
+        label="Search anything"
+        value="simpleQuery"
+      />
+      <mock-el-option
+        label="Select data type"
+        value="metadataType"
+      />
     </mock-el-select>
+     
   </div>
+   
   <div>
-    <form class="el-form el-form--inline" id="dataset-list-header">
-      <div role="radiogroup" class="el-radio-group"><label role="radio" aria-checked="true" tabindex="0" class="el-radio-button el-radio-button--small is-active"><input type="radio" tabindex="-1" class="el-radio-button__orig-radio" value="List"><span class="el-radio-button__inner">List</span></label> <label role="radio" tabindex="-1" class="el-radio-button el-radio-button--small"><input type="radio" tabindex="-1" class="el-radio-button__orig-radio" value="Summary"><span class="el-radio-button__inner">Summary</span></label></div>
-      <div role="group" aria-label="checkbox-group" class="el-checkbox-group dataset-status-checkboxes" mock-v-loading="0"><label class="el-checkbox cb-annotating is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="ANNOTATING"></span><span class="el-checkbox__label">
+    <form
+      class="el-form el-form--inline"
+      id="dataset-list-header"
+    >
+      <div
+        class="el-radio-group"
+        role="radiogroup"
+      >
+        <label
+          aria-checked="true"
+          class="el-radio-button el-radio-button--small is-active"
+          role="radio"
+          tabindex="0"
+        >
+          <input
+            class="el-radio-button__orig-radio"
+            tabindex="-1"
+            type="radio"
+            value="List"
+          />
+          <span
+            class="el-radio-button__inner"
+          >
+            List
+          </span>
+        </label>
+         
+        <label
+          class="el-radio-button el-radio-button--small"
+          role="radio"
+          tabindex="-1"
+        >
+          <input
+            class="el-radio-button__orig-radio"
+            tabindex="-1"
+            type="radio"
+            value="Summary"
+          />
+          <span
+            class="el-radio-button__inner"
+          >
+            Summary
+          </span>
+        </label>
+      </div>
+       
+      <div
+        aria-label="checkbox-group"
+        class="el-checkbox-group dataset-status-checkboxes"
+        mock-v-loading="0"
+        role="group"
+      >
+        <label
+          class="el-checkbox cb-annotating is-checked"
+        >
+          <span
+            class="el-checkbox__input is-checked"
+          >
+            <span
+              class="el-checkbox__inner"
+            />
+            <input
+              aria-hidden="false"
+              class="el-checkbox__original"
+              type="checkbox"
+              value="ANNOTATING"
+            />
+          </span>
+          <span
+            class="el-checkbox__label"
+          >
+            
           Processing (1)
-        <!----></span></label> <label class="el-checkbox cb-queued is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="QUEUED"></span><span class="el-checkbox__label">
+        
+            <!---->
+          </span>
+        </label>
+         
+        <label
+          class="el-checkbox cb-queued is-checked"
+        >
+          <span
+            class="el-checkbox__input is-checked"
+          >
+            <span
+              class="el-checkbox__inner"
+            />
+            <input
+              aria-hidden="false"
+              class="el-checkbox__original"
+              type="checkbox"
+              value="QUEUED"
+            />
+          </span>
+          <span
+            class="el-checkbox__label"
+          >
+            
           Queued (2)
-        <!----></span></label> <label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="FINISHED"></span><span class="el-checkbox__label">
+        
+            <!---->
+          </span>
+        </label>
+         
+        <label
+          class="el-checkbox is-checked"
+        >
+          <span
+            class="el-checkbox__input is-checked"
+          >
+            <span
+              class="el-checkbox__inner"
+            />
+            <input
+              aria-hidden="false"
+              class="el-checkbox__original"
+              type="checkbox"
+              value="FINISHED"
+            />
+          </span>
+          <span
+            class="el-checkbox__label"
+          >
+            
           Finished (20)
-        <!----></span></label>
+        
+            <!---->
+          </span>
+        </label>
+         
         <!---->
       </div>
-      <div style="flex-grow: 1;"></div> <button type="button" class="el-button el-button--default el-button--small">
+       
+      <div
+        style="flex-grow: 1;"
+      />
+       
+      <button
+        class="el-button el-button--default el-button--small"
+        type="button"
+      >
         <!---->
-        <!----><span>
+        <!---->
+        <span>
+          
         Export to CSV
-      </span></button>
+      
+        </span>
+      </button>
     </form>
   </div>
-  <div class="dataset-list allow-double-column" mock-v-loading="0">
-    <div class="dataset-item border border-solid border-gray-200 leading-5">
-      <mock-el-dialog title="Provided metadata">
-        <div class="el-row">
-          <mock-el-tree id="metadata-tree" data="[object Object],[object Object]" node-key="id" default-expanded-keys="MS analysis,Detector resolving power,Data Management"></mock-el-tree>
+   
+  <div
+    class="dataset-list allow-double-column"
+    mock-v-loading="0"
+  >
+    <div
+      class="dataset-item border border-solid border-gray-200 leading-5"
+    >
+      <mock-el-dialog
+        title="Provided metadata"
+      >
+        <div
+          class="el-row"
+        >
+          <mock-el-tree
+            data="[object Object],[object Object]"
+            default-expanded-keys="MS analysis,Detector resolving power,Data Management"
+            id="metadata-tree"
+            node-key="id"
+          />
         </div>
       </mock-el-dialog>
-      <div class="opt-image--container">
-        <div class="thumb"><img src="allDatasets.1.thumbnailOpticalImageUrl" alt="Optical image" class="thumb--img" style="transform: scaleY(1) translateY(0%); height: 100px;"> <img src="allDatasets.1.ionThumbnailUrl" alt="Ion image thumbnail" class="thumb--img thumb--img__ion" style="transform: scaleY(1) translateY(0%); height: 100px;">
+       
+      <div
+        class="opt-image--container"
+      >
+        <div
+          class="thumb"
+        >
+          <img
+            alt="Optical image"
+            class="thumb--img"
+            src="allDatasets.1.thumbnailOpticalImageUrl"
+            style="transform: scaleY(1) translateY(0%); height: 100px;"
+          />
+           
+          <img
+            alt="Ion image thumbnail"
+            class="thumb--img thumb--img__ion"
+            src="allDatasets.1.ionThumbnailUrl"
+            style="transform: scaleY(1) translateY(0%); height: 100px;"
+          />
+           
           <!---->
         </div>
       </div>
-      <div class="ds-info">
-        <div class="ds-item-line flex"><span title="allDatasets.1.name" class="font-bold truncate">allDatasets.1.name</span>
-          <mock-el-popover trigger="hover" placement="top" class="ml-1">
-            <div slot-key="default">
-              <div mock-v-loading="true">
-
+       
+      <div
+        class="ds-info"
+      >
+        <div
+          class="ds-item-line flex"
+        >
+          <span
+            class="font-bold truncate"
+            title="allDatasets.1.name"
+          >
+            allDatasets.1.name
+          </span>
+           
+          <mock-el-popover
+            class="ml-1"
+            placement="top"
+            trigger="hover"
+          >
+            <div
+              slot-key="default"
+            >
+              <div
+                mock-v-loading="true"
+              >
+                
+          
+        
               </div>
+               
             </div>
-            <div slot-key="reference"><i class="el-icon-lock"></i></div>
+            <div
+              slot-key="reference"
+            >
+              <i
+                class="el-icon-lock"
+              />
+            </div>
           </mock-el-popover>
         </div>
-        <div class="ds-item-line text-gray-700"><span title="Filter by species" class="ds-add-filter">
-        allDatasets.1.organism</span>,
-          <span title="Filter by organism part" class="ds-add-filter">
-        alldatasets.1.organismpart</span> <span title="Filter by condition" class="ds-add-filter">
-        (alldatasets.1.condition)</span></div>
-        <div class="ds-item-line"><span title="Filter by ionisation source" class="ds-add-filter">
-        allDatasets.1.ionisationSource</span> +
-          <span title="Filter by analyzer type" class="ds-add-filter">
-        allDatasets.1.analyzer.type</span>,
-          <span title="Filter by polarity" class="ds-add-filter">
-        positive mode</span>,
-          RP 123k @ 1234
+         
+        <div
+          class="ds-item-line text-gray-700"
+        >
+          <span
+            class="ds-add-filter"
+            title="Filter by species"
+          >
+            
+        allDatasets.1.organism
+          </span>
+          ,
+      
+          <span
+            class="ds-add-filter"
+            title="Filter by organism part"
+          >
+            
+        alldatasets.1.organismpart
+          </span>
+           
+          <span
+            class="ds-add-filter"
+            title="Filter by condition"
+          >
+            
+        (alldatasets.1.condition)
+          </span>
         </div>
-        <div class="ds-item-line">
-          Submitted <mock-elapsed-time date="allDatasets.1.uploadDT"></mock-elapsed-time> by
-          <span title="Filter by submitter" class="ds-add-filter">
-        allDatasets.1.submitter.name</span><span>,
-        <mock-el-dropdown show-timeout="50" placement="bottom" trigger="hover"><div slot-key="default"><span class="text-base text-primary cursor-pointer">
-            allDatasets.1.group.shortName
-          </span> </div>
-        <div slot-key="dropdown">
-          <mock-el-dropdown-menu>
-            <mock-el-dropdown-item command="filter_group">Filter by this group</mock-el-dropdown-item>
-            <mock-el-dropdown-item command="view_group">View group</mock-el-dropdown-item>
-          </mock-el-dropdown-menu>
-        </div>
-        </mock-el-dropdown></span>
-      </div>
-      <!---->
-    </div>
-    <div class="ds-actions">
-      <!---->
-      <!----> <span><div title="Waiting in the queue" class="striped-progressbar queued"></div></span>
-      <div><i class="el-icon-view"></i> <a href="#">Show full metadata</a></div>
-      <!---->
-      <div class="ds-download"><i class="el-icon-download"></i> <a href="#">Download</a></div>
-      <!---->
-      <!---->
-    </div>
-    <!---->
-  </div>
-  <div class="dataset-item border border-solid border-gray-200 leading-5">
-    <mock-el-dialog title="Provided metadata">
-      <div class="el-row">
-        <mock-el-tree id="metadata-tree" data="[object Object],[object Object]" node-key="id" default-expanded-keys="MS analysis,Detector resolving power,Data Management"></mock-el-tree>
-      </div>
-    </mock-el-dialog>
-    <div class="opt-image--container">
-      <div class="thumb"><img src="allDatasets.0.thumbnailOpticalImageUrl" alt="Optical image" class="thumb--img" style="transform: scaleY(1) translateY(0%); height: 100px;"> <img src="allDatasets.0.ionThumbnailUrl" alt="Ion image thumbnail" class="thumb--img thumb--img__ion" style="transform: scaleY(1) translateY(0%); height: 100px;">
-        <!---->
-      </div>
-    </div>
-    <div class="ds-info">
-      <div class="ds-item-line flex"><span title="allDatasets.0.name" class="font-bold truncate">allDatasets.0.name</span>
-        <!---->
-      </div>
-      <div class="ds-item-line text-gray-700"><span title="Filter by species" class="ds-add-filter">
-        allDatasets.0.organism</span>,
-        <span title="Filter by organism part" class="ds-add-filter">
-        alldatasets.0.organismpart</span> <span title="Filter by condition" class="ds-add-filter">
-        (alldatasets.0.condition)</span></div>
-      <div class="ds-item-line"><span title="Filter by ionisation source" class="ds-add-filter">
-        allDatasets.0.ionisationSource</span> +
-        <span title="Filter by analyzer type" class="ds-add-filter">
-        allDatasets.0.analyzer.type</span>,
-        <span title="Filter by polarity" class="ds-add-filter">
-        positive mode</span>,
-        RP 123k @ 1234
-      </div>
-      <div class="ds-item-line">
-        Submitted <mock-elapsed-time date="allDatasets.0.uploadDT"></mock-elapsed-time> by
-        <span title="Filter by submitter" class="ds-add-filter">
-        allDatasets.0.submitter.name</span><span>,
-        <mock-el-dropdown show-timeout="50" placement="bottom" trigger="hover"><div slot-key="default"><span class="text-base text-primary cursor-pointer">
-            allDatasets.0.group.shortName
-          </span> </div>
-      <div slot-key="dropdown">
-        <mock-el-dropdown-menu>
-          <mock-el-dropdown-item command="filter_group">Filter by this group</mock-el-dropdown-item>
-          <mock-el-dropdown-item command="view_group">View group</mock-el-dropdown-item>
-        </mock-el-dropdown-menu>
-      </div>
-      </mock-el-dropdown></span>
-    </div>
-    <!---->
-  </div>
-  <div class="ds-actions">
-    <!----> <span><div title="Processing is under way" class="striped-progressbar processing"></div></span>
-    <!---->
-    <div><i class="el-icon-view"></i> <a href="#">Show full metadata</a></div>
-    <!---->
-    <!---->
-    <!---->
-    <!---->
-  </div>
-  <!---->
-</div>
-<div class="dataset-item border border-solid border-gray-200 leading-5">
-  <mock-el-dialog title="Provided metadata">
-    <div class="el-row">
-      <mock-el-tree id="metadata-tree" data="[object Object],[object Object]" node-key="id" default-expanded-keys="MS analysis,Detector resolving power,Data Management"></mock-el-tree>
-    </div>
-  </mock-el-dialog>
-  <div class="opt-image--container">
-    <div class="thumb"><img src="allDatasets.2.thumbnailOpticalImageUrl" alt="Optical image" class="thumb--img" style="transform: scaleY(1) translateY(0%); height: 100px;"> <img src="allDatasets.2.ionThumbnailUrl" alt="Ion image thumbnail" class="thumb--img thumb--img__ion" style="transform: scaleY(1) translateY(0%); height: 100px;">
-      <!---->
-    </div>
-  </div>
-  <div class="ds-info">
-    <div class="ds-item-line flex"><span title="allDatasets.2.name" class="font-bold truncate">allDatasets.2.name</span>
-      <!---->
-    </div>
-    <div class="ds-item-line text-gray-700"><span title="Filter by species" class="ds-add-filter">
-        allDatasets.2.organism</span>,
-      <span title="Filter by organism part" class="ds-add-filter">
-        alldatasets.2.organismpart</span> <span title="Filter by condition" class="ds-add-filter">
-        (alldatasets.2.condition)</span></div>
-    <div class="ds-item-line"><span title="Filter by ionisation source" class="ds-add-filter">
-        allDatasets.2.ionisationSource</span> +
-      <span title="Filter by analyzer type" class="ds-add-filter">
-        allDatasets.2.analyzer.type</span>,
-      <span title="Filter by polarity" class="ds-add-filter">
-        positive mode</span>,
+         
+        <div
+          class="ds-item-line"
+        >
+          <span
+            class="ds-add-filter"
+            title="Filter by ionisation source"
+          >
+            
+        allDatasets.1.ionisationSource
+          </span>
+           +
+      
+          <span
+            class="ds-add-filter"
+            title="Filter by analyzer type"
+          >
+            
+        allDatasets.1.analyzer.type
+          </span>
+          ,
+      
+          <span
+            class="ds-add-filter"
+            title="Filter by polarity"
+          >
+            
+        positive mode
+          </span>
+          ,
       RP 123k @ 1234
+    
+        </div>
+         
+        <div
+          class="ds-item-line"
+        >
+          
+      Submitted 
+          <mock-elapsed-time
+            date="allDatasets.1.uploadDT"
+          />
+           by
+      
+          <span
+            class="ds-add-filter"
+            title="Filter by submitter"
+          >
+            
+        allDatasets.1.submitter.name
+          </span>
+          <span>
+            ,
+        
+            <mock-el-dropdown
+              placement="bottom"
+              show-timeout="50"
+              trigger="hover"
+            >
+              <div
+                slot-key="default"
+              >
+                <span
+                  class="text-base text-primary cursor-pointer"
+                >
+                  
+            allDatasets.1.group.shortName
+          
+                </span>
+                 
+              </div>
+              <div
+                slot-key="dropdown"
+              >
+                <mock-el-dropdown-menu>
+                  <mock-el-dropdown-item
+                    command="filter_group"
+                  >
+                    Filter by this group
+                  </mock-el-dropdown-item>
+                   
+                  <mock-el-dropdown-item
+                    command="view_group"
+                  >
+                    View group
+                  </mock-el-dropdown-item>
+                </mock-el-dropdown-menu>
+              </div>
+            </mock-el-dropdown>
+          </span>
+        </div>
+         
+        <!---->
+      </div>
+       
+      <div
+        class="ds-actions"
+      >
+        <!---->
+         
+        <!---->
+         
+        <span>
+          <div
+            class="striped-progressbar queued"
+            title="Waiting in the queue"
+          />
+        </span>
+         
+        <div>
+          <i
+            class="el-icon-view"
+          />
+           
+          <a
+            href="#"
+          >
+            Show full metadata
+          </a>
+        </div>
+         
+        <!---->
+         
+        <div
+          class="ds-download"
+        >
+          <i
+            class="el-icon-download"
+          />
+           
+          <a
+            href="#"
+          >
+            Download
+          </a>
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
     </div>
-    <div class="ds-item-line">
-      Submitted <mock-elapsed-time date="allDatasets.2.uploadDT"></mock-elapsed-time> by
-      <span title="Filter by submitter" class="ds-add-filter">
-        allDatasets.2.submitter.name</span><span>,
-        <mock-el-dropdown show-timeout="50" placement="bottom" trigger="hover"><div slot-key="default"><span class="text-base text-primary cursor-pointer">
+    <div
+      class="dataset-item border border-solid border-gray-200 leading-5"
+    >
+      <mock-el-dialog
+        title="Provided metadata"
+      >
+        <div
+          class="el-row"
+        >
+          <mock-el-tree
+            data="[object Object],[object Object]"
+            default-expanded-keys="MS analysis,Detector resolving power,Data Management"
+            id="metadata-tree"
+            node-key="id"
+          />
+        </div>
+      </mock-el-dialog>
+       
+      <div
+        class="opt-image--container"
+      >
+        <div
+          class="thumb"
+        >
+          <img
+            alt="Optical image"
+            class="thumb--img"
+            src="allDatasets.0.thumbnailOpticalImageUrl"
+            style="transform: scaleY(1) translateY(0%); height: 100px;"
+          />
+           
+          <img
+            alt="Ion image thumbnail"
+            class="thumb--img thumb--img__ion"
+            src="allDatasets.0.ionThumbnailUrl"
+            style="transform: scaleY(1) translateY(0%); height: 100px;"
+          />
+           
+          <!---->
+        </div>
+      </div>
+       
+      <div
+        class="ds-info"
+      >
+        <div
+          class="ds-item-line flex"
+        >
+          <span
+            class="font-bold truncate"
+            title="allDatasets.0.name"
+          >
+            allDatasets.0.name
+          </span>
+           
+          <!---->
+        </div>
+         
+        <div
+          class="ds-item-line text-gray-700"
+        >
+          <span
+            class="ds-add-filter"
+            title="Filter by species"
+          >
+            
+        allDatasets.0.organism
+          </span>
+          ,
+      
+          <span
+            class="ds-add-filter"
+            title="Filter by organism part"
+          >
+            
+        alldatasets.0.organismpart
+          </span>
+           
+          <span
+            class="ds-add-filter"
+            title="Filter by condition"
+          >
+            
+        (alldatasets.0.condition)
+          </span>
+        </div>
+         
+        <div
+          class="ds-item-line"
+        >
+          <span
+            class="ds-add-filter"
+            title="Filter by ionisation source"
+          >
+            
+        allDatasets.0.ionisationSource
+          </span>
+           +
+      
+          <span
+            class="ds-add-filter"
+            title="Filter by analyzer type"
+          >
+            
+        allDatasets.0.analyzer.type
+          </span>
+          ,
+      
+          <span
+            class="ds-add-filter"
+            title="Filter by polarity"
+          >
+            
+        positive mode
+          </span>
+          ,
+      RP 123k @ 1234
+    
+        </div>
+         
+        <div
+          class="ds-item-line"
+        >
+          
+      Submitted 
+          <mock-elapsed-time
+            date="allDatasets.0.uploadDT"
+          />
+           by
+      
+          <span
+            class="ds-add-filter"
+            title="Filter by submitter"
+          >
+            
+        allDatasets.0.submitter.name
+          </span>
+          <span>
+            ,
+        
+            <mock-el-dropdown
+              placement="bottom"
+              show-timeout="50"
+              trigger="hover"
+            >
+              <div
+                slot-key="default"
+              >
+                <span
+                  class="text-base text-primary cursor-pointer"
+                >
+                  
+            allDatasets.0.group.shortName
+          
+                </span>
+                 
+              </div>
+              <div
+                slot-key="dropdown"
+              >
+                <mock-el-dropdown-menu>
+                  <mock-el-dropdown-item
+                    command="filter_group"
+                  >
+                    Filter by this group
+                  </mock-el-dropdown-item>
+                   
+                  <mock-el-dropdown-item
+                    command="view_group"
+                  >
+                    View group
+                  </mock-el-dropdown-item>
+                </mock-el-dropdown-menu>
+              </div>
+            </mock-el-dropdown>
+          </span>
+        </div>
+         
+        <!---->
+      </div>
+       
+      <div
+        class="ds-actions"
+      >
+        <!---->
+         
+        <span>
+          <div
+            class="striped-progressbar processing"
+            title="Processing is under way"
+          />
+        </span>
+         
+        <!---->
+         
+        <div>
+          <i
+            class="el-icon-view"
+          />
+           
+          <a
+            href="#"
+          >
+            Show full metadata
+          </a>
+        </div>
+         
+        <!---->
+         
+        <!---->
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+    </div>
+    <div
+      class="dataset-item border border-solid border-gray-200 leading-5"
+    >
+      <mock-el-dialog
+        title="Provided metadata"
+      >
+        <div
+          class="el-row"
+        >
+          <mock-el-tree
+            data="[object Object],[object Object]"
+            default-expanded-keys="MS analysis,Detector resolving power,Data Management"
+            id="metadata-tree"
+            node-key="id"
+          />
+        </div>
+      </mock-el-dialog>
+       
+      <div
+        class="opt-image--container"
+      >
+        <div
+          class="thumb"
+        >
+          <img
+            alt="Optical image"
+            class="thumb--img"
+            src="allDatasets.2.thumbnailOpticalImageUrl"
+            style="transform: scaleY(1) translateY(0%); height: 100px;"
+          />
+           
+          <img
+            alt="Ion image thumbnail"
+            class="thumb--img thumb--img__ion"
+            src="allDatasets.2.ionThumbnailUrl"
+            style="transform: scaleY(1) translateY(0%); height: 100px;"
+          />
+           
+          <!---->
+        </div>
+      </div>
+       
+      <div
+        class="ds-info"
+      >
+        <div
+          class="ds-item-line flex"
+        >
+          <span
+            class="font-bold truncate"
+            title="allDatasets.2.name"
+          >
+            allDatasets.2.name
+          </span>
+           
+          <!---->
+        </div>
+         
+        <div
+          class="ds-item-line text-gray-700"
+        >
+          <span
+            class="ds-add-filter"
+            title="Filter by species"
+          >
+            
+        allDatasets.2.organism
+          </span>
+          ,
+      
+          <span
+            class="ds-add-filter"
+            title="Filter by organism part"
+          >
+            
+        alldatasets.2.organismpart
+          </span>
+           
+          <span
+            class="ds-add-filter"
+            title="Filter by condition"
+          >
+            
+        (alldatasets.2.condition)
+          </span>
+        </div>
+         
+        <div
+          class="ds-item-line"
+        >
+          <span
+            class="ds-add-filter"
+            title="Filter by ionisation source"
+          >
+            
+        allDatasets.2.ionisationSource
+          </span>
+           +
+      
+          <span
+            class="ds-add-filter"
+            title="Filter by analyzer type"
+          >
+            
+        allDatasets.2.analyzer.type
+          </span>
+          ,
+      
+          <span
+            class="ds-add-filter"
+            title="Filter by polarity"
+          >
+            
+        positive mode
+          </span>
+          ,
+      RP 123k @ 1234
+    
+        </div>
+         
+        <div
+          class="ds-item-line"
+        >
+          
+      Submitted 
+          <mock-elapsed-time
+            date="allDatasets.2.uploadDT"
+          />
+           by
+      
+          <span
+            class="ds-add-filter"
+            title="Filter by submitter"
+          >
+            
+        allDatasets.2.submitter.name
+          </span>
+          <span>
+            ,
+        
+            <mock-el-dropdown
+              placement="bottom"
+              show-timeout="50"
+              trigger="hover"
+            >
+              <div
+                slot-key="default"
+              >
+                <span
+                  class="text-base text-primary cursor-pointer"
+                >
+                  
             allDatasets.2.group.shortName
-          </span> </div>
-    <div slot-key="dropdown">
-      <mock-el-dropdown-menu>
-        <mock-el-dropdown-item command="filter_group">Filter by this group</mock-el-dropdown-item>
-        <mock-el-dropdown-item command="view_group">View group</mock-el-dropdown-item>
-      </mock-el-dropdown-menu>
-    </div>
-    </mock-el-dropdown></span>
-  </div>
-  <div class="ds-item-line"><span><a href="/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.2.metadataType" class="">20 annotations</a>
+          
+                </span>
+                 
+              </div>
+              <div
+                slot-key="dropdown"
+              >
+                <mock-el-dropdown-menu>
+                  <mock-el-dropdown-item
+                    command="filter_group"
+                  >
+                    Filter by this group
+                  </mock-el-dropdown-item>
+                   
+                  <mock-el-dropdown-item
+                    command="view_group"
+                  >
+                    View group
+                  </mock-el-dropdown-item>
+                </mock-el-dropdown-menu>
+              </div>
+            </mock-el-dropdown>
+          </span>
+        </div>
+         
+        <div
+          class="ds-item-line"
+        >
+          <span>
+            <a
+              class=""
+              href="/annotations?db=HMDB-v2.5&ds=FINISHED1&mdtype=allDatasets.2.metadataType"
+            >
+              20 annotations
+            </a>
+            
         @ FDR 10% (HMDB-v2.5)
-      </span></div>
-</div>
-<div class="ds-actions"><span><i class="el-icon-picture"></i> <mock-el-popover trigger="hover" placement="top"><div slot-key="default"><div class="db-link-list">
+      
+          </span>
+        </div>
+      </div>
+       
+      <div
+        class="ds-actions"
+      >
+        <span>
+          <i
+            class="el-icon-picture"
+          />
+           
+          <mock-el-popover
+            placement="top"
+            trigger="hover"
+          >
+            <div
+              slot-key="default"
+            >
+              <div
+                class="db-link-list"
+              >
+                
           Select a database:
-          <div><a href="/annotations?db=HMDB-v2.5&amp;ds=FINISHED1&amp;mdtype=allDatasets.2.metadataType" class="">
+          
+                <div>
+                  <a
+                    class=""
+                    href="/annotations?db=HMDB-v2.5&ds=FINISHED1&mdtype=allDatasets.2.metadataType"
+                  >
+                    
               HMDB-v2.5
-            </a></div><div><a href="/annotations?db=HMDB-v4&amp;ds=FINISHED1&amp;mdtype=allDatasets.2.metadataType" class="">
+            
+                  </a>
+                </div>
+                <div>
+                  <a
+                    class=""
+                    href="/annotations?db=HMDB-v4&ds=FINISHED1&mdtype=allDatasets.2.metadataType"
+                  >
+                    
               HMDB-v4
-            </a></div><div><a href="/annotations?db=CHEBI&amp;ds=FINISHED1&amp;mdtype=allDatasets.2.metadataType" class="">
+            
+                  </a>
+                </div>
+                <div>
+                  <a
+                    class=""
+                    href="/annotations?db=CHEBI&ds=FINISHED1&mdtype=allDatasets.2.metadataType"
+                  >
+                    
               CHEBI
-            </a></div></div> </div><div slot-key="reference"><a>Browse annotations</a></div></mock-el-popover> <br></span>
-  <!---->
-  <!---->
-  <div><i class="el-icon-view"></i> <a href="#">Show full metadata</a></div>
-  <!---->
-  <!---->
-  <!---->
-  <!---->
-</div>
-<!---->
-</div>
-<!---->
-</div>
+            
+                  </a>
+                </div>
+              </div>
+               
+            </div>
+            <div
+              slot-key="reference"
+            >
+              <a>
+                Browse annotations
+              </a>
+            </div>
+          </mock-el-popover>
+           
+          <br />
+        </span>
+         
+        <!---->
+         
+        <!---->
+         
+        <div>
+          <i
+            class="el-icon-view"
+          />
+           
+          <a
+            href="#"
+          >
+            Show full metadata
+          </a>
+        </div>
+         
+        <!---->
+         
+        <!---->
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+    </div>
+     
+    <!---->
+  </div>
 </div>
 `;


### PR DESCRIPTION
This pulls out the metadata and actions sections of `DatasetItem.vue` into their own (composition API) components. This refactor is needed so that I can make toggleable changes to this component for the Dataset Overview Page. I decided to put this refactor in its own PR so that it'll be clear what has actually changed vs what was just moved when the Dataset Overview Page PR lands.

There are 3 things worthy of note:
* I extracted `FilterLink` into a separate component to reduce the amount that gets rerendered whenever the filters change. These links' URLs are updated on every keystroke into the search box. Pulling these into their own component, so that those updates were limited to just the links, and not the full `DatasetItem`, reduced rerender time by 40%. I was hoping for more, but it's still a noticeable improvement.
* I extracted `VisibilityBadge` into its own component. It doesn't make much sense here, but I use it in the Dataset Overview Page as well.
* The `parentComponent: { store, router}` option passed to `mount`.
    This a workaround to some @vue/test-utils weirdness. When you `mount(MyComponent, { router, store })`, @vue/test-utils creates `MyComponent` with the `{router, store}` options, but it also creates a root component to hold it, which doesn't use those options. The issue is that Composition API code accesses `store` via `ctx.root.$store`, and `$store` isn't defined on that root component. The root component options are taken from that `parentComponent` option.

The first commit switches from using `expect(wrapper).toMatchSnapshot()` to `expect(wrapper.element).toMatchSnapshot()`, which is much better for diffing. For a much easier time comparing the snapshots, [skip the first commit and disable whitespace comparison](https://github.com/metaspace2020/metaspace/pull/591/files/e5f76371473eb35e361fcb0408ab5c19017a7461..31caea592e41e8dbe0723779c81ac98de689f462?file-filters%5B%5D=.snap&w=1)