### PR TITLE
Show all datasets when creating project

### DIFF
--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -125,7 +125,7 @@ export interface DatasetListItem {
 
 export const datasetListItemsQuery =
   gql`query GetDatasets($dFilter: DatasetFilter, $query: String) {
-    allDatasets(offset: 0, limit: -1, filter: $dFilter, simpleQuery: $query) {
+    allDatasets(offset: 0, limit: 10000, filter: $dFilter, simpleQuery: $query) {
       id
       name
       uploadDT

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -125,7 +125,7 @@ export interface DatasetListItem {
 
 export const datasetListItemsQuery =
   gql`query GetDatasets($dFilter: DatasetFilter, $query: String) {
-    allDatasets(offset: 0, limit: 100, filter: $dFilter, simpleQuery: $query) {
+    allDatasets(offset: 0, limit: -1, filter: $dFilter, simpleQuery: $query) {
       id
       name
       uploadDT

--- a/metaspace/webapp/src/components/DatasetCheckboxList.vue
+++ b/metaspace/webapp/src/components/DatasetCheckboxList.vue
@@ -16,10 +16,18 @@
         v-for="dataset in datasets"
         :key="dataset.id"
       >
-        <el-checkbox v-model="selectedDatasets[dataset.id]">
-          {{ dataset.name }}
-          <span class="text-gray-700">
-            (submitted <elapsed-time :date="dataset.uploadDT" />)
+        <el-checkbox
+          v-model="selectedDatasets[dataset.id]"
+          class="flex h-6 items-center"
+        >
+          <span
+            class="truncate"
+            :title="dataset.name"
+          >
+            {{ dataset.name }}
+          </span>
+          <span class="text-gray-700 text-xs tracking-wide pl-1">
+            <elapsed-time :date="dataset.uploadDT" />
           </span>
         </el-checkbox>
       </div>
@@ -44,6 +52,9 @@ export default class DatasetCheckboxList extends Vue {
     @Prop({ type: Array, required: true })
     datasets!: DatasetListItem[];
 
+    @Prop({ default: false })
+    initSelectAll!: boolean;
+
     @Model('input')
     selectedDatasets!: Record<string, boolean>;
 
@@ -51,7 +62,7 @@ export default class DatasetCheckboxList extends Vue {
     populateSelectedDatasetIds() {
       // Rebuild `selectedDatasets` so that the keys are in sync with the ids from `datasets`
       const selectedDatasets = fromPairs(this.datasets.map(({ id }) => {
-        return [id, id in this.selectedDatasets ? this.selectedDatasets[id] : true]
+        return [id, id in this.selectedDatasets ? this.selectedDatasets[id] : this.initSelectAll]
       }))
       this.$emit('input', selectedDatasets)
     }
@@ -77,5 +88,8 @@ export default class DatasetCheckboxList extends Vue {
   }
   .select-buttons {
     margin: 12px 0;
+  }
+  /deep/ .el-checkbox__label {
+    @apply inline-flex flex-grow justify-between items-baseline overflow-hidden;
   }
 </style>

--- a/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/TransferDatasetsDialog.vue
@@ -14,6 +14,7 @@
         <dataset-checkbox-list
           v-model="selectedDatasets"
           :datasets="allDatasets"
+          :init-select-all="true"
         />
         <p v-if="!isInvited">
           An email will be sent to the group's principal investigator to confirm your access.
@@ -141,7 +142,7 @@ export default class TransferDatasetsDialog extends Vue {
 </script>
 <style scoped lang="scss">
   .dialog /deep/ .el-dialog {
-    max-width: 600px;
+    @apply max-w-lg;
   }
   .button-bar {
     display: flex;

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -692,17 +692,13 @@ exports[`MetadataEditor should match snapshot 1`] = `
               <div>
                 <div class="select-buttons"><a href="#">Select none</a> <span> | </span> <a href="#">Select all</a></div>
                 <div class="dataset-checkbox-list leading-6 proportional-nums">
-                  <div><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-        allDatasets.0.name
-        <span class="text-gray-700">
-          (submitted <mock-elapsed-time date="allDatasets.0.uploadDT"></mock-elapsed-time>)
-        </span>
+                  <div><label class="el-checkbox flex h-6 items-center"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label"><span title="allDatasets.0.name" class="truncate">
+          allDatasets.0.name
+        </span> <span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="allDatasets.0.uploadDT"></mock-elapsed-time></span>
                       <!----></span></label></div>
-                  <div><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-        allDatasets.1.name
-        <span class="text-gray-700">
-          (submitted <mock-elapsed-time date="allDatasets.1.uploadDT"></mock-elapsed-time>)
-        </span>
+                  <div><label class="el-checkbox flex h-6 items-center"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label"><span title="allDatasets.1.name" class="truncate">
+          allDatasets.1.name
+        </span> <span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="allDatasets.1.uploadDT"></mock-elapsed-time></span>
                       <!----></span></label></div>
                 </div>
               </div>
@@ -714,7 +710,7 @@ exports[`MetadataEditor should match snapshot 1`] = `
       </span></button> <button type="button" class="el-button el-button--primary">
                 <!---->
                 <!----><span>
-        Create project and include 2 datasets
+        Create project
       </span></button></div>
           </div>
         </mock-el-dialog>

--- a/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
+++ b/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
@@ -143,7 +143,7 @@ export default class CreateProjectDialog extends Vue {
 </script>
 <style scoped lang="scss">
   .dialog /deep/ .el-dialog {
-    max-width: 600px;
+    @apply max-w-lg;
 
     .el-form-item {
       margin-bottom: 10px;

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -31,17 +31,13 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
         <div>
           <div class="select-buttons"><a href="#">Select none</a> <span> | </span> <a href="#">Select all</a></div>
           <div class="dataset-checkbox-list leading-6 proportional-nums">
-            <div><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-        allDatasets.0.name
-        <span class="text-gray-700">
-          (submitted <mock-elapsed-time date="allDatasets.0.uploadDT"></mock-elapsed-time>)
-        </span>
+            <div><label class="el-checkbox flex h-6 items-center"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label"><span title="allDatasets.0.name" class="truncate">
+          allDatasets.0.name
+        </span> <span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="allDatasets.0.uploadDT"></mock-elapsed-time></span>
                 <!----></span></label></div>
-            <div><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-        allDatasets.1.name
-        <span class="text-gray-700">
-          (submitted <mock-elapsed-time date="allDatasets.1.uploadDT"></mock-elapsed-time>)
-        </span>
+            <div><label class="el-checkbox flex h-6 items-center"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label"><span title="allDatasets.1.name" class="truncate">
+          allDatasets.1.name
+        </span> <span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="allDatasets.1.uploadDT"></mock-elapsed-time></span>
                 <!----></span></label></div>
           </div>
         </div>
@@ -53,7 +49,7 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
       </span></button> <button type="button" class="el-button el-button--primary">
           <!---->
           <!----><span>
-        Create project and include 2 datasets
+        Create project
       </span></button></div>
     </div>
   </mock-el-dialog>
@@ -183,17 +179,13 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
         <div>
           <div class="select-buttons"><a href="#">Select none</a> <span> | </span> <a href="#">Select all</a></div>
           <div class="dataset-checkbox-list leading-6 proportional-nums">
-            <div><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-        allDatasets.0.name
-        <span class="text-gray-700">
-          (submitted <mock-elapsed-time date="allDatasets.0.uploadDT"></mock-elapsed-time>)
-        </span>
+            <div><label class="el-checkbox flex h-6 items-center"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label"><span title="allDatasets.0.name" class="truncate">
+          allDatasets.0.name
+        </span> <span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="allDatasets.0.uploadDT"></mock-elapsed-time></span>
                 <!----></span></label></div>
-            <div><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-        allDatasets.1.name
-        <span class="text-gray-700">
-          (submitted <mock-elapsed-time date="allDatasets.1.uploadDT"></mock-elapsed-time>)
-        </span>
+            <div><label class="el-checkbox flex h-6 items-center"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label"><span title="allDatasets.1.name" class="truncate">
+          allDatasets.1.name
+        </span> <span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="allDatasets.1.uploadDT"></mock-elapsed-time></span>
                 <!----></span></label></div>
           </div>
         </div>
@@ -205,7 +197,7 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
       </span></button> <button type="button" class="el-button el-button--primary">
           <!---->
           <!----><span>
-        Create project and include 2 datasets
+        Create project
       </span></button></div>
     </div>
   </mock-el-dialog>
@@ -334,17 +326,13 @@ exports[`ProjectsListPage should match snapshot 1`] = `
         <div>
           <div class="select-buttons"><a href="#">Select none</a> <span> | </span> <a href="#">Select all</a></div>
           <div class="dataset-checkbox-list leading-6 proportional-nums">
-            <div><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-        allDatasets.0.name
-        <span class="text-gray-700">
-          (submitted <mock-elapsed-time date="allDatasets.0.uploadDT"></mock-elapsed-time>)
-        </span>
+            <div><label class="el-checkbox flex h-6 items-center"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label"><span title="allDatasets.0.name" class="truncate">
+          allDatasets.0.name
+        </span> <span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="allDatasets.0.uploadDT"></mock-elapsed-time></span>
                 <!----></span></label></div>
-            <div><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-        allDatasets.1.name
-        <span class="text-gray-700">
-          (submitted <mock-elapsed-time date="allDatasets.1.uploadDT"></mock-elapsed-time>)
-        </span>
+            <div><label class="el-checkbox flex h-6 items-center"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label"><span title="allDatasets.1.name" class="truncate">
+          allDatasets.1.name
+        </span> <span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="allDatasets.1.uploadDT"></mock-elapsed-time></span>
                 <!----></span></label></div>
           </div>
         </div>
@@ -356,7 +344,7 @@ exports[`ProjectsListPage should match snapshot 1`] = `
       </span></button> <button type="button" class="el-button el-button--primary">
           <!---->
           <!----><span>
-        Create project and include 2 datasets
+        Create project
       </span></button></div>
     </div>
   </mock-el-dialog>

--- a/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
@@ -189,17 +189,13 @@ exports[`EditUserPage should match snapshot 1`] = `
               <div>
                 <div class="select-buttons"><a href="#">Select none</a> <span> | </span> <a href="#">Select all</a></div>
                 <div class="dataset-checkbox-list leading-6 proportional-nums">
-                  <div><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-        allDatasets.0.name
-        <span class="text-gray-700">
-          (submitted <mock-elapsed-time date="allDatasets.0.uploadDT"></mock-elapsed-time>)
-        </span>
+                  <div><label class="el-checkbox flex h-6 items-center"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label"><span title="allDatasets.0.name" class="truncate">
+          allDatasets.0.name
+        </span> <span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="allDatasets.0.uploadDT"></mock-elapsed-time></span>
                       <!----></span></label></div>
-                  <div><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-        allDatasets.1.name
-        <span class="text-gray-700">
-          (submitted <mock-elapsed-time date="allDatasets.1.uploadDT"></mock-elapsed-time>)
-        </span>
+                  <div><label class="el-checkbox flex h-6 items-center"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label"><span title="allDatasets.1.name" class="truncate">
+          allDatasets.1.name
+        </span> <span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="allDatasets.1.uploadDT"></mock-elapsed-time></span>
                       <!----></span></label></div>
                 </div>
               </div>
@@ -211,7 +207,7 @@ exports[`EditUserPage should match snapshot 1`] = `
       </span></button> <button type="button" class="el-button el-button--primary">
                 <!---->
                 <!----><span>
-        Create project and include 2 datasets
+        Create project
       </span></button></div>
           </div>
         </mock-el-dialog>


### PR DESCRIPTION
I tested this locally by changing the default limit on the server and showing that I could see more if I passed a limit of `-1`, but it might want to be verified with an account that has more than 100 datasets on staging.

Also, I thought that a better default for this list is to start with no items selected rather than all. The "Transfer datasets" dialog should still work in the original way. Fine to talk more about this.
