### PR TITLE
Fix projectId data type in Python client

### DIFF
--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,2 +1,2 @@
 name = 'metaspace2020'
-__version__ = '1.7.3'
+__version__ = '1.7.4'

--- a/metaspace/python-client/metaspace/projects_client.py
+++ b/metaspace/python-client/metaspace/projects_client.py
@@ -91,7 +91,7 @@ class ProjectsClient:
         """
 
         result = self._gql.query(
-            """mutation($projectId: String!, $provider: String!, $link: String!, 
+            """mutation($projectId: ID!, $provider: String!, $link: String!, 
                         $replaceExisting: Boolean!) {
                 addProjectExternalLink(projectId: $projectId, provider: $provider, link: $link, 
                                        replaceExisting: $replaceExisting) {
@@ -120,7 +120,7 @@ class ProjectsClient:
         """
 
         result = self._gql.query(
-            """mutation($projectId: String!, $provider: String!, $link: String!) {
+            """mutation($projectId: ID!, $provider: String!, $link: String!) {
                 removeProjectExternalLink(projectId: $projectId, provider: $provider, link: $link) {
                     externalLinks { provider link }
                 } 


### PR DESCRIPTION
Fixes a bug discovered by the MetaboLights team. 

IIRC `projectId`'s datatype was changed during PR in response to feedback. I must have forgotten to rerun the python-client tests after that change. 

Running the tests again, they failed when the datatype was `String!` and now they pass with `ID!`.

I've pushed this to PyPI already as someone was waiting on the fix.