### PR TITLE
Change molecular_db.citation to use tiptap rich-text

### DIFF
--- a/ansible/aws/PRODUCTION_UPGRADE.md
+++ b/ansible/aws/PRODUCTION_UPGRADE.md
@@ -3,7 +3,7 @@
 https://github.com/metaspace2020/metaspace/compare/release...master
 
 Review all outstanding changes. If you're unfamiliar with any changes, 
-ask the author if there are any manual steps needed. In addition  
+ask the author if there are any manual steps needed. 
 
 ### Main places to check for changes:
 
@@ -40,6 +40,31 @@ where to start looking if something goes wrong.
 Make sure `webapp` and `graphql` builds are passing in the `master` branch in CircleCI. 
 It's possible for PRs that pass all tests to break the build after merging, 
 e.g. if a function the PR depends on is renamed after the PR branches from master.  
+
+# Update git branches and tags
+
+#### Update the `release` branch
+ 
+```bash
+git switch master
+git merge release  # Ideally this should do nothing, as hotfixes should be merged from release back into master ASAP
+git switch release
+git merge master  # Make sure this does a "fast-forward" merge
+git push origin master release
+```
+
+#### Create a release tag
+
+Check the [release list](https://github.com/metaspace2020/metaspace/releases) for the latest release tag.
+If the release contains a milestone feature, or backwards-incompatible API changes, increment the minor version. 
+Otherwise increment the patch version.
+
+Create and push a tag with the new version, e.g.
+```bash
+git switch release
+git tag 1.7.6
+git push origin 1.7.6
+```
 
 # Choose a deployment strategy
 

--- a/metaspace/graphql/package.json
+++ b/metaspace/graphql/package.json
@@ -127,7 +127,7 @@
       "node"
     ],
     "testEnvironment": "node",
-    "testTimeout": 15000,
+    "testTimeout": 60000,
     "setupFilesAfterEnv": [
       "<rootDir>/src/tests/setupTestFramework.ts"
     ],

--- a/metaspace/graphql/schemas/moldb.graphql
+++ b/metaspace/graphql/schemas/moldb.graphql
@@ -24,7 +24,7 @@ input CreateMolecularDBInput {
   fullName: String
   description: String
   link: String
-  citation: String
+  citation: String  # JSON-based rich text, in a format defined by tiptap (https://tiptap.scrumpy.io/)
 }
 
 input UpdateMolecularDBInput {
@@ -32,7 +32,7 @@ input UpdateMolecularDBInput {
   fullName: String
   description: String
   link: String
-  citation: String
+  citation: String  # JSON-based rich text, in a format defined by tiptap (https://tiptap.scrumpy.io/)
 }
 
 type Query {

--- a/metaspace/graphql/schemas/project.graphql
+++ b/metaspace/graphql/schemas/project.graphql
@@ -16,7 +16,7 @@ type Project {
   numDatasets: Int!
   createdDT: String!
   latestUploadDT: String
-  projectDescription: String
+  projectDescription: String  # JSON-based rich text, in a format defined by tiptap (https://tiptap.scrumpy.io/)
   reviewToken: String
   publicationStatus: PublicationStatus!
   publishedDT: String
@@ -38,7 +38,7 @@ input UpdateProjectInput {
   name: String
   isPublic: Boolean
   urlSlug: String
-  projectDescription: String
+  projectDescription: String  # JSON-based rich text, in a format defined by tiptap (https://tiptap.scrumpy.io/)
 }
 
 input UpdateUserProjectInput {

--- a/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
@@ -253,7 +253,7 @@ const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
     let outFdrLvls: number[] = [], outFdrCounts: number[] = [], maxCounts = 0, databaseId = null;
     if (ds._source.annotation_counts && ds._source.ds_status === 'FINISHED') {
       const annotCounts: any[] = ds._source.annotation_counts.filter(
-        el => ds._source.ds_moldb_ids.includes(el.db.id)
+        el => ds._source.ds_moldb_ids?.includes(el.db.id) ?? []
       );
       for (let el of annotCounts) {
         let maxCountsCand = el.counts.find((lvlObj: any) => {

--- a/metaspace/graphql/src/modules/moldb/controller.ts
+++ b/metaspace/graphql/src/modules/moldb/controller.ts
@@ -9,6 +9,7 @@ import {smApiCreateDatabase, smApiUpdateDatabase, smApiDeleteDatabase} from '../
 import {In} from 'typeorm';
 import {assertImportFileIsValid} from './util/assertImportFileIsValid';
 import {mapToMolecularDB} from './util/mapToMolecularDB';
+import { validateTiptapJson } from '../../utils/tiptap'
 
 
 const QueryResolvers: FieldResolversFor<Query, void> = {
@@ -53,6 +54,9 @@ const MutationResolvers: FieldResolversFor<Mutation, void>  = {
     logger.info(`User ${ctx.user.id} is creating molecular database ${JSON.stringify(databaseDetails)}`);
     const groupId = databaseDetails.groupId as string;
     assertUserBelongsToGroup(ctx, groupId);
+    if (databaseDetails.citation != null) {
+      validateTiptapJson(databaseDetails.citation, 'citation')
+    }
 
     await assertImportFileIsValid(databaseDetails.filePath);
 
@@ -64,6 +68,9 @@ const MutationResolvers: FieldResolversFor<Mutation, void>  = {
   async updateMolecularDB(source, { databaseId, databaseDetails }, ctx): Promise<MolecularDB> {
     logger.info(`User ${ctx.user.id} is updating molecular database ${JSON.stringify(databaseDetails)}`);
     await assertUserCanEditMolecularDB(ctx, databaseId);
+    if (databaseDetails.citation != null) {
+      validateTiptapJson(databaseDetails.citation, 'citation')
+    }
 
     const { id } = await smApiUpdateDatabase(databaseId, databaseDetails);
     const database = await ctx.entityManager.getRepository(MolecularDbModel).findOneOrFail({ id });

--- a/metaspace/graphql/src/modules/project/controller/Mutation.ts
+++ b/metaspace/graphql/src/modules/project/controller/Mutation.ts
@@ -30,6 +30,7 @@ import generateRandomToken from '../../../utils/generateRandomToken';
 import { addExternalLink, removeExternalLink, ExternalLinkProviderOptions as ELPO } from '../ExternalLink';
 import { validateUrlSlugChange } from "../../groupOrProject/urlSlug";
 import moment = require('moment')
+import { validateTiptapJson } from '../../../utils/tiptap'
 
 const asyncAssertCanEditProject = async (ctx: Context, projectId: string) => {
   const userProject = await ctx.entityManager.findOne(UserProjectModel, {
@@ -79,6 +80,9 @@ const MutationResolvers: FieldResolversFor<Mutation, void> = {
 
     if (projectDetails.urlSlug != null) {
       await validateUrlSlugChange(ctx.entityManager, ProjectModel, projectId, projectDetails.urlSlug)
+    }
+    if (projectDetails.projectDescription != null) {
+      validateTiptapJson(projectDetails.projectDescription, 'projectDescription')
     }
 
     await ctx.entityManager.update(ProjectModel, projectId, projectDetails);

--- a/metaspace/graphql/src/utils/tiptap.ts
+++ b/metaspace/graphql/src/utils/tiptap.ts
@@ -1,0 +1,20 @@
+import { UserError } from "graphql-errors"
+
+
+export const isValidTiptapJson = (doc: string) => {
+  try {
+    // The tiptap library can't validate JSON without having the full set of extensions configured, which seems like
+    // too much complexity to drag into graphql just for validation.
+    // It should be good enough to check that the field is valid JSON, and looks like it was created by tiptap.
+    const obj = JSON.parse(doc);
+    return obj.type == 'doc' && obj.content != null;
+  } catch {
+    return false;
+  }
+}
+
+export const validateTiptapJson = (doc: string, fieldName: string) => {
+  if (!isValidTiptapJson(doc)) {
+    throw new UserError(`Invalid "${fieldName}" value. This field must be in tiptap rich-text format`);
+  }
+}


### PR DESCRIPTION
As discussed, it's better for security if we avoid sending user-supplied HTML to the browser, so this converts the `molecular_db.citation` field to tiptap JSON rich-text. I manually validated the values defined in the migration script by copying them to project descriptions and ensuring they didn't make any console errors when loaded.

I didn't convert the `description` field, because I realized that we currently display that as inline text, and it would complicate things if we had to support that in the UI. 

I also included several small tweaks:
* Gracefully return no data from `Dataset.fdrCounts` if `ds_moldb_ids` doesn't exist in the elasticsearch record, instead of erroring and breaking the whole query
* Updated `PRODUCTION_UPGRADE.md` (@richardgoater please read the changes)
* Increased the graphql test timeout. Unfortunately I haven't been able to figure out the cause of the lag, but sometimes the first test is delayed by up to 50 seconds, usually causing it to timeout in CI.