### PR TITLE
Last minute fixes

### DIFF
--- a/metaspace/engine/sm/engine/msm_basic/msm_basic_search.py
+++ b/metaspace/engine/sm/engine/msm_basic/msm_basic_search.py
@@ -126,8 +126,9 @@ def compute_fdr_and_filter_results(
         'moldb_id', axis=1
     )
     moldb_metrics_fdr_df = compute_fdr(fdr, formula_metrics_df, moldb_formula_map_df)
-    max_fdr = 1.0 if moldb.targeted else 0.5
-    moldb_metrics_fdr_df = moldb_metrics_fdr_df[moldb_metrics_fdr_df.fdr <= max_fdr]
+    if not moldb.targeted:
+        max_fdr = 0.5
+        moldb_metrics_fdr_df = moldb_metrics_fdr_df[moldb_metrics_fdr_df.fdr <= max_fdr]
     moldb_ion_images_rdd = formula_images_rdd.filter(
         lambda kv: kv[0] in moldb_metrics_fdr_df.index  # pylint: disable=cell-var-from-loop
     )

--- a/metaspace/engine/sm/rest/dataset_manager.py
+++ b/metaspace/engine/sm/rest/dataset_manager.py
@@ -70,7 +70,8 @@ class SMapiDatasetManager:
         if 'id' not in doc:
             doc['id'] = now.strftime('%Y-%m-%d_%Hh%Mm%Ss')
 
-        doc['moldb_ids'] = self._add_default_moldbs(doc['moldb_ids'])
+        if 'moldb_ids' in doc:
+            doc['moldb_ids'] = self._add_default_moldbs(doc['moldb_ids'])
         ds_config_kwargs = dict((k, v) for k, v in doc.items() if k in FLAT_DS_CONFIG_KEYS)
 
         try:

--- a/metaspace/graphql/src/modules/moldb/MolecularDbRepository.ts
+++ b/metaspace/graphql/src/modules/moldb/MolecularDbRepository.ts
@@ -66,6 +66,7 @@ export class MolecularDbRepository {
 
   async findDatabasesByIds(ctx: Context, databaseIds: number[]): Promise<MolecularDB[]> {
     const dataLoader = this.getDataLoader(ctx);
-    return await dataLoader.loadMany(databaseIds);
+    const databases = await dataLoader.loadMany(databaseIds);
+    return databases.filter(db => db != null);
   }
 }

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
@@ -10,7 +10,7 @@ const DatasetItemActions = createComponent({
   props: {
     dataset: { type: Object as () => DatasetDetailItem, required: true },
     metadata: { type: Object as () => any, required: true },
-    currentUser: { type: Object as () => any, required: true },
+    currentUser: { type: Object as () => any },
   },
   setup(props, { emit, root: { $apollo, $confirm, $notify } }) {
     const state = reactive({


### PR DESCRIPTION
Several last-minute fixes for custom DB edge cases:
* Filter output of `findDatabasesByIds` to not include `null`s. Previous behavior would return an array with nulls, and the `Dataset.databases` resolver would return them, causing a validation error. The alternate solution would be to change the `findDatabasesByIds` return type to include nulls, and handle the nulls at every caller. However, I felt most callers were built under the assumption that hidden databases just weren't returned, so I think filtering in `findDatabasesByIds` is the expected behavior.
* Filter `ds._source.annotation_counts` correctly (my previous `?? []` fix would have broken it - I made that thinking I was changing a `.map`, not a `.filter`). And exclude DBs not visible to the current user.
* Remove `logger.error` when a database can't be found in `ds._source.annotation_counts`. I don't think these deliver value as we don't normally monitor the logs. It was easier to remove it than factor in the possibility that no data was found due to hidden DBs (which is an edge cases that only happens when HMDB-v4 is somehow excluded/private)
* Fix `if (databaseId != null) {` codepath. If `databaseId` was null due to having no visible annotation count records, this would have returned an invalid object with null `databaseId`/`dbName` fields, failing schema validation. Now it returns a `null` value instead of an object with `null` fields.
* Unrelated fix: Make the `currentUser` prop in `DatasetItemActions.vue` optional, because Vue was logging console warnings as it's `null` when not logged in. My bad for not testing this case in my PR.