### PR TITLE
[graphql] Check that only group members can use custom databases

### DIFF
--- a/metaspace/graphql/src/getContext.spec.ts
+++ b/metaspace/graphql/src/getContext.spec.ts
@@ -31,6 +31,7 @@ describe('getContext', () => {
     userId = testUser.id;
   });
   afterEach(onAfterEach);
+
   describe('cachedGetEntityById', () => {
     const testIds = [1,2,3].map(n => `00000000-1234-0000-0000-00000000000${n}`);
     const [id1, id2, id3] = testIds;
@@ -133,6 +134,7 @@ describe('getContext', () => {
       });
     });
   });
+
   describe('ContextUser.getProjectRoles', () => {
     const testIds = [1, 2].map(n => `00000000-1234-0000-0000-00000000000${n}`);
 
@@ -167,16 +169,18 @@ describe('getContext', () => {
 
   describe('ContextUser.getVisibleDatabaseIds', () => {
     const groupId = `00000000-1234-0000-0000-000000000000`;
-    let pubDatabase: MolecularDB;
-    let prvDatabase: MolecularDB;
+    let metaspacePubDatabase: MolecularDB,
+      groupPrvDatabase: MolecularDB,
+      groupPubDatabase: MolecularDB;
 
     const anotherGroupId = `00000000-1234-0000-0000-000000000001`;
     let anotherPrvDatabase: MolecularDB;
 
     beforeEach(async () => {
       await createTestGroup({ id: groupId });
-      pubDatabase = await createTestMolecularDB({ name: 'HMDB-v4', public: true });
-      prvDatabase = await createTestMolecularDB({ name: 'custom-db', public: false, groupId });
+      metaspacePubDatabase = await createTestMolecularDB({ name: 'HMDB-v4', public: true });
+      groupPrvDatabase = await createTestMolecularDB({ name: 'custom-db', public: false, groupId });
+      groupPubDatabase = await createTestMolecularDB({ name: 'custom-db-pub', public: true, groupId });
 
       await createTestGroup({ id: anotherGroupId });
       anotherPrvDatabase = await createTestMolecularDB(
@@ -184,29 +188,33 @@ describe('getContext', () => {
       );
     });
 
-    it('should return only public databases for anonymous user', async () => {
-      const context = getContext({ role: "anonymous" }, testEntityManager, null as any, null as any);
+    test('Should return only public databases for anonymous user', async () => {
+      const context = getContext({ role: 'anonymous' }, testEntityManager, null as any, null as any);
       const databaseIds = await context.user.getVisibleDatabaseIds();
 
-      expect(databaseIds).toEqual([pubDatabase.id]);
+      expect(databaseIds.sort()).toEqual([metaspacePubDatabase.id, groupPubDatabase.id].sort());
     });
 
-    it('should return all databases for admin', async () => {
+    test('Should return all databases for admin', async () => {
       const context = getContext(
-        { id: "abc", groupIds: [], role: "admin" }, testEntityManager, null as any, null as any
+        { id: 'abc', groupIds: [], role: 'admin' }, testEntityManager, null as any, null as any
       );
       const databaseIds = await context.user.getVisibleDatabaseIds();
 
-      expect(databaseIds.sort()).toEqual([pubDatabase.id, prvDatabase.id, anotherPrvDatabase.id]);
+      expect(databaseIds.sort()).toEqual(
+        [metaspacePubDatabase.id, groupPrvDatabase.id, groupPubDatabase.id, anotherPrvDatabase.id].sort()
+      );
     });
 
-    it('should return all public and databases that belong to user group', async () => {
+    test('Should return all public and databases that belong to user group', async () => {
       const context = getContext(
-        { id: "abc", groupIds: [groupId], role: "user" }, testEntityManager, null as any, null as any
+        { id: 'abc', groupIds: [groupId], role: 'user' }, testEntityManager, null as any, null as any
       );
       const databaseIds = await context.user.getVisibleDatabaseIds();
 
-      expect(databaseIds.sort()).toEqual([pubDatabase.id, prvDatabase.id]);
+      expect(databaseIds.sort()).toEqual(
+        [metaspacePubDatabase.id, groupPrvDatabase.id, groupPubDatabase.id].sort()
+      );
     });
   });
 });

--- a/metaspace/graphql/src/modules/dataset/controller/Mutation.spec.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Mutation.spec.ts
@@ -1,53 +1,77 @@
 import * as _ from 'lodash';
 
-import {processingSettingsChanged} from './Mutation';
-import {EngineDataset} from '../../engine/model';
+import { processingSettingsChanged } from './Mutation';
+import { EngineDataset } from '../../engine/model';
+import {
+  createTestDataset,
+  createTestGroup,
+  createTestMolecularDB,
+  createTestUserGroup
+} from '../../../tests/testDataCreation';
+import {
+  adminContext,
+  doQuery, onAfterAll, onAfterEach, onBeforeAll, onBeforeEach,
+  setupTestUsers, testEntityManager,
+  testUser,
+  userContext
+} from '../../../tests/graphqlTestEnvironment';
+import { Group, UserGroupRoleOptions as UGRO } from '../../group/model';
+import { MolecularDB } from '../../moldb/model';
+import { Dataset } from '../model';
+import { getContextForTest } from '../../../getContext';
 
+import * as _smApiDatasets from '../../../utils/smApi/datasets';
+jest.mock('../../../utils/smApi/datasets');
+const mockSmApiDatasets = _smApiDatasets as jest.Mocked<typeof _smApiDatasets>;
+mockSmApiDatasets.smApiDatasetRequest.mockReturnValue('{"status": "ok"}');
 
-describe('processingSettingsChanged', () => {
-  const metadata = {
-      "MS_Analysis": {
-        "Analyzer": "FTICR",
-        "Polarity": "Positive",
-        "Ionisation_Source": "MALDI",
-        "Detector_Resolving_Power": {
-          "mz": 400,
-          "Resolving_Power": 140000
-        }
-      },
-      "Submitted_By": {
-        "Submitter": {
-          "Email": "user@example.com",
-          "Surname": "Surname",
-          "First_Name": "Name"
-        },
-        "Institution": "Genentech",
-        "Principal_Investigator": {
-          "Email": "pi@example.com",
-          "Surname": "Surname",
-          "First_Name": "Name"
-        }
-      },
-      "Sample_Information": {
-        "Organism": "Mus musculus (mouse)",
-        "Condition": "Dosed vs. vehicle",
-        "Organism_Part": "EMT6 Tumors",
-        "Sample_Growth_Conditions": "NA"
-      },
-      "Sample_Preparation": {
-        "MALDI_Matrix": "2,5-dihydroxybenzoic acid (DHB)",
-        "Tissue_Modification": "N/A",
-        "Sample_Stabilisation": "Fresh frozen",
-        "MALDI_Matrix_Application": "TM sprayer"
-      },
-      "Additional_Information": {
-        "Publication_DOI": "NA",
-        "Expected_Molecules_Freetext": "tryptophan pathway",
-        "Sample_Preparation_Freetext": "NA",
-        "Additional_Information_Freetext": "NA"
-      }
+const sampleMetadata = {
+  "Data_Type": "Imaging MS",
+  "MS_Analysis": {
+    "Analyzer": "FTICR",
+    "Polarity": "Positive",
+    "Ionisation_Source": "MALDI",
+    "Detector_Resolving_Power": {
+      "mz": 400,
+      "Resolving_Power": 140000
     },
-    dsConfig = {
+    "Pixel_Size": { "Xaxis": 50, "Yaxis": 50 }
+  },
+  "Submitted_By": {
+    "Submitter": {
+      "Email": "user@example.com",
+      "Surname": "Surname",
+      "First_Name": "Name"
+    },
+    "Institution": "Genentech",
+    "Principal_Investigator": {
+      "Email": "pi@example.com",
+      "Surname": "Surname",
+      "First_Name": "Name"
+    }
+  },
+  "Sample_Information": {
+    "Organism": "Mus musculus (mouse)",
+    "Condition": "Dosed vs. vehicle",
+    "Organism_Part": "EMT6 Tumors",
+    "Sample_Growth_Conditions": "NA"
+  },
+  "Sample_Preparation": {
+    "MALDI_Matrix": "2,5-dihydroxybenzoic acid (DHB)",
+    "Tissue_Modification": "N/A",
+    "Sample_Stabilisation": "Fresh frozen",
+    "MALDI_Matrix_Application": "TM sprayer"
+  },
+  "Additional_Information": {
+    "Publication_DOI": "NA",
+    "Expected_Molecules_Freetext": "tryptophan pathway",
+    "Sample_Preparation_Freetext": "NA",
+    "Additional_Information_Freetext": "NA"
+  }
+};
+
+describe('Dataset mutations: processingSettingsChanged', () => {
+    const dsConfig = {
       "image_generation": {
         "q": 99,
         "do_preprocessing": false,
@@ -67,7 +91,7 @@ describe('processingSettingsChanged', () => {
     },
     ds = {
       config: dsConfig,
-      metadata: metadata,
+      metadata: sampleMetadata,
     } as EngineDataset;
 
   it('Reprocessing needed when database list changed', () => {
@@ -106,5 +130,76 @@ describe('processingSettingsChanged', () => {
 
     expect(newDB).toBe(false);
     expect(procSettingsUpd).toBe(false);
+  });
+});
+
+describe('Dataset mutations: molecular databases permissions', () => {
+  let dataset: Dataset,
+    group: Group,
+    databaseIds: number[] = [];
+
+  beforeAll(onBeforeAll);
+  afterAll(onAfterAll);
+  beforeEach(async () => {
+    await onBeforeEach();
+
+    await setupTestUsers();
+    dataset = await createTestDataset();
+    group = await createTestGroup();
+    const databaseDocs = [
+      { name: 'HMDB-v4', public: true, groupId: null },
+      { name: 'custom-db-pub', public: true, groupId: group.id },
+      { name: 'custom-db', public: false, groupId: group.id },
+    ];
+    for (const dbDoc of databaseDocs) {
+      databaseIds.push((await createTestMolecularDB(dbDoc)).id);
+    }
+  });
+  afterEach(onAfterEach);
+
+  const createDatasetQuery = `mutation createDataset($databaseIds: [Int!]) {
+      createDataset(
+        input: {
+          name: "ds-name"
+          inputPath: "input-path"
+          databaseIds: $databaseIds
+          metadataJson: ${JSON.stringify(JSON.stringify(sampleMetadata))}
+          adducts: ["+H"]
+          isPublic: true
+          submitterId: ""
+        }
+      )
+    }`,
+    updateDatasetQuery = `mutation updateDataset($datasetId: String!, $databaseIds: [Int!]) {
+      updateDataset(
+        id: $datasetId,
+        input: {
+          databaseIds: $databaseIds
+        },
+        reprocess: true
+      )
+    }`;
+
+  test('User allowed to use Metaspace public and group databases', async () => {
+    await createTestUserGroup(testUser.id!, group.id, UGRO.MEMBER, true);
+
+    const context = getContextForTest({...testUser, groupIds: [group.id]} as any, testEntityManager);
+    await doQuery(createDatasetQuery, { databaseIds }, { context });
+    await doQuery(updateDatasetQuery, { datasetId: dataset.id, databaseIds }, { context });
+  });
+
+  test('Non-group user not allowed to use group databases', async () => {
+    const createPromise = doQuery(createDatasetQuery, { databaseIds }, { context: userContext });
+    const updatePromise = doQuery(
+      updateDatasetQuery, { datasetId: dataset.id, databaseIds }, { context: userContext }
+    );
+
+    await expect(createPromise).rejects.toThrowError(/Unauthorized/);
+    await expect(updatePromise).rejects.toThrowError(/Unauthorized/);
+  });
+
+  test('Admin allowed to use Metaspace public and group databases', async () => {
+    await doQuery(createDatasetQuery, { databaseIds }, { context: adminContext });
+    await doQuery( updateDatasetQuery, { datasetId: dataset.id, databaseIds }, { context: adminContext });
   });
 });

--- a/metaspace/graphql/src/modules/moldb/controller.ts
+++ b/metaspace/graphql/src/modules/moldb/controller.ts
@@ -10,6 +10,7 @@ import {smApiCreateDatabase, smApiUpdateDatabase, smApiDeleteDatabase} from '../
 import {assertImportFileIsValid} from './util/assertImportFileIsValid';
 import {mapToMolecularDB} from './util/mapToMolecularDB';
 import {MolecularDbRepository} from './MolecularDbRepository';
+import {assertUserBelongsToGroup} from './util/assertUserBelongsToGroup';
 
 
 const QueryResolvers: FieldResolversFor<Query, void> = {
@@ -20,18 +21,6 @@ const QueryResolvers: FieldResolversFor<Query, void> = {
     }
     return databases.map(db => mapToMolecularDB(db));
   },
-};
-
-const assertUserBelongsToGroup = (ctx: Context, groupId: string) => {
-  ctx.getUserIdOrFail(); // Exit early if not logged in
-
-  if (ctx.isAdmin) {
-    return;
-  }
-
-  if (!ctx.user.groupIds || !ctx.user.groupIds.includes(groupId)) {
-    throw new UserError(`Unauthorized`);
-  }
 };
 
 const assertUserCanEditMolecularDB = async (ctx: Context, databaseId: number) => {

--- a/metaspace/graphql/src/modules/moldb/util/assertUserBelongsToGroup.ts
+++ b/metaspace/graphql/src/modules/moldb/util/assertUserBelongsToGroup.ts
@@ -1,0 +1,15 @@
+import { UserError } from 'graphql-errors';
+
+import { Context } from '../../../context';
+
+export const assertUserBelongsToGroup = (ctx: Context, groupId: string) => {
+  ctx.getUserIdOrFail(); // Exit early if not logged in
+
+  if (ctx.isAdmin) {
+    return;
+  }
+
+  if (!ctx.user.groupIds || !ctx.user.groupIds.includes(groupId)) {
+    throw new UserError(`Unauthorized`);
+  }
+};

--- a/metaspace/graphql/src/modules/moldb/util/mapDatabaseToDatabaseId.ts
+++ b/metaspace/graphql/src/modules/moldb/util/mapDatabaseToDatabaseId.ts
@@ -7,10 +7,5 @@ export const mapDatabaseToDatabaseId =
   async (entityManager: EntityManager, database: string): Promise<number> => {
     logger.warn('Addressing private databases by name was deprecated. Use database id instead.');
     const databaseModel = await entityManager.findOneOrFail(MolecularDbModel, { 'name': database });
-    if (!databaseModel.public) {
-      throw new UserError(
-        'Addressing a non-public molecular database by name. Use database id instead.'
-      );
-    }
     return databaseModel.id;
   };

--- a/metaspace/graphql/src/tests/testDataCreation.ts
+++ b/metaspace/graphql/src/tests/testDataCreation.ts
@@ -90,7 +90,9 @@ const genDatasetId = () => {
     .replace(/([\d\-]+)T(\d+):(\d+):(\d+).*/, '$1_$2h$3m$4s');
 };
 
-export const createTestDataset = async (dataset: Partial<Dataset> = {}, engineDataset: Partial<EngineDataset> = {}): Promise<Dataset> => {
+export const createTestDataset = async (
+  dataset: Partial<Dataset> = {}, engineDataset: Partial<EngineDataset> = {}
+): Promise<Dataset> => {
   const datasetId = engineDataset.id || genDatasetId();
   const datasetPromise = testEntityManager.save(Dataset, {
     id: datasetId,

--- a/metaspace/graphql/src/utils/smApi/datasets.ts
+++ b/metaspace/graphql/src/utils/smApi/datasets.ts
@@ -43,7 +43,7 @@ export const smApiDatasetRequest = async (uri: string, args: any={}) => {
       }));
     }
     else {
-      throw new UserError(`smAPIRequest: ${JSON.stringify(respDoc)}`);
+      throw new UserError(`Request to sm-api failed: ${JSON.stringify(respDoc)}`);
     }
   }
   else {


### PR DESCRIPTION
Public group databases can be used only by the group members but results against them can be viewed by everyone.