### PR TITLE
feat(engine): Save zero MSM annotations

### DIFF
--- a/metaspace/engine/sm/engine/colocalization.py
+++ b/metaspace/engine/sm/engine/colocalization.py
@@ -41,7 +41,7 @@ ANNOTATIONS_SEL = (
     '    SELECT id FROM job j '
     '    WHERE j.ds_id = %s AND j.moldb_id = %s '
     '    ORDER BY start DESC '
-    '    LIMIT 1) '
+    '    LIMIT 1) AND iso_image_ids[1] IS NOT NULL '
     'ORDER BY msm DESC'
 )
 

--- a/metaspace/engine/sm/engine/ion_thumbnail.py
+++ b/metaspace/engine/sm/engine/ion_thumbnail.py
@@ -12,7 +12,7 @@ ISO_IMAGE_SEL = (
     "SELECT iso_image_ids[1] "
     "FROM annotation m "
     "JOIN job j on j.id = m.job_id "
-    "WHERE ds_id = %s "
+    "WHERE ds_id = %s AND iso_image_ids[1] IS NOT NULL "
     "ORDER BY fdr, msm "
     "LIMIT 500"
 )

--- a/metaspace/engine/sm/engine/molecular_db.py
+++ b/metaspace/engine/sm/engine/molecular_db.py
@@ -117,7 +117,7 @@ def create(
                 (
                     name,
                     version,
-                    datetime.utcnow(),
+                    datetime.now(),
                     group_id,
                     is_public,
                     description,

--- a/metaspace/engine/sm/engine/molecular_db.py
+++ b/metaspace/engine/sm/engine/molecular_db.py
@@ -136,6 +136,7 @@ def delete(moldb_id: int):
     DB().alter('DELETE FROM molecular_db WHERE id = %s', params=(moldb_id,))
 
 
+# pylint: disable=unused-argument
 def update(
     moldb_id: int,
     archived: bool = None,

--- a/metaspace/engine/sm/engine/molecular_db.py
+++ b/metaspace/engine/sm/engine/molecular_db.py
@@ -145,16 +145,15 @@ def update(
     link: str = None,
     citation: str = None,
 ) -> MolecularDB:
-    assert archived is not None or description or full_name or link or citation
-
     kwargs = {k: v for k, v in locals().items() if v is not None}
     kwargs.pop('moldb_id')
 
-    update_fields = [f'{field} = %s' for field in kwargs.keys()]
-    update_values = list(kwargs.values())
+    if kwargs:
+        update_fields = [f'{field} = %s' for field in kwargs.keys()]
+        update_values = list(kwargs.values())
 
-    moldb_update = 'UPDATE molecular_db SET {} WHERE id = %s'.format(', '.join(update_fields))
-    DB().alter(moldb_update, params=[*update_values, moldb_id])
+        moldb_update = 'UPDATE molecular_db SET {} WHERE id = %s'.format(', '.join(update_fields))
+        DB().alter(moldb_update, params=[*update_values, moldb_id])
 
     return find_by_id(moldb_id)
 

--- a/metaspace/engine/sm/engine/molecular_db.py
+++ b/metaspace/engine/sm/engine/molecular_db.py
@@ -139,6 +139,7 @@ def delete(moldb_id: int):
 def update(
     moldb_id: int,
     archived: bool = None,
+    is_public: bool = None,
     description: str = None,
     full_name: str = None,
     link: str = None,

--- a/metaspace/engine/sm/engine/msm_basic/formula_imager.py
+++ b/metaspace/engine/sm/engine/msm_basic/formula_imager.py
@@ -1,6 +1,7 @@
 import logging
 import pickle
 from pathlib import Path
+from typing import List, Dict, Set
 
 import numpy as np
 import pandas as pd
@@ -113,7 +114,13 @@ def get_file_path(name):
     return Path(SparkFiles.get(name))
 
 
-def create_process_segment(ds_segments, coordinates, ds_config, target_formula_inds):
+def create_process_segment(
+    ds_segments: List,
+    coordinates: np.ndarray,
+    ds_config: Dict,
+    target_formula_inds: Set[int],
+    targeted_database_formula_inds: Set[int],
+):
     sample_area_mask = make_sample_area_mask(coordinates)
     nrows, ncols = get_ds_dims(coordinates)
     compute_metrics = make_compute_image_metrics(
@@ -141,7 +148,12 @@ def create_process_segment(ds_segments, coordinates, ds_config, target_formula_i
                 ds_segm_it, centr_df=centr_df, nrows=nrows, ncols=ncols, isocalc=isocalc
             )
             formula_metrics_df, formula_images = formula_image_metrics(
-                formula_images_it, compute_metrics, target_formula_inds, n_peaks, min_px
+                formula_images_it,
+                compute_metrics,
+                target_formula_inds,
+                targeted_database_formula_inds,
+                n_peaks,
+                min_px,
             )
             logger.info(f'Segment {segm_i} finished')
         else:

--- a/metaspace/engine/sm/engine/msm_basic/formula_validator.py
+++ b/metaspace/engine/sm/engine/msm_basic/formula_validator.py
@@ -65,6 +65,10 @@ def make_compute_image_metrics(sample_area_mask, nrows, ncols, img_gen_config):
             iso_imgs_flat = [img.flatten()[sample_area_mask_flat] for img in iso_imgs]
             iso_imgs_flat = iso_imgs_flat[: len(formula_ints)]
 
+            doc['total_iso_ints'] = [img.sum() for img in iso_imgs]
+            doc['min_iso_ints'] = [img.min() for img in iso_imgs]
+            doc['max_iso_ints'] = [img.max() for img in iso_imgs]
+
             doc['spectral'] = isotope_pattern_match(iso_imgs_flat, formula_ints)
             if doc['spectral'] > 0:
 
@@ -76,9 +80,6 @@ def make_compute_image_metrics(sample_area_mask, nrows, ncols, img_gen_config):
                     if doc['chaos'] > 0:
 
                         doc['msm'] = doc['chaos'] * doc['spatial'] * doc['spectral']
-                        doc['total_iso_ints'] = [img.sum() for img in iso_imgs]
-                        doc['min_iso_ints'] = [img.min() for img in iso_imgs]
-                        doc['max_iso_ints'] = [img.max() for img in iso_imgs]
         return OrderedDict((k, replace_nan(v)) for k, v in doc.items())
 
     return compute_metrics

--- a/metaspace/engine/tests/test_msm_basic_search_integr.py
+++ b/metaspace/engine/tests/test_msm_basic_search_integr.py
@@ -54,9 +54,7 @@ def make_fetch_formula_centroids_mock():
 
 
 def make_formula_image_metrics_mock_side_effect():
-    def formula_image_metrics_mock(
-        formula_images_it, compute_metrics, target_formula_inds, n_peaks, min_px
-    ):
+    def formula_image_metrics_mock(formula_images_it, *args, **kwargs):
         formula_is = set(item[0] for item in formula_images_it)
         formula_metrics_df = pd.DataFrame(
             [(i, 0.95) for i in formula_is], columns=['formula_i', 'msm']

--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -59,6 +59,7 @@ type Dataset {
 type FdrCounts {
   databaseId: Int!
   dbName: String!
+  dbVersion: String!
   levels: [Float!]!
   counts: [Float!]!
 }

--- a/metaspace/graphql/schemas/moldb.graphql
+++ b/metaspace/graphql/schemas/moldb.graphql
@@ -26,6 +26,7 @@ input CreateMolecularDBInput {
   name: String!
   version: String!
   filePath: String!
+  isPublic: Boolean! = False
   groupId: ID!
   fullName: String
   description: String
@@ -35,6 +36,7 @@ input CreateMolecularDBInput {
 
 input UpdateMolecularDBInput {
   archived: Boolean
+  isPublic: Boolean
   fullName: String
   description: String
   link: String

--- a/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
@@ -282,6 +282,7 @@ const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
         return {
           'databaseId': databaseId,
           'dbName': database.name,
+          'dbVersion': database.version,
           'levels': outFdrLvls,
           'counts': outFdrCounts
         };

--- a/metaspace/graphql/src/modules/moldb/controller.spec.ts
+++ b/metaspace/graphql/src/modules/moldb/controller.spec.ts
@@ -134,6 +134,7 @@ describe('Molecular database mutation permissions', () => {
       createMolecularDB(databaseDetails: {
         name: "test-db"
         version: "v1"
+        isPublic: true
         filePath: "s3://${config.upload.bucket}/${config.upload.moldbPrefix}/abc"
         groupId: $groupId
       }) {

--- a/metaspace/graphql/src/utils/smApi/databases.ts
+++ b/metaspace/graphql/src/utils/smApi/databases.ts
@@ -41,6 +41,7 @@ export const smApiDatabaseRequest = async (uri: string, args?: any) => {
 interface CreateDatabaseArgs {
     name: string;
     version: string;
+    isPublic: boolean;
     groupId: string;
     filePath: string;
     fullName?: string;
@@ -55,6 +56,7 @@ export const smApiCreateDatabase = async (args: CreateDatabaseArgs) => {
 
 interface UpdateDatabaseArgs {
     archived?: boolean;
+    isPublic?: boolean;
     fullName?: string;
     description?: string;
     link?: string;


### PR DESCRIPTION
For targeted databases, save annotations even with zero scores if at least one image is not empty.

_Edit:_
* Add `isPublic` field to molecular database mutations.
* `MolecularDB.createdDT` init with the local time zone and not UTC. I double checked behavior of this graphql field, it's consistent with `Project.createdDT`.