### PR TITLE
Small front-end fixes

### DIFF
--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
@@ -188,12 +188,16 @@ export default class AnnotationView extends Vue {
 
    get bestOpticalImage(): OpticalImage | null {
      if (this.opticalImages != null && this.opticalImages.length > 0) {
-       const { zoom } = this.imagePosition
+       // Try to guess a zoom level that is likely to be close to 1 image pixel per display pixel
+       // MainImage is ~2/3rds of the window width. Optical images are 1000 px wide * zoom level
+       const targetZoom = this.imagePosition.zoom
+         * Math.max(1, window.innerWidth * window.devicePixelRatio * 2 / 3 / 1000)
+
        // Find the best optical image, preferring images with a higher zoom level than the current zoom
        const sortedOpticalImages = sortBy(this.opticalImages, optImg =>
-         optImg.zoom >= zoom
-           ? optImg.zoom - zoom
-           : 100 + (zoom - optImg.zoom))
+         optImg.zoom >= targetZoom
+           ? optImg.zoom - targetZoom
+           : 100 + (targetZoom - optImg.zoom))
 
        return sortedOpticalImages[0]
      }

--- a/metaspace/webapp/src/modules/Filters/__snapshots__/FilterPanel.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Filters/__snapshots__/FilterPanel.spec.ts.snap
@@ -416,16 +416,8 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container pl-3">
       <div slot-key="default">
         <div>
-          <mock-el-select remote-method="function () { [native code] }" placeholder="Select chemical modification" filterable="" clearable="" remote="">
-            <mock-el-option label="No chemical modification" value="none"></mock-el-option>
-            <mock-el-option label="chemMods.0.name" value="chemMods.0.chemMod"></mock-el-option>
-            <mock-el-option label="chemMods.1.name" value="chemMods.1.chemMod"></mock-el-option>
-          </mock-el-select>
-          <mock-el-select remote-method="function () { [native code] }" placeholder="Select neutral loss" filterable="" clearable="" remote="">
-            <mock-el-option label="No neutral loss" value="none"></mock-el-option>
-            <mock-el-option label="neutralLosses.0.name" value="neutralLosses.0.neutralLoss"></mock-el-option>
-            <mock-el-option label="neutralLosses.1.name" value="neutralLosses.1.neutralLoss"></mock-el-option>
-          </mock-el-select>
+          <!---->
+          <!---->
           <mock-el-select value="+K" placeholder="Select ionising adduct" filterable="" clearable="" remote="">
             <mock-el-option label="[M + H]⁺" value="+H"></mock-el-option>
             <mock-el-option label="[M + Na]⁺" value="+Na"></mock-el-option>

--- a/metaspace/webapp/src/modules/Filters/filter-components/AdductFilter.vue
+++ b/metaspace/webapp/src/modules/Filters/filter-components/AdductFilter.vue
@@ -6,6 +6,7 @@
   >
     <div slot="edit">
       <el-select
+        v-if="showChemMods"
         :value="filterValues.chemMod"
         :remote-method="updateChemModQuery"
         :loading="chemModOptionsLoading !== 0"
@@ -24,6 +25,7 @@
         />
       </el-select>
       <el-select
+        v-if="showNeutralLosses"
         :value="filterValues.neutralLoss"
         :remote-method="updateNeutralLossQuery"
         :loading="neutralLossOptionsLoading !== 0"
@@ -134,6 +136,14 @@ export default class AdductFilter extends Vue {
     get adductOptions() {
       return this.filterLists.adducts
         .filter((a: AdductSuggestion) => config.features.all_adducts || !a.hidden)
+    }
+
+    get showChemMods() {
+      return config.features.chem_mods || this.filterValues.chemMod != null
+    }
+
+    get showNeutralLosses() {
+      return config.features.neutral_losses || this.filterValues.neutralLoss != null
     }
 
     formatValue() {

--- a/metaspace/webapp/src/store/getters.js
+++ b/metaspace/webapp/src/store/getters.js
@@ -102,7 +102,7 @@ export default {
     const { datasetIds, colocalizedWith, database, fdrLevel } = getters.filter;
     const colocalizationAlgo = getters.settings.annotationView.colocalizationAlgo;
     if (datasetIds && !datasetIds.includes('|') && colocalizedWith != null && database != null && fdrLevel != null) {
-      return { colocalizedWith, colocalizationAlgo, database, fdrLevel };
+      return { colocalizedWith, colocalizationAlgo, databaseId: database, fdrLevel };
     } else {
       return null;
     }

--- a/metaspace/webapp/src/tours/intro/steps/00-upload.md
+++ b/metaspace/webapp/src/tours/intro/steps/00-upload.md
@@ -8,6 +8,6 @@ route: '/upload'
 This is the place to go when you acquire a new dataset.
 
 To submit a dataset for annotation:
-1. drag-and-drop a [centroided imzML](http://project.metaspace2020.eu/imzml) dataset into the box
-2. fill out the metdata whilst it's uploading
+1. drag-and-drop a [centroided imzML](https://docs.google.com/document/d/e/2PACX-1vTT4QrMQ2RJMjziscaU8S3gbznlv6Rm5ojwrsdAXPbR5bt7Ivp-ThkC0hefrk3ZdVqiyCX7VU_ddA62/pub) dataset into the box
+2. fill out the metadata while the dataset uploads
 3. hit submit


### PR DESCRIPTION
* Fixed the "Colocalized with" filter as discussed
* Fixed the link to imzML help & some of the grammar during the upload tour
* Hide the Chemical Modification and Neutral Loss filters if those features are turned off. They weren't hidden in the original implementation, because the plan was to release those features shortly after the initial deployment, so it didn't seem worth the effort. The features were a lot less intuitive than planned and were never released. Showing Chem Mods / Neutral Losses in the adduct filter is just confusing, when most people don't have access to those features
* Multiply the optical image zoom level by a resolution-dependent factor. It's not the nicest fix, but it does improve the situation significantly by defaulting to 2x zoom on 1080p monitors, and possibly higher on HiDPI monitors. (fixes #461)