### PR TITLE
Misc back-end fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # METASPACE
 
-[![Build Status](https://circleci.com/gh/metaspace2020/metaspace.svg?style=svg)](https://circleci.com/gh/metaspace2020/metaspace) [![Documentation Status](https://readthedocs.org/projects/sm-distributed/badge/?version=latest)](http://sm-distributed.readthedocs.org/en/latest/?badge=latest) [![codecov](https://codecov.io/gh/metaspace2020/metaspace/branch/master/graph/badge.svg)](https://codecov.io/gh/metaspace2020/metaspace) [![Gitter](https://badges.gitter.im/metaspace2020/metaspace.svg)](https://gitter.im/metaspace2020/metaspace?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Build Status](https://circleci.com/gh/metaspace2020/metaspace.svg?style=svg)](https://circleci.com/gh/metaspace2020/metaspace) [![Documentation Status](https://readthedocs.org/projects/sm-distributed/badge/?version=latest)](http://sm-distributed.readthedocs.org/en/latest/?badge=latest) [![codecov](https://codecov.io/gh/metaspace2020/metaspace/branch/master/graph/badge.svg)](https://codecov.io/gh/metaspace2020/metaspace)
 
 [The METASPACE platform](http://metaspace2020.eu/) hosts an engine for
  metabolite annotation of imaging mass spectrometry data as well as a
@@ -9,7 +9,7 @@
 
 The METASPACE platform is developed by software engineers, data scientists and
  mass spectrometrists from the [Alexandrov team at EMBL](http://www.embl.de/research/units/scb/alexandrov/).
- This work is a part of the [European project METASPACE](http://project.metaspace2020.eu/).
+ This work is a part of the [European project METASPACE](https://cordis.europa.eu/project/id/634402).
 
 ## Projects
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -5,15 +5,6 @@
 * [AWS Installation](aws/README.md)
 * [Docker installation](../docker/README.md)
 
-## Funding
+## Acknowledgements and license
 
-This project is funded from the [European Horizon2020](https://ec.europa.eu/programmes/horizon2020/)
-project [METASPACE](http://project.metaspace2020.eu/) (no. 634402),
-[NIH NIDDK project KPMP](http://kpmp.org/)
-and internal funds of the [European Molecular Biology Laboratory](https://www.embl.org/).
-
-## License
-
-Unless specified otherwise in file headers or LICENSE files present in subdirectories,
-all files are licensed under the [Apache 2.0 license](LICENSE).
-
+[See the top-level README](../../README.md#acknowledgements)

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -7,4 +7,4 @@
 
 ## Acknowledgements and license
 
-[See the top-level README](../../README.md#acknowledgements)
+[See the top-level README](../README.md#acknowledgements)

--- a/metaspace/engine/README.md
+++ b/metaspace/engine/README.md
@@ -21,13 +21,7 @@ Please visit the help page of our web application running on AWS:
 
 Install [CircleCI CLI tool](https://circleci.com/docs/2.0/local-jobs/) and run `circleci build` from the project root.
 
-## Funding
+## Acknowledgements and license
 
-This project is funded from the [European Horizon2020](https://ec.europa.eu/programmes/horizon2020/)
-project [METASPACE](http://project.metaspace2020.eu/) (no. 634402),
-[NIH NIDDK project KPMP](http://kpmp.org/)
-and internal funds of the [European Molecular Biology Laboratory](https://www.embl.org/).
+[See the top-level README](../../README.md#acknowledgements)
 
-## License
-
-This project is licensed under the [Apache 2.0 license](LICENSE).

--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -41,8 +41,8 @@
   },
   "spark": {
     "master": "{{ spark_master_host | default('local[*]') }}",
-    "spark.executor.memory": "10g",
-    "spark.driver.memory": "4g",
+    "spark.executor.memory": "16g",
+    "spark.driver.memory": "8g",
     "spark.driver.maxResultSize": "3g",
     "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
     "spark.kryoserializer.buffer.max": "512m",

--- a/metaspace/engine/sm/engine/png_generator.py
+++ b/metaspace/engine/sm/engine/png_generator.py
@@ -14,7 +14,9 @@ class ImageStoreServiceWrapper:
     def __init__(self, img_service_url):
         self._img_service_url = img_service_url
         self._session = requests.Session()
-        self._session.mount(self._img_service_url, HTTPAdapter(max_retries=5, pool_maxsize=100))
+        self._session.mount(
+            self._img_service_url, HTTPAdapter(max_retries=5, pool_maxsize=50, pool_block=True)
+        )
 
     def _format_url(self, storage_type, img_type, method='', img_id=''):
         assert storage_type, 'Wrong storage_type: %s' % storage_type

--- a/metaspace/engine/sm/engine/png_generator.py
+++ b/metaspace/engine/sm/engine/png_generator.py
@@ -1,3 +1,4 @@
+import logging
 from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from os import path
@@ -8,6 +9,10 @@ import requests
 from requests.adapters import HTTPAdapter
 from PIL import Image
 from scipy.ndimage import zoom
+
+from sm.engine.util import retry_on_exception
+
+logger = logging.getLogger('engine')
 
 
 class ImageStoreServiceWrapper:
@@ -23,6 +28,7 @@ class ImageStoreServiceWrapper:
         assert img_type, 'Wrong img_type: %s' % img_type
         return path.join(self._img_service_url, storage_type, img_type + 's', method, img_id)
 
+    @retry_on_exception()
     def post_image(self, storage_type, img_type, fp):
         """
         Args
@@ -44,6 +50,7 @@ class ImageStoreServiceWrapper:
         resp.raise_for_status()
         return resp.json()['image_id']
 
+    @retry_on_exception()
     def delete_image(self, url):
         resp = self._session.delete(url)
         if resp.status_code != 202:
@@ -51,6 +58,7 @@ class ImageStoreServiceWrapper:
                 'Failed to delete: {}'.format(url)
             )  # logger has issues with pickle when sent to spark
 
+    @retry_on_exception()
     def get_image_by_id(self, storage_type, img_type, img_id):
         """
         Args
@@ -122,6 +130,7 @@ class ImageStoreServiceWrapper:
             h, w = mask.shape
             value = np.empty((len(img_ids), h * w), dtype=np.float32)
 
+        @retry_on_exception()
         def process_img(img_id, idx, do_setup=False):
             img = self.get_image_by_id(storage_type, 'iso_image', img_id)
             if do_setup:
@@ -154,6 +163,7 @@ class ImageStoreServiceWrapper:
 
         return value, mask, (h, w)
 
+    @retry_on_exception()
     def delete_image_by_id(self, storage_type, img_type, img_id):
         url = self._format_url(
             storage_type=storage_type, img_type=img_type, method='delete', img_id=img_id

--- a/metaspace/engine/sm/engine/util.py
+++ b/metaspace/engine/sm/engine/util.py
@@ -7,7 +7,7 @@ import os
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from random import random
+import random
 from time import sleep
 
 from sm.engine.db import ConnectionPool
@@ -173,13 +173,13 @@ class GlobalInit:
         self.pool.close()
 
 
-def retry_on_exception(exception_type=Exception, num_attempts=3):
+def retry_on_exception(exception_type=Exception, num_retries=3):
     def decorator(func):
         func_name = getattr(func, '__name__', 'Function')
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            for i in range(num_attempts - 1):
+            for i in range(num_retries):
                 try:
                     return func(*args, **kwargs)
                 except exception_type as e:

--- a/metaspace/engine/sm/engine/util.py
+++ b/metaspace/engine/sm/engine/util.py
@@ -1,11 +1,14 @@
 import json
 import logging
 import re
+from functools import wraps
 from logging.config import dictConfig
 import os
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
+from random import random
+from time import sleep
 
 from sm.engine.db import ConnectionPool
 from sm.engine import molecular_db
@@ -168,3 +171,27 @@ class GlobalInit:
 
     def __exit__(self, ext_type, ext_value, traceback):
         self.pool.close()
+
+
+def retry_on_exception(exception_type=Exception, num_attempts=3):
+    def decorator(func):
+        func_name = getattr(func, '__name__', 'Function')
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            for i in range(num_attempts - 1):
+                try:
+                    return func(*args, **kwargs)
+                except exception_type as e:
+                    delay = random.uniform(2, 5 + i * 3)
+                    logger.warning(
+                        f'{func_name} raised {type(e)} on attempt {i+1}. '
+                        f'Retrying after {delay:.1f} seconds...'
+                    )
+                    sleep(delay)
+            # Last attempt, don't catch the exception
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/metaspace/graphql/README.md
+++ b/metaspace/graphql/README.md
@@ -64,14 +64,6 @@ The following steps can help debugging, if you have made a mistake in a feature 
 3. Run `yarn exec typeorm migration:run` to ensure you have all migrations from `master` applied.    
 4. Run `yarn exec typeorm schema:sync` to re-synchronize the schema.
 
-## Funding
+## Acknowledgements and license
 
-This project is funded from the [European Horizon2020](https://ec.europa.eu/programmes/horizon2020/)
-project [METASPACE](http://project.metaspace2020.eu/) (no. 634402),
-[NIH NIDDK project KPMP](http://kpmp.org/)
-and internal funds of the [European Molecular Biology Laboratory](https://www.embl.org/).
-
-## License
-
-This project is licensed under the [Apache 2.0 license](LICENSE).
-
+[See the top-level README](../../README.md#acknowledgements)

--- a/metaspace/metadata/README.md
+++ b/metaspace/metadata/README.md
@@ -6,13 +6,6 @@ This repository contains information about the minimal metadata for imaging mass
 
 The work on aligning this metadata with metadata required by the [EBI MetaboLights repository](www.ebi.ac.uk/metabolights/) is in progress.
 
-## Funding
+## Acknowledgements and license
 
-This project is funded from the [European Horizon2020](https://ec.europa.eu/programmes/horizon2020/)
-project [METASPACE](http://project.metaspace2020.eu/) (no. 634402),
-[NIH NIDDK project KPMP](http://kpmp.org/)
-and internal funds of the [European Molecular Biology Laboratory](https://www.embl.org/).
-
-## License
-
-This project is licensed under the [Apache 2.0 license](LICENSE).
+[See the top-level README](../../README.md#acknowledgements)

--- a/metaspace/off-sample/README.md
+++ b/metaspace/off-sample/README.md
@@ -28,3 +28,7 @@ It accepts POST requests with JSON, images must be Base64 encoded, max 32 per re
 
 
 Jupyter [notebook](api-example.ipynb) with API use example
+
+## Acknowledgements and license
+
+[See the top-level README](../../README.md#acknowledgements)

--- a/metaspace/python-client/README.md
+++ b/metaspace/python-client/README.md
@@ -29,14 +29,6 @@ There are several playbooks available to retrieve dataset information as well as
 | **update_DBs_dataset_api**| Reprocesses a dataset with a different set of databases |
 | **upload_dataset_api**| Uploads a new dataset with the provided metadata |
 
+## Acknowledgements and license
 
-## Funding
-
-This project is funded from the [European Horizon2020](https://ec.europa.eu/programmes/horizon2020/)
-project [METASPACE](http://project.metaspace2020.eu/) (no. 634402),
-[NIH NIDDK project KPMP](https://www.niddk.nih.gov/research-funding/research-programs/kidney-precision-medicine-project-kpmp)
-and internal funds of the [European Molecular Biology Laboratory](https://www.embl.org/).
-
-## License
-
-Unless specified otherwise in file headers, all files are licensed under the [Apache 2.0 license](LICENSE).
+[See the top-level README](../../README.md#acknowledgements)

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -868,7 +868,10 @@ class SMDataset(object):
             if not url:
                 return None
             url = self._baseurl + url
-            im = mpimg.imread(BytesIO(self._session.get(url).content))
+            try:
+                im = mpimg.imread(BytesIO(self._session.get(url).content))
+            except:
+                im = mpimg.imread(BytesIO(self._session.get(url).content))
             mask = im[:, :, 3]
             data = im[:, :, 0]
             data[mask == 0] = 0

--- a/metaspace/webapp/README.md
+++ b/metaspace/webapp/README.md
@@ -28,13 +28,6 @@ To check code coverage: `yarn run coverage` then open `coverage/lcov-report/inde
 Run `yarn run build` to build and minify the project. 
 The files in the `dist/` directory can then be served by a web server such as nginx.
 
-## Funding
+## Acknowledgements and license
 
-This project is funded from the [European Horizon2020](https://ec.europa.eu/programmes/horizon2020/)
-project [METASPACE](http://project.metaspace2020.eu/) (no. 634402),
-[NIH NIDDK project KPMP](http://kpmp.org/)
-and internal funds of the [European Molecular Biology Laboratory](https://www.embl.org/).
-
-## License
-
-This project is licensed under the [Apache 2.0 license](LICENSE).
+[See the top-level README](../../README.md#acknowledgements)


### PR DESCRIPTION
* Increase Spark memory. I decided that it was better to possibly set it too high than too low. If Java OOMs we get confusing exception messages. If Python OOMs because Java has already eaten too much memory, we get nicer exception messages.
* Change all the `README.md` files to link to the main `README.md`'s acknowledgements/funding/license sections, as the main one is nicer and more up-to-date.
* Removed the link to Gitter from `README.md`. The link has already been removed from webapp.
* Retry downloading images in python-client if there's an error. VS found that she would often get errors on her home internet connection.
* Retry downloading/uploading/deleting images if there's an error in `ImageStoreServiceWrapper`. This probably won't be an issue once the instance is upgraded, but the prod logs include several failures in image upload and image download(for colocalization). The requests library only retries on certain types of exception, so it seemed safer to handle the retry logic externally.
* Reduced pool size and added `pool_block=True` to `ImageStoreServiceWrapper` to try to reduce the frequency of exceptions. Normally the number of connections is actually allowed to exceed `pool_maxsize`, it just won't actually keep them in the pool above that number. `pool_block=True` changes this so that it will block execution instead of allocate non-pooled connections.
* Change ESExporter's retry decorator to retry on any ES-specific exception. I found a few cases of `ConnectionTimeout`s in the logs, and I found that if `update_ds` hypothetically manages to have a conflict (this generally doesn't happen anymore due the DB-based dataset locker), it would often actually throw as a `NotFoundError` because of conflicts creating/deleting the pipeline. I felt it safer to just retry on any error.