### PR TITLE
Python client improvements

### DIFF
--- a/metaspace/python-client/example/api_examples.ipynb
+++ b/metaspace/python-client/example/api_examples.ipynb
@@ -56,7 +56,7 @@
     }
    ],
    "source": [
-    "from metaspace.sm_annotations_utils import SMInstance\n",
+    "from metaspace import SMInstance\n",
     "sm = SMInstance()\n",
     "sm"
    ]

--- a/metaspace/python-client/example/colocalized-annotations.ipynb
+++ b/metaspace/python-client/example/colocalized-annotations.ipynb
@@ -26,7 +26,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "from metaspace.sm_annotation_utils import SMInstance"
+    "from metaspace import SMInstance"
    ]
   },
   {

--- a/metaspace/python-client/example/explore_off_sample_results.ipynb
+++ b/metaspace/python-client/example/explore_off_sample_results.ipynb
@@ -44,9 +44,9 @@
     "%matplotlib inline\n",
     "from matplotlib import pyplot as plt\n",
     "import pandas as pd\n",
-    "from metaspace.sm_annotation_utils import SMInstance\n",
+    "from metaspace import SMInstance\n",
     "import getpass\n",
-    "sm_inst = SMInstance(host='https://staging.metaspace2020.eu')\n",
+    "sm_inst = SMInstance()\n",
     "sm_inst"
    ]
   },

--- a/metaspace/python-client/example/iso_img_retrieval.ipynb
+++ b/metaspace/python-client/example/iso_img_retrieval.ipynb
@@ -20,7 +20,8 @@
     "%matplotlib inline\n",
     "from matplotlib import pyplot as plt\n",
     "import pandas as pd\n",
-    "from metaspace.sm_annotation_utils import SMInstance\n",
+    "import numpy as np\n",
+    "from metaspace import SMInstance\n",
     "import getpass\n",
     "sm = SMInstance()\n",
     "sm"

--- a/metaspace/python-client/example/metadata_access.ipynb
+++ b/metaspace/python-client/example/metadata_access.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "from metaspace.sm_annotation_utils import SMInstance\n",
+    "from metaspace import SMInstance\n",
     "import matplotlib.pyplot as plt"
    ]
   },

--- a/metaspace/python-client/example/simple_database_queries.ipynb
+++ b/metaspace/python-client/example/simple_database_queries.ipynb
@@ -31,8 +31,7 @@
    "outputs": [],
    "source": [
     "# Install from metaspace python-client https://github.com/metaspace2020/metaspace/tree/master/metaspace/python-client\n",
-    "from metaspace.sm_annotation_utils import SMInstance\n",
-    "from metaspace import sm_annotation_utils\n",
+    "from metaspace import SMInstance\n",
     "sm = SMInstance()"
    ]
   },

--- a/metaspace/python-client/example/update_DBs_dataset_api.ipynb
+++ b/metaspace/python-client/example/update_DBs_dataset_api.ipynb
@@ -22,7 +22,7 @@
    "outputs": [],
    "source": [
     "import json, pprint, getpass\n",
-    "from metaspace.sm_annotation_utils import SMInstance\n",
+    "from metaspace import SMInstance\n",
     "sm = SMInstance()\n",
     "sm"
    ]

--- a/metaspace/python-client/example/upload_dataset_api.ipynb
+++ b/metaspace/python-client/example/upload_dataset_api.ipynb
@@ -29,7 +29,7 @@
    "outputs": [],
    "source": [
     "import json, pprint, getpass\n",
-    "from metaspace.sm_annotation_utils import SMInstance\n",
+    "from metaspace import SMInstance\n",
     "sm = SMInstance()\n",
     "sm"
    ]

--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,2 +1,9 @@
 name = 'metaspace2020'
 __version__ = '1.7.5'
+
+from metaspace.sm_annotation_utils import (
+    SMInstance,
+    GraphQLClient,
+    DatasetNotFound,
+)
+from metaspace.image_processing import clip_hotspots, colocalization, colocalization_matrix

--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,2 +1,2 @@
 name = 'metaspace2020'
-__version__ = '1.7.4'
+__version__ = '1.7.5'

--- a/metaspace/python-client/metaspace/image_processing.py
+++ b/metaspace/python-client/metaspace/image_processing.py
@@ -1,0 +1,87 @@
+from typing import List, overload
+
+import numpy as np
+import pandas as pd
+
+
+def clip_hotspots(img: np.ndarray):
+    """
+    Performs hotspot removal on an ion image to match the METASPACE website's ion image rendering
+    """
+    min_visible = np.max(img) / 256
+    hotspot_threshold = np.quantile(img[img > min_visible], 0.99)
+    print('min_visible', min_visible)
+    print('hotspot_threshold', hotspot_threshold)
+    return np.clip(img, None, hotspot_threshold)
+
+
+def colocalization(img_a: np.ndarray, img_b: np.ndarray):
+    """
+    Calculates degree of colocalization between two ion images, using the same algorithm METASPACE uses.
+    Returns a float between 0 (no colocalization) and 1 (full colocalization).
+
+    Citation: Ovchinnikova et al. (2020) ColocML. https://doi.org/10.1093/bioinformatics/btaa085
+
+    Requires additional packages to be installed: scipy, scikit-learn
+    """
+    from scipy.ndimage import median_filter
+    from sklearn.metrics.pairwise import cosine_similarity
+
+    h, w = img_a.shape
+
+    def preprocess(img):
+        img = img.copy().reshape((h, w))
+        img[img < np.quantile(img, 0.5)] = 0
+        return median_filter(img, (3, 3)).reshape([1, h * w])
+
+    return cosine_similarity(preprocess(img_a), preprocess(img_b))[0, 0]
+
+
+@overload
+def colocalization_matrix(images: List[np.ndarray], labels: None = None) -> np.ndarray:
+    ...
+
+
+@overload
+def colocalization_matrix(images: List[np.ndarray], labels: List[str]) -> pd.DataFrame:
+    ...
+
+
+def colocalization_matrix(images: List[np.ndarray], labels=None):
+    """
+    Calculates level of colocalization between all pairs of images in a list of ion images.
+    If many checks are needed, it is usually faster to generate the entire matrix than to do
+    many separate calls to "colocalization".
+
+    Citation: Ovchinnikova et al. (2020) ColocML. https://doi.org/10.1093/bioinformatics/btaa085
+
+    Requires additional packages to be installed: scipy, scikit-learn
+
+    :param images: A list of ion images
+    :param labels: If supplied, output will be a pandas DataFrame where the labels are used to define
+                   the index and columns. It can be useful to pass ion formulas
+                   or (formula, adduct) pairs here, to facilitate easy lookup of colocalization values
+                   If not supplied, the output will be a numpy ndarray
+    :return:
+    """
+    from scipy.ndimage import median_filter
+    from sklearn.metrics.pairwise import pairwise_kernels
+
+    count = len(images)
+    if count == 0:
+        similarity_matrix = np.ones((0, 0))
+    elif count == 1:
+        similarity_matrix = np.ones((1, 1))
+    else:
+        h, w = images[0].shape
+        flat_images = np.vstack(images)
+        flat_images[flat_images < np.quantile(flat_images, 0.5, axis=1, keepdims=True)] = 0
+        filtered_images = median_filter(flat_images.reshape((count, h, w)), (1, 3, 3)).reshape(
+            (count, h * w)
+        )
+        similarity_matrix = pairwise_kernels(filtered_images, metric='cosine')
+
+    if labels is None:
+        return similarity_matrix
+    else:
+        return pd.DataFrame(similarity_matrix, index=labels, columns=labels)

--- a/metaspace/python-client/metaspace/image_processing.py
+++ b/metaspace/python-client/metaspace/image_processing.py
@@ -10,8 +10,6 @@ def clip_hotspots(img: np.ndarray):
     """
     min_visible = np.max(img) / 256
     hotspot_threshold = np.quantile(img[img > min_visible], 0.99)
-    print('min_visible', min_visible)
-    print('hotspot_threshold', hotspot_threshold)
     return np.clip(img, None, hotspot_threshold)
 
 
@@ -74,7 +72,7 @@ def colocalization_matrix(images: List[np.ndarray], labels=None):
         similarity_matrix = np.ones((1, 1))
     else:
         h, w = images[0].shape
-        flat_images = np.vstack(images)
+        flat_images = np.vstack([i.flatten() for i in images])
         flat_images[flat_images < np.quantile(flat_images, 0.5, axis=1, keepdims=True)] = 0
         filtered_images = median_filter(flat_images.reshape((count, h, w)), (1, 3, 3)).reshape(
             (count, h * w)

--- a/metaspace/python-client/metaspace/image_processing.py
+++ b/metaspace/python-client/metaspace/image_processing.py
@@ -9,8 +9,11 @@ def clip_hotspots(img: np.ndarray):
     Performs hotspot removal on an ion image to match the METASPACE website's ion image rendering
     """
     min_visible = np.max(img) / 256
-    hotspot_threshold = np.quantile(img[img > min_visible], 0.99)
-    return np.clip(img, None, hotspot_threshold)
+    if min_visible > 0:
+        hotspot_threshold = np.quantile(img[img > min_visible], 0.99)
+        return np.clip(img, None, hotspot_threshold)
+    else:
+        return img
 
 
 def colocalization(img_a: np.ndarray, img_b: np.ndarray):

--- a/metaspace/python-client/metaspace/projects_client.py
+++ b/metaspace/python-client/metaspace/projects_client.py
@@ -1,5 +1,5 @@
 from typing import Optional, List
-from metaspace.sm_annotation_utils import SMInstance, GraphQLClient
+from metaspace.sm_annotation_utils import GraphQLClient
 
 try:
     from typing import TypedDict  # Requires Python 3.8

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -899,6 +899,7 @@ class SMDataset(object):
                     images[i] = np.zeros(shape, dtype=non_empty_images[0].dtype)
                 else:
                     images[i] *= float(image_metadata[i]['maxIntensity'])
+                    images[i] += float(image_metadata[i]['minIntensity'])
 
         if hotspot_clipping:
             for i, img in enumerate(images):

--- a/metaspace/python-client/metaspace/tests/test_image_processing.py
+++ b/metaspace/python-client/metaspace/tests/test_image_processing.py
@@ -1,0 +1,43 @@
+import pytest
+import numpy as np
+import pandas as pd
+
+from metaspace.image_processing import clip_hotspots, colocalization, colocalization_matrix
+
+IMG_A = np.array([[1, 1, 0], [1, 1, 0], [1, 1, 0]])
+IMG_B = np.array([[1, 1, 1], [1, 1, 1], [0, 0, 0]])
+IMG_C = np.array([[0, 0, 0], [0, 0, 0], [0, 0, 1]])
+
+
+def test_clip_hotspots():
+    # First 99 pixels are "effectively empty" (less than 1/256th of the max)
+    # and shouldn't count towards the thresholds
+    # Second half of the image is a gradient from 100 to 200, meaning the hotspot threshold
+    # should be 199 and the last pixel should be clipped
+    img = np.concatenate([np.ones(99) * 0.5, np.arange(100, 201)]).reshape(20, 10)
+    clipped = clip_hotspots(img)
+    print(clipped)
+    assert img.shape == clipped.shape
+    assert np.isclose(clipped.flat[:199], img.flat[:199]).all()
+    assert clipped.flat[199] == 199
+
+
+def test_colocalization():
+    assert np.isclose(colocalization(IMG_A, IMG_A), 1)
+    assert np.isclose(colocalization(IMG_A, IMG_B), 2 / 3)
+    assert np.isclose(colocalization(IMG_B, IMG_A), 2 / 3)
+    assert np.isclose(colocalization(IMG_A, IMG_C), 0)
+
+
+def test_colocalization_matrix():
+    IMGS = [IMG_A, IMG_B, IMG_C]
+    LABELS = ['a', 'b', 'c']
+    EXPECTED = [[1, 2 / 3, 0], [2 / 3, 1, 0], [0, 0, 0]]
+    mat = colocalization_matrix(IMGS)
+    assert isinstance(mat, np.ndarray)
+    assert np.isclose(mat, EXPECTED).all()
+
+    df = colocalization_matrix(IMGS, labels=LABELS)
+    pd.testing.assert_frame_equal(
+        df, pd.DataFrame(EXPECTED, index=LABELS, columns=LABELS), check_dtype=False
+    )

--- a/metaspace/python-client/metaspace/tests/test_image_processing.py
+++ b/metaspace/python-client/metaspace/tests/test_image_processing.py
@@ -4,9 +4,10 @@ import pandas as pd
 
 from metaspace.image_processing import clip_hotspots, colocalization, colocalization_matrix
 
-IMG_A = np.array([[1, 1, 0], [1, 1, 0], [1, 1, 0]])
-IMG_B = np.array([[1, 1, 1], [1, 1, 1], [0, 0, 0]])
-IMG_C = np.array([[0, 0, 0], [0, 0, 0], [0, 0, 1]])
+IMG_A = np.array([[1, 1, 0, 0], [1, 1, 0, 0], [1, 1, 0, 0], [1, 1, 0, 0]])
+IMG_B = np.array([[1, 1, 1, 1], [1, 1, 1, 1], [0, 0, 0, 0], [0, 0, 0, 0]])
+IMG_C = np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 1], [0, 0, 1, 1]])
+COLOC_A_B = 0.5
 
 
 def test_clip_hotspots():
@@ -16,7 +17,6 @@ def test_clip_hotspots():
     # should be 199 and the last pixel should be clipped
     img = np.concatenate([np.ones(99) * 0.5, np.arange(100, 201)]).reshape(20, 10)
     clipped = clip_hotspots(img)
-    print(clipped)
     assert img.shape == clipped.shape
     assert np.isclose(clipped.flat[:199], img.flat[:199]).all()
     assert clipped.flat[199] == 199
@@ -24,20 +24,19 @@ def test_clip_hotspots():
 
 def test_colocalization():
     assert np.isclose(colocalization(IMG_A, IMG_A), 1)
-    assert np.isclose(colocalization(IMG_A, IMG_B), 2 / 3)
-    assert np.isclose(colocalization(IMG_B, IMG_A), 2 / 3)
+    assert np.isclose(colocalization(IMG_A, IMG_B), COLOC_A_B)
+    assert np.isclose(colocalization(IMG_B, IMG_A), COLOC_A_B)
     assert np.isclose(colocalization(IMG_A, IMG_C), 0)
 
 
 def test_colocalization_matrix():
     IMGS = [IMG_A, IMG_B, IMG_C]
     LABELS = ['a', 'b', 'c']
-    EXPECTED = [[1, 2 / 3, 0], [2 / 3, 1, 0], [0, 0, 0]]
+    EXPECTED = [[1, COLOC_A_B, 0], [COLOC_A_B, 1, 0], [0, 0, 1]]
     mat = colocalization_matrix(IMGS)
     assert isinstance(mat, np.ndarray)
     assert np.isclose(mat, EXPECTED).all()
 
     df = colocalization_matrix(IMGS, labels=LABELS)
-    pd.testing.assert_frame_equal(
-        df, pd.DataFrame(EXPECTED, index=LABELS, columns=LABELS), check_dtype=False
-    )
+    expected_df = pd.DataFrame(EXPECTED, index=LABELS, columns=LABELS, dtype='d')
+    pd.testing.assert_frame_equal(df, expected_df)

--- a/metaspace/python-client/metaspace/tests/test_sm_dataset.py
+++ b/metaspace/python-client/metaspace/tests/test_sm_dataset.py
@@ -126,6 +126,24 @@ def test_isotope_images_advanced(advanced_dataset: SMDataset):
     assert isinstance(images[0], np.ndarray)
 
 
+def test_isotope_images_scaling(dataset: SMDataset):
+    ann = dataset.results(neutralLoss='', chemMod='').iloc[0]
+    formula, adduct = ann.name
+
+    scaled_img = dataset.isotope_images(formula, adduct)[0]
+    unscaled_img = dataset.isotope_images(formula, adduct, scale_intensity=False)[0]
+    clipped_img = dataset.isotope_images(formula, adduct, hotspot_clipping=True)[0]
+    clipped_unscaled_img = dataset.isotope_images(
+        formula, adduct, scale_intensity=False, hotspot_clipping=True
+    )[0]
+
+    assert np.max(scaled_img) == pytest.approx(ann.intensity)
+    assert np.max(unscaled_img) == pytest.approx(1)
+    assert np.max(clipped_img) < ann.intensity
+    assert np.max(clipped_img) > ann.intensity / 2  # Somewhat arbitrary, but generally holds true
+    assert np.max(clipped_unscaled_img) == pytest.approx(1)
+
+
 def test_all_annotation_images(dataset: SMDataset):
     image_list = dataset.all_annotation_images(only_first_isotope=True)
 


### PR DESCRIPTION
* Fix ion image intensities not taking `minIntensity` into account
* Add hotspot clipping & median-thresholded colocalization utility functions
* Re-export `SMInstance`, etc. from the root `metaspace` module so that people can do
   ```python
    from metaspace import SMInstance
   ```
    instead of
    ```python
    from metaspace.sm_annotation_utils import SMInstance
    ```
* Change usage of `MolecularDB.public` -> `MolecularDB.isPublic`