### PR TITLE
More python client fixes

### DIFF
--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -22,6 +22,11 @@ try:
 except ImportError:
     TypedDict = dict
 
+try:
+    from pandas import json_normalize  # Only in Pandas 1.0.0+
+except ImportError:
+    from pandas.io.json import json_normalize  # Logs DeprecationWarning if used in Pandas 1.0.0+
+
 
 DEFAULT_DATABASE = 'HMDB-v4'
 
@@ -787,7 +792,7 @@ class SMDataset(object):
         if not records:
             return pd.DataFrame()
 
-        df = pd.io.json.json_normalize(records)
+        df = json_normalize(records)
         return (
             df.assign(
                 moleculeNames=df.possibleCompounds.apply(
@@ -1129,7 +1134,7 @@ class SMInstance(object):
         Pandas dataframe for a subset of datasets
         where rows are flattened metadata JSON objects
         """
-        df = pd.io.json.json_normalize([d.metadata.json for d in datasets])
+        df = json_normalize([d.metadata.json for d in datasets])
         df.index = [d.name for d in datasets]
         return df
 
@@ -1142,7 +1147,7 @@ class SMInstance(object):
         records = self._gqclient.getAnnotations(
             annotationFilter={'database': db_name, 'fdrLevel': fdr}, datasetFilter=datasetFilter
         )
-        df = pd.io.json.json_normalize(records)
+        df = json_normalize(records)
         return pd.DataFrame(
             dict(
                 formula=df['sumFormula'],
@@ -1163,7 +1168,7 @@ class SMInstance(object):
         datasets = self._gqclient.getDatasets(datasetFilter=datasetFilter)
         df = pd.concat(
             [
-                pd.DataFrame(pd.io.json.json_normalize(json.loads(dataset['metadataJson'])))
+                pd.DataFrame(json_normalize(json.loads(dataset['metadataJson'])))
                 for dataset in datasets
             ]
         )

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -400,8 +400,7 @@ class GraphQLClient(object):
             }"""
 
         return self.query(
-            query=query,
-            variables={'filter': annotationFilter, 'dFilter': datasetFilter}
+            query=query, variables={'filter': annotationFilter, 'dFilter': datasetFilter}
         )
 
     def getDatasets(self, datasetFilter=None):

--- a/metaspace/python-client/metaspace/tests/test_sm_dataset.py
+++ b/metaspace/python-client/metaspace/tests/test_sm_dataset.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 import pytest
 import numpy as np
@@ -87,6 +88,22 @@ def test_results_with_str_database_id(dataset: SMDataset):
         assert False
     except GraphQLException:
         assert True
+
+
+@patch(
+    'metaspace.sm_annotation_utils.GraphQLClient.get_databases',
+    return_value=[{'id': '22', 'name': 'HMDB-v4'}],
+)
+@patch('metaspace.sm_annotation_utils.GraphQLClient.getAnnotations', return_value=[])
+def test_map_database_works_handles_strs_ids_from_api(
+    mock_getAnnotations, mock_get_databases, dataset: SMDataset
+):
+    # This test is just to ensure that the forward-compatibility with string IDs has the correct behavior
+    dataset.results()
+
+    print(mock_getAnnotations.call_args)
+    annot_filter = mock_getAnnotations.call_args[1]['annotationFilter']
+    assert annot_filter['databaseId'] == '22'
 
 
 def test_results_neutral_loss_chem_mod(advanced_dataset: SMDataset):

--- a/metaspace/python-client/metaspace/tests/test_sm_dataset.py
+++ b/metaspace/python-client/metaspace/tests/test_sm_dataset.py
@@ -4,7 +4,7 @@ from tempfile import TemporaryDirectory
 import pytest
 import numpy as np
 
-from metaspace.sm_annotation_utils import IsotopeImages, SMDataset, GraphQLClient, SMInstance
+from metaspace.sm_annotation_utils import IsotopeImages, SMDataset, GraphQLClient, SMInstance, GraphQLException
 from metaspace.tests.utils import sm, my_ds_id, advanced_ds_id
 
 
@@ -65,6 +65,22 @@ def test_results_with_coloc(dataset: SMDataset):
 
     assert len(coloc_annotations) > 0
     assert coloc_annotations.colocCoeff.all()
+
+
+def test_results_with_int_database_id(dataset: SMDataset):
+    annotations = dataset.results(22, fdr=0.5)
+
+    assert len(annotations) > 0
+
+
+def test_results_with_str_database_id(dataset: SMDataset):
+    try:
+        annotations = dataset.results('22', fdr=0.5)
+        # If the above code succeeds, it's time to start coercing the databaseId type to fit the API.
+        # See the comment in GraphQLClient.map_database_to_id for context.
+        assert False
+    except GraphQLException:
+        assert True
 
 
 def test_results_neutral_loss_chem_mod(advanced_dataset: SMDataset):

--- a/metaspace/python-client/metaspace/tests/test_sm_dataset.py
+++ b/metaspace/python-client/metaspace/tests/test_sm_dataset.py
@@ -4,7 +4,13 @@ from tempfile import TemporaryDirectory
 import pytest
 import numpy as np
 
-from metaspace.sm_annotation_utils import IsotopeImages, SMDataset, GraphQLClient, SMInstance, GraphQLException
+from metaspace.sm_annotation_utils import (
+    IsotopeImages,
+    SMDataset,
+    GraphQLClient,
+    SMInstance,
+    GraphQLException,
+)
 from metaspace.tests.utils import sm, my_ds_id, advanced_ds_id
 
 


### PR DESCRIPTION
This fixes two issues that would make a python-client release potentially problematic.

I moved the default database filter out of `GraphQLClient.getAnnotations` into `SMDataset.results` and `SMDataset.annotations`. Several reasons:
* Due to `database` being converted to `databaseId` in the `SMDataset` layer, `database` was being re-added in the `GraphQLClient` layer. GraphQL gives priority to `databaseId`, but it caused warnings to be printed, and made it impossible to remove the database filter entirely.
* Due to weird indentation that probably resulted from a merge conflict, the default filters were only applied in `GraphQLClient` when some value was supplied for `annotationFilter`. This meant that anyone using `GraphQLClient` directly could get very unexpected behavior when adding/removing filters.
* Having the defaults in the low-level methods has caused a lot of issues in the past, as it's really easy to change the code in the high-level layer in a way that makes it impossible to remove the filter by overriding the default value with an explicit `None`.

For forwards compatibility with the discussed change, I made `map_database_to_id` handle both integer and stringified integer IDs, and added some tests, and cleaned up a few places where passing no database at all may have caused issues.

Also, I changed how `json_normalize` is used so that it doesn't log `DeprecationWarning`s with Pandas >=1.0.0