### PR TITLE
Include environment/revision in Sentry error reports

### DIFF
--- a/ansible/roles/metaspace_repo/tasks/main.yml
+++ b/ansible/roles/metaspace_repo/tasks/main.yml
@@ -41,13 +41,22 @@
 
 - name: Save git version as a variable
   shell: git rev-parse HEAD
-  register: metaspace_repo_revision
+  args:
+    chdir: "{{ metaspace_home }}"
+  register: metaspace_repo_revision_git
   when: local_deploy is not defined
 
 - name: Save git version as a variable (local_deploy)
   shell: echo local_deploy
-  register: metaspace_repo_revision
+  register: metaspace_repo_revision_local
   when: local_deploy is defined
+
+# Workaround for Ansible not providing an intuitive way to use "register" in branching tasks
+# https://github.com/ansible/ansible/issues/4297
+- name: Merge git version variables
+  set_fact:
+    metaspace_repo_revision: "{{ metaspace_repo_revision_git.stdout if local_deploy is not defined else metaspace_repo_revision_local.stdout }}"
+
 
 # Double check all exclude paths
 - name: Upload local files

--- a/ansible/roles/metaspace_repo/tasks/main.yml
+++ b/ansible/roles/metaspace_repo/tasks/main.yml
@@ -39,6 +39,16 @@
     force: yes
   when: local_deploy is not defined
 
+- name: Save git version as a variable
+  shell: git rev-parse HEAD
+  register: metaspace_repo_revision
+  when: local_deploy is not defined
+
+- name: Save git version as a variable (local_deploy)
+  shell: echo local_deploy
+  register: metaspace_repo_revision
+  when: local_deploy is defined
+
 # Double check all exclude paths
 - name: Upload local files
   synchronize:

--- a/metaspace/graphql/config/config.js.template
+++ b/metaspace/graphql/config/config.js.template
@@ -53,6 +53,7 @@ config.jwt.algorithm = "HS256";
 config.sentry = {
   dsn: "{{ sentry_dsn }}",
   serverName: "{{ stage }}",
+  release: "{{ metaspace_repo_revision }}",
 };
 
 config.aws = {

--- a/metaspace/graphql/config/config.js.template
+++ b/metaspace/graphql/config/config.js.template
@@ -52,6 +52,7 @@ config.jwt.algorithm = "HS256";
 
 config.sentry = {
   dsn: "{{ sentry_dsn }}",
+  serverName: "{{ stage }}",
 };
 
 config.aws = {

--- a/metaspace/graphql/config/config.js.template
+++ b/metaspace/graphql/config/config.js.template
@@ -52,7 +52,7 @@ config.jwt.algorithm = "HS256";
 
 config.sentry = {
   dsn: "{{ sentry_dsn }}",
-  serverName: "{{ stage }}",
+  environment: "{{ stage | replace('/', '_') }}",
   release: "{{ metaspace_repo_revision }}",
 };
 

--- a/metaspace/graphql/config/default.js
+++ b/metaspace/graphql/config/default.js
@@ -100,6 +100,7 @@ module.exports = {
 
   sentry: {
     dsn: null,
+    serverName: "default",
   },
 
   google: {

--- a/metaspace/graphql/config/default.js
+++ b/metaspace/graphql/config/default.js
@@ -100,7 +100,7 @@ module.exports = {
 
   sentry: {
     dsn: null,
-    serverName: "default",
+    environment: "default",
   },
 
   google: {

--- a/metaspace/graphql/package.json
+++ b/metaspace/graphql/package.json
@@ -25,7 +25,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@sentry/node": "^5.15.5",
+    "@sentry/node": "^5.20.1",
     "@types/amqplib": "^0.5.9",
     "@types/aws-sdk": "^2.7.0",
     "@types/bcrypt": "^3.0.0",

--- a/metaspace/graphql/server.js
+++ b/metaspace/graphql/server.js
@@ -48,7 +48,7 @@ const configureSession = (app) => {
 
 const configureSentryRequestHandler = (app) => {
   if (env !== 'development' && config.sentry.dsn) {
-    Sentry.init({ dsn: config.sentry.dsn });
+    Sentry.init({ dsn: config.sentry.dsn, serverName: config.sentry.serverName });
     // Sentry.Handlers.requestHandler should be the first middleware
     app.use(Sentry.Handlers.requestHandler());
   }

--- a/metaspace/graphql/server.js
+++ b/metaspace/graphql/server.js
@@ -48,7 +48,7 @@ const configureSession = (app) => {
 
 const configureSentryRequestHandler = (app) => {
   if (env !== 'development' && config.sentry.dsn) {
-    Sentry.init({ dsn: config.sentry.dsn, serverName: config.sentry.serverName });
+    Sentry.init(config.sentry);
     // Sentry.Handlers.requestHandler should be the first middleware
     app.use(Sentry.Handlers.requestHandler());
   }

--- a/metaspace/graphql/src/utils/config.ts
+++ b/metaspace/graphql/src/utils/config.ts
@@ -81,7 +81,7 @@ export interface Config {
   };
   sentry: {
     dsn: string | null;
-    serverName?: string;
+    environment?: string;
     release?: string;
   };
   features: {

--- a/metaspace/graphql/src/utils/config.ts
+++ b/metaspace/graphql/src/utils/config.ts
@@ -81,7 +81,8 @@ export interface Config {
   };
   sentry: {
     dsn: string | null;
-    serverName: string;
+    serverName?: string;
+    release?: string;
   };
   features: {
     graphqlMocks: boolean;

--- a/metaspace/graphql/src/utils/config.ts
+++ b/metaspace/graphql/src/utils/config.ts
@@ -81,6 +81,7 @@ export interface Config {
   };
   sentry: {
     dsn: string | null;
+    serverName: string;
   };
   features: {
     graphqlMocks: boolean;

--- a/metaspace/graphql/yarn.lock
+++ b/metaspace/graphql/yarn.lock
@@ -560,83 +560,83 @@
   resolved "https://registry.yarnpkg.com/@request/interface/-/interface-0.1.0.tgz#c913504d3dc2810afad555b599aeaec2cc4c6768"
   integrity sha1-yRNQTT3CgQr61VW1ma6uwsxMZ2g=
 
-"@sentry/apm@5.15.5":
-  version "5.15.5"
-  resolved "https://registry.yarnpkg.com/@sentry/apm/-/apm-5.15.5.tgz#dc0515f16405de52b3ba0d26f8a6dc2fcefe5fcc"
-  integrity sha512-2PyifsiQdvFEQhbL7tQnCKGLOO1JtZeqso3bc6ARJBvKxM77mtyMo/D0C2Uzt9sXCYiALhQ1rbB1aY8iYyglpg==
+"@sentry/apm@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@sentry/apm/-/apm-5.20.1.tgz#2126407ec8ecc6f78f42a8a8de99b90dec982036"
+  integrity sha512-oqfyYqRR1CaM/U5qZg3KY9MxCe4OWYs3uiOvVGMOHCyx50dYsDZziM5DDVUvi6pOuokLCNbyXO9xGROSmploBQ==
   dependencies:
-    "@sentry/browser" "5.15.5"
-    "@sentry/hub" "5.15.5"
-    "@sentry/minimal" "5.15.5"
-    "@sentry/types" "5.15.5"
-    "@sentry/utils" "5.15.5"
+    "@sentry/browser" "5.20.1"
+    "@sentry/hub" "5.20.1"
+    "@sentry/minimal" "5.20.1"
+    "@sentry/types" "5.20.1"
+    "@sentry/utils" "5.20.1"
     tslib "^1.9.3"
 
-"@sentry/browser@5.15.5":
-  version "5.15.5"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.15.5.tgz#d9a51f1388581067b50d30ed9b1aed2cbb333a36"
-  integrity sha512-rqDvjk/EvogfdbZ4TiEpxM/lwpPKmq23z9YKEO4q81+1SwJNua53H60dOk9HpRU8nOJ1g84TMKT2Ov8H7sqDWA==
+"@sentry/browser@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.20.1.tgz#be59522d0914d58309e1367d997d4b3cd5385d7e"
+  integrity sha512-ClykuvrEsMKgAvifx5VHzRjchwYbJFX8YiIicYx+Wr3MXL2jLG6OEfHHJwJeyBL2C3vxd5O0KPK3pGMR9wPMLA==
   dependencies:
-    "@sentry/core" "5.15.5"
-    "@sentry/types" "5.15.5"
-    "@sentry/utils" "5.15.5"
+    "@sentry/core" "5.20.1"
+    "@sentry/types" "5.20.1"
+    "@sentry/utils" "5.20.1"
     tslib "^1.9.3"
 
-"@sentry/core@5.15.5":
-  version "5.15.5"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.15.5.tgz#40ea79bff5272d3fbbeeb4a98cdc59e1adbd2c92"
-  integrity sha512-enxBLv5eibBMqcWyr+vApqeix8uqkfn0iGsD3piKvoMXCgKsrfMwlb/qo9Ox0lKr71qIlZVt+9/A2vZohdgnlg==
+"@sentry/core@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.20.1.tgz#857cc7186931c37ff032a1bcb573600ebacde961"
+  integrity sha512-gG622/UY2TePruF6iUzgVrbIX5vN8w2cjlWFo1Est8MvCfQsz8agGaLMCAyl5hCGJ6K2qTUZDOlbCNIKoMclxg==
   dependencies:
-    "@sentry/hub" "5.15.5"
-    "@sentry/minimal" "5.15.5"
-    "@sentry/types" "5.15.5"
-    "@sentry/utils" "5.15.5"
+    "@sentry/hub" "5.20.1"
+    "@sentry/minimal" "5.20.1"
+    "@sentry/types" "5.20.1"
+    "@sentry/utils" "5.20.1"
     tslib "^1.9.3"
 
-"@sentry/hub@5.15.5":
-  version "5.15.5"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.15.5.tgz#f5abbcdbe656a70e2ff02c02a5a4cffa0f125935"
-  integrity sha512-zX9o49PcNIVMA4BZHe//GkbQ4Jx+nVofqU/Il32/IbwKhcpPlhGX3c1sOVQo4uag3cqd/JuQsk+DML9TKkN0Lw==
+"@sentry/hub@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.20.1.tgz#05e83ba972a96e9d7225a64c7d3728aa9fcefc4e"
+  integrity sha512-Nv5BXf14BEc08acDguW6eSqkAJLVf8wki283FczEvTsQZZuSBHM9cJ5Hnehr6n+mr8wWpYLgUUYM0oXXigUmzQ==
   dependencies:
-    "@sentry/types" "5.15.5"
-    "@sentry/utils" "5.15.5"
+    "@sentry/types" "5.20.1"
+    "@sentry/utils" "5.20.1"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.15.5":
-  version "5.15.5"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.15.5.tgz#a0e4e071f01d9c4d808094ae7203f6c4cca9348a"
-  integrity sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==
+"@sentry/minimal@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.20.1.tgz#2e2b63d9cd265b7e2f593f3eab4e9874bd87eeef"
+  integrity sha512-2PeJKDTHNsUd1jtSLQBJ6oRI+xrIJrYDQmsyK/qs9D7HqHfs+zNAMUjYseiVeSAFGas5IcNSuZbPRV4BnuoZ0w==
   dependencies:
-    "@sentry/hub" "5.15.5"
-    "@sentry/types" "5.15.5"
+    "@sentry/hub" "5.20.1"
+    "@sentry/types" "5.20.1"
     tslib "^1.9.3"
 
-"@sentry/node@^5.15.5":
-  version "5.15.5"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-5.15.5.tgz#f64cfcf8770cc0249f48b3ef439a7efcabdcec1d"
-  integrity sha512-BK0iTOiiIM0UnydLeT/uUBY1o1Sp85aqwaQRMfZbjMCsgXERLNGvzzV68FDH1cyC1nR6dREK3Gs8bxS4S54aLQ==
+"@sentry/node@^5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-5.20.1.tgz#c38dd8c1f8f227420abb0c04354177d7296535bf"
+  integrity sha512-43YFDnD7Rv+vGHV+Fmb3LaSSWrFzsPmFRu3wmf9eYMgWiuDks6c6/kWRCgkqX9Np9ImC89wcTZs/V6S4MlOm4g==
   dependencies:
-    "@sentry/apm" "5.15.5"
-    "@sentry/core" "5.15.5"
-    "@sentry/hub" "5.15.5"
-    "@sentry/types" "5.15.5"
-    "@sentry/utils" "5.15.5"
-    cookie "^0.3.1"
-    https-proxy-agent "^4.0.0"
+    "@sentry/apm" "5.20.1"
+    "@sentry/core" "5.20.1"
+    "@sentry/hub" "5.20.1"
+    "@sentry/types" "5.20.1"
+    "@sentry/utils" "5.20.1"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/types@5.15.5":
-  version "5.15.5"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.15.5.tgz#16c97e464cf09bbd1d2e8ce90d130e781709076e"
-  integrity sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw==
+"@sentry/types@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.20.1.tgz#ccc4fa4c9d0f94d93014b04e674762d5d5cd30a2"
+  integrity sha512-OU+i/lcjGpDJv0XkNpsKrI2r1VPp8qX0H6Knq8NuZrlZe3AbvO3jRJJK0pH14xFv8Xok5jbZZpKKoQLxYfxqsw==
 
-"@sentry/utils@5.15.5":
-  version "5.15.5"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.15.5.tgz#dec1d4c79037c4da08b386f5d34409234dcbfb15"
-  integrity sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==
+"@sentry/utils@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.20.1.tgz#68cfae0d0e3b321b4649b59f30265024b29eae63"
+  integrity sha512-dhK6IdO6g7Q2CoxCbB+q8gwUapDUH5VjraFg0UBzgkrtNhtHLylqmwx0sWQvXCcp14Q/3MuzEbb4euvoh8o8oA==
   dependencies:
-    "@sentry/types" "5.15.5"
+    "@sentry/types" "5.20.1"
     tslib "^1.9.3"
 
 "@sinonjs/commons@^1.7.0":
@@ -1217,10 +1217,12 @@ acorn@^7.1.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
   integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
 
-agent-base@5:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
-  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
+agent-base@6:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.1.tgz#808007e4e5867decb0ab6ab2f928fbdb5a596db4"
+  integrity sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==
+  dependencies:
+    debug "4"
 
 ajv@4.10.0:
   version "4.10.0"
@@ -2421,7 +2423,7 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.3.1, cookie@^0.3.1:
+cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
@@ -2430,6 +2432,11 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+cookie@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 cookiejar@^2.1.0:
   version "2.1.2"
@@ -3961,12 +3968,12 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-proxy-agent@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
-  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
   dependencies:
-    agent-base "5"
+    agent-base "6"
     debug "4"
 
 human-signals@^1.1.1:
@@ -5263,11 +5270,6 @@ lodash.uniqby@4.5.0:
     lodash._baseuniq "~4.6.0"
 
 lodash@^4.12.0, lodash@^4.13.1, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
-lodash@^4.17.19:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==

--- a/metaspace/webapp/package.json
+++ b/metaspace/webapp/package.json
@@ -28,6 +28,8 @@
   },
   "dependencies": {
     "@fullhuman/postcss-purgecss": "^2.1.0",
+    "@sentry/browser": "^5.20.1",
+    "@sentry/integrations": "^5.20.1",
     "@types/js-cookie": "^2.1.0",
     "@types/marked": "^0.6.2",
     "@types/sanitize-html": "^1.18.2",
@@ -58,7 +60,6 @@
     "plotly.js": "^1.34.0",
     "popper.js": "^1.14.7",
     "querystring": "^0.2.0",
-    "raven-js": "^3.25.2",
     "sanitize-html": "^1.20.0",
     "simple-statistics": "^7.0.2",
     "subscriptions-transport-ws": "^0.9.16",

--- a/metaspace/webapp/src/clientConfig.json.template
+++ b/metaspace/webapp/src/clientConfig.json.template
@@ -17,7 +17,11 @@
     "storage": "{{ sm_webapp_upload_destination }}"
   },
 
-  "ravenDsn": "{{ sentry_dsn }}",
+  "sentry": {
+    "dsn": "{{ sentry_dsn }}",
+    "serverName": "{{ stage }}",
+    "release": "{{ metaspace_repo_revision }}",
+  },
 
   "metadataTypes": {{ sm_webapp_metadata_types | to_json }},
 

--- a/metaspace/webapp/src/clientConfig.json.template
+++ b/metaspace/webapp/src/clientConfig.json.template
@@ -19,8 +19,8 @@
 
   "sentry": {
     "dsn": "{{ sentry_dsn }}",
-    "serverName": "{{ stage }}",
-    "release": "{{ metaspace_repo_revision }}",
+    "environment": "{{ stage | replace('/', '_') }}",
+    "release": "{{ metaspace_repo_revision }}"
   },
 
   "metadataTypes": {{ sm_webapp_metadata_types | to_json }},

--- a/metaspace/webapp/src/lib/config.ts
+++ b/metaspace/webapp/src/lib/config.ts
@@ -50,7 +50,11 @@ interface ClientConfig {
   google_client_id: string;
 
   fineUploader: FineUploaderConfig;
-  ravenDsn: string | null;
+  sentry: null | {
+    dsn: string;
+    environment?: string;
+    release?: string;
+  };
   metadataTypes: string[];
   features: Features;
 }
@@ -63,7 +67,7 @@ const defaultConfig: ClientConfig = {
   fineUploader: {
     storage: 'local',
   },
-  ravenDsn: null,
+  sentry: null,
   metadataTypes: ['ims'],
   features: {
     coloc: true,

--- a/metaspace/webapp/src/lib/reportError.ts
+++ b/metaspace/webapp/src/lib/reportError.ts
@@ -1,5 +1,5 @@
 import { ElNotification } from 'element-ui/types/notification'
-import * as Raven from 'raven-js'
+import * as Sentry from '@sentry/browser'
 import { every } from 'lodash-es'
 
 let $notify: ElNotification
@@ -21,7 +21,7 @@ const DEFAULT_MESSAGE = 'Oops! Something went wrong. Please refresh the page and
 export default function reportError(err: Error, message: string | null = DEFAULT_MESSAGE) {
   try {
     if (!isHandled(err)) {
-      Raven.captureException(err)
+      Sentry.captureException(err)
       console.error(err)
       if ($notify != null && message) {
         $notify.error(message)

--- a/metaspace/webapp/src/main.ts
+++ b/metaspace/webapp/src/main.ts
@@ -1,8 +1,8 @@
 import Vue from 'vue'
 
 import config, { updateConfigFromQueryString } from './lib/config'
-import * as Raven from 'raven-js'
-import * as RavenVue from 'raven-js/plugins/vue'
+import * as Sentry from '@sentry/browser'
+import { Vue as SentryVue } from '@sentry/integrations/dist/vue'
 
 import VueApollo from 'vue-apollo'
 import { DefaultApolloClient } from '@vue/apollo-composable'
@@ -28,10 +28,11 @@ import VueCompositionApi from '@vue/composition-api'
 
 Vue.use(VueCompositionApi)
 
-if (config.ravenDsn != null && config.ravenDsn !== '') {
-  Raven.config(config.ravenDsn)
-    .addPlugin(RavenVue, Vue)
-    .install()
+if (config.sentry != null && config.sentry.dsn !== '') {
+  Sentry.init({
+    ...config.sentry,
+    integrations: [new SentryVue({ Vue, logErrors: true })],
+  })
 }
 Vue.use(VueApollo)
 

--- a/metaspace/webapp/src/types/vue-shims.d.ts
+++ b/metaspace/webapp/src/types/vue-shims.d.ts
@@ -10,7 +10,6 @@ declare module '*.svg' {
 }
 
 declare module 'vue-analytics'
-declare module 'raven-js/plugins/vue'
 
 declare module 'plotly.js/src/components/colorscale/scales.js'
 declare module 'plotly.js/src/components/colorscale/extract_scale.js'

--- a/metaspace/webapp/yarn.lock
+++ b/metaspace/webapp/yarn.lock
@@ -1458,6 +1458,67 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sentry/browser@^5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.20.1.tgz#be59522d0914d58309e1367d997d4b3cd5385d7e"
+  integrity sha512-ClykuvrEsMKgAvifx5VHzRjchwYbJFX8YiIicYx+Wr3MXL2jLG6OEfHHJwJeyBL2C3vxd5O0KPK3pGMR9wPMLA==
+  dependencies:
+    "@sentry/core" "5.20.1"
+    "@sentry/types" "5.20.1"
+    "@sentry/utils" "5.20.1"
+    tslib "^1.9.3"
+
+"@sentry/core@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.20.1.tgz#857cc7186931c37ff032a1bcb573600ebacde961"
+  integrity sha512-gG622/UY2TePruF6iUzgVrbIX5vN8w2cjlWFo1Est8MvCfQsz8agGaLMCAyl5hCGJ6K2qTUZDOlbCNIKoMclxg==
+  dependencies:
+    "@sentry/hub" "5.20.1"
+    "@sentry/minimal" "5.20.1"
+    "@sentry/types" "5.20.1"
+    "@sentry/utils" "5.20.1"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.20.1.tgz#05e83ba972a96e9d7225a64c7d3728aa9fcefc4e"
+  integrity sha512-Nv5BXf14BEc08acDguW6eSqkAJLVf8wki283FczEvTsQZZuSBHM9cJ5Hnehr6n+mr8wWpYLgUUYM0oXXigUmzQ==
+  dependencies:
+    "@sentry/types" "5.20.1"
+    "@sentry/utils" "5.20.1"
+    tslib "^1.9.3"
+
+"@sentry/integrations@^5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-5.20.1.tgz#c42dd53c2162b96bf4da641cd1c2bd53c0bbdce3"
+  integrity sha512-VpeZHYT8Fvw1J5478MqXXORf3Ftpt34YM4e+sTPuGrmf4Gro7lXdyownqiSaa7kwwNVQEV3zMlRDczVZzXQThw==
+  dependencies:
+    "@sentry/types" "5.20.1"
+    "@sentry/utils" "5.20.1"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.20.1.tgz#2e2b63d9cd265b7e2f593f3eab4e9874bd87eeef"
+  integrity sha512-2PeJKDTHNsUd1jtSLQBJ6oRI+xrIJrYDQmsyK/qs9D7HqHfs+zNAMUjYseiVeSAFGas5IcNSuZbPRV4BnuoZ0w==
+  dependencies:
+    "@sentry/hub" "5.20.1"
+    "@sentry/types" "5.20.1"
+    tslib "^1.9.3"
+
+"@sentry/types@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.20.1.tgz#ccc4fa4c9d0f94d93014b04e674762d5d5cd30a2"
+  integrity sha512-OU+i/lcjGpDJv0XkNpsKrI2r1VPp8qX0H6Knq8NuZrlZe3AbvO3jRJJK0pH14xFv8Xok5jbZZpKKoQLxYfxqsw==
+
+"@sentry/utils@5.20.1":
+  version "5.20.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.20.1.tgz#68cfae0d0e3b321b4649b59f30265024b29eae63"
+  integrity sha512-dhK6IdO6g7Q2CoxCbB+q8gwUapDUH5VjraFg0UBzgkrtNhtHLylqmwx0sWQvXCcp14Q/3MuzEbb4euvoh8o8oA==
+  dependencies:
+    "@sentry/types" "5.20.1"
+    tslib "^1.9.3"
+
 "@soda/friendly-errors-webpack-plugin@^1.7.1":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@soda/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.1.tgz#706f64bcb4a8b9642b48ae3ace444c70334d615d"
@@ -14414,10 +14475,6 @@ rat-vec@^1.1.1:
   resolved "https://registry.yarnpkg.com/rat-vec/-/rat-vec-1.1.1.tgz#0dde2b66b7b34bb1bcd2a23805eac806d87fd17f"
   dependencies:
     big-rat "^1.0.3"
-
-raven-js@^3.25.2:
-  version "3.25.2"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.25.2.tgz#d3ad1c694f70855dda6f705204ee6ab76ba62884"
 
 raw-body@2.4.0:
   version "2.4.0"


### PR DESCRIPTION
* Updated Sentry so that it gives slightly more environmental info, e.g. props for the current Vue component, if the error occurs during a Vue callback.
* Included the environment so that we can can exclude notifications for error reports from Staging, meaning fewer false alarms in the Slack channel.
* Included the git revision as a release name, so that we can mark errors as "resolved in next release", and it will re-trigger the alert if the error isn't solved after the next deployment