### PR TITLE
Disable type checking graphql during deployment 

### DIFF
--- a/ansible/roles/sm_graphql/templates/sm-graphql.supervisor.j2
+++ b/ansible/roles/sm_graphql/templates/sm-graphql.supervisor.j2
@@ -2,7 +2,7 @@
 
 [program:{{ sm_graphql_app_name }}]
 process_name = {{ sm_graphql_app_name }}
-environment = NODE_ENV="production"
+environment = NODE_ENV="production",TS_NODE_TRANSPILE_ONLY="true"
 directory = {{ sm_graphql_home }}
 command = bash -c '. ~/.nvm/nvm.sh && nvm use && exec yarn run start'
 redirect_stderr = true


### PR DESCRIPTION
sm-graphql's startup time gets slower as the project grows. Now it's ~30s, which causes noticeable downtime when deploying.

This change turns off type checking, which greatly reduces downtime. After this change it's only 6.5s on Staging.

As sm-graphql is vital to METASPACE's operation, I think that in the case that a type error is deployed, it's better to start the service in partially functional state than to fail the deployment and cause more downtime. With Sentry and CircleCI, it's unlikely that type errors deployed to production could go unnoticed for long.