### PR TITLE
Security fixes & small tweaks

### DIFF
--- a/docker/sm-engine/requirements.txt
+++ b/docker/sm-engine/requirements.txt
@@ -14,7 +14,7 @@ pyyaml
 elasticsearch-dsl>=5.0.0,<6.0.0
 pika==0.11.0b1
 bottle
-Pillow==6.2.0
+Pillow==7.2.0
 pyopenms==2.2.0
 numpy>=1.11.2
 scipy>=0.18.1

--- a/docker/sm-graphql/docker-entrypoint.sh
+++ b/docker/sm-graphql/docker-entrypoint.sh
@@ -18,7 +18,9 @@ if [ "$SM_DOCKER_ENV" = "development" ]; then
   export NODE_ENV=development
   cd /opt/dev/metaspace/metaspace/graphql
   yarn install
+  npm rebuild bcrypt # Ensure the musl version is installed
   yarn run deref-schema
+  yarn run gen-binding
   nodemon -e graphql -q --exec "yarn run gen-binding" &
   # exec nodemon -e js,json,ts --require ts-node/register server.js
   exec yarn exec ts-node-dev -- --respawn server.js

--- a/docker/sm-webapp/docker-entrypoint.sh
+++ b/docker/sm-webapp/docker-entrypoint.sh
@@ -16,6 +16,7 @@ if [ "$SM_DOCKER_ENV" = "development" ]; then
   export NODE_ENV=development
   cd /opt/dev/metaspace/metaspace/webapp
   yarn install
+  npm rebuild node-sass # Ensure the musl version is installed
 else
   export NODE_ENV=production
   cd /opt/metaspace/metaspace/webapp

--- a/metaspace/engine/requirements.txt
+++ b/metaspace/engine/requirements.txt
@@ -14,7 +14,7 @@ pyyaml>=5.1
 elasticsearch-dsl>=5.0.0,<6.0.0
 pika==0.11.0b1
 bottle
-Pillow==6.2.0
+Pillow==7.2.0
 pyopenms==2.2.0
 numpy>=1.11.2
 scipy>=0.18.1

--- a/metaspace/engine/sm/engine/colocalization.py
+++ b/metaspace/engine/sm/engine/colocalization.py
@@ -143,15 +143,21 @@ def _label_clusters(scores):
 
     results = []
     last_error = None
-    for n_clusters in range(min_clusters, max_clusters + 1):
-        try:
-            labels = spectral_clustering(
-                affinity=scores, n_clusters=n_clusters, random_state=1, n_init=100
-            )
-            cluster_score = np.mean([scores[a, b] for a, b in enumerate(labels)])
-            results.append((n_clusters, cluster_score, labels))
-        except Exception as e:
-            last_error = e
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            'ignore',
+            '.*Graph is not fully connected, spectral embedding may not work as expected.*',
+        )
+        for n_clusters in range(min_clusters, max_clusters + 1):
+            try:
+                labels = spectral_clustering(
+                    affinity=scores, n_clusters=n_clusters, random_state=1, n_init=100
+                )
+                cluster_score = np.mean([scores[a, b] for a, b in enumerate(labels)])
+                results.append((n_clusters, cluster_score, labels))
+            except Exception as e:
+                last_error = e
 
     if not results:
         raise last_error

--- a/metaspace/graphql/config/default.js
+++ b/metaspace/graphql/config/default.js
@@ -34,7 +34,7 @@ module.exports = {
       iso_image: {
         type: 'image/png',
         path: '/iso_images/',
-        storage_types: ['fs', 'db']
+        storage_types: ['fs']
       },
       optical_image: {
         type: 'image/jpeg',

--- a/metaspace/graphql/config/test.js
+++ b/metaspace/graphql/config/test.js
@@ -21,7 +21,7 @@ config.img_upload = {
     iso_image: {
       type: 'image/png',  // applies only to post requests
       path: '/iso_images/',
-      storage_types: ['fs', 'db']
+      storage_types: ['fs']
     },
     optical_image: {
       type: 'image/jpeg',

--- a/metaspace/graphql/esConnector.ts
+++ b/metaspace/graphql/esConnector.ts
@@ -23,7 +23,7 @@ export interface ESAnnotation {
   _source: ESAnnotationSource;
 }
 
-export type ImageStorageType = 'fs' | 'db';
+export type ImageStorageType = 'fs';
 
 export interface ESDatasetSource {
   ds_id: string;

--- a/metaspace/graphql/package.json
+++ b/metaspace/graphql/package.json
@@ -64,7 +64,6 @@
     "express": "^4.14.0",
     "express-session": "^1.15.6",
     "fs-extra": "^4.0.3",
-    "get-pixels": "^3.3.0",
     "graphql": "^14.5.3",
     "graphql-errors": "^2.1.0",
     "graphql-subscriptions": "^1.1.0",

--- a/metaspace/graphql/src/modules/webServer/storageServer.test.ts
+++ b/metaspace/graphql/src/modules/webServer/storageServer.test.ts
@@ -3,35 +3,30 @@
  * @jest-environment node
  */
 import * as supertest from 'supertest';
-import * as Knex from 'knex';
 import * as fs from 'fs';
 
 import config, {ImageStorageType} from '../../utils/config';
 import logger from '../../utils/logger';
-import {createStorageServerApp, initDBConnection} from './storageServer';
+import {createStorageServerApp} from './storageServer';
 
 
 const getRespMimeMap = {
-  fs: 'image/png',
-  db: 'application/octet-stream'
+  fs: 'image/png'
 };
 
-describe('imageUploadTest with fs and db backends', () => {
-  (['db', 'fs'] as ImageStorageType[]).forEach( (storageType) => {
+describe('imageUploadTest with fs backend', () => {
+  (['fs'] as ImageStorageType[]).forEach( (storageType) => {
 
     describe(`${storageType} storage type`, () => {
       let server: supertest.SuperTest<supertest.Test>;
-      let knex: Knex;
 
       beforeAll(async () => {
         logger.info('> Before all');
-        knex = initDBConnection();
-        server = supertest(await createStorageServerApp(config, knex));
+        server = supertest(await createStorageServerApp(config));
       });
 
       afterAll(async () => {
         logger.info('> After all');
-        await knex.destroy();
       });
 
       let image_id: string;

--- a/metaspace/graphql/src/modules/webServer/storageServer.ts
+++ b/metaspace/graphql/src/modules/webServer/storageServer.ts
@@ -3,7 +3,6 @@
  */
 import * as express from 'express';
 import * as http from 'http';
-import * as Knex from 'knex';
 import * as multer from 'multer';
 import * as path from 'path';
 import * as cors from 'cors';
@@ -12,123 +11,11 @@ import * as fs from 'fs-extra';
 import * as companion from '@uppy/companion';
 import * as bodyParser from "body-parser";
 import * as genUuid from "uuid";
-const getPixels = require('get-pixels');
 import logger from '../../utils/logger';
-import config, {Config, ImageCategory} from '../../utils/config';
+import {Config, ImageCategory} from '../../utils/config';
 import fineUploaderS3Middleware from './fineUploaderS3Middleware';
 import fineUploaderLocalMiddleware from './fineUploaderLocalMiddleware';
 
-export const IMG_TABLE_NAME = 'image';
-
-type NDArray = any;
-
-const defaultDBConfig = () => {
-  const {host, database, user, password} = config.db;
-  return {
-    host, database, user, password,
-    max: 10, // client pool size
-    idleTimeoutMillis: 30000
-  };
-};
-
-export const initDBConnection = (config = defaultDBConfig) => {
-  return Knex({
-    client: 'pg',
-    connection: config(),
-    searchPath: ['engine', 'public'],
-    // @ts-ignore
-    asyncStackTraces: true,
-  });
-};
-
-function imageProviderDBBackend(knex: Knex) {
-  /**
-   @param {object} knex - knex database handler
-   **/
-  return async (app: express.Application, category: ImageCategory, mimeType: string, basePath: string, categoryPath: string) => {
-    /**
-     @param {string} category - field name / database table name
-     @param {string} mimeType - e.g. 'image/png' or 'image/jpeg'
-     @param {string} basePath - base URL path to the backend, e.g. '/db/'
-     @param {string} categoryPath - URL path to the backend serving the given category of images, e.g. '/iso_images/'
-     **/
-    let storage = multer.memoryStorage();
-    let upload = multer({storage: storage});
-    let pixelsToBinary = (pixels: NDArray) => {
-      // assuming pixels are stored as rgba
-      const result = Buffer.allocUnsafe(pixels.data.length / 4);
-      for (let i = 0; i < pixels.data.length; i += 4) {
-        result.writeUInt8(pixels.data[i], i / 4);
-      }
-      return result;
-    };
-
-    const imgTableExists = await knex.schema.hasTable(IMG_TABLE_NAME);
-    if (!imgTableExists) {
-      await knex.schema.createTable(IMG_TABLE_NAME, function (table) {
-        table.text('id').primary();
-        table.text('category');
-        table.binary('data');
-      });
-    }
-    let uri = path.join(basePath, categoryPath, ":image_id");
-    app.get(uri,
-      async function (req, res) {
-        try {
-          const row = await knex.select(knex.raw('data')).from(IMG_TABLE_NAME).where('id', '=', req.params.image_id).first();
-          if (row === undefined) {
-            throw Error(`Image with id=${req.params.image_id} does not exist`);
-          }
-          const imgBuf = row.data;
-          res.type('application/octet-stream');
-          res.end(imgBuf, 'binary');
-        } catch (e) {
-          logger.error(e.message);
-          res.status(404).send('Not found');
-        }
-      });
-    logger.debug(`Accepting GET on ${uri}`);
-
-    uri = path.join(basePath, categoryPath, 'upload');
-    app.post(uri, upload.single(category),
-      function (req, res) {
-        logger.debug(req.file.originalname);
-        let imgID = crypto.randomBytes(16).toString('hex');
-
-        getPixels(req.file.buffer, mimeType, async function (err?: Error, pixels?: NDArray) {
-          if (err) {
-            logger.error(err.message);
-            res.status(500).send('Failed to parse image');
-          }
-          else {
-            try {
-              let row = {'id': imgID, 'category': category, 'data': pixelsToBinary(pixels)};
-              const m = await knex.insert(row).into(IMG_TABLE_NAME);
-              logger.debug(`${m}`);
-              res.status(201).json({image_id: imgID});
-            } catch (e) {
-              logger.error(e.message);
-              res.status(500).send('Failed to store image');
-            }
-          }
-        });
-      });
-    logger.debug(`Accepting POST on ${uri}`);
-
-    uri = path.join(basePath, categoryPath, 'delete', ':image_id');
-    app.delete(uri,
-      async function (req, res) {
-        try {
-          const m = await knex.del().from(IMG_TABLE_NAME).where('id', '=', req.params.image_id);
-          logger.debug(`${m}`);
-          res.status(202).end();
-        } catch (e) {
-          logger.error(e.message);
-        }
-      });
-    logger.debug(`Accepting DELETE on ${uri}`);
-  }
-}
 
 function imageProviderFSBackend(storageRootDir: string) {
   /**
@@ -197,14 +84,13 @@ function imageProviderFSBackend(storageRootDir: string) {
   }
 }
 
-export async function createStorageServerApp(config: Config, knex: Knex) {
+export async function createStorageServerApp(config: Config) {
   try {
     const app = express();
     app.use(cors());
 
     const backendFactories = {
       'fs': imageProviderFSBackend(config.img_upload.iso_img_fs_path),
-      'db': imageProviderDBBackend(knex)
     };
 
     for (const category of Object.keys(config.img_upload.categories) as ImageCategory[]) {
@@ -227,8 +113,7 @@ export async function createStorageServerApp(config: Config, knex: Knex) {
 }
 
 export async function createStorageServerAsync(config: Config) {
-  const knex = initDBConnection();
-  const app = await createStorageServerApp(config, knex);
+  const app = await createStorageServerApp(config);
 
   const httpServer = http.createServer(app);
   await new Promise((resolve, reject) => {

--- a/metaspace/graphql/src/utils/config.ts
+++ b/metaspace/graphql/src/utils/config.ts
@@ -2,7 +2,7 @@ import * as config from 'config';
 import { IConfig } from 'config';
 import {Algorithm} from 'jsonwebtoken';
 
-export type ImageStorageType = 'db' | 'fs';
+export type ImageStorageType = 'fs';
 export interface ImageCategoryConfig {
   type: string,
   path: string,

--- a/metaspace/graphql/yarn.lock
+++ b/metaspace/graphql/yarn.lock
@@ -1232,16 +1232,6 @@ ajv@4.10.0:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
-  integrity sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
-  dependencies:
-    co "^4.6.0"
-    fast-deep-equal "^1.0.0"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.3.0"
-
 ajv@^6.5.5:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
@@ -1702,11 +1692,6 @@ aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
-
-aws4@^1.6.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
-  integrity sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==
 
 aws4@^1.8.0:
   version "1.9.1"
@@ -2286,13 +2271,6 @@ combine-errors@^3.0.3:
     custom-error-instance "2.1.1"
     lodash.uniqby "4.5.0"
 
-combined-stream@1.0.6, combined-stream@~1.0.5:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
-  integrity sha1-cj599ugBrFYTETp+RFqbactjKBg=
-  dependencies:
-    delayed-stream "~1.0.0"
-
 combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -2567,13 +2545,6 @@ custom-error-instance@2.1.1:
   resolved "https://registry.yarnpkg.com/custom-error-instance/-/custom-error-instance-2.1.1.tgz#3cf6391487a6629a6247eb0ca0ce00081b7e361a"
   integrity sha1-PPY5FIemYppiR+sMoM4ACBt+Nho=
 
-cwise-compiler@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/cwise-compiler/-/cwise-compiler-1.1.3.tgz#f4d667410e850d3a313a7d2db7b1e505bb034cc5"
-  integrity sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=
-  dependencies:
-    uniq "^1.0.0"
-
 cycle@1.0.x:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
@@ -2595,11 +2566,6 @@ dasherize@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dasherize/-/dasherize-2.0.0.tgz#6d809c9cd0cf7bb8952d80fc84fa13d47ddb1308"
   integrity sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg=
-
-data-uri-to-buffer@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-0.0.3.tgz#18ae979a6a0ca994b0625853916d2662bbae0b1a"
-  integrity sha1-GK6XmmoMqZSwYlhTkW0mYruuCxo=
 
 data-urls@^1.1.0:
   version "1.1.0"
@@ -3196,7 +3162,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@^3.0.2, extend@~3.0.1, extend@~3.0.2:
+extend@^3.0.0, extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -3229,11 +3195,6 @@ eyes@0.1.x:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
   integrity sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
-
-fast-deep-equal@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
-  integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
 
 fast-deep-equal@^3.1.1:
   version "3.1.1"
@@ -3406,15 +3367,6 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
-form-data@~2.3.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
-  integrity sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "1.0.6"
-    mime-types "^2.1.12"
-
 formidable@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
@@ -3506,23 +3458,6 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
-
-get-pixels@^3.3.0:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/get-pixels/-/get-pixels-3.3.2.tgz#3f62fb8811932c69f262bba07cba72b692b4ff03"
-  integrity sha512-6ar+8yPxRd1pskEcl2GSEu1La0+xYRjjnkby6AYiRDDwZ0tJbPQmHnSeH9fGLskT8kvR0OukVgtZLcsENF9YKQ==
-  dependencies:
-    data-uri-to-buffer "0.0.3"
-    jpeg-js "^0.3.2"
-    mime-types "^2.0.1"
-    ndarray "^1.0.13"
-    ndarray-pack "^1.1.1"
-    node-bitmap "0.0.1"
-    omggif "^1.0.5"
-    parse-data-uri "^0.2.0"
-    pngjs "^3.3.3"
-    request "^2.44.0"
-    through "^2.3.4"
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -3748,14 +3683,6 @@ har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
-
-har-validator@~5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
-  integrity sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=
-  dependencies:
-    ajv "^5.1.0"
-    har-schema "^2.0.0"
 
 har-validator@~5.1.0, har-validator@~5.1.3:
   version "5.1.3"
@@ -4080,11 +4007,6 @@ invert-kv@^1.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   integrity sha1-EEqOSqym09jNFXqO+L+rLXo//bY=
 
-iota-array@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/iota-array/-/iota-array-1.0.0.tgz#81ef57fe5d05814cd58c2483632a99c30a0e8087"
-  integrity sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc=
-
 ip-address@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-6.2.0.tgz#c1b87c45097874a56a812348e09f92b74d9836fa"
@@ -4147,7 +4069,7 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-buffer@^1.0.2, is-buffer@^1.1.5, is-buffer@~1.1.1:
+is-buffer@^1.1.5, is-buffer@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
@@ -4835,11 +4757,6 @@ jmespath@0.15.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
-jpeg-js@^0.3.2:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.3.4.tgz#dc2ba501ee3d58b7bb893c5d1fab47294917e7e7"
-  integrity sha512-6IzjQxvnlT8UlklNmDXIJMWxijULjqGrzgqc0OG7YadZdvm7KPQ1j0ehmQQHckgEWOfgpptzcnWgESovxudpTA==
-
 js-base64@^2.4.9:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.2.tgz#313b6274dda718f714d00b3330bbae6e38e90209"
@@ -4923,11 +4840,6 @@ json-schema-deref-sync@^0.10.1:
     memory-cache "~0.2.0"
     traverse "~0.6.6"
     valid-url "~1.0.9"
-
-json-schema-traverse@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
-  integrity sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -5492,7 +5404,7 @@ mime-types@2.1.25:
   dependencies:
     mime-db "1.42.0"
 
-mime-types@^2.0.1, mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18:
+mime-types@^2.1.12, mime-types@~2.1.18:
   version "2.1.19"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
   integrity sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==
@@ -5683,22 +5595,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-ndarray-pack@^1.1.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ndarray-pack/-/ndarray-pack-1.2.1.tgz#8caebeaaa24d5ecf70ff86020637977da8ee585a"
-  integrity sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=
-  dependencies:
-    cwise-compiler "^1.1.2"
-    ndarray "^1.0.13"
-
-ndarray@^1.0.13:
-  version "1.0.18"
-  resolved "https://registry.yarnpkg.com/ndarray/-/ndarray-1.0.18.tgz#b60d3a73224ec555d0faa79711e502448fd3f793"
-  integrity sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=
-  dependencies:
-    iota-array "^1.0.0"
-    is-buffer "^1.0.2"
-
 needle@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.5.0.tgz#e6fc4b3cc6c25caed7554bd613a5cf0bac8c31c0"
@@ -5732,11 +5628,6 @@ node-addon-api@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.0.1.tgz#990544a2607ec3f538443df4858f8c40089b7783"
   integrity sha512-YUpjl57P55u2yUaKX5Bgy4t5s6SCNYMg+62XNg+k41aYbBL1NgWrZfcgljR5MxDxHDjzl0qHDNtH6SkW4DXNCA==
-
-node-bitmap@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/node-bitmap/-/node-bitmap-0.0.1.tgz#180eac7003e0c707618ef31368f62f84b2a69091"
-  integrity sha1-GA6scAPgxwdhjvMTaPYvhLKmkJE=
 
 node-fetch@^1.6.3:
   version "1.7.3"
@@ -5892,7 +5783,7 @@ nwsapi@^2.2.0:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
-oauth-sign@^0.8.2, oauth-sign@~0.8.2:
+oauth-sign@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
   integrity sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=
@@ -5990,11 +5881,6 @@ object.pick@^1.2.0, object.pick@^1.3.0:
   integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
   dependencies:
     isobject "^3.0.1"
-
-omggif@^1.0.5:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/omggif/-/omggif-1.0.9.tgz#dcb7024dacd50c52b4d303f04802c91c057c765f"
-  integrity sha1-3LcCTazVDFK00wPwSALJHAV8dl8=
 
 on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"
@@ -6137,13 +6023,6 @@ parent-require@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parent-require/-/parent-require-1.0.0.tgz#746a167638083a860b0eef6732cb27ed46c32977"
   integrity sha1-dGoWdjgIOoYLDu9nMssn7UbDKXc=
-
-parse-data-uri@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/parse-data-uri/-/parse-data-uri-0.2.0.tgz#bf04d851dd5c87b0ab238e5d01ace494b604b4c9"
-  integrity sha1-vwTYUd1ch7CrI45dAazklLYEtMk=
-  dependencies:
-    data-uri-to-buffer "0.0.3"
 
 parse-filepath@^1.0.1:
   version "1.0.2"
@@ -6427,11 +6306,6 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
-pngjs@^3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.3.3.tgz#85173703bde3edac8998757b96e5821d0966a21b"
-  integrity sha512-1n3Z4p3IOxArEs1VRXnZ/RXdfEniAUS9jb68g58FIXMNkPJeZd+Qh4Uq7/e0LVxAQGos1eIUrqrt4FpjdnEd+Q==
-
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -6584,7 +6458,7 @@ qs@6.5.1:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
   integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
 
-qs@6.5.2, qs@~6.5.1, qs@~6.5.2:
+qs@6.5.2, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
@@ -6902,32 +6776,6 @@ request@2.88.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
-request@^2.44.0:
-  version "2.87.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
-  integrity sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.6.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.1"
-    forever-agent "~0.6.1"
-    form-data "~2.3.1"
-    har-validator "~5.0.3"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.17"
-    oauth-sign "~0.8.2"
-    performance-now "^2.1.0"
-    qs "~6.5.1"
-    safe-buffer "^5.1.1"
-    tough-cookie "~2.3.3"
-    tunnel-agent "^0.6.0"
-    uuid "^3.1.0"
-
 request@^2.88.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
@@ -7069,7 +6917,7 @@ safe-buffer@5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
   integrity sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==
 
-safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -7758,7 +7606,7 @@ throat@^5.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
-through@2, through@^2.3.4:
+through@2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -7839,13 +7687,6 @@ tough-cookie@^3.0.1:
     ip-regex "^2.1.0"
     psl "^1.1.28"
     punycode "^2.1.1"
-
-tough-cookie@~2.3.3:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
-  integrity sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==
-  dependencies:
-    punycode "^1.4.1"
 
 tr46@^1.0.1:
   version "1.0.1"
@@ -8102,11 +7943,6 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^2.0.1"
-
-uniq@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
-  integrity sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
* Removed the DB-based image storage. This code had a dependency on an insecure version of the jpeg-js package. Although it was probably trivial to fix, we don't use this storage method, and probably won't ever use it in the future, so I thought it better to just remove the code and the dependency.
    * I've left the fields in place to allow different storage types, as I don't know what the S3/COS storage will look like yet.
* Upgrade Pillow 6.2.0 -> 7.2.0 to address the security advisory. I tested annotation and optical image upload - both worked with no code changes
* Fixed a couple issues in the JS dockerfiles:
    * Yarn doesn't detect when packages need to be rebuilt for the Alpine images' musl libc. I was getting frequent issues caused by missing musl libraries when I `yarn install`ed outside the container.
    * The nodemon-triggered `gen-binding` script often wouldn't finish compilation before TypeScript would try to load it. The solution was to explicitly run gen-binding synchronously before starting the TypeScript process.
* Suppress a spammy warning generated by spectral clustering 