### PR TITLE
Fix molecular_db.find_default()

### DIFF
--- a/metaspace/engine/sm/engine/molecular_db.py
+++ b/metaspace/engine/sm/engine/molecular_db.py
@@ -194,7 +194,7 @@ def find_by_name(name: str) -> MolecularDB:
 
 
 def find_default() -> List[MolecularDB]:
-    data = DB().select_one_with_fields(
+    data = DB().select_with_fields(
         'SELECT id, name, version, targeted, group_id FROM molecular_db WHERE "default" = TRUE',
     )
     return [MolecularDB(**row) for row in data]


### PR DESCRIPTION
With `select_one_with_fields`, `data` is a `dict` instead of a `list` which leads to this error:
```
2020-08-19 10:04:14,918 - ERROR - api[MainThread] - datasets.py:63 - type object argument after ** must be a mapping, not str
Traceback (most recent call last):
  File "/opt/dev/metaspace/metaspace/engine/sm/rest/datasets.py", line 52, in _func
    res = handler(ds_man, ds_id, params)
  File "/opt/dev/metaspace/metaspace/engine/sm/rest/datasets.py", line 107, in add
    priority=params.get('priority', DatasetActionPriority.DEFAULT),
  File "/opt/dev/metaspace/metaspace/engine/sm/rest/dataset_manager.py", line 72, in add
    doc['moldb_ids'] = self._add_default_moldbs(doc['moldb_ids'])
  File "/opt/dev/metaspace/metaspace/engine/sm/rest/dataset_manager.py", line 62, in _add_default_moldbs
    default_moldb_ids = [moldb.id for moldb in molecular_db.find_default()]
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/molecular_db.py", line 200, in find_default
    return [MolecularDB(**row) for row in data]
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/molecular_db.py", line 200, in <listcomp>
    return [MolecularDB(**row) for row in data]
TypeError: type object argument after ** must be a mapping, not str
```