### PR TITLE
MolecularDBs feature deployed to staging fixes

### DIFF
--- a/metaspace/engine/scripts/db_schema.sql
+++ b/metaspace/engine/scripts/db_schema.sql
@@ -290,7 +290,7 @@ ALTER TABLE "graphql"."user" ADD CONSTRAINT "FK_1b5eb1327a74d679537bdc1fa5b" FOR
 
 ALTER TABLE "graphql"."coloc_job" ADD CONSTRAINT "FK_b0adf5ffef6529f187f48231e38" FOREIGN KEY (
   "moldb_id") REFERENCES "public"."molecular_db"("id"
-) ON DELETE NO ACTION ON UPDATE NO ACTION;
+) ON DELETE CASCADE ON UPDATE NO ACTION;
 
 ALTER TABLE "graphql"."coloc_annotation" ADD CONSTRAINT "FK_09673424d3aceab89f931b9f20d" FOREIGN KEY (
   "coloc_job_id") REFERENCES "graphql"."coloc_job"("id"

--- a/metaspace/engine/scripts/db_schema.sql
+++ b/metaspace/engine/scripts/db_schema.sql
@@ -306,7 +306,7 @@ ALTER TABLE "public"."job" ADD CONSTRAINT "FK_f6baae98b3a2436b6f98318d5d0" FOREI
 
 ALTER TABLE "public"."job" ADD CONSTRAINT "FK_07f17ed55cabe0ef556bc0e0c93" FOREIGN KEY (
   "moldb_id") REFERENCES "public"."molecular_db"("id"
-) ON DELETE NO ACTION ON UPDATE NO ACTION;
+) ON DELETE CASCADE ON UPDATE NO ACTION;
 
 ALTER TABLE "public"."annotation" ADD CONSTRAINT "FK_bfed30991918671d59fc1f5d5e4" FOREIGN KEY (
   "job_id") REFERENCES "public"."job"("id"

--- a/metaspace/engine/scripts/run_off_sample.py
+++ b/metaspace/engine/scripts/run_off_sample.py
@@ -16,6 +16,8 @@ WHERE j.status = 'FINISHED'
 ORDER BY j.ds_id DESC;
 """
 
+logger = logging.getLogger('engine')
+
 
 def run_off_sample(sm_config, ds_ids_str, sql_where, fix_missing, overwrite_existing):
     db = DB()
@@ -81,9 +83,8 @@ def parse_args():
     return args
 
 
-if __name__ == '__main__':
+def main():
     args = parse_args()
-    logger = logging.getLogger('engine')
 
     with GlobalInit(args.config) as sm_config:
         run_off_sample(
@@ -93,3 +94,7 @@ if __name__ == '__main__':
             fix_missing=args.fix_missing,
             overwrite_existing=args.overwrite_existing,
         )
+
+
+if __name__ == '__main__':
+    main()

--- a/metaspace/engine/scripts/run_off_sample.py
+++ b/metaspace/engine/scripts/run_off_sample.py
@@ -1,12 +1,11 @@
 import argparse
 import logging
-from functools import partial
 
 from sm.engine.dataset import Dataset
 from sm.engine.db import DB
 from sm.engine.es_export import ESExporter
 from sm.engine.off_sample_wrapper import classify_dataset_ion_images
-from sm.engine.util import bootstrap_and_run
+from sm.engine.util import GlobalInit
 
 MISSING_OFF_SAMPLE_SEL = """
 SELECT DISTINCT j.ds_id
@@ -18,22 +17,17 @@ ORDER BY j.ds_id DESC;
 """
 
 
-def run_off_sample(sm_config, ds_id_str, sql_where, fix_missing, overwrite_existing):
-    assert (
-        len([data_source for data_source in [ds_id_str, sql_where, fix_missing] if data_source])
-        == 1
-    ), "Exactly one data source (ds_id, sql_where, fix_missing) must be specified"
-    assert not (ds_id_str and sql_where)
-
+def run_off_sample(sm_config, ds_ids_str, sql_where, fix_missing, overwrite_existing):
     db = DB()
 
-    if ds_id_str:
-        ds_ids = ds_id_str.split(',')
+    ds_ids = None
+    if ds_ids_str:
+        ds_ids = ds_ids_str.split(',')
     elif sql_where:
         ds_ids = [
             id for (id,) in db.select(f'SELECT DISTINCT dataset.id FROM dataset WHERE {sql_where}')
         ]
-    else:
+    elif fix_missing:
         logger.info('Checking for missing off-sample jobs...')
         results = db.select(MISSING_OFF_SAMPLE_SEL)
         ds_ids = [ds_id for ds_id, in results]
@@ -55,11 +49,11 @@ def run_off_sample(sm_config, ds_id_str, sql_where, fix_missing, overwrite_exist
             logger.error(f'Failed to run off-sample on {ds_id}', exc_info=True)
 
 
-if __name__ == '__main__':
+def parse_args():
     parser = argparse.ArgumentParser(description='Run off-sample classification')
     parser.add_argument('--config', default='conf/config.json', help='SM config path')
     parser.add_argument(
-        '--ds-id', dest='ds_id', default=None, help='DS id (or comma-separated list of ids)'
+        '--ds-ids', dest='ds_ids', default=None, help='DS id (or comma-separated list of ids)'
     )
     parser.add_argument(
         '--sql-where',
@@ -79,15 +73,23 @@ if __name__ == '__main__':
         help='Run classification for annotations even if they have already been classified',
     )
     args = parser.parse_args()
+
+    assert (
+        sum(map(bool, [args.ds_ids, args.sql_where, args.fix_missing])) == 1
+    ), "Exactly one data source (ds_id, sql_where, fix_missing) must be specified"
+
+    return args
+
+
+if __name__ == '__main__':
+    args = parse_args()
     logger = logging.getLogger('engine')
 
-    bootstrap_and_run(
-        args.config,
-        partial(
-            run_off_sample,
-            ds_id=args.ds_id,
+    with GlobalInit(args.config) as sm_config:
+        run_off_sample(
+            sm_config,
+            ds_ids_str=args.ds_ids,
             sql_where=args.sql_where,
             fix_missing=args.fix_missing,
             overwrite_existing=args.overwrite_existing,
-        ),
-    )
+        )

--- a/metaspace/engine/sm/engine/off_sample_wrapper.py
+++ b/metaspace/engine/sm/engine/off_sample_wrapper.py
@@ -64,7 +64,7 @@ SEL_ION_IMAGES = (
     'from dataset d '
     'join job j on j.ds_id = d.id '
     'join annotation m on m.job_id = j.id '
-    'where d.id = %s and (%s or m.off_sample is null)'
+    'where d.id = %s and (%s or m.off_sample is null) and iso_image_ids[1] is not NULL '
     'order by m.id '
 )
 UPD_OFF_SAMPLE = (

--- a/metaspace/graphql/src/migrations/1598564813260-JobDeleteOnMoldbDelete.ts
+++ b/metaspace/graphql/src/migrations/1598564813260-JobDeleteOnMoldbDelete.ts
@@ -4,14 +4,16 @@ export class JobDeleteOnMoldbDelete1598564813260 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<any> {
         await queryRunner.query(`ALTER TABLE "public"."job" DROP CONSTRAINT "FK_07f17ed55cabe0ef556bc0e0c93"`);
-        // await queryRunner.query(`ALTER TABLE "public"."molecular_db" ALTER COLUMN "created_dt" SET NOT NULL`);
         await queryRunner.query(`ALTER TABLE "public"."job" ADD CONSTRAINT "FK_07f17ed55cabe0ef556bc0e0c93" FOREIGN KEY ("moldb_id") REFERENCES "public"."molecular_db"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "graphql"."coloc_job" DROP CONSTRAINT "FK_b0adf5ffef6529f187f48231e38"`);
+        await queryRunner.query(`ALTER TABLE "graphql"."coloc_job" ADD CONSTRAINT "FK_b0adf5ffef6529f187f48231e38" FOREIGN KEY ("moldb_id") REFERENCES "public"."molecular_db"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<any> {
         await queryRunner.query(`ALTER TABLE "public"."job" DROP CONSTRAINT "FK_07f17ed55cabe0ef556bc0e0c93"`);
-        // await queryRunner.query(`ALTER TABLE "public"."molecular_db" ALTER COLUMN "created_dt" DROP NOT NULL`);
         await queryRunner.query(`ALTER TABLE "public"."job" ADD CONSTRAINT "FK_07f17ed55cabe0ef556bc0e0c93" FOREIGN KEY ("moldb_id") REFERENCES "graphql"."molecular_db"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "graphql"."coloc_job" DROP CONSTRAINT "FK_b0adf5ffef6529f187f48231e38"`);
+        await queryRunner.query(`ALTER TABLE "graphql"."coloc_job" ADD CONSTRAINT "FK_b0adf5ffef6529f187f48231e38" FOREIGN KEY ("moldb_id") REFERENCES "graphql"."molecular_db"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
     }
 
 }

--- a/metaspace/graphql/src/migrations/1598564813260-JobDeleteOnMoldbDelete.ts
+++ b/metaspace/graphql/src/migrations/1598564813260-JobDeleteOnMoldbDelete.ts
@@ -1,0 +1,17 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class JobDeleteOnMoldbDelete1598564813260 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "public"."job" DROP CONSTRAINT "FK_07f17ed55cabe0ef556bc0e0c93"`);
+        // await queryRunner.query(`ALTER TABLE "public"."molecular_db" ALTER COLUMN "created_dt" SET NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "public"."job" ADD CONSTRAINT "FK_07f17ed55cabe0ef556bc0e0c93" FOREIGN KEY ("moldb_id") REFERENCES "public"."molecular_db"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "public"."job" DROP CONSTRAINT "FK_07f17ed55cabe0ef556bc0e0c93"`);
+        // await queryRunner.query(`ALTER TABLE "public"."molecular_db" ALTER COLUMN "created_dt" DROP NOT NULL`);
+        await queryRunner.query(`ALTER TABLE "public"."job" ADD CONSTRAINT "FK_07f17ed55cabe0ef556bc0e0c93" FOREIGN KEY ("moldb_id") REFERENCES "graphql"."molecular_db"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/metaspace/graphql/src/modules/annotation/model.ts
+++ b/metaspace/graphql/src/modules/annotation/model.ts
@@ -40,7 +40,7 @@ export class ColocJob {
   @OneToMany(type => ColocAnnotation, colocAnnotation => colocAnnotation.colocJob)
   colocAnnotations: ColocAnnotation[];
 
-  @ManyToOne(type => MolecularDB)
+  @ManyToOne(type => MolecularDB, {onDelete: "CASCADE"})
   @JoinColumn({ name: 'moldb_id' })
   molecularDB: MolecularDB;
 }

--- a/metaspace/graphql/src/modules/engine/model.ts
+++ b/metaspace/graphql/src/modules/engine/model.ts
@@ -97,7 +97,7 @@ export class Job {
   @JoinColumn({ name: 'ds_id' })
   dataset: EngineDataset;
 
-  @ManyToOne(type => MolecularDB)
+  @ManyToOne(type => MolecularDB, {onDelete: 'CASCADE'})
   @JoinColumn({ name: 'moldb_id' })
   molecularDB: MolecularDB;
 


### PR DESCRIPTION
* Enable cascade delete of jobs and coloc_jobs on molecular database delete. At the moment, only the admins can delete databases.
* Fix and refactor the off-sample processing script.
* For off-sample prediction of custom database annotations, select only annotations with the first isotopic image present.