### PR TITLE
Several back-end bug fixes

### DIFF
--- a/metaspace/engine/sm/engine/png_generator.py
+++ b/metaspace/engine/sm/engine/png_generator.py
@@ -136,7 +136,6 @@ class ImageStoreServiceWrapper:
             h, w = mask.shape
             value = np.empty((len(img_ids), h * w), dtype=np.float32)
 
-        @retry_on_exception()
         def process_img(img_id, idx, do_setup=False):
             img = self.get_image_by_id(storage_type, 'iso_image', img_id)
             if do_setup:

--- a/metaspace/engine/sm/engine/png_generator.py
+++ b/metaspace/engine/sm/engine/png_generator.py
@@ -74,7 +74,13 @@ class ImageStoreServiceWrapper:
         Image.Image
         """
         url = self._format_url(storage_type=storage_type, img_type=img_type, img_id=img_id)
-        return Image.open(self._session.get(url, stream=True).raw)
+        try:
+            response = self._session.get(url)
+            response.raise_for_status()
+            return Image.open(BytesIO(response.content))
+        except Exception:
+            logger.error(f'get_image_by_id: Error getting url {url}')
+            raise
 
     def get_ion_images_for_analysis(
         self, storage_type, img_ids, hotspot_percentile=99, max_size=None, max_mem_mb=2048

--- a/metaspace/engine/sm/rest/dataset_manager.py
+++ b/metaspace/engine/sm/rest/dataset_manager.py
@@ -103,7 +103,7 @@ class SMapiDatasetManager:
         self._set_ds_busy(ds, kwargs.get('force', False))
         self._post_sm_msg(ds=ds, queue=self._update_queue, action=DaemonAction.DELETE, **kwargs)
 
-    def update(self, ds_id, doc, **kwargs):
+    def update(self, ds_id, doc, async_es_update, **kwargs):
         """ Save dataset and send update message to the queue """
         ds = Dataset.load(self._db, ds_id)
         ds.name = doc.get('name', ds.name)
@@ -112,7 +112,7 @@ class SMapiDatasetManager:
             ds.metadata = doc['metadata']
         ds.upload_dt = doc.get('upload_dt', ds.upload_dt)
         ds.is_public = doc.get('is_public', ds.is_public)
-        ds.save(self._db, self._es)
+        ds.save(self._db, None if async_es_update else self._es)
 
         self._post_sm_msg(
             ds=ds,

--- a/metaspace/engine/sm/rest/datasets.py
+++ b/metaspace/engine/sm/rest/datasets.py
@@ -127,16 +127,20 @@ def update(ds_man, ds_id, params):
             group_id
             project_ids
         }
+        async_es_update
     }
     :return:
     """
     doc = params.get('doc', None)
     force = params.get('force', False)
+    async_es_update = params.get('async_es_update', False)
     if not doc and not force:
         logger.info(f'Nothing to update for "{ds_id}"')
     else:
         priority = params.get('priority', DatasetActionPriority.STANDARD)
-        ds_man.update(ds_id=ds_id, doc=doc, force=force, priority=priority)
+        ds_man.update(
+            ds_id=ds_id, doc=doc, force=force, priority=priority, async_es_update=async_es_update
+        )
 
 
 @app.post('/<ds_id>/delete')

--- a/metaspace/graphql/package.json
+++ b/metaspace/graphql/package.json
@@ -51,6 +51,7 @@
     "ajv": "4.10.0",
     "amqplib": "^0.5.1",
     "apollo-server-express": "^2.15.0",
+    "await-semaphore": "^0.1.3",
     "aws-sdk": "^2.13.0",
     "bcrypt": "^5.0.0",
     "body-parser": "^1.15.2",

--- a/metaspace/graphql/src/modules/group/controller.ts
+++ b/metaspace/graphql/src/modules/group/controller.ts
@@ -70,7 +70,7 @@ const updateUserGroupDatasets = async (entityManager: EntityManager, userId: str
   });
   await Promise.all(datasetsToUpdate.map(async ds => {
     await datasetRepo.update({id: ds.id}, {groupApproved});
-    await smApiUpdateDataset(ds.id, {groupId});
+    await smApiUpdateDataset(ds.id, {groupId}, {asyncEsUpdate: true});
   }));
 };
 
@@ -243,7 +243,7 @@ export const Resolvers = {
         logger.info(`Updating '${groupId}' group datasets...`);
         const groupDSs = await entityManager.getRepository(DatasetModel).find({ groupId });
         await Promise.all(groupDSs.map(async ds => {
-          await smApiUpdateDataset(ds.id, {groupId});
+          await smApiUpdateDataset(ds.id, {groupId}, {asyncEsUpdate: true});
         }));
       }
       logger.info(`'${groupId}' group updated`);
@@ -465,7 +465,7 @@ export const Resolvers = {
       const dsRepo = entityManager.getRepository(DatasetModel);
       await Promise.all(datasetIds.map(async (dsId: string) => {
         await dsRepo.update(dsId, { groupId, groupApproved: true });
-        await smApiUpdateDataset(dsId, {groupId});
+        await smApiUpdateDataset(dsId, {groupId}, {asyncEsUpdate: true});
       }));
       logger.info(`User '${user!.id}' imported datasets to '${groupId}' group`);
       return true;

--- a/metaspace/graphql/src/modules/project/controller/Mutation.publishing.spec.ts
+++ b/metaspace/graphql/src/modules/project/controller/Mutation.publishing.spec.ts
@@ -127,8 +127,8 @@ describe('Project publication status manipulations', () => {
     const updatedProject = await testEntityManager.findOne(ProjectModel, { id: project.id });
     expect(updatedProject).toEqual(expect.objectContaining({ publicationStatus: PSO.PUBLISHED, isPublic: true }));
 
-    expect(mockSmApiDatasets.smApiUpdateDataset).toHaveBeenCalledWith(datasetBelongsToProject.id, { isPublic: true });
-    expect(mockSmApiDatasets.smApiUpdateDataset).not.toHaveBeenCalledWith(randomDataset.id, expect.anything());
+    expect(mockSmApiDatasets.smApiUpdateDataset).toHaveBeenCalledWith(datasetBelongsToProject.id, { isPublic: true }, {asyncEsUpdate: true});
+    expect(mockSmApiDatasets.smApiUpdateDataset).not.toHaveBeenCalledWith(randomDataset.id, expect.anything(), expect.anything());
   });
 
   test('Project member cannot publish project', async () => {
@@ -169,8 +169,8 @@ describe('Project publication status manipulations', () => {
     let updatedProject = await testEntityManager.findOne(ProjectModel, { id: project.id });
     expect(updatedProject).toEqual(expect.objectContaining({ isPublic: false, publicationStatus: PSO.UNDER_REVIEW }));
 
-    expect(mockSmApiDatasets.smApiUpdateDataset).toHaveBeenCalledWith(datasetBelongsToProject.id, { isPublic: false });
-    expect(mockSmApiDatasets.smApiUpdateDataset).not.toHaveBeenCalledWith(randomDataset.id, expect.anything());
+    expect(mockSmApiDatasets.smApiUpdateDataset).toHaveBeenCalledWith(datasetBelongsToProject.id, { isPublic: false }, {asyncEsUpdate: true});
+    expect(mockSmApiDatasets.smApiUpdateDataset).not.toHaveBeenCalledWith(randomDataset.id, expect.anything(), expect.anything());
   });
 
   test.each([PSO.UNDER_REVIEW, PSO.PUBLISHED])(

--- a/metaspace/graphql/src/modules/project/controller/Mutation.ts
+++ b/metaspace/graphql/src/modules/project/controller/Mutation.ts
@@ -93,7 +93,7 @@ const MutationResolvers: FieldResolversFor<Mutation, void> = {
       await Promise.all(affectedDatasets.map(async dp => {
         await smApiUpdateDataset(dp.datasetId, {
           projectIds: dp.dataset.datasetProjects.map(p => p.projectId)
-        })
+        }, {asyncEsUpdate: true})
       }));
     }
 
@@ -122,7 +122,7 @@ const MutationResolvers: FieldResolversFor<Mutation, void> = {
             projectIds: dp.dataset.datasetProjects
               .filter(p => p.projectId !== projectId)
               .map(p => p.projectId)
-          })
+          }, {asyncEsUpdate: true})
         }));
 
         await ctx.entityManager.delete(UserProjectModel, { projectId });
@@ -267,7 +267,7 @@ const MutationResolvers: FieldResolversFor<Mutation, void> = {
 
     const affectedDatasets = await ctx.entityManager.find(DatasetProjectModel, { where: { projectId } });
     await Promise.all(affectedDatasets.map(async dp => {
-      await smApiUpdateDataset(dp.datasetId, { isPublic: true });
+      await smApiUpdateDataset(dp.datasetId, { isPublic: true }, { asyncEsUpdate: true });
     }));
 
     return await ctx.entityManager.getCustomRepository(ProjectSourceRepository)
@@ -288,7 +288,7 @@ const MutationResolvers: FieldResolversFor<Mutation, void> = {
     if (isPublic != null) {
       const affectedDatasets = await ctx.entityManager.find(DatasetProjectModel, { where: { projectId } });
       await Promise.all(affectedDatasets.map(async dp => {
-        await smApiUpdateDataset(dp.datasetId, { isPublic });
+        await smApiUpdateDataset(dp.datasetId, { isPublic }, { asyncEsUpdate: true });
       }));
     }
 

--- a/metaspace/graphql/src/modules/project/operation/updateProjectDatasets.ts
+++ b/metaspace/graphql/src/modules/project/operation/updateProjectDatasets.ts
@@ -39,7 +39,7 @@ export default async function (ctx: Context, projectId: string, datasetIds: stri
       _.pull(projectIds, projectId);
     }
 
-    await smApiUpdateDataset(datasetId, {projectIds});
+    await smApiUpdateDataset(datasetId, {projectIds}, {asyncEsUpdate: true});
   });
 
   await Promise.all(promises);

--- a/metaspace/graphql/src/modules/user/controller.ts
+++ b/metaspace/graphql/src/modules/user/controller.ts
@@ -195,7 +195,7 @@ export const Resolvers = {
         if (userDSs) {
           logger.info(`Updating user '${userId}' datasets...`);
           await Promise.all(userDSs.map(async ds => {
-            await smApiUpdateDataset(ds.id, { submitterId: userId });
+            await smApiUpdateDataset(ds.id, { submitterId: userId }, { asyncEsUpdate: true });
           }));
         }
       }

--- a/metaspace/graphql/src/utils/smApi/datasets.ts
+++ b/metaspace/graphql/src/utils/smApi/datasets.ts
@@ -1,10 +1,9 @@
 import {UserError} from 'graphql-errors';
-import fetch from 'node-fetch';
 import * as _ from 'lodash';
 import {snakeCase} from "typeorm/util/StringUtils";
 
-import config from '../config';
 import logger from '../logger';
+import { smApiJsonPost } from './smApiCall'
 
 interface DatasetRequestBody {
   doc?: Object;
@@ -26,30 +25,23 @@ export const smApiDatasetRequest = async (uri: string, args: any={}) => {
   // @ts-ignore
   reqDoc.doc = _.mapKeys(reqDoc.doc, (v, k) => datasetDocFieldMapping[k] || snakeCase(k));
 
-  let resp = await fetch(`http://${config.services.sm_engine_api_host}${uri}`, {
-    method: 'POST',
-    body: JSON.stringify(reqDoc),
-    headers: {
-      'Content-Type': 'application/json'
-    }
-  });
+  const {response, content} = await smApiJsonPost(uri, reqDoc);
 
-  const respDoc = await resp.json();
-  if (!resp.ok) {
-    if (respDoc.status === 'dataset_busy') {
+  if (!response.ok) {
+    if (content.status === 'dataset_busy') {
       throw new UserError(JSON.stringify({
         'type': 'dataset_busy',
         'hint': `Dataset is busy. Try again later.`
       }));
     }
     else {
-      throw new UserError(`Request to sm-api failed: ${JSON.stringify(respDoc)}`);
+      throw new UserError(`Request to sm-api failed: ${JSON.stringify(content)}`);
     }
   }
   else {
     logger.info(`Successful ${uri}`);
     logger.debug(`Body: ${JSON.stringify(reqDoc)}`);
-    return respDoc;
+    return content;
   }
 };
 

--- a/metaspace/graphql/src/utils/smApi/datasets.ts
+++ b/metaspace/graphql/src/utils/smApi/datasets.ts
@@ -57,10 +57,18 @@ interface UpdateDatasetArgs {
   projectIds?: string[];
 }
 
-export const smApiUpdateDataset = async (id: string, updates: UpdateDatasetArgs) => {
+interface UpdateDatasetMetaArgs {
+  asyncEsUpdate?: boolean;
+  priority?: number;
+  force?: boolean;
+}
+
+export const smApiUpdateDataset = async (id: string, updates: UpdateDatasetArgs, args: UpdateDatasetMetaArgs = {}) => {
   try {
+    const camelCaseArgs = _.mapKeys(args, (v, k) => snakeCase(k));
     await smApiDatasetRequest(`/v1/datasets/${id}/update`, {
-      doc: updates
+      doc: updates,
+      ...camelCaseArgs,
     });
   } catch (err) {
     logger.error('Failed to update dataset', err);

--- a/metaspace/graphql/src/utils/smApi/smApiCall.ts
+++ b/metaspace/graphql/src/utils/smApi/smApiCall.ts
@@ -1,0 +1,35 @@
+import {Semaphore} from 'await-semaphore';
+import fetch from 'node-fetch'
+import config from '../config'
+import logger from '../logger'
+
+/**
+ * Semaphore to limit the maximum number of parallel requests to sm-api. Having too many parallel requests can result in
+ * running out of file handles.
+ * Bottle doesn't handle requests in parallel, so there's no benefit to raising this too high. To make matters worse,
+ * after a certain number of queued requests, Bottle seems to start working in a FILO-style queue, which can cause
+ * earlier requests to be delayed so long that they timeout.
+ */
+export const smApiSemaphore = new Semaphore(4)
+
+
+export const smApiJsonPost = async (path: string, requestDoc: any) => {
+  return smApiSemaphore.use(async () => {
+    console.log(`starting request to ${path}`)
+    const response = await fetch(`http://${config.services.sm_engine_api_host}${path}`, {
+      method: 'POST',
+      body: JSON.stringify(requestDoc),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    let content
+    try {
+      content = await response.json()
+    } catch (ex) {
+      logger.error(ex)
+      content = null
+    }
+
+    return {response, content}
+  })
+}

--- a/metaspace/graphql/src/utils/smApi/smApiCall.ts
+++ b/metaspace/graphql/src/utils/smApi/smApiCall.ts
@@ -7,10 +7,10 @@ import logger from '../logger'
  * Semaphore to limit the maximum number of parallel requests to sm-api. Having too many parallel requests can result in
  * running out of file handles.
  * Bottle doesn't handle requests in parallel, so there's no benefit to raising this too high. To make matters worse,
- * after a certain number of queued requests, Bottle seems to start working in a FILO-style queue, which can cause
- * earlier requests to be delayed so long that they timeout.
+ * with ~8 queued requests, Bottle seems to start working in a FILO-style queue, which can cause earlier requests
+ * to be delayed so long that they timeout.
  */
-export const smApiSemaphore = new Semaphore(4)
+export const smApiSemaphore = new Semaphore(8)
 
 
 export const smApiJsonPost = async (path: string, requestDoc: any) => {

--- a/metaspace/graphql/src/utils/smApi/smApiCall.ts
+++ b/metaspace/graphql/src/utils/smApi/smApiCall.ts
@@ -12,10 +12,8 @@ import logger from '../logger'
  */
 export const smApiSemaphore = new Semaphore(8)
 
-
 export const smApiJsonPost = async (path: string, requestDoc: any) => {
   return smApiSemaphore.use(async () => {
-    console.log(`starting request to ${path}`)
     const response = await fetch(`http://${config.services.sm_engine_api_host}${path}`, {
       method: 'POST',
       body: JSON.stringify(requestDoc),

--- a/metaspace/graphql/yarn.lock
+++ b/metaspace/graphql/yarn.lock
@@ -1643,6 +1643,11 @@ atob@2.1.2, atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+await-semaphore@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/await-semaphore/-/await-semaphore-0.1.3.tgz#2b88018cc8c28e06167ae1cdff02504f1f9688d3"
+  integrity sha512-d1W2aNSYcz/sxYO4pMGX9vq65qOTu0P800epMud+6cYYX0QcT7zyqcxec3VWzpgvdXo57UWmVbZpLMjX2m1I7Q==
+
 aws-sdk@*, aws-sdk@2.587.0, aws-sdk@^2.13.0:
   version "2.587.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.587.0.tgz#5fbd0ae0662291471f95d009c002fb16dc69ae22"


### PR DESCRIPTION
* (Per slack discussion) use `PIL.Image(BytesIO(resp.content))` instead of `PIL(resp.raw)` to see if it fixes the intermittent bug while downloading images for colocalization
* Remove the redundant `@retry_on_exception()` in `get_ion_images_for_analysis`, because I found in the logs that failing downloads were actually attempted 9 times due to nesting of `@retry_on_exception()` functions
* Add a semaphore to smApi calls so that no more than 4 calls are made simultaneously. Also slightly refactor smApi calls so that they all go through one function
* Add a parameter `async_es_update` to the update dataset sm-api endpoint, and supply this parameter for all bulk DS updates. I found that this provides a huge speedup in the API call (no speedup to the queued index update though) - renaming a project that contains 170 datasets goes from 91s to 7.3s. This is a big deal, because the front-end actually waits for this to finish.
    * Initially I was thinking of applying this to all DS update calls, but this could introduce a race condition for direct DS updates (e.g. renames & private/public updates) - the UI could potentially show the user old data when they're returned to the datasets list. My gut tells me we'd have to debug this in the future if the direct updates were made async.
    * When `asyncEsUpdate` is true, the dataset only gets a partial update-by-query (via `ESExporter.update_ds`) instead of a full update (via `ESExporter.sync_dataset`). This means fewer fields are sync'd... This needs a sanity check - do you think this is ok?