### PR TITLE
IndexError in all_annotations_images when all images are None

### DIFF
--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.8.1'
+__version__ = '1.8.2'
 
 from metaspace.sm_annotation_utils import (
     SMInstance,

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -1051,14 +1051,15 @@ class SMDataset(object):
 
         if scale_intensity:
             non_empty_images = [i for i in images if i is not None]
-            shape = non_empty_images[0].shape
-            for i in range(len(images)):
-                if images[i] is None:
-                    images[i] = np.zeros(shape, dtype=non_empty_images[0].dtype)
-                else:
-                    lo = float(image_metadata[i]['minIntensity'])
-                    hi = float(image_metadata[i]['maxIntensity'])
-                    images[i] = lo + images[i] * (hi - lo)
+            if non_empty_images:
+                shape = non_empty_images[0].shape
+                for i in range(len(images)):
+                    if images[i] is None:
+                        images[i] = np.zeros(shape, dtype=non_empty_images[0].dtype)
+                    else:
+                        lo = float(image_metadata[i]['minIntensity'])
+                        hi = float(image_metadata[i]['maxIntensity'])
+                        images[i] = lo + images[i] * (hi - lo)
 
         if hotspot_clipping:
             for i in range(len(images)):


### PR DESCRIPTION
I got an error for a specific dataset. The python client returns ions including "C20H28O2+K", but no ion images for that ion, causing an index error on the `non_empty_images` list. 

The following code reproduces it (fill in login details, set a breakpoint in sm_annotation_utils.py:1054):

```python
from metaspace.sm_annotation_utils import SMInstance
sm = SMInstance()
sm.login(email="XXX", api_key="YYY")
dataset = sm.dataset(id="2020-09-22_14h53m35s")
dataset.all_annotation_images(fdr=0.5, database=("HMDB-endogenous", "v4"), only_first_isotope=True)
```

Traceback:
```
  File "…/metaspace/sm_annotation_utils.py", line 1103, in get_annotation_images
    return self.isotope_images(
  File "…/metaspace/sm_annotation_utils.py", line 1054, in isotope_images
    shape = non_empty_images[0].shape
IndexError: list index out of range
```

It seems the case that the `images` list contains None is a valid situation (then no underlying bug?), but the case that None is returned for all is not considered. 

A fix could be to skip the code if the filtered `non_empty_images` list is empty. However I'm not sure about the intended return value. Originally with `scale_intensity = True`, None would be replaced by zeroed arrays (for which shape must be known), but for `scale_intensity = False` the return value would still contain None.