### PR TITLE
Default projects to private

### DIFF
--- a/metaspace/engine/scripts/db_schema.sql
+++ b/metaspace/engine/scripts/db_schema.sql
@@ -75,7 +75,7 @@ CREATE TABLE "graphql"."project" (
   "id" uuid NOT NULL DEFAULT uuid_generate_v1mc(), 
   "name" text NOT NULL, 
   "url_slug" text, 
-  "is_public" boolean NOT NULL DEFAULT true, 
+  "is_public" boolean NOT NULL DEFAULT false, 
   "created_dt" TIMESTAMP NOT NULL, 
   "project_description" text, 
   "review_token" text, 

--- a/metaspace/graphql/src/modules/project/model.ts
+++ b/metaspace/graphql/src/modules/project/model.ts
@@ -39,7 +39,7 @@ export class Project {
   @OneToMany(type => UserProject, userProject => userProject.project)
   members: UserProject[];
 
-  @Column({ name: 'is_public', type: 'boolean', default: true })
+  @Column({ name: 'is_public', type: 'boolean', default: false })
   isPublic: boolean;
 
   @OneToMany(type => DatasetProject, datasetProject => datasetProject.project)

--- a/metaspace/webapp/src/assets/inline/refactoring-ui/lock.svg
+++ b/metaspace/webapp/src/assets/inline/refactoring-ui/lock.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <path class="primary" d="M5 10h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-8c0-1.1.9-2 2-2zm6 6.73V18a1 1 0 0 0 2 0v-1.27a2 2 0 1 0-2 0z"></path>
-  <path class="secondary" d="M12 19a1 1 0 0 0 1-1v-1.27A2 2 0 0 0 12 13v-3h3V7a3 3 0 0 0-6 0v3H7V7a5 5 0 1 1 10 0v3h2a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-7v-3z"></path>
-</svg>

--- a/metaspace/webapp/src/assets/inline/refactoring-ui/lock.svg
+++ b/metaspace/webapp/src/assets/inline/refactoring-ui/lock.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path class="primary" d="M5 10h14a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-8c0-1.1.9-2 2-2zm6 6.73V18a1 1 0 0 0 2 0v-1.27a2 2 0 1 0-2 0z"></path>
+  <path class="secondary" d="M12 19a1 1 0 0 0 1-1v-1.27A2 2 0 0 0 12 13v-3h3V7a3 3 0 0 0-6 0v3H7V7a5 5 0 1 1 10 0v3h2a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-7v-3z"></path>
+</svg>

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -665,8 +665,8 @@ exports[`MetadataEditor should match snapshot 1`] = `
         </mock-el-dialog>
         <mock-el-dialog append-to-body="" title="Create project" class="dialog">
           <div mock-v-loading="1">
-            <form class="el-form el-form--label-top" size="mini">
-              <div><label class="leading-6"><span class="font-medium">Title</span>
+            <form class="el-form leading-6 v-rhythm-3 el-form--label-top" size="mini">
+              <div><label><span class="text-base font-medium">Title</span>
                   <div class="py-1 el-input">
                     <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
                     <!---->
@@ -674,18 +674,16 @@ exports[`MetadataEditor should match snapshot 1`] = `
                     <!---->
                     <!---->
                   </div></label></div>
-              <div class="el-form-item my-3">
-                <!---->
-                <div class="el-form-item__content">
+              <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
+        Visibility of the project only, does not apply to included datasets
+      </span></label>
+                <div class="h-6 flex items-center">
                   <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
-                  <!---->
-                  <transition-stub name="el-zoom-in-top">
-                    <!---->
-                  </transition-stub>
                 </div>
+                <!---->
               </div>
             </form>
-            <div>
+            <div class="mt-6">
               <h4 class="m-0">
                 Would you like to include previously submitted datasets?
               </h4>

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -677,7 +677,7 @@ exports[`MetadataEditor should match snapshot 1`] = `
               <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>
-                <div class="h-6 flex items-center">
+                <div class="h-10 flex items-center">
                   <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
                 </div>
                 <!---->

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -674,17 +674,15 @@ exports[`MetadataEditor should match snapshot 1`] = `
                     <!---->
                     <!---->
                   </div></label></div>
-              <div class="el-form-item my-3">
-                <!---->
-                <div class="el-form-item__content"><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-      Allow other users to see this project
-    <!----></span></label>
-                  <transition-stub name="el-zoom-in-top">
-                    <!---->
-                  </transition-stub>
-                </div>
-              </div>
             </form>
+            <div class="flex my-3 items-center justify-center">
+              <mock-lock-icon class="sm-colour-icon mx-3"></mock-lock-icon>
+              <p class="ml-3 leading-5"><strong class="block">Projects are now private by default.</strong> <span>
+          Visibility can be changed in project settings,
+          <br>
+          or by using the <em>Publishing</em> workflow.
+        </span></p>
+            </div>
             <div>
               <h4 class="m-0">
                 Would you like to include previously submitted datasets?

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -676,7 +676,7 @@ exports[`MetadataEditor should match snapshot 1`] = `
                   </div></label></div>
             </form>
             <div class="flex my-3 items-center justify-center">
-              <mock-lock-icon class="sm-colour-icon mx-3"></mock-lock-icon>
+              <svg-lock-icon class="sm-colour-icon mx-3"></svg-lock-icon>
               <p class="ml-3 leading-5"><strong class="block">Projects are now private by default.</strong> <span>
           Visibility can be changed in project settings,
           <br>

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -674,15 +674,17 @@ exports[`MetadataEditor should match snapshot 1`] = `
                     <!---->
                     <!---->
                   </div></label></div>
+              <div class="el-form-item my-3">
+                <!---->
+                <div class="el-form-item__content">
+                  <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
+                  <!---->
+                  <transition-stub name="el-zoom-in-top">
+                    <!---->
+                  </transition-stub>
+                </div>
+              </div>
             </form>
-            <div class="flex my-3 items-center justify-center">
-              <svg-lock-icon class="sm-colour-icon mx-3"></svg-lock-icon>
-              <p class="ml-3 leading-5"><strong class="block">Projects are now private by default.</strong> <span>
-          Visibility can be changed in project settings,
-          <br>
-          or by using the <em>Publishing</em> workflow.
-        </span></p>
-            </div>
             <div>
               <h4 class="m-0">
                 Would you like to include previously submitted datasets?

--- a/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
+++ b/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
@@ -13,6 +13,17 @@
         v-model="project"
         size="mini"
       />
+      <div class="flex my-3 items-center justify-center">
+        <lock-icon class="sm-colour-icon mx-3" />
+        <p class="ml-3 leading-5">
+          <strong class="block">Projects are now private by default.</strong>
+          <span>
+            Visibility can be changed in project settings,
+            <br />
+            or by using the <em>Publishing</em> workflow.
+          </span>
+        </p>
+      </div>
       <div v-if="allDatasets.length > 0">
         <h4 class="m-0">
           Would you like to include previously submitted datasets?
@@ -49,10 +60,14 @@ import DatasetCheckboxList from '../../components/DatasetCheckboxList.vue'
 import { createProjectMutation, importDatasetsIntoProjectMutation } from '../../api/project'
 import reportError from '../../lib/reportError'
 
+import '../../components/ColourIcon.css'
+import LockIcon from '../../assets/inline/refactoring-ui/lock.svg'
+
   @Component<CreateProjectDialog>({
     components: {
       EditProjectForm,
       DatasetCheckboxList,
+      LockIcon,
     },
     apollo: {
       allDatasets: {

--- a/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
+++ b/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
@@ -13,17 +13,6 @@
         v-model="project"
         size="mini"
       />
-      <div class="flex my-3 items-center justify-center">
-        <lock-icon class="sm-colour-icon mx-3" />
-        <p class="ml-3 leading-5">
-          <strong class="block">Projects are now private by default.</strong>
-          <span>
-            Visibility can be changed in project settings,
-            <br />
-            or by using the <em>Publishing</em> workflow.
-          </span>
-        </p>
-      </div>
       <div v-if="allDatasets.length > 0">
         <h4 class="m-0">
           Would you like to include previously submitted datasets?
@@ -60,14 +49,10 @@ import DatasetCheckboxList from '../../components/DatasetCheckboxList.vue'
 import { createProjectMutation, importDatasetsIntoProjectMutation } from '../../api/project'
 import reportError from '../../lib/reportError'
 
-import '../../components/ColourIcon.css'
-import LockIcon from '../../assets/inline/refactoring-ui/lock.svg'
-
   @Component<CreateProjectDialog>({
     components: {
       EditProjectForm,
       DatasetCheckboxList,
-      LockIcon,
     },
     apollo: {
       allDatasets: {

--- a/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
+++ b/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
@@ -12,8 +12,12 @@
         ref="form"
         v-model="project"
         size="mini"
+        class="v-rhythm-3"
       />
-      <div v-if="allDatasets.length > 0">
+      <div
+        v-if="allDatasets.length > 0"
+        class="mt-6"
+      >
         <h4 class="m-0">
           Would you like to include previously submitted datasets?
         </h4>

--- a/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
+++ b/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
@@ -83,7 +83,7 @@ export default class CreateProjectDialog extends Vue {
     isSubmitting: Boolean = false;
     project = {
       name: '',
-      isPublic: true,
+      isPublic: false,
       urlSlug: '',
     };
 

--- a/metaspace/webapp/src/modules/Project/EditProjectForm.vue
+++ b/metaspace/webapp/src/modules/Project/EditProjectForm.vue
@@ -25,7 +25,7 @@
           Visibility of the project only, does not apply to included datasets
         </secondary-label-text>
       </label>
-      <div class="h-6 flex items-center">
+      <div class="h-10 flex items-center">
         <el-switch
           v-model="value.isPublic"
           :disabled="isPublished"

--- a/metaspace/webapp/src/modules/Project/EditProjectForm.vue
+++ b/metaspace/webapp/src/modules/Project/EditProjectForm.vue
@@ -21,14 +21,18 @@
       prop="isPublic"
       class="my-3"
     >
-      <el-checkbox
+      <el-switch
         v-model="value.isPublic"
         :disabled="isPublished"
+        active-text="Public"
+        inactive-text="Private"
+      />
+      <span
+        v-if="isPublished"
+        class="text-gray-700 float-right"
       >
-        {{ isPublished ?
-          'Published projects must be visible' :
-          'Allow other users to see this project' }}
-      </el-checkbox>
+        Published projects are always visible.
+      </span>
     </el-form-item>
   </el-form>
 </template>

--- a/metaspace/webapp/src/modules/Project/EditProjectForm.vue
+++ b/metaspace/webapp/src/modules/Project/EditProjectForm.vue
@@ -5,11 +5,12 @@
     :disabled="disabled"
     :rules="rules"
     label-position="top"
+    class="leading-6"
     @submit="handleSubmit"
   >
     <div>
-      <label class="leading-6">
-        <span class="font-medium">Title</span>
+      <label>
+        <primary-label-text>Title</primary-label-text>
         <el-input
           v-model="value.name"
           class="py-1"
@@ -17,23 +18,28 @@
         />
       </label>
     </div>
-    <el-form-item
-      prop="isPublic"
-      class="my-3"
-    >
-      <el-switch
-        v-model="value.isPublic"
-        :disabled="isPublished"
-        active-text="Public"
-        inactive-text="Private"
-      />
-      <span
+    <div>
+      <label>
+        <primary-label-text>Privacy</primary-label-text>
+        <secondary-label-text>
+          Visibility of the project only, does not apply to included datasets
+        </secondary-label-text>
+      </label>
+      <div class="h-6 flex items-center">
+        <el-switch
+          v-model="value.isPublic"
+          :disabled="isPublished"
+          active-text="Public"
+          inactive-text="Private"
+        />
+      </div>
+      <p
         v-if="isPublished"
-        class="text-gray-700 float-right"
+        class="m-0 italic text-sm text-gray-700"
       >
-        Published projects are always visible.
-      </span>
-    </el-form-item>
+        published projects are always visible
+      </p>
+    </div>
   </el-form>
 </template>
 <script lang="ts">
@@ -41,12 +47,19 @@ import Vue from 'vue'
 import { Component, Model, Prop } from 'vue-property-decorator'
 import { ElForm } from 'element-ui/types/form'
 
+import { PrimaryLabelText, SecondaryLabelText } from '../../components/Form'
+
   interface Model {
     name: string;
     isPublic: boolean;
   }
 
-  @Component
+  @Component({
+    components: {
+      PrimaryLabelText,
+      SecondaryLabelText,
+    },
+  })
 export default class EditProjectForm extends Vue {
     @Model('input', { type: Object, required: true })
     value!: Model;

--- a/metaspace/webapp/src/modules/Project/EditProjectForm.vue
+++ b/metaspace/webapp/src/modules/Project/EditProjectForm.vue
@@ -17,19 +17,6 @@
         />
       </label>
     </div>
-    <el-form-item
-      prop="isPublic"
-      class="my-3"
-    >
-      <el-checkbox
-        v-model="value.isPublic"
-        :disabled="isPublished"
-      >
-        {{ isPublished ?
-          'Published projects must be visible' :
-          'Allow other users to see this project' }}
-      </el-checkbox>
-    </el-form-item>
   </el-form>
 </template>
 <script lang="ts">
@@ -39,7 +26,6 @@ import { ElForm } from 'element-ui/types/form'
 
   interface Model {
     name: string;
-    isPublic: boolean;
   }
 
   @Component
@@ -49,9 +35,6 @@ export default class EditProjectForm extends Vue {
 
     @Prop({ type: Boolean, default: false })
     disabled!: Boolean;
-
-    @Prop({ type: Boolean, default: false })
-    isPublished!: Boolean;
 
     rules = {
       name: [{ type: 'string', required: true, min: 2, message: 'Name is required', trigger: 'manual' }],

--- a/metaspace/webapp/src/modules/Project/EditProjectForm.vue
+++ b/metaspace/webapp/src/modules/Project/EditProjectForm.vue
@@ -17,6 +17,19 @@
         />
       </label>
     </div>
+    <el-form-item
+      prop="isPublic"
+      class="my-3"
+    >
+      <el-checkbox
+        v-model="value.isPublic"
+        :disabled="isPublished"
+      >
+        {{ isPublished ?
+          'Published projects must be visible' :
+          'Allow other users to see this project' }}
+      </el-checkbox>
+    </el-form-item>
   </el-form>
 </template>
 <script lang="ts">
@@ -26,6 +39,7 @@ import { ElForm } from 'element-ui/types/form'
 
   interface Model {
     name: string;
+    isPublic: boolean;
   }
 
   @Component
@@ -35,6 +49,9 @@ export default class EditProjectForm extends Vue {
 
     @Prop({ type: Boolean, default: false })
     disabled!: Boolean;
+
+    @Prop({ type: Boolean, default: false })
+    isPublished!: Boolean;
 
     rules = {
       name: [{ type: 'string', required: true, min: 2, message: 'Name is required', trigger: 'manual' }],

--- a/metaspace/webapp/src/modules/Project/ProjectSettings.vue
+++ b/metaspace/webapp/src/modules/Project/ProjectSettings.vue
@@ -12,7 +12,7 @@
         <h2>Project Details</h2>
         <edit-project-form
           v-model="model"
-          class="mt-3"
+          class="mt-3 mb-6 v-rhythm-6"
           :is-published="isPublished"
           :disabled="isSaving"
         />

--- a/metaspace/webapp/src/modules/Project/ProjectSettings.vue
+++ b/metaspace/webapp/src/modules/Project/ProjectSettings.vue
@@ -16,6 +16,16 @@
           :is-published="isPublished"
           :disabled="isSaving"
         />
+        <div class="my-3">
+          <el-checkbox
+            v-model="model.isPublic"
+            :disabled="isPublished"
+          >
+            {{ isPublished ?
+              'Published projects must be visible' :
+              'Allow other users to see this project' }}
+          </el-checkbox>
+        </div>
         <short-link-field
           id="project-settings-short-link"
           v-model="model.urlSlug"

--- a/metaspace/webapp/src/modules/Project/ProjectSettings.vue
+++ b/metaspace/webapp/src/modules/Project/ProjectSettings.vue
@@ -16,16 +16,6 @@
           :is-published="isPublished"
           :disabled="isSaving"
         />
-        <div class="my-3">
-          <el-checkbox
-            v-model="model.isPublic"
-            :disabled="isPublished"
-          >
-            {{ isPublished ?
-              'Published projects must be visible' :
-              'Allow other users to see this project' }}
-          </el-checkbox>
-        </div>
         <short-link-field
           id="project-settings-short-link"
           v-model="model.urlSlug"

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -13,17 +13,15 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
               <!---->
               <!---->
             </div></label></div>
-        <div class="el-form-item my-3">
-          <!---->
-          <div class="el-form-item__content"><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-      Allow other users to see this project
-    <!----></span></label>
-            <transition-stub name="el-zoom-in-top">
-              <!---->
-            </transition-stub>
-          </div>
-        </div>
       </form>
+      <div class="flex my-3 items-center justify-center">
+        <mock-lock-icon class="sm-colour-icon mx-3"></mock-lock-icon>
+        <p class="ml-3 leading-5"><strong class="block">Projects are now private by default.</strong> <span>
+          Visibility can be changed in project settings,
+          <br>
+          or by using the <em>Publishing</em> workflow.
+        </span></p>
+      </div>
       <div>
         <h4 class="m-0">
           Would you like to include previously submitted datasets?
@@ -161,17 +159,15 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
               <!---->
               <!---->
             </div></label></div>
-        <div class="el-form-item my-3">
-          <!---->
-          <div class="el-form-item__content"><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-      Allow other users to see this project
-    <!----></span></label>
-            <transition-stub name="el-zoom-in-top">
-              <!---->
-            </transition-stub>
-          </div>
-        </div>
       </form>
+      <div class="flex my-3 items-center justify-center">
+        <mock-lock-icon class="sm-colour-icon mx-3"></mock-lock-icon>
+        <p class="ml-3 leading-5"><strong class="block">Projects are now private by default.</strong> <span>
+          Visibility can be changed in project settings,
+          <br>
+          or by using the <em>Publishing</em> workflow.
+        </span></p>
+      </div>
       <div>
         <h4 class="m-0">
           Would you like to include previously submitted datasets?
@@ -308,17 +304,15 @@ exports[`ProjectsListPage should match snapshot 1`] = `
               <!---->
               <!---->
             </div></label></div>
-        <div class="el-form-item my-3">
-          <!---->
-          <div class="el-form-item__content"><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-      Allow other users to see this project
-    <!----></span></label>
-            <transition-stub name="el-zoom-in-top">
-              <!---->
-            </transition-stub>
-          </div>
-        </div>
       </form>
+      <div class="flex my-3 items-center justify-center">
+        <mock-lock-icon class="sm-colour-icon mx-3"></mock-lock-icon>
+        <p class="ml-3 leading-5"><strong class="block">Projects are now private by default.</strong> <span>
+          Visibility can be changed in project settings,
+          <br>
+          or by using the <em>Publishing</em> workflow.
+        </span></p>
+      </div>
       <div>
         <h4 class="m-0">
           Would you like to include previously submitted datasets?

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -15,7 +15,7 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
             </div></label></div>
       </form>
       <div class="flex my-3 items-center justify-center">
-        <mock-lock-icon class="sm-colour-icon mx-3"></mock-lock-icon>
+        <svg-lock-icon class="sm-colour-icon mx-3"></svg-lock-icon>
         <p class="ml-3 leading-5"><strong class="block">Projects are now private by default.</strong> <span>
           Visibility can be changed in project settings,
           <br>
@@ -161,7 +161,7 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
             </div></label></div>
       </form>
       <div class="flex my-3 items-center justify-center">
-        <mock-lock-icon class="sm-colour-icon mx-3"></mock-lock-icon>
+        <svg-lock-icon class="sm-colour-icon mx-3"></svg-lock-icon>
         <p class="ml-3 leading-5"><strong class="block">Projects are now private by default.</strong> <span>
           Visibility can be changed in project settings,
           <br>
@@ -306,7 +306,7 @@ exports[`ProjectsListPage should match snapshot 1`] = `
             </div></label></div>
       </form>
       <div class="flex my-3 items-center justify-center">
-        <mock-lock-icon class="sm-colour-icon mx-3"></mock-lock-icon>
+        <svg-lock-icon class="sm-colour-icon mx-3"></svg-lock-icon>
         <p class="ml-3 leading-5"><strong class="block">Projects are now private by default.</strong> <span>
           Visibility can be changed in project settings,
           <br>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -16,7 +16,7 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
         <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>
-          <div class="h-6 flex items-center">
+          <div class="h-10 flex items-center">
             <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
           </div>
           <!---->
@@ -162,7 +162,7 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
         <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>
-          <div class="h-6 flex items-center">
+          <div class="h-10 flex items-center">
             <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
           </div>
           <!---->
@@ -307,7 +307,7 @@ exports[`ProjectsListPage should match snapshot 1`] = `
         <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>
-          <div class="h-6 flex items-center">
+          <div class="h-10 flex items-center">
             <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
           </div>
           <!---->

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -4,8 +4,8 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
 <div class="page">
   <mock-el-dialog append-to-body="" title="Create project" class="dialog">
     <div mock-v-loading="0">
-      <form class="el-form el-form--label-top" size="mini">
-        <div><label class="leading-6"><span class="font-medium">Title</span>
+      <form class="el-form leading-6 v-rhythm-3 el-form--label-top" size="mini">
+        <div><label><span class="text-base font-medium">Title</span>
             <div class="py-1 el-input">
               <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
               <!---->
@@ -13,18 +13,16 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
               <!---->
               <!---->
             </div></label></div>
-        <div class="el-form-item my-3">
-          <!---->
-          <div class="el-form-item__content">
+        <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
+        Visibility of the project only, does not apply to included datasets
+      </span></label>
+          <div class="h-6 flex items-center">
             <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
-            <!---->
-            <transition-stub name="el-zoom-in-top">
-              <!---->
-            </transition-stub>
           </div>
+          <!---->
         </div>
       </form>
-      <div>
+      <div class="mt-6">
         <h4 class="m-0">
           Would you like to include previously submitted datasets?
         </h4>
@@ -152,8 +150,8 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
 <div class="page">
   <mock-el-dialog append-to-body="" title="Create project" class="dialog">
     <div mock-v-loading="0">
-      <form class="el-form el-form--label-top" size="mini">
-        <div><label class="leading-6"><span class="font-medium">Title</span>
+      <form class="el-form leading-6 v-rhythm-3 el-form--label-top" size="mini">
+        <div><label><span class="text-base font-medium">Title</span>
             <div class="py-1 el-input">
               <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
               <!---->
@@ -161,18 +159,16 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
               <!---->
               <!---->
             </div></label></div>
-        <div class="el-form-item my-3">
-          <!---->
-          <div class="el-form-item__content">
+        <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
+        Visibility of the project only, does not apply to included datasets
+      </span></label>
+          <div class="h-6 flex items-center">
             <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
-            <!---->
-            <transition-stub name="el-zoom-in-top">
-              <!---->
-            </transition-stub>
           </div>
+          <!---->
         </div>
       </form>
-      <div>
+      <div class="mt-6">
         <h4 class="m-0">
           Would you like to include previously submitted datasets?
         </h4>
@@ -299,8 +295,8 @@ exports[`ProjectsListPage should match snapshot 1`] = `
 <div class="page">
   <mock-el-dialog append-to-body="" title="Create project" class="dialog">
     <div mock-v-loading="0">
-      <form class="el-form el-form--label-top" size="mini">
-        <div><label class="leading-6"><span class="font-medium">Title</span>
+      <form class="el-form leading-6 v-rhythm-3 el-form--label-top" size="mini">
+        <div><label><span class="text-base font-medium">Title</span>
             <div class="py-1 el-input">
               <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
               <!---->
@@ -308,18 +304,16 @@ exports[`ProjectsListPage should match snapshot 1`] = `
               <!---->
               <!---->
             </div></label></div>
-        <div class="el-form-item my-3">
-          <!---->
-          <div class="el-form-item__content">
+        <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
+        Visibility of the project only, does not apply to included datasets
+      </span></label>
+          <div class="h-6 flex items-center">
             <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
-            <!---->
-            <transition-stub name="el-zoom-in-top">
-              <!---->
-            </transition-stub>
           </div>
+          <!---->
         </div>
       </form>
-      <div>
+      <div class="mt-6">
         <h4 class="m-0">
           Would you like to include previously submitted datasets?
         </h4>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -13,15 +13,17 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
               <!---->
               <!---->
             </div></label></div>
+        <div class="el-form-item my-3">
+          <!---->
+          <div class="el-form-item__content">
+            <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
+            <!---->
+            <transition-stub name="el-zoom-in-top">
+              <!---->
+            </transition-stub>
+          </div>
+        </div>
       </form>
-      <div class="flex my-3 items-center justify-center">
-        <svg-lock-icon class="sm-colour-icon mx-3"></svg-lock-icon>
-        <p class="ml-3 leading-5"><strong class="block">Projects are now private by default.</strong> <span>
-          Visibility can be changed in project settings,
-          <br>
-          or by using the <em>Publishing</em> workflow.
-        </span></p>
-      </div>
       <div>
         <h4 class="m-0">
           Would you like to include previously submitted datasets?
@@ -159,15 +161,17 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
               <!---->
               <!---->
             </div></label></div>
+        <div class="el-form-item my-3">
+          <!---->
+          <div class="el-form-item__content">
+            <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
+            <!---->
+            <transition-stub name="el-zoom-in-top">
+              <!---->
+            </transition-stub>
+          </div>
+        </div>
       </form>
-      <div class="flex my-3 items-center justify-center">
-        <svg-lock-icon class="sm-colour-icon mx-3"></svg-lock-icon>
-        <p class="ml-3 leading-5"><strong class="block">Projects are now private by default.</strong> <span>
-          Visibility can be changed in project settings,
-          <br>
-          or by using the <em>Publishing</em> workflow.
-        </span></p>
-      </div>
       <div>
         <h4 class="m-0">
           Would you like to include previously submitted datasets?
@@ -304,15 +308,17 @@ exports[`ProjectsListPage should match snapshot 1`] = `
               <!---->
               <!---->
             </div></label></div>
+        <div class="el-form-item my-3">
+          <!---->
+          <div class="el-form-item__content">
+            <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
+            <!---->
+            <transition-stub name="el-zoom-in-top">
+              <!---->
+            </transition-stub>
+          </div>
+        </div>
       </form>
-      <div class="flex my-3 items-center justify-center">
-        <svg-lock-icon class="sm-colour-icon mx-3"></svg-lock-icon>
-        <p class="ml-3 leading-5"><strong class="block">Projects are now private by default.</strong> <span>
-          Visibility can be changed in project settings,
-          <br>
-          or by using the <em>Publishing</em> workflow.
-        </span></p>
-      </div>
       <div>
         <h4 class="m-0">
           Would you like to include previously submitted datasets?

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
@@ -788,8 +788,8 @@ exports[`ViewProjectPage settings tab should disable actions when published 1`] 
             <div class="mt-6 mb-12">
               <form action="#" class="sm-form">
                 <h2>Project Details</h2>
-                <form class="el-form mt-3 el-form--label-top">
-                  <div><label class="leading-6"><span class="font-medium">Title</span>
+                <form class="el-form leading-6 mt-3 mb-6 v-rhythm-6 el-form--label-top">
+                  <div><label><span class="text-base font-medium">Title</span>
                       <div class="py-1 el-input">
                         <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
                         <!---->
@@ -797,16 +797,15 @@ exports[`ViewProjectPage settings tab should disable actions when published 1`] 
                         <!---->
                         <!---->
                       </div></label></div>
-                  <div class="el-form-item my-3">
-                    <!---->
-                    <div class="el-form-item__content">
-                      <div role="switch" aria-disabled="true" class="el-switch is-disabled"><input type="checkbox" name="" true-value="true" disabled="disabled" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div> <span class="text-gray-700 float-right">
-      Published projects are always visible.
-    </span>
-                      <transition-stub name="el-zoom-in-top">
-                        <!---->
-                      </transition-stub>
+                  <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
+        Visibility of the project only, does not apply to included datasets
+      </span></label>
+                    <div class="h-6 flex items-center">
+                      <div role="switch" aria-disabled="true" class="el-switch is-disabled"><input type="checkbox" name="" true-value="true" disabled="disabled" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
                     </div>
+                    <p class="m-0 italic text-sm text-gray-700">
+                      published projects are always visible
+                    </p>
                   </div>
                 </form>
                 <div><label for="project-settings-short-link"><span class="text-base font-medium">Short link</span><span class="block text-sm text-gray-800">Must be unique, min. 4 characters, using a–z, 0–9, hyphen or underscore</span></label>
@@ -890,8 +889,8 @@ exports[`ViewProjectPage settings tab should disable actions when under review 1
             <div class="mt-6 mb-12">
               <form action="#" class="sm-form">
                 <h2>Project Details</h2>
-                <form class="el-form mt-3 el-form--label-top">
-                  <div><label class="leading-6"><span class="font-medium">Title</span>
+                <form class="el-form leading-6 mt-3 mb-6 v-rhythm-6 el-form--label-top">
+                  <div><label><span class="text-base font-medium">Title</span>
                       <div class="py-1 el-input">
                         <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
                         <!---->
@@ -899,15 +898,13 @@ exports[`ViewProjectPage settings tab should disable actions when under review 1
                         <!---->
                         <!---->
                       </div></label></div>
-                  <div class="el-form-item my-3">
-                    <!---->
-                    <div class="el-form-item__content">
+                  <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
+        Visibility of the project only, does not apply to included datasets
+      </span></label>
+                    <div class="h-6 flex items-center">
                       <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
-                      <!---->
-                      <transition-stub name="el-zoom-in-top">
-                        <!---->
-                      </transition-stub>
                     </div>
+                    <!---->
                   </div>
                 </form>
                 <div><label for="project-settings-short-link"><span class="text-base font-medium">Short link</span><span class="block text-sm text-gray-800">Must be unique, min. 4 characters, using a–z, 0–9, hyphen or underscore</span></label>
@@ -986,8 +983,8 @@ exports[`ViewProjectPage settings tab should match snapshot 1`] = `
             <div class="mt-6 mb-12">
               <form action="#" class="sm-form">
                 <h2>Project Details</h2>
-                <form class="el-form mt-3 el-form--label-top">
-                  <div><label class="leading-6"><span class="font-medium">Title</span>
+                <form class="el-form leading-6 mt-3 mb-6 v-rhythm-6 el-form--label-top">
+                  <div><label><span class="text-base font-medium">Title</span>
                       <div class="py-1 el-input">
                         <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
                         <!---->
@@ -995,15 +992,13 @@ exports[`ViewProjectPage settings tab should match snapshot 1`] = `
                         <!---->
                         <!---->
                       </div></label></div>
-                  <div class="el-form-item my-3">
-                    <!---->
-                    <div class="el-form-item__content">
+                  <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
+        Visibility of the project only, does not apply to included datasets
+      </span></label>
+                    <div class="h-6 flex items-center">
                       <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
-                      <!---->
-                      <transition-stub name="el-zoom-in-top">
-                        <!---->
-                      </transition-stub>
                     </div>
+                    <!---->
                   </div>
                 </form>
                 <div><label for="project-settings-short-link"><span class="text-base font-medium">Short link</span><span class="block text-sm text-gray-800">Must be unique, min. 4 characters, using a–z, 0–9, hyphen or underscore</span></label>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
@@ -788,7 +788,7 @@ exports[`ViewProjectPage settings tab should disable actions when published 1`] 
             <div class="mt-6 mb-12">
               <form action="#" class="sm-form">
                 <h2>Project Details</h2>
-                <form class="el-form mt-3 el-form--label-top" is-published="true">
+                <form class="el-form mt-3 el-form--label-top">
                   <div><label class="leading-6"><span class="font-medium">Title</span>
                       <div class="py-1 el-input">
                         <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
@@ -797,10 +797,18 @@ exports[`ViewProjectPage settings tab should disable actions when published 1`] 
                         <!---->
                         <!---->
                       </div></label></div>
+                  <div class="el-form-item my-3">
+                    <!---->
+                    <div class="el-form-item__content">
+                      <div role="switch" aria-disabled="true" class="el-switch is-disabled"><input type="checkbox" name="" true-value="true" disabled="disabled" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div> <span class="text-gray-700 float-right">
+      Published projects are always visible.
+    </span>
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
+                    </div>
+                  </div>
                 </form>
-                <div class="my-3"><label class="el-checkbox is-disabled"><span class="el-checkbox__input is-disabled"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" disabled="disabled" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-          Published projects must be visible
-        <!----></span></label></div>
                 <div><label for="project-settings-short-link"><span class="text-base font-medium">Short link</span><span class="block text-sm text-gray-800">Must be unique, min. 4 characters, using a–z, 0–9, hyphen or underscore</span></label>
                   <div class="el-input is-disabled el-input-group el-input-group--prepend">
                     <div class="el-input-group__prepend"><span>http://localhost/project/</span></div><input type="text" disabled="disabled" autocomplete="off" id="project-settings-short-link" maxlength="50" minlength="4" pattern="[a-zA-Z0-9_-]+" title="min. 4 characters, a–z, 0–9, hyphen or underscore" class="el-input__inner">
@@ -891,10 +899,17 @@ exports[`ViewProjectPage settings tab should disable actions when under review 1
                         <!---->
                         <!---->
                       </div></label></div>
+                  <div class="el-form-item my-3">
+                    <!---->
+                    <div class="el-form-item__content">
+                      <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
+                      <!---->
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
+                    </div>
+                  </div>
                 </form>
-                <div class="my-3"><label class="el-checkbox"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-          Allow other users to see this project
-        <!----></span></label></div>
                 <div><label for="project-settings-short-link"><span class="text-base font-medium">Short link</span><span class="block text-sm text-gray-800">Must be unique, min. 4 characters, using a–z, 0–9, hyphen or underscore</span></label>
                   <div class="el-input el-input-group el-input-group--prepend">
                     <div class="el-input-group__prepend"><span>http://localhost/project/</span></div><input type="text" autocomplete="off" id="project-settings-short-link" maxlength="50" minlength="4" pattern="[a-zA-Z0-9_-]+" title="min. 4 characters, a–z, 0–9, hyphen or underscore" class="el-input__inner">
@@ -980,10 +995,17 @@ exports[`ViewProjectPage settings tab should match snapshot 1`] = `
                         <!---->
                         <!---->
                       </div></label></div>
+                  <div class="el-form-item my-3">
+                    <!---->
+                    <div class="el-form-item__content">
+                      <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
+                      <!---->
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
+                    </div>
+                  </div>
                 </form>
-                <div class="my-3"><label class="el-checkbox"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-          Allow other users to see this project
-        <!----></span></label></div>
                 <div><label for="project-settings-short-link"><span class="text-base font-medium">Short link</span><span class="block text-sm text-gray-800">Must be unique, min. 4 characters, using a–z, 0–9, hyphen or underscore</span></label>
                   <div class="el-input el-input-group el-input-group--prepend">
                     <div class="el-input-group__prepend"><span>http://localhost/project/</span></div><input type="text" autocomplete="off" id="project-settings-short-link" maxlength="50" minlength="4" pattern="[a-zA-Z0-9_-]+" title="min. 4 characters, a–z, 0–9, hyphen or underscore" class="el-input__inner">

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
@@ -800,7 +800,7 @@ exports[`ViewProjectPage settings tab should disable actions when published 1`] 
                   <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>
-                    <div class="h-6 flex items-center">
+                    <div class="h-10 flex items-center">
                       <div role="switch" aria-disabled="true" class="el-switch is-disabled"><input type="checkbox" name="" true-value="true" disabled="disabled" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
                     </div>
                     <p class="m-0 italic text-sm text-gray-700">
@@ -901,7 +901,7 @@ exports[`ViewProjectPage settings tab should disable actions when under review 1
                   <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>
-                    <div class="h-6 flex items-center">
+                    <div class="h-10 flex items-center">
                       <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
                     </div>
                     <!---->
@@ -995,7 +995,7 @@ exports[`ViewProjectPage settings tab should match snapshot 1`] = `
                   <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>
-                    <div class="h-6 flex items-center">
+                    <div class="h-10 flex items-center">
                       <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
                     </div>
                     <!---->

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
@@ -788,7 +788,7 @@ exports[`ViewProjectPage settings tab should disable actions when published 1`] 
             <div class="mt-6 mb-12">
               <form action="#" class="sm-form">
                 <h2>Project Details</h2>
-                <form class="el-form mt-3 el-form--label-top">
+                <form class="el-form mt-3 el-form--label-top" is-published="true">
                   <div><label class="leading-6"><span class="font-medium">Title</span>
                       <div class="py-1 el-input">
                         <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
@@ -797,17 +797,10 @@ exports[`ViewProjectPage settings tab should disable actions when published 1`] 
                         <!---->
                         <!---->
                       </div></label></div>
-                  <div class="el-form-item my-3">
-                    <!---->
-                    <div class="el-form-item__content"><label class="el-checkbox is-disabled"><span class="el-checkbox__input is-disabled"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" disabled="disabled" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-      Published projects must be visible
-    <!----></span></label>
-                      <transition-stub name="el-zoom-in-top">
-                        <!---->
-                      </transition-stub>
-                    </div>
-                  </div>
                 </form>
+                <div class="my-3"><label class="el-checkbox is-disabled"><span class="el-checkbox__input is-disabled"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" disabled="disabled" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
+          Published projects must be visible
+        <!----></span></label></div>
                 <div><label for="project-settings-short-link"><span class="text-base font-medium">Short link</span><span class="block text-sm text-gray-800">Must be unique, min. 4 characters, using a–z, 0–9, hyphen or underscore</span></label>
                   <div class="el-input is-disabled el-input-group el-input-group--prepend">
                     <div class="el-input-group__prepend"><span>http://localhost/project/</span></div><input type="text" disabled="disabled" autocomplete="off" id="project-settings-short-link" maxlength="50" minlength="4" pattern="[a-zA-Z0-9_-]+" title="min. 4 characters, a–z, 0–9, hyphen or underscore" class="el-input__inner">
@@ -898,17 +891,10 @@ exports[`ViewProjectPage settings tab should disable actions when under review 1
                         <!---->
                         <!---->
                       </div></label></div>
-                  <div class="el-form-item my-3">
-                    <!---->
-                    <div class="el-form-item__content"><label class="el-checkbox"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-      Allow other users to see this project
-    <!----></span></label>
-                      <transition-stub name="el-zoom-in-top">
-                        <!---->
-                      </transition-stub>
-                    </div>
-                  </div>
                 </form>
+                <div class="my-3"><label class="el-checkbox"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
+          Allow other users to see this project
+        <!----></span></label></div>
                 <div><label for="project-settings-short-link"><span class="text-base font-medium">Short link</span><span class="block text-sm text-gray-800">Must be unique, min. 4 characters, using a–z, 0–9, hyphen or underscore</span></label>
                   <div class="el-input el-input-group el-input-group--prepend">
                     <div class="el-input-group__prepend"><span>http://localhost/project/</span></div><input type="text" autocomplete="off" id="project-settings-short-link" maxlength="50" minlength="4" pattern="[a-zA-Z0-9_-]+" title="min. 4 characters, a–z, 0–9, hyphen or underscore" class="el-input__inner">
@@ -994,17 +980,10 @@ exports[`ViewProjectPage settings tab should match snapshot 1`] = `
                         <!---->
                         <!---->
                       </div></label></div>
-                  <div class="el-form-item my-3">
-                    <!---->
-                    <div class="el-form-item__content"><label class="el-checkbox"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-      Allow other users to see this project
-    <!----></span></label>
-                      <transition-stub name="el-zoom-in-top">
-                        <!---->
-                      </transition-stub>
-                    </div>
-                  </div>
                 </form>
+                <div class="my-3"><label class="el-checkbox"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
+          Allow other users to see this project
+        <!----></span></label></div>
                 <div><label for="project-settings-short-link"><span class="text-base font-medium">Short link</span><span class="block text-sm text-gray-800">Must be unique, min. 4 characters, using a–z, 0–9, hyphen or underscore</span></label>
                   <div class="el-input el-input-group el-input-group--prepend">
                     <div class="el-input-group__prepend"><span>http://localhost/project/</span></div><input type="text" autocomplete="off" id="project-settings-short-link" maxlength="50" minlength="4" pattern="[a-zA-Z0-9_-]+" title="min. 4 characters, a–z, 0–9, hyphen or underscore" class="el-input__inner">

--- a/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
@@ -174,7 +174,7 @@ exports[`EditUserPage should match snapshot 1`] = `
               <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>
-                <div class="h-6 flex items-center">
+                <div class="h-10 flex items-center">
                   <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
                 </div>
                 <!---->

--- a/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
@@ -171,15 +171,17 @@ exports[`EditUserPage should match snapshot 1`] = `
                     <!---->
                     <!---->
                   </div></label></div>
+              <div class="el-form-item my-3">
+                <!---->
+                <div class="el-form-item__content">
+                  <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
+                  <!---->
+                  <transition-stub name="el-zoom-in-top">
+                    <!---->
+                  </transition-stub>
+                </div>
+              </div>
             </form>
-            <div class="flex my-3 items-center justify-center">
-              <svg-lock-icon class="sm-colour-icon mx-3"></svg-lock-icon>
-              <p class="ml-3 leading-5"><strong class="block">Projects are now private by default.</strong> <span>
-          Visibility can be changed in project settings,
-          <br>
-          or by using the <em>Publishing</em> workflow.
-        </span></p>
-            </div>
             <div>
               <h4 class="m-0">
                 Would you like to include previously submitted datasets?

--- a/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
@@ -173,7 +173,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                   </div></label></div>
             </form>
             <div class="flex my-3 items-center justify-center">
-              <mock-lock-icon class="sm-colour-icon mx-3"></mock-lock-icon>
+              <svg-lock-icon class="sm-colour-icon mx-3"></svg-lock-icon>
               <p class="ml-3 leading-5"><strong class="block">Projects are now private by default.</strong> <span>
           Visibility can be changed in project settings,
           <br>

--- a/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
@@ -162,8 +162,8 @@ exports[`EditUserPage should match snapshot 1`] = `
       <div class="el-row">
         <mock-el-dialog append-to-body="" title="Create project" class="dialog">
           <div mock-v-loading="0">
-            <form class="el-form el-form--label-top" size="mini">
-              <div><label class="leading-6"><span class="font-medium">Title</span>
+            <form class="el-form leading-6 v-rhythm-3 el-form--label-top" size="mini">
+              <div><label><span class="text-base font-medium">Title</span>
                   <div class="py-1 el-input">
                     <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
                     <!---->
@@ -171,18 +171,16 @@ exports[`EditUserPage should match snapshot 1`] = `
                     <!---->
                     <!---->
                   </div></label></div>
-              <div class="el-form-item my-3">
-                <!---->
-                <div class="el-form-item__content">
+              <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
+        Visibility of the project only, does not apply to included datasets
+      </span></label>
+                <div class="h-6 flex items-center">
                   <div role="switch" class="el-switch"><input type="checkbox" name="" true-value="true" class="el-switch__input"><span class="el-switch__label el-switch__label--left is-active"><!----><span>Private</span></span><span class="el-switch__core" style="width: 40px;"></span><span class="el-switch__label el-switch__label--right"><!----><span aria-hidden="true">Public</span></span></div>
-                  <!---->
-                  <transition-stub name="el-zoom-in-top">
-                    <!---->
-                  </transition-stub>
                 </div>
+                <!---->
               </div>
             </form>
-            <div>
+            <div class="mt-6">
               <h4 class="m-0">
                 Would you like to include previously submitted datasets?
               </h4>

--- a/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
@@ -171,17 +171,15 @@ exports[`EditUserPage should match snapshot 1`] = `
                     <!---->
                     <!---->
                   </div></label></div>
-              <div class="el-form-item my-3">
-                <!---->
-                <div class="el-form-item__content"><label class="el-checkbox is-checked"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span><span class="el-checkbox__label">
-      Allow other users to see this project
-    <!----></span></label>
-                  <transition-stub name="el-zoom-in-top">
-                    <!---->
-                  </transition-stub>
-                </div>
-              </div>
             </form>
+            <div class="flex my-3 items-center justify-center">
+              <mock-lock-icon class="sm-colour-icon mx-3"></mock-lock-icon>
+              <p class="ml-3 leading-5"><strong class="block">Projects are now private by default.</strong> <span>
+          Visibility can be changed in project settings,
+          <br>
+          or by using the <em>Publishing</em> workflow.
+        </span></p>
+            </div>
             <div>
               <h4 class="m-0">
                 Would you like to include previously submitted datasets?

--- a/metaspace/webapp/tests/utils/registerSVGIcons.ts
+++ b/metaspace/webapp/tests/utils/registerSVGIcons.ts
@@ -3,22 +3,19 @@ import Vue, { CreateElement, VNode } from 'vue'
 const fs = require('fs')
 const path = require('path')
 
+const relativePath = '../../src/assets/inline/refactoring-ui'
+const files = fs.readdirSync(path.resolve(__dirname, relativePath))
+
 export default () => {
-  const relativePath = '../../src/assets/inline/refactoring-ui'
-  fs.readdir(path.resolve(__dirname, relativePath), (err: Error, files: string[]) => {
-    if (err) {
-      throw err
-    }
-    for (const file of files) {
-      const name = `${file.split('.')[0]}-icon`
-      const mockName = `svg-${name}`
-      Vue.config.ignoredElements.push(mockName)
-      Vue.component(name, {
-        name,
-        render(h: CreateElement): VNode {
-          return h(mockName, {}, [this.$slots.default])
-        },
-      })
-    }
-  })
+  for (const file of files) {
+    const name = `${file.split('.')[0]}-icon`
+    const mockName = `svg-${name}`
+    Vue.config.ignoredElements.push(mockName)
+    Vue.component(name, {
+      name,
+      render(h: CreateElement): VNode {
+        return h(mockName)
+      },
+    })
+  }
 }

--- a/metaspace/webapp/tests/utils/registerSVGIcons.ts
+++ b/metaspace/webapp/tests/utils/registerSVGIcons.ts
@@ -1,0 +1,24 @@
+import Vue, { CreateElement, VNode } from 'vue'
+
+const fs = require('fs')
+const path = require('path')
+
+export default () => {
+  const relativePath = '../../src/assets/inline/refactoring-ui'
+  fs.readdir(path.resolve(__dirname, relativePath), (err: Error, files: string[]) => {
+    if (err) {
+      throw err
+    }
+    for (const file of files) {
+      const name = `${file.split('.')[0]}-icon`
+      const mockName = `svg-${name}`
+      Vue.config.ignoredElements.push(mockName)
+      Vue.component(name, {
+        name,
+        render(h: CreateElement): VNode {
+          return h(mockName, {}, [this.$slots.default])
+        },
+      })
+    }
+  })
+}

--- a/metaspace/webapp/tests/utils/setupTestFramework.ts
+++ b/metaspace/webapp/tests/utils/setupTestFramework.ts
@@ -45,8 +45,7 @@ jest.mock('../../src/lib/delay', () => jest.fn(() => Promise.resolve()))
 registerMockComponent('elapsed-time', { path: '../../src/components/ElapsedTime' })
 
 // Mock svg icons
-// registerSVGIcons() <-- doesn't work
-registerMockComponent('lock-icon')
+registerSVGIcons()
 
 // Automatically clean up components after each test to prevent stale components from updating due to e.g. route changes
 // @ts-ignore

--- a/metaspace/webapp/tests/utils/setupTestFramework.ts
+++ b/metaspace/webapp/tests/utils/setupTestFramework.ts
@@ -7,6 +7,7 @@ import * as vueTestUtils from '@vue/test-utils'
 import { replaceConfigWithDefaultForTests } from '../../src/lib/config'
 import VueCompositionApi from '@vue/composition-api'
 import './mockGenerateId'
+import registerSVGIcons from './registerSVGIcons'
 
 window.fetch = jest.fn()
 window.scrollTo = jest.fn()
@@ -42,6 +43,10 @@ jest.mock('../../src/lib/delay', () => jest.fn(() => Promise.resolve()))
 
 // Mock elapsed time as it relies on variables such as current time and locale
 registerMockComponent('elapsed-time', { path: '../../src/components/ElapsedTime' })
+
+// Mock svg icons
+// registerSVGIcons() <-- doesn't work
+registerMockComponent('lock-icon')
 
 // Automatically clean up components after each test to prevent stale components from updating due to e.g. route changes
 // @ts-ignore


### PR DESCRIPTION
**Notes on optional 2nd commit:**
Felt that the empty checkbox causes unnecessary worry at point in the process where a user probably needs to write the description and organise datasets before making the project public. A note provides instructions on where/how to find the setting after the project is created.