### PR TITLE
Fix "inconsistent annotations" error

### DIFF
--- a/metaspace/webapp/src/api/annotation.ts
+++ b/metaspace/webapp/src/api/annotation.ts
@@ -188,10 +188,10 @@ export const relatedMoleculesQuery =
   }`
 
 export const isobarsQuery =
-  gql`query IsobarsQuery($datasetId: String!, $ionFormula: String!, $databaseId: String!) {
+  gql`query IsobarsQuery($datasetId: String!, $filter: AnnotationFilter!) {
     allAnnotations(
       datasetFilter: { ids: $datasetId },
-      filter: { isobaricWith: $ionFormula, databaseId: $databaseId },
+      filter: $filter,
       orderBy: ORDER_BY_FDR_MSM,
       sortingOrder: ASCENDING
     ) {

--- a/metaspace/webapp/src/api/annotation.ts
+++ b/metaspace/webapp/src/api/annotation.ts
@@ -36,6 +36,9 @@ gql`query GetAnnotations($orderBy: AnnotationOrderBy, $sortingOrder: SortingOrde
           metadataJson
           isPublic
         }
+        databaseDetails {
+          id
+        }
         isotopeImages {
           mz
           url
@@ -185,9 +188,13 @@ export const relatedMoleculesQuery =
   }`
 
 export const isobarsQuery =
-  gql`query IsobarsQuery($datasetId: String!, $ionFormula: String!) {
-    allAnnotations(datasetFilter: { ids: $datasetId }, filter: { isobaricWith: $ionFormula },
-                   orderBy: ORDER_BY_FDR_MSM, sortingOrder: ASCENDING) {
+  gql`query IsobarsQuery($datasetId: String!, $ionFormula: String!, $databaseId: String!) {
+    allAnnotations(
+      datasetFilter: { ids: $datasetId },
+      filter: { isobaricWith: $ionFormula, databaseId: $databaseId },
+      orderBy: ORDER_BY_FDR_MSM,
+      sortingOrder: ASCENDING
+    ) {
       id
       ion
       ionFormula

--- a/metaspace/webapp/src/lib/reportError.ts
+++ b/metaspace/webapp/src/lib/reportError.ts
@@ -1,6 +1,7 @@
 import { ElNotification } from 'element-ui/types/notification'
 import * as Sentry from '@sentry/browser'
 import { every } from 'lodash-es'
+import { Primitive } from 'ts-essentials'
 
 let $notify: ElNotification
 
@@ -18,11 +19,15 @@ function isHandled(err: any) {
 
 const DEFAULT_MESSAGE = 'Oops! Something went wrong. Please refresh the page and try again.'
 
-export default function reportError(err: Error, message: string | null = DEFAULT_MESSAGE) {
+export default function reportError(
+  err: Error,
+  message: string | null = DEFAULT_MESSAGE,
+  extraData?: Record<string, Primitive>,
+) {
   try {
     if (!isHandled(err)) {
-      Sentry.captureException(err)
-      console.error(err)
+      Sentry.captureException(err, { contexts: extraData })
+      console.error(err, extraData)
       if ($notify != null && message) {
         $notify.error(message)
       }

--- a/metaspace/webapp/src/lib/reportError.ts
+++ b/metaspace/webapp/src/lib/reportError.ts
@@ -26,7 +26,7 @@ export default function reportError(
 ) {
   try {
     if (!isHandled(err)) {
-      Sentry.captureException(err, { contexts: extraData })
+      Sentry.captureException(err, { contexts: { 'Extra Data': extraData } })
       console.error(err, extraData)
       if ($notify != null && message) {
         $notify.error(message)

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.spec.ts
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.spec.ts
@@ -6,6 +6,7 @@ import store from '../../../../store/index'
 import Vue from 'vue'
 import Vuex from 'vuex'
 import { sync } from 'vuex-router-sync'
+import * as reportErrorModule from '../../../../lib/reportError'
 
 Vue.use(Vuex)
 sync(store, router)
@@ -40,6 +41,9 @@ describe('Diagnostics', () => {
     dataset: {
       id: '2019-02-12_15h55m06s',
       name: 'Untreated_3_434',
+    },
+    databaseDetails: {
+      id: 24,
     },
     offSample: false,
     offSampleProb: 0.03,
@@ -130,13 +134,14 @@ describe('Diagnostics', () => {
         allAnnotations: () => ([isobarAnnotation]),
       }),
     })
-    console.error = (...args: any[]) => { throw new Error(...args) }
+    const reportErrorFunc = jest.spyOn(reportErrorModule, 'default')
 
     const wrapper = mount(Diagnostics, { store, router, apolloProvider, stubs, propsData: props })
     await Vue.nextTick()
     wrapper.setData({ comparisonIonFormula: isobarAnnotation.ionFormula })
     await Vue.nextTick()
 
+    expect(reportErrorFunc).not.toBeCalled() // "Inconsistent annotations" warning should fail the test
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
@@ -156,7 +156,7 @@ interface AnnotationGroup {
         return {
           datasetId: this.annotation.dataset.id,
           ionFormula: this.annotation.ionFormula,
-          database: this.annotation.database,
+          database: this.annotation.databaseDetails.id,
         }
       },
       update(data) {

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
@@ -206,11 +206,15 @@ export default class Diagnostics extends Vue {
       if (!this.loading
           && this.isobarAnnotationsIonFormula === this.annotation.ionFormula
           && missingIonFormulas.length > 0) {
-        reportError(new Error(
-          'Inconsistent annotations between Annotation.isobars and isobaricWith query results. '
-              + `Annotation ${this.annotation.id} ${this.annotation.ion}: `
-              + `${Object.keys(isobarsByIonFormula).join(',')} != ${Object.keys(annotationsByIonFormula).join(',')}`,
-        ), null)
+        reportError(
+          new Error('Inconsistent annotations between Annotation.isobars and isobaricWith query results.'),
+          null,
+          {
+            annotationId: this.annotation.id,
+            ion: this.annotation.ion,
+            isobarsFromAnnotation: Object.keys(isobarsByIonFormula).join(','),
+            isobarsFromQuery: Object.keys(annotationsByIonFormula).join(','),
+          })
       }
 
       const groups = ionFormulas.map(ionFormula => {

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/Diagnostics.vue
@@ -155,8 +155,10 @@ interface AnnotationGroup {
         this.isobarAnnotationsIonFormula = this.annotation.ionFormula
         return {
           datasetId: this.annotation.dataset.id,
-          ionFormula: this.annotation.ionFormula,
-          database: this.annotation.databaseDetails.id,
+          filter: {
+            isobaricWith: this.annotation.ionFormula,
+            databaseId: this.annotation.databaseDetails.id,
+          },
         }
       },
       update(data) {
@@ -212,8 +214,8 @@ export default class Diagnostics extends Vue {
           {
             annotationId: this.annotation.id,
             ion: this.annotation.ion,
-            isobarsFromAnnotation: Object.keys(isobarsByIonFormula).join(','),
-            isobarsFromQuery: Object.keys(annotationsByIonFormula).join(','),
+            isobarsFromPropsAnnotation: isobarsKeys.join(','),
+            isobarsFromQuery: annotationsKeys.join(','),
           })
       }
 


### PR DESCRIPTION
Fixes #653

Context: Two annotations are isobaric if they have overlapping m/z ranges for one or more of their ion images. This is a reflexive relationship - if A is isobaric with B, B is isobaric with A. The `Diagnostics` component relies on this reflexivity - some data comes from the list of isobars in the original annotation, and other data comes from a "all annotations that list (original annotation) as an isobar" query. Because it needs data from both queries for each isobar, it reports an error when the two lists don't match up.

The isobars query was missing a parameter for the database ID. This parameter is important because isobars are always calculated within the set of annotations for a single database. When annotation A was isobaric with annotation B from a different database, A wouldn't list B as an isobar, but the isobars query would find B anyway because it had no database filter. This lead to the error report that the isobars were inconsistent. Based on Sentry, this has happened >1200 times.

Additionally, Sentry has had trouble consolidating these errors because they use a different error message every time. This has gotten really spammy lately, because it keeps reporting them as new errors. I added a new `extraData` parameter to `reportError` so that the message would stay the same, but the data would still be sent. When `extraData` is supplied, the data appears near the bottom of the page on Sentry:

![image](https://user-images.githubusercontent.com/26366936/95682424-71d2f880-0be5-11eb-8333-ba5cb1b1ce7c.png)
