### PR TITLE
Ignore ResizeObserver errors

### DIFF
--- a/metaspace/webapp/src/main.ts
+++ b/metaspace/webapp/src/main.ts
@@ -32,6 +32,12 @@ if (config.sentry != null && config.sentry.dsn !== '') {
   Sentry.init({
     ...config.sentry,
     integrations: [new SentryVue({ Vue, logErrors: true })],
+    ignoreErrors: [
+      // Ignore ResizeObserver errors - this seems to be a benign issue, but there's not enough detail to track down
+      // the root cause, and the error reports are so spammy they can easily blow our monthly quota.
+      'ResizeObserver loop completed with undelivered notifications.',
+      'ResizeObserver loop limit exceeded',
+    ],
   })
 }
 Vue.use(VueApollo)


### PR DESCRIPTION
This error blew our Sentry quota (5000 events/month):

![image](https://user-images.githubusercontent.com/26366936/97701325-86503580-1aad-11eb-8b9f-6beb9141ccfb.png)

The reports don't give enough detail to determine which component is causing these events. Sentry reports show the events happening on the Annotations page, the Upload page, and project pages...

The error seems benign enough to ignore. To prevent circular updates, when there are nested elements with attached ResizeObservers, the spec says that dependent changes should only flow from parent to child. This error is raised if an observed child element causes an observed parent element to change size. So basically, worst case, some element doesn't resize/reposition itself correctly in response to a browser resize event or page layout change. 