### PR TITLE
Prevent datasets from being un-deleted

### DIFF
--- a/metaspace/engine/sm/engine/dataset.py
+++ b/metaspace/engine/sm/engine/dataset.py
@@ -128,7 +128,7 @@ class Dataset:
         res = db.select_one(self.DS_SEL, params=(self.id,))
         return bool(res)
 
-    def save(self, db, es=None):
+    def save(self, db, es=None, allow_insert=False):
         doc = {
             'id': self.id,
             'name': self.name,
@@ -141,7 +141,10 @@ class Dataset:
             'is_public': self.is_public,
         }
         if not self.is_stored(db):
-            db.insert(self.DS_INSERT, rows=[doc])
+            if allow_insert:
+                db.insert(self.DS_INSERT, rows=[doc])
+            else:
+                raise UnknownDSID(f'Dataset does not exist: {self.id}')
         else:
             db.alter(self.DS_UPD, params=doc)
         logger.info(f'Inserted into dataset table: {self.id}, {self.name}')

--- a/metaspace/engine/sm/engine/sm_daemons.py
+++ b/metaspace/engine/sm/engine/sm_daemons.py
@@ -14,7 +14,7 @@ from sm.engine.colocalization import Colocalization
 from sm.engine.daemon_action import DaemonAction, DaemonActionStage
 from sm.engine.dataset import Dataset, DatasetStatus
 from sm.engine.db import DB
-from sm.engine.errors import AnnotationError, ImzMLError, IndexUpdateError, SMError
+from sm.engine.errors import AnnotationError, ImzMLError, IndexUpdateError, SMError, UnknownDSID
 from sm.engine.es_export import ESExporter
 from sm.engine.ion_thumbnail import generate_ion_thumbnail
 from sm.engine.isocalc_wrapper import IsocalcWrapper
@@ -341,7 +341,11 @@ class SMIndexUpdateDaemon:
                 except Exception as e:  # don't fail dataset when off-sample pred fails
                     self.logger.warning(f'Failed to classify off-sample: {e}')
 
-                self._manager.index(ds=ds)
+                try:
+                    self._manager.index(ds=ds)
+                except UnknownDSID:
+                    # Sometimes the DS will have been deleted before this point
+                    self.logger.warning(f'DS missing after off-sample classification: {ds.id}')
 
             elif msg['action'] == DaemonAction.UPDATE:
                 self._manager.update(ds, msg['fields'])

--- a/metaspace/engine/sm/rest/dataset_manager.py
+++ b/metaspace/engine/sm/rest/dataset_manager.py
@@ -89,7 +89,7 @@ class SMapiDatasetManager:
             is_public=doc.get('is_public'),
             status=DatasetStatus.QUEUED,
         )
-        ds.save(self._db, self._es, allow_insert=True)
+        ds.save(self._db, self._es)
         self._status_queue.publish(
             {'ds_id': ds.id, 'action': DaemonAction.ANNOTATE, 'stage': DaemonActionStage.QUEUED}
         )

--- a/metaspace/engine/sm/rest/dataset_manager.py
+++ b/metaspace/engine/sm/rest/dataset_manager.py
@@ -89,7 +89,7 @@ class SMapiDatasetManager:
             is_public=doc.get('is_public'),
             status=DatasetStatus.QUEUED,
         )
-        ds.save(self._db, self._es)
+        ds.save(self._db, self._es, allow_insert=True)
         self._status_queue.publish(
             {'ds_id': ds.id, 'action': DaemonAction.ANNOTATE, 'stage': DaemonActionStage.QUEUED}
         )

--- a/metaspace/engine/tests/conftest.py
+++ b/metaspace/engine/tests/conftest.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from copy import deepcopy
 from random import randint
 from pathlib import Path
 import uuid
@@ -15,7 +16,7 @@ from sm.engine.db import DB, ConnectionPool
 from sm.engine.tests.db_sql_schema import DB_SQL_SCHEMA
 from sm.engine.util import proj_root, SMConfig, init_loggers, populate_aws_env_vars
 from sm.engine.es_export import ESIndexManager
-from .utils import create_test_molecular_db
+from .utils import TEST_METADATA, TEST_DS_CONFIG, create_test_molecular_db
 
 TEST_CONFIG_PATH = 'conf/test_config.json'
 
@@ -36,35 +37,12 @@ def global_setup(sm_config):
 
 @pytest.fixture()
 def metadata():
-    return {
-        "Data_Type": "Imaging MS",
-        "MS_Analysis": {
-            "Polarity": "Positive",
-            "Ionisation_Source": "MALDI",
-            "Detector_Resolving_Power": {"Resolving_Power": 80000, "mz": 700},
-            "Analyzer": "FTICR",
-            "Pixel_Size": {"Xaxis": 100, "Yaxis": 100},
-        },
-    }
+    return deepcopy(TEST_METADATA)
 
 
 @pytest.fixture()
 def ds_config():
-    return {
-        "image_generation": {"n_levels": 30, "ppm": 3, "min_px": 1},
-        "analysis_version": 1,
-        "isotope_generation": {
-            "adducts": ["+H", "+Na", "+K", "[M]+"],
-            "charge": 1,
-            "isocalc_sigma": 0.000619,
-            "instrument": "FTICR",
-            "n_peaks": 4,
-            "neutral_losses": [],
-            "chem_mods": [],
-        },
-        "fdr": {"decoy_sample_size": 20},
-        "database_ids": [0],
-    }
+    return deepcopy(TEST_DS_CONFIG)
 
 
 @pytest.fixture(scope='module')

--- a/metaspace/engine/tests/sci_test/spheroid.py
+++ b/metaspace/engine/tests/sci_test/spheroid.py
@@ -140,7 +140,7 @@ class SciTester:
 
         ds = create_ds_from_files(self.ds_id, self.ds_name, self.input_path)
         self.db.alter('DELETE FROM job WHERE ds_id=%s', params=(ds.id,))
-        ds.save(self.db)
+        ds.save(self.db, allow_insert=True)
         AnnotationJob(img_store, ds).run()
 
     def clear_data_dirs(self):

--- a/metaspace/engine/tests/test_api_dataset_manager.py
+++ b/metaspace/engine/tests/test_api_dataset_manager.py
@@ -8,9 +8,10 @@ from sm.engine.db import DB
 from sm.engine.es_export import ESExporter
 from sm.engine.queue import QueuePublisher
 from sm.rest.dataset_manager import SMapiDatasetManager
-from sm.rest.dataset_manager import Dataset, DatasetActionPriority, DatasetStatus
+from sm.rest.dataset_manager import DatasetActionPriority, DatasetStatus
 from sm.engine.png_generator import ImageStoreServiceWrapper
 from sm.engine.optical_image import OpticalImageType
+from tests.utils import create_test_ds
 
 
 def create_api_ds_man(
@@ -85,21 +86,11 @@ class TestSMapiDatasetManager:
     def test_delete_ds(self, fill_db, metadata, ds_config):
         update_queue = MagicMock(spec=QueuePublisher)
         ds_man = create_api_ds_man(update_queue=update_queue)
-        ds_id = '2000-01-01'
-        ds = Dataset(
-            id=ds_id,
-            name='ds_name',
-            input_path='input_path',
-            upload_dt=datetime.now(),
-            metadata=metadata,
-            config=ds_config,
-            status=DatasetStatus.FINISHED,
-        )
-        ds.save(DB())
+        ds = create_test_ds()
 
-        ds_man.delete(ds_id)
+        ds_man.delete(ds.id)
 
-        msg = {'ds_id': ds_id, 'ds_name': 'ds_name', 'action': DaemonAction.DELETE}
+        msg = {'ds_id': ds.id, 'ds_name': 'ds_name', 'action': DaemonAction.DELETE}
         update_queue.publish.assert_has_calls([call(msg, DatasetActionPriority.STANDARD)])
 
     def test_add_optical_image(self, fill_db, metadata, ds_config):
@@ -123,32 +114,22 @@ class TestSMapiDatasetManager:
         )
         ds_man._annotation_image_shape = MagicMock(return_value=(100, 100))
 
-        ds_id = '2000-01-01'
-        ds = Dataset(
-            id=ds_id,
-            name='ds_name',
-            input_path='input_path',
-            upload_dt=datetime.now(),
-            metadata=metadata,
-            config=ds_config,
-            status=DatasetStatus.QUEUED,
-        )
-        ds.save(db)
+        ds = create_test_ds()
 
         zoom_levels = [1, 2, 3]
         raw_img_id = 'raw_opt_img_id'
         ds_man.add_optical_image(
-            ds_id, raw_img_id, [[1, 0, 0], [0, 1, 0], [0, 0, 1]], zoom_levels=zoom_levels
+            ds.id, raw_img_id, [[1, 0, 0], [0, 1, 0], [0, 0, 1]], zoom_levels=zoom_levels
         )
         optical_images = db.select(f"SELECT ds_id, type, zoom FROM optical_image")
         for type, zoom in product(
             [OpticalImageType.SCALED, OpticalImageType.CLIPPED_TO_ION_IMAGE], zoom_levels
         ):
-            assert (ds_id, type, zoom) in optical_images
+            assert (ds.id, type, zoom) in optical_images
 
-        assert db.select('SELECT optical_image FROM dataset where id = %s', params=(ds_id,)) == [
+        assert db.select('SELECT optical_image FROM dataset where id = %s', params=(ds.id,)) == [
             (raw_img_id,)
         ]
-        assert db.select('SELECT thumbnail FROM dataset where id = %s', params=(ds_id,)) == [
+        assert db.select('SELECT thumbnail FROM dataset where id = %s', params=(ds.id,)) == [
             ('thumbnail_id',)
         ]

--- a/metaspace/engine/tests/test_colocalization.py
+++ b/metaspace/engine/tests/test_colocalization.py
@@ -1,14 +1,12 @@
-from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
 
 from sm.engine.colocalization import analyze_colocalization, Colocalization, FreeableRef
-from sm.engine.dataset import Dataset
 from sm.engine.db import DB
 from sm.engine.png_generator import ImageStoreServiceWrapper
-from .utils import create_test_molecular_db
+from .utils import create_test_molecular_db, create_test_ds
 
 
 def test_valid_colocalization_jobs_generated():
@@ -44,15 +42,7 @@ def test_new_ds_saves_to_db(test_db, metadata, ds_config):
     db = DB()
     moldb = create_test_molecular_db()
     ds_config['database_ids'] = [moldb.id]
-    ds = Dataset(
-        id='ds_id',
-        name='ds_name',
-        input_path='input_path',
-        upload_dt=datetime.now(),
-        metadata=metadata,
-        config=ds_config,
-    )
-    ds.save(db)
+    ds = create_test_ds(config={**ds_config, 'database_ids': [moldb.id]})
 
     ion_metrics_df = pd.DataFrame(
         {

--- a/metaspace/engine/tests/test_ion_thumbnails.py
+++ b/metaspace/engine/tests/test_ion_thumbnails.py
@@ -1,35 +1,23 @@
-from datetime import datetime
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 
 from sm.engine.ion_thumbnail import generate_ion_thumbnail, ALGORITHMS
-from sm.engine.dataset import Dataset, DatasetStatus
 from sm.engine.db import DB
 from sm.engine.png_generator import ImageStoreServiceWrapper
-from .utils import create_test_molecular_db
+from .utils import create_test_molecular_db, create_test_ds
 
 OLD_IMG_ID = 'old-ion-thumb-id'
 IMG_ID = 'new-ion-thumb-id'
-DS_ID = '2000-01-01_00h00m'
 
 
-def _make_fake_ds(db, ds_id, metadata, ds_config):
-    ds = Dataset(
-        id=ds_id,
-        name='name',
-        input_path='path',
-        upload_dt=datetime.now(),
-        metadata=metadata,
-        config=ds_config,
-        status=DatasetStatus.FINISHED,
-    )
-    ds.save(db)
+def _make_fake_ds(db, metadata, ds_config):
+    ds = create_test_ds(metadata=metadata, config=ds_config)
 
     moldb = create_test_molecular_db()
     (job_id,) = db.insert_return(
-        "INSERT INTO job (moldb_id, ds_id) VALUES (%s, %s) RETURNING id", rows=[(moldb.id, ds_id)]
+        "INSERT INTO job (moldb_id, ds_id) VALUES (%s, %s) RETURNING id", rows=[(moldb.id, ds.id)]
     )
     db.insert(
         (
@@ -40,6 +28,8 @@ def _make_fake_ds(db, ds_id, metadata, ds_config):
         ),
         rows=[(job_id, f'H{i+1}O', '+H', [str(i), str(1000 + i)]) for i in range(200)],
     )
+
+    return ds
 
 
 def _mock_get_ion_images_for_analysis(storage_type, img_ids, **kwargs):
@@ -54,10 +44,10 @@ def test_creates_ion_thumbnail(test_db, algorithm, metadata, ds_config):
     img_store_mock = MagicMock(spec=ImageStoreServiceWrapper)
     img_store_mock.post_image.return_value = IMG_ID
     img_store_mock.get_ion_images_for_analysis.side_effect = _mock_get_ion_images_for_analysis
-    _make_fake_ds(db, DS_ID, metadata, ds_config)
+    ds = _make_fake_ds(db, metadata, ds_config)
 
-    generate_ion_thumbnail(db, img_store_mock, DS_ID, algorithm=algorithm)
+    generate_ion_thumbnail(db, img_store_mock, ds.id, algorithm=algorithm)
 
-    (new_ion_thumbnail,) = db.select_one("SELECT ion_thumbnail FROM dataset WHERE id = %s", [DS_ID])
+    (new_ion_thumbnail,) = db.select_one("SELECT ion_thumbnail FROM dataset WHERE id = %s", [ds.id])
     assert new_ion_thumbnail == IMG_ID
     assert img_store_mock.post_image.called

--- a/metaspace/engine/tests/utils.py
+++ b/metaspace/engine/tests/utils.py
@@ -1,8 +1,38 @@
+from copy import deepcopy
 from datetime import datetime
 
+from sm.engine.dataset import Dataset, DatasetStatus
 from sm.engine.db import DB
 from sm.engine import molecular_db
 from sm.engine.molecular_db import MolecularDB
+
+
+TEST_METADATA = {
+    "Data_Type": "Imaging MS",
+    "MS_Analysis": {
+        "Polarity": "Positive",
+        "Ionisation_Source": "MALDI",
+        "Detector_Resolving_Power": {"Resolving_Power": 80000, "mz": 700},
+        "Analyzer": "FTICR",
+        "Pixel_Size": {"Xaxis": 100, "Yaxis": 100},
+    },
+}
+
+TEST_DS_CONFIG = {
+    "image_generation": {"n_levels": 30, "ppm": 3, "min_px": 1},
+    "analysis_version": 1,
+    "isotope_generation": {
+        "adducts": ["+H", "+Na", "+K", "[M]+"],
+        "charge": 1,
+        "isocalc_sigma": 0.000619,
+        "instrument": "FTICR",
+        "n_peaks": 4,
+        "neutral_losses": [],
+        "chem_mods": [],
+    },
+    "fdr": {"decoy_sample_size": 20},
+    "database_ids": [0],
+}
 
 
 def create_test_molecular_db(
@@ -17,3 +47,28 @@ def create_test_molecular_db(
         rows=[(name, version, created_dt, group_id, archived)],
     )
     return molecular_db.find_by_id(moldb_id)
+
+
+def create_test_ds(
+    id='2000-01-01',
+    name='ds_name',
+    input_path='input_path',
+    upload_dt=None,
+    metadata=None,
+    config=None,
+    status=DatasetStatus.FINISHED,
+    es=None,
+):
+    upload_dt = upload_dt or datetime.now()
+
+    ds = Dataset(
+        id=id,
+        name=name,
+        input_path=input_path,
+        upload_dt=upload_dt or datetime.now(),
+        metadata=metadata or deepcopy(TEST_METADATA),
+        config=config or deepcopy(TEST_DS_CONFIG),
+        status=status or DatasetStatus.QUEUED,
+    )
+    ds.save(DB(), es=es, allow_insert=True)
+    return ds


### PR DESCRIPTION
Fixes #700 by preventing everywhere in sm-engine (except the tests) from actually inserting `public.dataset` rows. Normally these rows are only created in graphql.

In making this change, I found a lot of repeated code for creating datasets in tests, so I consolidated it into `create_test_ds`. This required moving the default `metadata` and `ds_config` values into constants, as it wasn't possible to inject fixtures that deep.