### PR TITLE
Update engine deps in docker startup & fix link in email

### DIFF
--- a/docker/sm-engine/Dockerfile
+++ b/docker/sm-engine/Dockerfile
@@ -22,6 +22,7 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
         git \
         nano \
         netcat \
+        sudo \
         && \
 # ----- Spark -----
     DEBIAN_FRONTEND=noninteractive $APT_INSTALL \

--- a/docker/sm-engine/start-common.sh
+++ b/docker/sm-engine/start-common.sh
@@ -18,7 +18,9 @@ else
   cd /opt/metaspace/metaspace/engine
 fi
 
-#pip install -qr requirements.txt  # doesn't work with docker-compose service 'user' option
+# sudo is needed because the Python environment is set up in the Dockerfile (running as root),
+# but the container may be running as a user due the docker-compose 'user' option
+sudo pip install -qr requirements.txt
 
 wait_for "nc -z postgres 5432" "Postgres"
 wait_for "nc -z rabbitmq 5672" "RabbitMQ"

--- a/metaspace/graphql/src/modules/project/email.ts
+++ b/metaspace/graphql/src/modules/project/email.ts
@@ -10,7 +10,7 @@ export const sendPublishProjectNotificationEmail = (email: string, project: Proj
 
 Some time ago you created a review link for the project "${project.name}".
 If it has been published, please consider making it public and adding the publication DOI to the project description.
-Here is a project link ${config.web_public_url}/project/${project.urlSlug}
+Here is a project link ${config.web_public_url}/project/${project.urlSlug || project.id}
 
 Best wishes,
 METASPACE Team`;


### PR DESCRIPTION
Two small fixes:

* Make the sm-api/sm-update-daemon/sm-annotate-daemon reinstall pip dependencies on startup so that they stay in sync with `requirements.txt`. Bizarrely, the ubuntu docker image doesn't include `sudo`, so I had to update the Dockerfile to include it. The missing `sudo` doesn't actually break startup, but if you want the reinstall feature or to stop getting a warning on startup, you can rebuild your docker containers with these commands after this is merged (cc @richardgoater ):
```
docker-compose rm -fs sm-api sm-update-daemon sm-annotate-daemon
docker-compose build sm-api sm-update-daemon sm-annotate-daemon
docker-compose up -d sm-api sm-update-daemon sm-annotate-daemon
```

* Fix the link in the project publishing reminder email. I received an email advising me to go to https://metaspace2020.eu/project/null because `urlSlug` is nullable.