### PR TITLE
Fix DS creation

### DIFF
--- a/metaspace/engine/sm/rest/dataset_manager.py
+++ b/metaspace/engine/sm/rest/dataset_manager.py
@@ -89,7 +89,7 @@ class SMapiDatasetManager:
             is_public=doc.get('is_public'),
             status=DatasetStatus.QUEUED,
         )
-        ds.save(self._db, self._es)
+        ds.save(self._db, self._es, allow_insert=True)
         self._status_queue.publish(
             {'ds_id': ds.id, 'action': DaemonAction.ANNOTATE, 'stage': DaemonActionStage.QUEUED}
         )


### PR DESCRIPTION
I had specifically tested whether `allow_insert=True` was needed on this line when preparing #701 , but I forgot that sm-engine doesn't auto-reload on code changes, so I was testing against old code when I checked it :facepalm:. 

Fortunately it appears no users have encountered this bug yet.