### PR TITLE
fix(sm-api): Log custom exception messages

### DIFF
--- a/metaspace/engine/sm/engine/molecular_db.py
+++ b/metaspace/engine/sm/engine/molecular_db.py
@@ -6,21 +6,22 @@ from datetime import datetime
 import pandas as pd
 from pyMSpec.pyisocalc.canopy.sum_formula_actions import InvalidFormulaError
 from pyMSpec.pyisocalc.pyisocalc import parseSumFormula
+
 from sm.engine.db import DB, transaction_context
 from sm.engine.errors import SMError
 
 logger = logging.getLogger('engine')
 
 
-class MalformedCSV(Exception):
+class MalformedCSV(SMError):
     def __init__(self, message):
+        super().__init__(message)
         self.message = message
-        super().__init__()
 
 
-class BadData(Exception):
+class BadData(SMError):
     def __init__(self, message, *errors):
-        super().__init__()
+        super().__init__(message)
         self.message = message
         self.errors = errors
 

--- a/metaspace/off-sample/README.md
+++ b/metaspace/off-sample/README.md
@@ -4,7 +4,7 @@ Simple API for classifying Imaging Mass Spectrometry Ion images as on/off sample
 # Setup
 Inside root directory
 
-By default, Dockerfile expects a Fastai model file at `./models/model.fai` path.
+By default, Dockerfile expects a Fastai model file at `./models/model.fai.pth` path.
 
 ```
 docker build -t metaspace2020/off-sample -f docker/Dockerfile .

--- a/metaspace/off-sample/README.md
+++ b/metaspace/off-sample/README.md
@@ -4,6 +4,8 @@ Simple API for classifying Imaging Mass Spectrometry Ion images as on/off sample
 # Setup
 Inside root directory
 
+By default, Dockerfile expects a Fastai model file at `./models/model.fai` path.
+
 ```
 docker build -t metaspace2020/off-sample -f docker/Dockerfile .
 docker run -d -p 9876:8000 --name off-sample metaspace2020/off-sample


### PR DESCRIPTION
Pass custom exception `message` to its parent init to log it properly.
Unrelated: update off-sample README.