### PR TITLE
Hotfix to prevent quick search losing focus while typing

### DIFF
--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
@@ -486,7 +486,9 @@ export default Vue.extend({
               this.setCurrentRow(this.currentRowIndex)
             }
           }
-          if (this.$refs.table) {
+          // Move focus to the table so that keyboard navigation works, except when focus is on an input element
+          const shouldMoveFocus = document.activeElement?.closest('input,select,textarea') == null
+          if (this.$refs.table && shouldMoveFocus) {
             this.$refs.table.$el.focus()
           }
         })


### PR DESCRIPTION
This change prevents the annotation table from stealing focus when focus is on an input element.

I've manually tested these cases:
* Typing in the quick search bar - doesn't steal focus
* Typing a molecule name into the molecule filter - doesn't steal focus
* Changing FDR - doesn't steal focus
* Removing a filter - table takes focus
* Loading the page - table takes focus
* Changing between pages of annotation via keyboard or mouse - table re-takes focus after re-appearing
* IE11 - the patch seems to work, thanks to polyfill.io including an `Element.closest` polyfill