### PR TITLE
Upload custom mol DB files in binary mode

### DIFF
--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.8.2'
+__version__ = '1.8.3'
 
 from metaspace.sm_annotation_utils import (
     SMInstance,

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -189,7 +189,7 @@ def multipart_upload(local_path, companion_url):
     PART_SIZE = 5 * 1024 ** 2
     etags = []
     part = 0
-    with open(local_path, 'r') as f:
+    with open(local_path, 'rb') as f:
         while True:
             file_data = f.read(PART_SIZE)
             if not file_data:


### PR DESCRIPTION
Alyona encountered this error:
```
GraphQLException: {"type":"malformed_csv","error":"Malformed CSV: 'utf-8' codec can't decode byte 0xb1 in position 1: invalid start byte"}
```

The file was valid on the local filesystem, but when I re-downloaded it from S3 it had an invalid `B1` byte instead of a `±` UTF-8 character (represented in UTF-8 with 2 bytes: `C2 B1`). Switching to reading the input file as bytes seems to have fixed it.