### PR TITLE
Fix formulae in "Colocalized Annotations" section

### DIFF
--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/RelatedAnnotations.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/RelatedAnnotations.vue
@@ -21,10 +21,9 @@
           :isobars="other.isobars"
           :open-delay="100"
         >
-          <span
+          <molecular-formula
             v-if="other.ion !== colocReferenceIon"
-            class="sf cell-span"
-            v-html="renderFormula(other)"
+            :ion="other.ion"
           />
           <span v-else>Reference annotation<sub><!-- Subscript to make height consistent with formulas --></sub></span>
         </candidate-molecules-popover>
@@ -89,16 +88,16 @@
 </template>
 
 <script>
-import { get, omit } from 'lodash-es'
-import { renderMolFormulaHtml } from '../../../../lib/util'
+import { omit } from 'lodash-es'
 import ImageLoader from '../../../../components/ImageLoader.vue'
 import { relatedAnnotationsQuery } from '../../../../api/annotation'
 import { encodeParams, stripFilteringParams } from '../../../Filters'
 import { ANNOTATION_SPECIFIC_FILTERS } from '../../../Filters/filterSpecs'
 import CandidateMoleculesPopover from '../CandidateMoleculesPopover'
+import MolecularFormula from '../../../../components/MolecularFormula'
 
 export default {
-  components: { ImageLoader, CandidateMoleculesPopover },
+  components: { ImageLoader, CandidateMoleculesPopover, MolecularFormula },
   props: ['query', 'annotation', 'databaseId', 'imageLoaderSettings'],
   data() {
     return {
@@ -145,9 +144,6 @@ export default {
     },
   },
   methods: {
-    renderFormula(other) {
-      return renderMolFormulaHtml(other.ion)
-    },
     linkToAnnotation(other) {
       let filters = null
       if (this.query === 'allAdducts') {


### PR DESCRIPTION
Screenshot:
![image](https://user-images.githubusercontent.com/1429721/107091211-4958b500-67f9-11eb-980e-158c1af5b0a4.png)

The root cause of this was the `cell-span` class used in the table component, which was also applied here (perhaps an old copypasta?). I searched and couldn't see any other places it was being used, so should be safe.
