### PR TITLE
Periodically force webapp to reload the page

### DIFF
--- a/metaspace/webapp/src/router.ts
+++ b/metaspace/webapp/src/router.ts
@@ -112,7 +112,7 @@ router.beforeEach((to, from, next) => {
   // such as incorrect API usage, or causing error reports for bugs that have already been fixed.
   // Force the browser to reload the page, preferring to do so during page transitions to minimize impact.
   const daysSincePageLoad = (Date.now() - pageLoadedAt) / 1000 / 60 / 60 / 24
-  if (to.path !== from.path && daysSincePageLoad > 1 || daysSincePageLoad > 7) {
+  if (to.path !== from.path && daysSincePageLoad > 1.75 || daysSincePageLoad > 7) {
     window.location.replace(to.fullPath)
     next(false)
   } else {

--- a/metaspace/webapp/src/router.ts
+++ b/metaspace/webapp/src/router.ts
@@ -106,6 +106,20 @@ const router = new VueRouter({
   },
 })
 
+const pageLoadedAt = Date.now()
+router.beforeEach((to, from, next) => {
+  // If user has had the window open for a long time, it's likely they're using old code. This can cause issues
+  // such as incorrect API usage, or causing error reports for bugs that have already been fixed.
+  // Force the browser to reload the page, preferring to do so during page transitions to minimize impact.
+  const daysSincePageLoad = (Date.now() - pageLoadedAt) / 1000 / 60 / 60 / 24
+  if (to.path !== from.path && daysSincePageLoad > 1 || daysSincePageLoad > 7) {
+    window.location.replace(to.fullPath)
+    next(false)
+  } else {
+    next()
+  }
+})
+
 const { href } = router.resolve({ name: 'project', params: { projectIdOrSlug: 'REMOVE' } }, undefined, true)
 export const PROJECT_URL_PREFIX = location.origin + href.replace('REMOVE', '')
 

--- a/metaspace/webapp/src/router.ts
+++ b/metaspace/webapp/src/router.ts
@@ -113,7 +113,7 @@ router.beforeEach((to, from, next) => {
   // Force the browser to reload the page, preferring to do so during page transitions to minimize impact.
   const daysSincePageLoad = (Date.now() - pageLoadedAt) / 1000 / 60 / 60 / 24
   if (to.path !== from.path && daysSincePageLoad > 1.75 || daysSincePageLoad > 7) {
-    window.location.replace(to.fullPath)
+    window.location.assign(to.fullPath)
     next(false)
   } else {
     next()


### PR DESCRIPTION
I tested it locally with `daysSincePageLoad > 0.0001` to reduce the wait time. The refreshing is a little bit disruptive - it shows a blank screen for ~1s while reloading everything. Since it's always during page transitions (unless they hit 7 days), it's unlikely that it will cause state loss.

A small issue is that the browser history doesn't behave correctly if the reload is caused by the user hitting back - it creates a new forward navigation instead of a backward navigation. I don't think it will happen often enough to impact anyone though.

I chose an interval of 1.75 days because refreshing every single day seems like it would become noticeable and annoying. Also, if it were an integer number of days, habitual users would get hit with a refresh at slightly later times each day, which could interrupt their flow. With 1.75, it's most likely that they'll get the refresh on their first use of the day.