### PR TITLE
Handle Lithops stalls

### DIFF
--- a/ansible/aws/templates/all/vars.yml.template
+++ b/ansible/aws/templates/all/vars.yml.template
@@ -82,8 +82,8 @@ sm_cluster_autostart_redis:
   port: "{{ web_redis.port }}"
 
 # Configuration for IBM Cloud / Lithops. See metaspace/engine/docs/Lithops.md for instructions on setting up an
-# IBM Cloud environment. Set `sm_lithops_daemon_threads` to `0` to disable Lithops.
-sm_lithops_daemon_threads: 0
+# IBM Cloud environment. Set `sm_lithops_daemon_nprocs` to `0` to disable Lithops.
+sm_lithops_daemon_nprocs: 0
 sm_lithops_iam_api_key: "{{ vault_lithops_iam_api_key }}"
 sm_lithops_cos_access_key: "{{ vault_lithops_cos_access_key }}"
 sm_lithops_cos_secret_key: "{{ vault_lithops_cos_secret_key }}"

--- a/ansible/roles/sm_lithops_daemon/tasks/main.yml
+++ b/ansible/roles/sm_lithops_daemon/tasks/main.yml
@@ -6,5 +6,5 @@
 
 - name: Update and restart supervisor app
   supervisorctl:
-    name: "{{ sm_lithops_daemon_app_name }}"
+    name: "{{ sm_lithops_daemon_app_name }}:"
     state: restarted

--- a/ansible/roles/sm_lithops_daemon/templates/sm-lithops-daemon.supervisor.j2
+++ b/ansible/roles/sm_lithops_daemon/templates/sm-lithops-daemon.supervisor.j2
@@ -6,7 +6,6 @@ environment = PATH="{{ miniconda_prefix }}/envs/{{ miniconda_env.name }}/bin"
 directory = {{ sm_home }}
 command = {{ miniconda_prefix }}/envs/{{ miniconda_env.name }}/bin/python scripts/run_sm_daemon.py --name=lithops
 redirect_stderr = true
-stdout_logfile = {{ sm_home }}/logs/{{ sm_lithops_daemon_app_name }}.log
-numprocs = 1
-numprocs_start = 8000
+stdout_logfile = {{ sm_home }}/logs/{{ sm_lithops_daemon_app_name }}-%(process_num)s.log
+numprocs = {{ sm_lithops_daemon_nprocs }}
 startsecs = 10

--- a/ansible/roles/sm_lithops_daemon/templates/sm-lithops-daemon.supervisor.j2
+++ b/ansible/roles/sm_lithops_daemon/templates/sm-lithops-daemon.supervisor.j2
@@ -1,7 +1,7 @@
 # -*- conf -*-
 
 [program:{{ sm_lithops_daemon_app_name }}]
-process_name = {{ sm_lithops_daemon_app_name }}
+process_name = {{ sm_lithops_daemon_app_name }}-%(process_num)s
 environment = PATH="{{ miniconda_prefix }}/envs/{{ miniconda_env.name }}/bin"
 directory = {{ sm_home }}
 command = {{ miniconda_prefix }}/envs/{{ miniconda_env.name }}/bin/python scripts/run_sm_daemon.py --name=lithops

--- a/metaspace/engine/conf/config.docker.json
+++ b/metaspace/engine/conf/config.docker.json
@@ -38,7 +38,6 @@
     "web_app_url": "http://localhost:8999",
     "send_email": false,
     "update_daemon_threads": 4,
-    "lithops_daemon_threads": 2,
     "colocalization": false,
     "ion_thumbnail": false
   },

--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -65,7 +65,7 @@
       "data_cleaner": true,
       "data_limit": false,
       "workers": 1000,
-      "execution_timeout": 2400
+      "execution_timeout": 3600
     },
     "serverless": {
       "backend": "ibm_cf",

--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -29,7 +29,6 @@
     "web_app_url": "{{ web_public_url }}",
     "send_email": {{ sm_send_email | to_json }},
     "update_daemon_threads": 4,
-    "lithops_daemon_threads": {{ sm_lithops_daemon_threads }},
     "colocalization": true,
     "ion_thumbnail": true
   },
@@ -74,7 +73,8 @@
       "runtime_memory": 2048
     },
     "standalone": {
-      "backend": "ibm_vpc"
+      "backend": "ibm_vpc",
+      "soft_dismantle_timeout": 30
     },
     "localhost": {
     },

--- a/metaspace/engine/scripts/run_sm_daemon.py
+++ b/metaspace/engine/scripts/run_sm_daemon.py
@@ -60,7 +60,9 @@ def main(daemon_name):
             daemon = SMUpdateDaemon(get_manager(), make_update_queue_cons)
             daemons.append(daemon)
     elif daemon_name == 'lithops':
-        daemon = LithopsDaemon(get_manager(), lit_qdesc=SM_LITHOPS, upd_qdesc=SM_UPDATE)
+        daemon = LithopsDaemon(
+            get_manager(), lit_qdesc=SM_LITHOPS, annot_qdesc=SM_ANNOTATE, upd_qdesc=SM_UPDATE
+        )
         daemons.append(daemon)
     else:
         raise Exception(f'Wrong SM daemon name: {daemon_name}')

--- a/metaspace/engine/scripts/run_sm_daemon.py
+++ b/metaspace/engine/scripts/run_sm_daemon.py
@@ -58,9 +58,8 @@ def main(daemon_name):
             daemon = SMUpdateDaemon(get_manager(), make_update_queue_cons)
             daemons.append(daemon)
     elif daemon_name == 'lithops':
-        for _ in range(sm_config['services'].get('lithops_daemon_threads', 0)):
-            daemon = LithopsDaemon(get_manager(), lit_qdesc=SM_LITHOPS, upd_qdesc=SM_UPDATE)
-            daemons.append(daemon)
+        daemon = LithopsDaemon(get_manager(), lit_qdesc=SM_LITHOPS, upd_qdesc=SM_UPDATE)
+        daemons.append(daemon)
     else:
         raise Exception(f'Wrong SM daemon name: {daemon_name}')
 

--- a/metaspace/engine/sm/engine/annotation_lithops/calculate_centroids.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/calculate_centroids.py
@@ -49,7 +49,7 @@ def calculate_centroids(
 
         peaks_df.set_index('formula_i', inplace=True)
 
-        print(f'Storing centroids chunk {id}')
+        print(f'Storing centroids chunk {segm_i}')
         peaks_cobject = save_cobj(storage, peaks_df)
 
         return peaks_cobject, peaks_df.shape[0]

--- a/metaspace/engine/sm/engine/annotation_lithops/executor.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/executor.py
@@ -336,6 +336,13 @@ class Executor:
         executor_type, executor = valid_executors[0]
         logger.debug(f'Selected executor {executor_type}')
 
+        if executor.config['lithops']['mode'] == 'standalone':
+            # Set number of parallel workers based on memory requirements
+            # With Lithops>=2.2.17 it would be configure this via `.map(..., worker_processes=workers)`
+            executor.config['lithops']['workers'] = min(
+                20, MEM_LIMITS.get(executor_type) // runtime_memory
+            )
+
         return executor
 
     def map_unpack(self, func, args: Sequence, *, runtime_memory=None, **kwargs):

--- a/metaspace/engine/sm/engine/annotation_lithops/io.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/io.py
@@ -68,7 +68,11 @@ def load_cobj(storage: Storage, cobj: CloudObject):
 
 
 def load_cobj(storage: Storage, cobj):
-    return deserialize(storage.get_cloudobject(cobj))
+    try:
+        return deserialize(storage.get_cloudobject(cobj))
+    except Exception:
+        logger.error(f'Failed to deserialize {cobj}')
+        raise
 
 
 def save_cobjs(storage: Storage, objs: Iterable[TItem]) -> List[CObj[TItem]]:

--- a/metaspace/engine/sm/engine/annotation_lithops/run_fdr.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/run_fdr.py
@@ -19,6 +19,7 @@ def run_fdr(
     msms_df = formula_scores_df[['msm']]
 
     def _run_fdr_for_db(db_data_cobject: CObj[DbFDRData], *, storage: Storage):
+        print(f'Loading FDR data from {db_data_cobject}')
         db_data = load_cobj(storage, db_data_cobject)
         moldb_id = db_data['id']
         fdr = db_data['fdr']

--- a/metaspace/engine/sm/engine/daemons/annotate.py
+++ b/metaspace/engine/sm/engine/daemons/annotate.py
@@ -100,3 +100,7 @@ class SMAnnotateDaemon:
             self._annot_queue_consumer.stop()
             self._annot_queue_consumer.join()
             self._stopped = True
+
+    def join(self):
+        if not self._stopped:
+            self._annot_queue_consumer.join()

--- a/metaspace/engine/sm/engine/daemons/lithops.py
+++ b/metaspace/engine/sm/engine/daemons/lithops.py
@@ -84,3 +84,7 @@ class LithopsDaemon:
             self._lithops_queue_cons.stop()
             self._lithops_queue_cons.join()
             self._stopped = True
+
+    def join(self):
+        if not self._stopped:
+            self._lithops_queue_cons.join()

--- a/metaspace/engine/sm/engine/daemons/lithops.py
+++ b/metaspace/engine/sm/engine/daemons/lithops.py
@@ -1,7 +1,10 @@
 import json
 import logging
+import os
+import signal
 from traceback import format_exc
 
+from sm.engine.annotation_lithops.executor import LithopsStalledException
 from sm.engine.daemons.actions import DaemonActionStage, DaemonAction
 from sm.engine.dataset import DatasetStatus
 from sm.engine.errors import ImzMLError, AnnotationError
@@ -13,7 +16,7 @@ from sm.rest.dataset_manager import DatasetActionPriority
 class LithopsDaemon:
     logger = logging.getLogger('lithops-daemon')
 
-    def __init__(self, manager, lit_qdesc, upd_qdesc):
+    def __init__(self, manager, lit_qdesc, annot_qdesc, upd_qdesc):
         self._sm_config = SMConfig.get_conf()
         self._stopped = False
         self._manager = manager
@@ -26,6 +29,12 @@ class LithopsDaemon:
             on_success=self._on_success,
             on_failure=self._on_failure,
         )
+        self._lithops_queue_pub = QueuePublisher(
+            config=self._sm_config['rabbitmq'], qdesc=lit_qdesc, logger=self.logger
+        )
+        self._annot_queue_pub = QueuePublisher(
+            config=self._sm_config['rabbitmq'], qdesc=annot_qdesc, logger=self.logger
+        )
         self._update_queue_pub = QueuePublisher(
             config=self._sm_config['rabbitmq'], qdesc=upd_qdesc, logger=self.logger
         )
@@ -35,11 +44,28 @@ class LithopsDaemon:
         self._manager.post_to_slack('dart', ' [v] Annotation succeeded: {}'.format(json.dumps(msg)))
 
     def _on_failure(self, msg, e):
-        self._manager.ds_failure_handler(msg, e)
+        if isinstance(e, LithopsStalledException):
+            # Requeue the message so it retries, then exit the process
+            if msg.get('retry_attempt', 0) < 1:
+                self.logger.info('Lithops stalled. Retrying')
+                self._lithops_queue_pub.publish(
+                    {**msg, 'retry_attempt': msg.get('retry_attempt', 0) + 1}
+                )
+            else:
+                self.logger.critical('Lithops stalled. Retrying on Spark')
+                self._annot_queue_pub.publish(msg)
 
-        if 'email' in msg:
-            traceback = e.__cause__.traceback if isinstance(e.__cause__, ImzMLError) else None
-            self._manager.send_failed_email(msg, traceback)
+            self._manager.post_to_slack(
+                'bomb', f" [x] Lithops stall: {json.dumps(msg)}\n```{format_exc(limit=10)}```"
+            )
+            os.kill(os.getpid(), signal.SIGINT)
+
+        else:
+            self._manager.ds_failure_handler(msg, e)
+
+            if 'email' in msg:
+                traceback = e.__cause__.traceback if isinstance(e.__cause__, ImzMLError) else None
+                self._manager.send_failed_email(msg, traceback)
 
     def _callback(self, msg):
         try:
@@ -72,6 +98,8 @@ class LithopsDaemon:
 
             self._manager.set_ds_status(ds, DatasetStatus.FINISHED)
             self._manager.notify_update(ds.id, msg['action'], DaemonActionStage.FINISHED)
+        except LithopsStalledException:
+            raise
         except Exception as e:
             raise AnnotationError(ds_id=msg['ds_id'], traceback=format_exc(chain=False)) from e
 

--- a/metaspace/engine/sm/engine/daemons/update.py
+++ b/metaspace/engine/sm/engine/daemons/update.py
@@ -94,3 +94,7 @@ class SMUpdateDaemon:
             self._update_queue_cons.stop()
             self._update_queue_cons.join()
             self._stopped = True
+
+    def join(self):
+        if not self._stopped:
+            self._update_queue_cons.join()

--- a/metaspace/engine/sm/engine/queue.py
+++ b/metaspace/engine/sm/engine/queue.py
@@ -471,10 +471,10 @@ class QueueConsumer(Thread):
         self.logger.info(' [*] Waiting for messages...')
 
         while True:
-            self.get_message()
-            self._failed_attempts = 0
             if self.stopped():
                 raise StopThread()
+            self.get_message()
+            self._failed_attempts = 0
             sleep(self._poll_interval)
 
     def stop(self):

--- a/metaspace/engine/tests/test_queue.py
+++ b/metaspace/engine/tests/test_queue.py
@@ -25,16 +25,17 @@ def delete_queue(sm_config):
     queue_pub.delete_queue()
 
 
-def run_queue_consumer_thread(config, callback, output_q, wait=1):
+def run_queue_consumer_thread(config, callback, output_q, wait=0.1):
     queue_consumer = QueueConsumer(
         config,
         QDESC,
         callback,
         lambda *args: output_q.put('on_success'),
         lambda *args: output_q.put('on_failure'),
-        poll_interval=0.1,
+        poll_interval=wait,
     )
     queue_consumer.start()
+    time.sleep(wait)
     queue_consumer.stop()
     queue_consumer.join()
 
@@ -56,14 +57,14 @@ def test_queue_msg_published_consumed_on_success_called(sm_config, delete_queue)
 
     output_q = Queue()
     run_queue_consumer_thread(
-        config, callback=lambda *args: output_q.put('callback'), output_q=output_q, wait=1
+        config, callback=lambda *args: output_q.put('callback'), output_q=output_q
     )
 
-    assert output_q.get() == 'callback'
-    assert output_q.get() == 'on_success'
+    assert output_q.get(block=False) == 'callback'
+    assert output_q.get(block=False) == 'on_success'
     assert output_q.empty()
 
-    time.sleep(5)
+    time.sleep(1)
     assert queue_is_empty(config)
 
 
@@ -79,10 +80,10 @@ def test_queue_msg_published_consumed_on_failure_called(sm_config):
         output_q.put('callback')
         raise Exception('Callback exception')
 
-    run_queue_consumer_thread(config, callback=raise_exception, output_q=output_q, wait=1)
+    run_queue_consumer_thread(config, callback=raise_exception, output_q=output_q)
 
-    assert output_q.get() == 'callback'
-    assert output_q.get() == 'on_failure'
+    assert output_q.get(block=False) == 'callback'
+    assert output_q.get(block=False) == 'on_failure'
 
-    time.sleep(5)
+    time.sleep(1)
     assert queue_is_empty(config)

--- a/metaspace/engine/tests/test_queue.py
+++ b/metaspace/engine/tests/test_queue.py
@@ -64,7 +64,7 @@ def test_queue_msg_published_consumed_on_success_called(sm_config, delete_queue)
     assert output_q.get(block=False) == 'on_success'
     assert output_q.empty()
 
-    time.sleep(1)
+    time.sleep(5)
     assert queue_is_empty(config)
 
 
@@ -85,5 +85,5 @@ def test_queue_msg_published_consumed_on_failure_called(sm_config):
     assert output_q.get(block=False) == 'callback'
     assert output_q.get(block=False) == 'on_failure'
 
-    time.sleep(1)
+    time.sleep(5)
     assert queue_is_empty(config)


### PR DESCRIPTION
Lithops stalls are hard to handle:
* It has several timeout mechanisms, but they seem to be under active development and have had a number of bugs and regressions
* Edge cases are hard to test - usually OOMs result in failures, but occasionally they're killed before they can write a status file to COS
* Lithops runs background processes and threads to monitor the jobs, so even if the current thread was interrupted by a `SIGINT` or injected exception, the background threads would continue running, making API calls and costing money

This PR runs Lithops in a separate thread, and if the thread takes an exceptionally long time (41 minutes, configurable) then it raises an exception, re-queues the message, and exits a process. The first retry will be with Lithops again, but if it fails a second time, the message will be transferred to the Annotate queue for Spark to handle.

Supervisor handles restarting the process as long as the exit code is non-zero. To actually achieve this I call `sys.exit(1)` from the interrupt handler, ensure that the main thread stays alive so that it can catch the `SystemExit` exception by `join`ing the daemon threads, and triggering a `SIGINT` from inside the daemon. This could probably be a lot cleaner if we used a framework for the daemons (e.g. Celery).

Additionally a bunch of small changes were rolled into this PR to resolve issues I found during testing:
* Fixed the Ansible step & Supervisor config template for running multiple sm-lithops-daemon processes
* Added a DB-based mutex around VM execution so that the multiple processes didn't try to use the VM simultaneously
* Limit the number of parallel workers on VM and localhost executors to be 128GB/`runtime_memory` and 32GB/`runtime_memory` respectively
* Add extra logging for deserialization errors. I found that the centroids cache in COS had some invalid pickle files because the `FDR` class had moved. The extra logging should help find exactly which files are affected if this happens again.
* increase the production `execution_timeout` from 40 to 60 minutes, as one of the DSs timed out at 40 mins
* Changed `TimeoutError` handling so that it retries with double memory, similar to `MemoryError`, instead of jumping straight to VMs. The reason is that `process_centr_segment` usually has too many jobs to run on the VM, but occasionally it will timeout instead of OOM when running on 2GB. On 4GB it seems to work without issues.
