### PR TITLE
[Hotfix] Remove memory check during annotation

### DIFF
--- a/metaspace/engine/sm/engine/annotation_lithops/annotate.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/annotate.py
@@ -151,12 +151,6 @@ def read_ds_segments(
 
     ds_segms_mb = len(ds_segms_cobjs) * ds_segm_size_mb
     safe_mb = 512
-    read_memory_mb = ds_segms_mb + safe_mb
-    if read_memory_mb > pw_mem_mb:
-        raise MemoryError(
-            f"There isn't enough memory to read dataset segments, consider increasing "
-            f"Lithops's memory to at least {read_memory_mb} mb."
-        )
 
     concat_memory_mb = ds_segms_mb * 3 + safe_mb
     if concat_memory_mb > pw_mem_mb:
@@ -238,6 +232,7 @@ def process_centr_segments(
     image_gen_config = ds_config['image_generation']
     compute_metrics = make_compute_image_metrics(sample_area_mask, nrows, ncols, image_gen_config)
     min_px = image_gen_config['min_px']
+    # TODO: Get available memory from Lithops somehow so it updates if memory is increased on retry
     pw_mem_mb = 2048 if is_intensive_dataset else 1024
 
     def process_centr_segment(


### PR DESCRIPTION
This memory check is broken - it doesn't know there's more memory available when the "retry with more memory" logic happens, so it continues to fail even when it gets a 128GB VM.

It seems my testing on Staging didn't pick this up because I used datasets that were either small enough to fit in 1024MB, or big enough that the `pw_mem_mb = 2048 if is_intensive_dataset else 1024` check gave them 2048MB of RAM. The dataset that caused this error had `is_intensive_dataset=False` but was 1.8GB.