### PR TITLE
fix: Graphql config update

### DIFF
--- a/metaspace/graphql/config/default.js
+++ b/metaspace/graphql/config/default.js
@@ -50,7 +50,7 @@ module.exports = {
     },
   },
 
-  s3_storage: {
+  upload: {
     bucket: '',
     moldb_prefix: 'databases',
   },

--- a/metaspace/graphql/config/development.docker.js
+++ b/metaspace/graphql/config/development.docker.js
@@ -13,7 +13,6 @@ config.defaults = {
 
 config.upload = {
   bucket: 'sm-engine-dev',
-  moldb_prefix: 'databases',
 }
 
 config.s3 = {

--- a/metaspace/graphql/src/modules/webServer/databaseUploadMiddleware.ts
+++ b/metaspace/graphql/src/modules/webServer/databaseUploadMiddleware.ts
@@ -11,7 +11,7 @@ export default function(httpServer: http.Server) {
   const options = getCompanionOptions(
     '/database_upload',
     (req: express.Request, filename: string) => {
-      return `${config.upload.moldb_prefix}/${genUuid()}/${filename}`
+      return `${config.upload.moldb_prefix}/${genUuid()}/${encodeURIComponent(filename)}`
     },
   )
 


### PR DESCRIPTION
Graphql config: "config.upload" was renamed to "config.s3_storage" but not everywhere.

**Post deployment TODO:**
- [ ] Move database files from prefix "<bucket_name>/undefined" to "<bucket_name>/databases"