### PR TITLE
Image storage: serve iso images, lithops support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,7 +363,7 @@ jobs:
           name: Run scientific test
           command: |
             #while true; do echo '---'; sleep 5; done  # uncomment this line for debugging
-            python tests/sci_test/spheroid.py -r --mock-img-store --lithops --config=conf/scitest_config.json
+            python tests/sci_test/spheroid.py -r --mock-image-storage --lithops --config=conf/scitest_config.json
 
 workflows:
   version: 2

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -102,7 +102,7 @@ services:
     # extra_hosts: # Uncomment if graphql is run outside of Docker
     #  - "graphql:172.17.0.1"
 
-  sm-lithops-daemon:
+  lithops-daemon:
     build:
       context: ..
       dockerfile: docker/sm-engine/Dockerfile

--- a/metaspace/engine/.pylintrc
+++ b/metaspace/engine/.pylintrc
@@ -152,7 +152,9 @@ disable=print-statement,
         # duplicate-code is a nightmare to disable when there are legit usages for it (e.g. in scripts).
         # Disabling it per-line is extremely finnicky, and disabling it per-file is impossible due to
         # https://github.com/PyCQA/pylint/issues/2368
-        duplicate-code
+        duplicate-code,
+        # Redefined outer variable name is a recurring problem in scripts
+        redefined-outer-name
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/metaspace/engine/scripts/run_molecule_search.py
+++ b/metaspace/engine/scripts/run_molecule_search.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from sm.engine.db import DB
 from sm.engine.es_export import ESExporter
 from sm.engine.daemons.dataset_manager import DatasetManager
-from sm.engine.util import bootstrap_and_run
+from sm.engine.util import GlobalInit
 from sm.engine.utils.create_ds_from_files import create_ds_from_files
 
 
@@ -45,4 +45,5 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    bootstrap_and_run(args.sm_config_path, run_search)
+    with GlobalInit(config_path=args.sm_config_path) as sm_config:
+        run_search(sm_config)

--- a/metaspace/engine/scripts/update_es_index.py
+++ b/metaspace/engine/scripts/update_es_index.py
@@ -1,12 +1,11 @@
 import argparse
 import logging
 from copy import deepcopy
-from functools import partial
 
 from sm.engine.db import DB
 from sm.engine.es_export import ESExporter, ESIndexManager
 from sm.engine.annotation.isocalc_wrapper import IsocalcWrapper
-from sm.engine.util import bootstrap_and_run
+from sm.engine.util import GlobalInit
 
 logger = logging.getLogger('engine')
 
@@ -105,14 +104,12 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
 
-    bootstrap_and_run(
-        args.config,
-        partial(
-            reindex_results,
+    with GlobalInit(config_path=args.config) as sm_config:
+        reindex_results(
+            sm_config=sm_config,
             ds_id=args.ds_id,
             ds_mask=args.ds_name,
             use_inactive_index=args.inactive,
             offline_reindex=args.offline_reindex,
             update_fields=args.update_fields,
-        ),
-    )
+        )

--- a/metaspace/engine/scripts/update_ion_thumbnails.py
+++ b/metaspace/engine/scripts/update_ion_thumbnails.py
@@ -37,7 +37,7 @@ def run(sm_config, ds_id_str, sql_where, algorithm, use_lithops):
             ds = Dataset.load(db, ds_id)
             if use_lithops:
                 # noinspection PyUnboundLocalVariable
-                generate_ion_thumbnail_lithops(executor, db, sm_config, ds, algorithm=algorithm)
+                generate_ion_thumbnail_lithops(executor, db, ds, algorithm=algorithm)
             else:
                 generate_ion_thumbnail(db, ds, algorithm=algorithm)
         except Exception:

--- a/metaspace/engine/scripts/update_ion_thumbnails.py
+++ b/metaspace/engine/scripts/update_ion_thumbnails.py
@@ -1,7 +1,6 @@
 import argparse
 import logging
 import sys
-from functools import partial
 
 from sm.engine.annotation_lithops.executor import Executor
 from sm.engine.dataset import Dataset
@@ -11,7 +10,7 @@ from sm.engine.postprocessing.ion_thumbnail import (
     generate_ion_thumbnail,
     generate_ion_thumbnail_lithops,
 )
-from sm.engine.util import bootstrap_and_run
+from sm.engine.util import GlobalInit
 from sm.engine.db import DB
 
 
@@ -73,13 +72,11 @@ if __name__ == '__main__':
         print('error: must specify either --ds-id or --sql-where')
         sys.exit(1)
 
-    bootstrap_and_run(
-        args.config,
-        partial(
-            run,
+    with GlobalInit(config_path=args.config) as sm_config:
+        run(
+            sm_config=sm_config,
             ds_id_str=args.ds_id,
             sql_where=args.sql_where,
             algorithm=args.algorithm,
-            lithops=args.lithops,
-        ),
-    )
+            use_lithops=args.lithops,
+        )

--- a/metaspace/engine/scripts/update_optical_images.py
+++ b/metaspace/engine/scripts/update_optical_images.py
@@ -1,10 +1,9 @@
 import argparse
 import logging
-from functools import partial
 
 from sm.engine.db import DB
 from sm.engine.optical_image import add_optical_image
-from sm.engine.util import bootstrap_and_run
+from sm.engine.util import GlobalInit
 from sm.engine.image_store import ImageStoreServiceWrapper
 
 
@@ -52,9 +51,9 @@ if __name__ == "__main__":
     logger = logging.getLogger('engine')
 
     if args.ds_id or args.sql_where:
-        bootstrap_and_run(
-            args.config,
-            partial(update_optical_images, ds_id_str=args.ds_id, sql_where=args.sql_where),
-        )
+        with GlobalInit(config_path=args.config) as sm_config:
+            update_optical_images(
+                sm_config=sm_config, ds_id_str=args.ds_id, sql_where=args.sql_where
+            )
     else:
         parser.print_help()

--- a/metaspace/engine/sm/engine/annotation/formula_centroids.py
+++ b/metaspace/engine/sm/engine/annotation/formula_centroids.py
@@ -135,7 +135,7 @@ class CentroidsGenerator:
                 return True
         else:
             return all(
-                [(Path(self._ion_centroids_path) / fn).exists() for fn in self._parquet_file_names]
+                (Path(self._ion_centroids_path) / fn).exists() for fn in self._parquet_file_names
             )
 
     def _download_from_s3(self):

--- a/metaspace/engine/sm/engine/annotation/job.py
+++ b/metaspace/engine/sm/engine/annotation/job.py
@@ -51,9 +51,7 @@ def del_jobs(ds: Dataset, moldb_ids: Optional[Iterable[int]] = None):
             )
 
             for _ in executor.map(
-                lambda img_id: image_storage.delete_image(
-                    image_storage.ImageStorage.Type.ISO, ds.id, img_id
-                ),
+                lambda img_id: image_storage.delete_image(image_storage.ISO, ds.id, img_id),
                 (img_id for img_ids in img_id_rows for img_id in img_ids if img_id is not None),
             ):
                 pass

--- a/metaspace/engine/sm/engine/annotation_lithops/annotate.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/annotate.py
@@ -81,7 +81,7 @@ class ImagesManager:
             ).set_index('formula_i')
             self._images_dfs.append(images_df)
         else:
-            print(f'No images to save')
+            print('No images to save')
 
         self._images_buffer.clear()
         self._formula_images_size = 0

--- a/metaspace/engine/sm/engine/annotation_lithops/annotation_job.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/annotation_job.py
@@ -10,7 +10,6 @@ import pandas as pd
 from lithops.storage import Storage
 from lithops.storage.utils import StorageNoSuchKeyError, CloudObject
 
-from sm.engine import molecular_db
 from sm.engine.annotation.formula_validator import METRICS
 from sm.engine.annotation.job import del_jobs, insert_running_job, update_finished_job, JobStatus
 from sm.engine.annotation_lithops.executor import Executor
@@ -22,13 +21,12 @@ from sm.engine.dataset import Dataset
 from sm.engine.db import DB
 from sm.engine.ds_config import DSConfig
 from sm.engine.es_export import ESExporter
-from sm.engine.image_store import ImageStoreServiceWrapper
-from sm.engine.annotation.isocalc_wrapper import IsocalcWrapper
 from sm.engine.molecular_db import read_moldb_file
 from sm.engine.util import split_s3_path, split_cos_path
 from sm.engine.config import SMConfig
 from sm.engine.utils.perf_profile import Profiler
 from sm.engine.storage import get_s3_client
+from sm.engine import image_storage
 
 logger = logging.getLogger('engine')
 
@@ -156,7 +154,7 @@ class LocalAnnotationJob:
     """
     Runs an annotation job from local files and saves the results to the filesystem.
 
-    As a developer convienence, if a list of integers is given for `moldb_files`,
+    As a developer convenience, if a list of integers is given for `moldb_files`,
     then it will try to connect to the configured postgres database and dump the formulas
     for the specified databases.
     Otherwise, this can be used to run the pipeline without any external dependencies.
@@ -219,13 +217,12 @@ class LocalAnnotationJob:
 class ServerAnnotationJob:
     """
     Runs an annotation job for a dataset in the database, saving the results back to the database
-    and image store.
+    and image storage.
     """
 
     def __init__(
         self,
         executor: Executor,
-        img_store: ImageStoreServiceWrapper,
         ds: Dataset,
         perf: Profiler,
         sm_config: Optional[Dict] = None,
@@ -244,7 +241,6 @@ class ServerAnnotationJob:
         self.s3_client = get_s3_client()
         self.ds = ds
         self.perf = perf
-        self.img_store = img_store
         self.db = DB()
         self.es = ESExporter(self.db, sm_config)
         self.imzml_cobj, self.ibd_cobj = _upload_imzmls_from_prefix_if_needed(
@@ -274,10 +270,11 @@ class ServerAnnotationJob:
 
     def _store_images(self, all_results_dfs, formula_png_iter):
         db_formula_image_ids = defaultdict(dict)
+        ds_id = self.ds.id
 
         def _upload_images(formula_id, db_id, pngs):
             image_ids = [
-                self.img_store.post_image('iso_image', png) if png is not None else None
+                image_storage.post_image(image_storage.ISO, ds_id, png) if png is not None else None
                 for png in pngs
             ]
             db_formula_image_ids[db_id][formula_id] = {'iso_image_ids': image_ids}
@@ -297,7 +294,6 @@ class ServerAnnotationJob:
         return db_formula_image_ids
 
     def run(self, **kwargs):
-        isocalc = IsocalcWrapper(self.ds.config)
         # TODO: Only run missing moldbs
         del_jobs(self.ds)
         moldb_to_job_map = {}
@@ -326,7 +322,6 @@ class ServerAnnotationJob:
                 search_results.store_ion_metrics(results_df, formula_image_ids, self.db)
 
                 update_finished_job(job_id, JobStatus.FINISHED)
-                self.es.index_ds(self.ds.id, molecular_db.find_by_id(moldb_id), isocalc)
         except Exception:
             for moldb_id, job_id in moldb_to_job_map.items():
                 update_finished_job(job_id, JobStatus.FAILED)

--- a/metaspace/engine/sm/engine/annotation_spark/search_results.py
+++ b/metaspace/engine/sm/engine/annotation_spark/search_results.py
@@ -89,7 +89,7 @@ class SearchResults:
                     if img is not None:
                         img_bytes = png_generator.generate_png(img.toarray())
                         iso_image_ids[k] = image_storage.post_image(
-                            ImageStorage.Type.ISO, ds_id, img_bytes
+                            image_storage.ISO, ds_id, img_bytes
                         )
 
                 yield formula_i, {'iso_image_ids': iso_image_ids}

--- a/metaspace/engine/sm/engine/annotation_spark/search_results.py
+++ b/metaspace/engine/sm/engine/annotation_spark/search_results.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 import pyspark
 
-from sm.engine.config import SMConfig
 from sm.engine.image_storage import ImageStorage
 from sm.engine.db import DB
 from sm.engine.ion_mapping import get_ion_id_mapping
@@ -77,11 +76,10 @@ class SearchResults:
     def _post_images_to_image_store(self, ion_images_rdd, alpha_channel, n_peaks):
         logger.info('Posting iso images to image store')
         png_generator = PngGenerator(alpha_channel, greyscale=True)
-        sm_config = SMConfig.get_conf()
         ds_id = self.ds_id
 
         def generate_png_and_post(partition):
-            image_storage = ImageStorage(sm_config['image_storage'])
+            image_storage = ImageStorage()
 
             for formula_i, imgs in partition:
                 iso_image_ids = [None] * n_peaks

--- a/metaspace/engine/sm/engine/annotation_spark/segmenter.py
+++ b/metaspace/engine/sm/engine/annotation_spark/segmenter.py
@@ -51,7 +51,7 @@ def spectra_sample_gen(imzml_parser, sample_size):
 
 
 def define_ds_segments(sample_mzs, sample_ratio, imzml_parser, ds_segm_size_mb=5):
-    logger.info(f'Defining dataset segment bounds')
+    logger.info('Defining dataset segment bounds')
     sp_arr_row_size_b = (
         np.dtype(SpIdxDType).itemsize
         + np.dtype(imzml_parser.mz_precision).itemsize

--- a/metaspace/engine/sm/engine/daemons/annotate.py
+++ b/metaspace/engine/sm/engine/daemons/annotate.py
@@ -39,7 +39,7 @@ class SMAnnotateDaemon:
         Path(self._sm_config['fs']['spark_data_path']).mkdir(parents=True, exist_ok=True)
 
     def _on_success(self, msg):
-        self.logger.info(f" SM annotate daemon: success")
+        self.logger.info(' SM annotate daemon: success')
 
         ds = self._manager.load_ds(msg['ds_id'])
         self._manager.set_ds_status(ds, DatasetStatus.FINISHED)
@@ -58,16 +58,14 @@ class SMAnnotateDaemon:
 
     def _callback(self, msg):
         try:
-            self.logger.info(f" SM annotate daemon received a message: {msg}")
+            self.logger.info(f' SM annotate daemon received a message: {msg}')
             self._redis_client.set('cluster-busy', 'yes', ex=3600 * 13)  # key expires in 13h
 
             ds = self._manager.load_ds(msg['ds_id'])
             self._manager.set_ds_status(ds, DatasetStatus.ANNOTATING)
             self._manager.notify_update(ds.id, msg['action'], DaemonActionStage.STARTED)
 
-            self._manager.post_to_slack(
-                'new', " [v] New annotation message: {}".format(json.dumps(msg))
-            )
+            self._manager.post_to_slack('new', f' [v] New annotation message: {json.dumps(msg)}')
 
             self._manager.annotate(ds=ds, del_first=msg.get('del_first', False))
 

--- a/metaspace/engine/sm/engine/daemons/dataset_manager.py
+++ b/metaspace/engine/sm/engine/daemons/dataset_manager.py
@@ -19,6 +19,7 @@ from sm.engine.es_export import ESExporter
 from sm.engine.postprocessing.ion_thumbnail import (
     generate_ion_thumbnail,
     generate_ion_thumbnail_lithops,
+    delete_ion_thumbnail,
 )
 from sm.engine.annotation.isocalc_wrapper import IsocalcWrapper
 from sm.engine.postprocessing.off_sample_wrapper import classify_dataset_ion_images
@@ -151,6 +152,7 @@ class DatasetManager:
         del_jobs(ds)
         # TODO: enable after image storage supports optical images
         # del_optical_image(self._db, self._img_store, ds.id)
+        delete_ion_thumbnail(self._db, ds)
         self._es.delete_ds(ds.id)
         self._db.alter('DELETE FROM dataset WHERE id=%s', params=(ds.id,))
 

--- a/metaspace/engine/sm/engine/daemons/dataset_manager.py
+++ b/metaspace/engine/sm/engine/daemons/dataset_manager.py
@@ -46,13 +46,13 @@ class DatasetManager:
 
     def post_to_slack(self, emoji, msg):
         if self._slack_conf.get('webhook_url', None):
-            m = {
-                "channel": self._slack_conf['channel'],
-                "username": "webhookbot",
-                "text": ":{}:{}".format(emoji, msg),
-                "icon_emoji": ":robot_face:",
+            doc = {
+                'channel': self._slack_conf['channel'],
+                'username': 'webhookbot',
+                'text': f":{emoji}:{msg}",
+                'icon_emoji': ':robot_face:',
             }
-            post(self._slack_conf['webhook_url'], json=m)
+            post(self._slack_conf['webhook_url'], json=doc)
 
     def fetch_ds_metadata(self, ds_id):
         res = self._db.select_one(
@@ -67,7 +67,7 @@ class DatasetManager:
             md_type_quoted = urllib.parse.quote(ds_meta['Data_Type'])
             base_url = self._sm_config['services']['web_app_url']
             ds_id_quoted = urllib.parse.quote(msg['ds_id'])
-            link = '{}/annotations?mdtype={}&ds={}'.format(base_url, md_type_quoted, ds_id_quoted)
+            link = f'{base_url}/annotations?mdtype={md_type_quoted}&ds={ds_id_quoted}'
         except Exception as e:
             self.logger.error(e)
         return link
@@ -110,18 +110,14 @@ class DatasetManager:
         with perf_profile(self._db, 'annotate_lithops', ds.id) as perf:
             executor = Executor(self._sm_config['lithops'], perf=perf)
 
-            ServerAnnotationJob(executor, self._img_store, ds, perf).run()
+            ServerAnnotationJob(executor, ds, perf).run()
 
             if self._sm_config['services'].get('colocalization', True):
                 Colocalization(self._db).run_coloc_job_lithops(executor, ds, reprocess=del_first)
 
             if self._sm_config['services'].get('ion_thumbnail', True):
                 generate_ion_thumbnail_lithops(
-                    executor=executor,
-                    db=self._db,
-                    sm_config=self._sm_config,
-                    ds=ds,
-                    only_if_needed=not del_first,
+                    executor=executor, db=self._db, ds=ds, only_if_needed=not del_first,
                 )
 
     def index(self, ds: Dataset):
@@ -196,7 +192,7 @@ class DatasetManager:
         )
         if traceback:
             content += (
-                f"\n\nWe could not successfully read the dataset's imzML file. "
+                f'\n\nWe could not successfully read the dataset\'s imzML file. '
                 f'Please make sure you are using up-to-date software for '
                 f'exporting the dataset to imzML format.\nIf you are a developer, '
                 f'the following stack trace may be useful:\n\n{traceback}'
@@ -209,9 +205,9 @@ class DatasetManager:
         self._send_email(msg['email'], 'METASPACE service notification (FAILED)', email_body)
 
     def ds_failure_handler(self, msg, e):
-        self.logger.error(f" SM {msg['action']} daemon: failure", exc_info=True)
+        self.logger.error(f' SM {msg["action"]} daemon: failure', exc_info=True)
         ds = self.load_ds(msg['ds_id'])
         self.set_ds_status(ds, status=DatasetStatus.FAILED)
         self.notify_update(ds.id, msg['action'], stage=DaemonActionStage.FAILED)
         slack_msg = f'{json.dumps(msg)}\n```{e.traceback}```'
-        self.post_to_slack('hankey', f" [x] {msg['action']} failed: {slack_msg}")
+        self.post_to_slack('hankey', f' [x] {msg["action"]} failed: {slack_msg}')

--- a/metaspace/engine/sm/engine/daemons/lithops.py
+++ b/metaspace/engine/sm/engine/daemons/lithops.py
@@ -40,8 +40,8 @@ class LithopsDaemon:
         )
 
     def _on_success(self, msg):
-        self.logger.info(f" SM lithops daemon: success")
-        self._manager.post_to_slack('dart', ' [v] Annotation succeeded: {}'.format(json.dumps(msg)))
+        self.logger.info(' SM lithops daemon: success')
+        self._manager.post_to_slack('dart', f' [v] Annotation succeeded: {json.dumps(msg)}')
 
     def _on_failure(self, msg, e):
         if isinstance(e, LithopsStalledException):
@@ -69,10 +69,8 @@ class LithopsDaemon:
 
     def _callback(self, msg):
         try:
-            self.logger.info(f" SM lithops daemon received a message: {msg}")
-            self._manager.post_to_slack(
-                'new', " [v] New annotation message: {}".format(json.dumps(msg))
-            )
+            self.logger.info(f' SM lithops daemon received a message: {msg}')
+            self._manager.post_to_slack('new', f' [v] New annotation message: {json.dumps(msg)}')
 
             ds = self._manager.load_ds(msg['ds_id'])
             self._manager.set_ds_status(ds, DatasetStatus.ANNOTATING)

--- a/metaspace/engine/sm/engine/daemons/update.py
+++ b/metaspace/engine/sm/engine/daemons/update.py
@@ -21,7 +21,7 @@ class SMUpdateDaemon:
         self._stopped = False
 
     def _on_success(self, msg):
-        self.logger.info(f" SM update daemon: success")
+        self.logger.info(' SM update daemon: success')
 
         if msg['action'] == DaemonAction.DELETE:
             self._manager.notify_update(
@@ -38,7 +38,7 @@ class SMUpdateDaemon:
 
         if msg['action'] != DaemonAction.UPDATE:
             self._manager.post_to_slack(
-                'dart', f" [v] Succeeded to {msg['action']}: {json.dumps(msg)}"
+                'dart', f' [v] Succeeded to {msg["action"]}: {json.dumps(msg)}'
             )
 
         if msg.get('email'):
@@ -54,7 +54,7 @@ class SMUpdateDaemon:
         try:
             self.logger.info(f' SM update daemon received a message: {msg}')
             self._manager.post_to_slack(
-                'new', f" [v] New {msg['action']} message: {json.dumps(msg)}"
+                'new', f' [v] New {msg["action"]} message: {json.dumps(msg)}'
             )
 
             ds = self._manager.load_ds(msg['ds_id'])
@@ -81,7 +81,7 @@ class SMUpdateDaemon:
             elif msg['action'] == DaemonAction.DELETE:
                 self._manager.delete(ds=ds)
             else:
-                raise SMError(f"Wrong action: {msg['action']}")
+                raise SMError(f'Wrong action: {msg["action"]}')
         except Exception as e:
             raise IndexUpdateError(msg['ds_id'], traceback=format_exc(chain=False)) from e
 

--- a/metaspace/engine/sm/engine/db.py
+++ b/metaspace/engine/sm/engine/db.py
@@ -64,7 +64,7 @@ def transaction_context():
         try:
             yield thread_local.conn
 
-        except Exception as e:
+        except Exception:
             logger.debug('Rolling back transaction')
             thread_local.conn.rollback()
             raise

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -385,6 +385,12 @@ class ESExporter:
             mzs, _ = isocalc.centroids(ion_without_pol)
             doc['centroid_mzs'] = list(mzs) if mzs is not None else []
             doc['mz'] = mzs[0] if mzs is not None else 0
+            doc['iso_image_urls'] = [
+                image_storage.get_image_url(image_storage.ImageType.ISO, ds_id, image_id)
+                if image_id
+                else None
+                for image_id in doc.pop('iso_image_ids')
+            ]
 
             if moldb.targeted:
                 fdr_level = doc['fdr'] = -1
@@ -582,8 +588,8 @@ class ESExporterIsobars:
             for peak_i, mz in enumerate(doc['centroid_mzs']):
                 if (
                     mz != 0
-                    and peak_i < len(doc['iso_image_ids'])
-                    and doc['iso_image_ids'][peak_i] is not None
+                    and peak_i < len(doc['iso_image_urls'])
+                    and doc['iso_image_urls'][peak_i] is not None
                 ):
                     peaks.append(
                         (

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -82,7 +82,7 @@ FROM (
     d.config #> '{isotope_generation,neutral_losses}' AS ds_neutral_losses,
     d.config #> '{isotope_generation,chem_mods}' AS ds_chem_mods,
     d.acq_geometry AS ds_acq_geometry,
-    d.ion_thumbnail as ds_ion_thumbnail
+    d.ion_thumbnail AS ds_ion_thumbnail
   FROM dataset as d
   LEFT JOIN job ON job.ds_id = d.id
   GROUP BY d.id
@@ -427,7 +427,7 @@ class ESExporter:
                 ds_doc['annotation_counts'] = []
 
             ds_doc['ds_ion_thumbnail_url'] = image_storage.get_image_url(
-                image_storage.ImageType.THUMB, ds_id, ds_doc.pop('ds_ion_thumbnail')
+                image_storage.THUMB, ds_id, ds_doc['ds_ion_thumbnail']
             )
             annotation_counts = self._index_ds_annotations(ds_id, moldb, ds_doc, isocalc)
 

--- a/metaspace/engine/sm/engine/es_export.py
+++ b/metaspace/engine/sm/engine/es_export.py
@@ -386,7 +386,7 @@ class ESExporter:
             doc['centroid_mzs'] = list(mzs) if mzs is not None else []
             doc['mz'] = mzs[0] if mzs is not None else 0
             doc['iso_image_urls'] = [
-                image_storage.get_image_url(image_storage.ImageType.ISO, ds_id, image_id)
+                image_storage.get_image_url(image_storage.ISO, ds_id, image_id)
                 if image_id
                 else None
                 for image_id in doc.pop('iso_image_ids')

--- a/metaspace/engine/sm/engine/image_storage.py
+++ b/metaspace/engine/sm/engine/image_storage.py
@@ -13,7 +13,7 @@ import PIL.Image
 try:
     from mypy_boto3_s3.service_resource import S3ServiceResource
     from mypy_boto3_s3.client import S3Client
-except:  # pylint: disable=bare-except
+except ImportError:
     S3ServiceResource = object
     S3Client = object
 

--- a/metaspace/engine/sm/engine/image_storage.py
+++ b/metaspace/engine/sm/engine/image_storage.py
@@ -17,6 +17,7 @@ except ImportError:
     S3ServiceResource = object
     S3Client = object
 
+from sm.engine.config import SMConfig
 from sm.engine.storage import get_s3_resource, create_bucket
 
 logger = logging.getLogger('engine')
@@ -33,11 +34,12 @@ class ImageStorage:
     OPTICAL = ImageType.ISO
     THUMB = ImageType.THUMB
 
-    def __init__(self, config: Dict):
-        logger.info(f'Initializing image storage from config: {config}')
+    def __init__(self):
+        sm_config = SMConfig.get_conf()
+        logger.info(f'Initializing image storage from config: {sm_config["image_storage"]}')
         self.s3: S3ServiceResource = get_s3_resource()
         self.s3_client: S3Client = self.s3.meta.client
-        self._configure_bucket(config)
+        self._configure_bucket(sm_config["image_storage"])
 
     def _configure_bucket(self, config: Dict):
         create_bucket(self.s3_client, config['bucket'])
@@ -86,6 +88,98 @@ class ImageStorage:
         key = self._make_key(image_type, ds_id, image_id)
         return f'{endpoint}/{self.bucket.name}/{key}'
 
+    def get_ion_images_for_analysis(
+        self,
+        ds_id: str,
+        image_ids: List[str],
+        hotspot_percentile: int = 99,
+        max_size: Tuple[int, int] = None,
+        max_mem_mb: int = 2048,
+    ):
+        """Retrieves ion images, does hot-spot removal and resizing,
+        and returns them as numpy array.
+
+        Args:
+            ds_id:
+            image_ids:
+            hotspot_percentile:
+            max_size (Union[None, tuple[int, int]]):
+                If images are greater than this size, they will be downsampled to fit in this size
+            max_mem_mb (Union[None, float]):
+                If the output numpy array would require more than this amount of memory,
+                images will be downsampled to fit
+
+        Returns:
+            tuple[np.ndarray, np.ndarray, tuple[int, int]]
+                (value, mask, (h, w))
+                value - A float32 numpy array with shape (len(img_ids), h * w)
+                    where each row is one image
+                mask - A float32 numpy array with shape (h, w) containing the ion image mask.
+                    May contain values that are between 0 and 1 if downsampling
+                    caused both filled and empty pixels to be merged
+                h, w - shape of each image in value such that value[i].reshape(h, w)
+                    reconstructs the image
+        """
+        assert all(image_ids)
+
+        zoom_factor = 1
+        h, w = None, None
+        value, mask = None, None
+
+        def setup_shared_vals(img):
+            nonlocal zoom_factor, h, w, value, mask
+
+            img_h, img_w = img.height, img.width
+            if max_size:
+                size_zoom = min(max_size[0] / img_h, max_size[1] / img_w)
+                zoom_factor = min(zoom_factor, size_zoom)
+            if max_mem_mb:
+                expected_mem = img_h * img_w * len(image_ids) * 4 / 1024 / 1024
+                zoom_factor = min(zoom_factor, max_mem_mb / expected_mem)
+
+            raw_mask = np.float32(np.array(img)[:, :, 3] != 0)
+            if abs(zoom_factor - 1) < 0.001:
+                zoom_factor = 1
+                mask = raw_mask
+            else:
+                mask = zoom(raw_mask, zoom_factor, prefilter=False)
+
+            h, w = mask.shape
+            value = np.empty((len(image_ids), h * w), dtype=np.float32)
+
+        def process_img(img_id: str, idx, do_setup=False):
+            img_bytes = self.get_image(self.ISO, ds_id, img_id)
+            img = PIL.Image.open(io.BytesIO(img_bytes))
+            if do_setup:
+                setup_shared_vals(img)
+
+            img_arr = np.asarray(img, dtype=np.float32)[:, :, 0]
+
+            # Try to use the hotspot percentile,
+            # but fall back to the image's maximum or 1.0 if needed
+            # to ensure that there are no divide-by-zero issues
+            hotspot_threshold = np.percentile(img_arr, hotspot_percentile) or np.max(img_arr) or 1.0
+            np.clip(img_arr, None, hotspot_threshold, out=img_arr)
+
+            if zoom_factor != 1:
+                zoomed_img = zoom(img_arr, zoom_factor)
+            else:
+                zoomed_img = img_arr
+
+            # Note: due to prefiltering & smoothing, zoom can change the min/max of the image,
+            # so hotspot_threshold cannot be reused here for scaling
+            np.clip(zoomed_img, 0, None, out=zoomed_img)
+            zoomed_img /= np.max(zoomed_img) or 1
+
+            value[idx, :] = zoomed_img.ravel()  # pylint: disable=unsupported-assignment-operation
+
+        process_img(image_ids[0], 0, do_setup=True)
+        with ThreadPoolExecutor() as executor:
+            for _ in executor.map(process_img, image_ids[1:], range(1, len(image_ids))):
+                pass
+
+        return value, mask, (h, w)
+
 
 # pylint: disable=invalid-name
 _instance: ImageStorage
@@ -98,104 +192,16 @@ get_image: Callable[[ImageType, str, str], bytes]
 post_image: Callable[[ImageType, str, bytes], str]
 delete_image: Callable[[ImageType, str, str], None]
 get_image_url: Callable[[ImageType, str, str], str]
+get_ion_images_for_analysis = None
 
 
-def init(config: Dict):
+def init():
     # pylint: disable=global-statement
     global _instance, get_image, post_image, delete_image, get_image_url
-    _instance = ImageStorage(config)
+    global get_ion_images_for_analysis
+    _instance = ImageStorage()
     get_image = _instance.get_image
     post_image = _instance.post_image
     delete_image = _instance.delete_image
     get_image_url = _instance.get_image_url
-
-
-def get_ion_images_for_analysis(
-    ds_id: str,
-    image_ids: List[str],
-    hotspot_percentile: int = 99,
-    max_size: Tuple[int, int] = None,
-    max_mem_mb: int = 2048,
-):
-    """Retrieves ion images, does hot-spot removal and resizing,
-    and returns them as numpy array.
-
-    Args:
-        image_ids:
-        hotspot_percentile:
-        max_size (Union[None, tuple[int, int]]):
-            If images are greater than this size, they will be downsampled to fit in this size
-        max_mem_mb (Union[None, float]):
-            If the output numpy array would require more than this amount of memory,
-            images will be downsampled to fit
-
-    Returns:
-        tuple[np.ndarray, np.ndarray, tuple[int, int]]
-            (value, mask, (h, w))
-            value - A float32 numpy array with shape (len(img_ids), h * w)
-                where each row is one image
-            mask - A float32 numpy array with shape (h, w) containing the ion image mask.
-                May contain values that are between 0 and 1 if downsampling
-                caused both filled and empty pixels to be merged
-            h, w - shape of each image in value such that value[i].reshape(h, w)
-                reconstructs the image
-    """
-    assert all(image_ids)
-
-    zoom_factor = 1
-    h, w = None, None
-    value, mask = None, None
-
-    def setup_shared_vals(img):
-        nonlocal zoom_factor, h, w, value, mask
-
-        img_h, img_w = img.height, img.width
-        if max_size:
-            size_zoom = min(max_size[0] / img_h, max_size[1] / img_w)
-            zoom_factor = min(zoom_factor, size_zoom)
-        if max_mem_mb:
-            expected_mem = img_h * img_w * len(image_ids) * 4 / 1024 / 1024
-            zoom_factor = min(zoom_factor, max_mem_mb / expected_mem)
-
-        raw_mask = np.float32(np.array(img)[:, :, 3] != 0)
-        if abs(zoom_factor - 1) < 0.001:
-            zoom_factor = 1
-            mask = raw_mask
-        else:
-            mask = zoom(raw_mask, zoom_factor, prefilter=False)
-
-        h, w = mask.shape
-        value = np.empty((len(image_ids), h * w), dtype=np.float32)
-
-    def process_img(img_id: str, idx, do_setup=False):
-        img_bytes = get_image(ISO, ds_id, img_id)
-        img = PIL.Image.open(io.BytesIO(img_bytes))
-        if do_setup:
-            setup_shared_vals(img)
-
-        img_arr = np.asarray(img, dtype=np.float32)[:, :, 0]
-
-        # Try to use the hotspot percentile,
-        # but fall back to the image's maximum or 1.0 if needed
-        # to ensure that there are no divide-by-zero issues
-        hotspot_threshold = np.percentile(img_arr, hotspot_percentile) or np.max(img_arr) or 1.0
-        np.clip(img_arr, None, hotspot_threshold, out=img_arr)
-
-        if zoom_factor != 1:
-            zoomed_img = zoom(img_arr, zoom_factor)
-        else:
-            zoomed_img = img_arr
-
-        # Note: due to prefiltering & smoothing, zoom can change the min/max of the image,
-        # so hotspot_threshold cannot be reused here for scaling
-        np.clip(zoomed_img, 0, None, out=zoomed_img)
-        zoomed_img /= np.max(zoomed_img) or 1
-
-        value[idx, :] = zoomed_img.ravel()  # pylint: disable=unsupported-assignment-operation
-
-    process_img(image_ids[0], 0, do_setup=True)
-    with ThreadPoolExecutor() as executor:
-        for _ in executor.map(process_img, image_ids[1:], range(1, len(image_ids))):
-            pass
-
-    return value, mask, (h, w)
+    get_ion_images_for_analysis = _instance.get_ion_images_for_analysis

--- a/metaspace/engine/sm/engine/image_storage.py
+++ b/metaspace/engine/sm/engine/image_storage.py
@@ -4,16 +4,16 @@ import logging
 import uuid
 from concurrent.futures.thread import ThreadPoolExecutor
 from enum import Enum
-from typing import List, Tuple, Dict, Callable, TYPE_CHECKING
+from typing import List, Tuple, Dict, Callable
 
 import numpy as np
 from scipy.ndimage import zoom
 import PIL.Image
 
-if TYPE_CHECKING:
+try:
     from mypy_boto3_s3.service_resource import S3ServiceResource
     from mypy_boto3_s3.client import S3Client
-else:
+except:  # pylint: disable=bare-except
     S3ServiceResource = object
     S3Client = object
 
@@ -29,7 +29,9 @@ class ImageType(str, Enum):
 
 
 class ImageStorage:
-    Type = ImageType
+    ISO = ImageType.ISO
+    OPTICAL = ImageType.ISO
+    THUMB = ImageType.THUMB
 
     def __init__(self, config: Dict):
         logger.info(f'Initializing image storage from config: {config}')
@@ -87,6 +89,10 @@ class ImageStorage:
 
 # pylint: disable=invalid-name
 _instance: ImageStorage
+
+ISO = ImageType.ISO
+OPTICAL = ImageType.ISO
+THUMB = ImageType.THUMB
 
 get_image: Callable[[ImageType, str, str], bytes]
 post_image: Callable[[ImageType, str, bytes], str]
@@ -162,7 +168,7 @@ def get_ion_images_for_analysis(
         value = np.empty((len(image_ids), h * w), dtype=np.float32)
 
     def process_img(img_id: str, idx, do_setup=False):
-        img_bytes = get_image(ImageType.ISO, ds_id, img_id)
+        img_bytes = get_image(ISO, ds_id, img_id)
         img = PIL.Image.open(io.BytesIO(img_bytes))
         if do_setup:
             setup_shared_vals(img)

--- a/metaspace/engine/sm/engine/molecular_db.py
+++ b/metaspace/engine/sm/engine/molecular_db.py
@@ -83,7 +83,7 @@ def read_moldb_file(file_path):
             buffer = Path(file_path).open()
         moldb_df = pd.read_csv(buffer, sep='\t', dtype=object, na_filter=False)
     except ValueError as e:
-        raise MalformedCSV(f'Malformed CSV: {e}')
+        raise MalformedCSV(f'Malformed CSV: {e}') from e
 
     if moldb_df.empty:
         raise MalformedCSV('No data rows found')

--- a/metaspace/engine/sm/engine/postprocessing/ion_thumbnail.py
+++ b/metaspace/engine/sm/engine/postprocessing/ion_thumbnail.py
@@ -2,7 +2,6 @@
 import logging
 from io import BytesIO
 from itertools import combinations
-from typing import Dict
 
 import numpy as np
 import png
@@ -11,7 +10,6 @@ from sklearn.cluster import KMeans
 from sm.engine import image_storage
 from sm.engine.annotation_lithops.executor import Executor
 from sm.engine.dataset import Dataset
-from sm.engine.image_store import ImageStoreServiceWrapper
 
 ISO_IMAGE_SEL = (
     "SELECT iso_image_ids[1] "
@@ -172,6 +170,7 @@ def _thumb_from_pixel_clusters(images, mask, h, w, use_distance_from_centroid=Fa
     return unmasked_pixel_vals.reshape((h, w, 4))
 
 
+# pylint: disable=too-many-function-args
 def _generate_ion_thumbnail_image(ds_id, annotation_rows, algorithm):
     image_ids = [image_id for image_id, in annotation_rows]
 
@@ -192,7 +191,7 @@ def _save_ion_thumbnail_image(ds_id, thumbnail):
     png_writer = png.Writer(width=w, height=h, alpha=True, compression=9)
     png_writer.write(fp, thumbnail.reshape(h, w * depth).tolist())
     fp.seek(0)
-    return image_storage.post_image(image_storage.ImageType.THUMB, ds_id, fp.read())
+    return image_storage.post_image(image_storage.THUMB, ds_id, fp.read())
 
 
 def generate_ion_thumbnail(db, ds, only_if_needed=False, algorithm=DEFAULT_ALGORITHM):
@@ -214,28 +213,17 @@ def generate_ion_thumbnail(db, ds, only_if_needed=False, algorithm=DEFAULT_ALGOR
         db.alter(THUMB_UPD, [image_id, ds.id])
 
         if existing_thumb_id:
-            image_storage.delete_image(image_storage.ImageType.THUMB, ds.id, existing_thumb_id)
+            image_storage.delete_image(image_storage.THUMB, ds.id, existing_thumb_id)
 
     except Exception:
         logger.error('Error generating ion thumbnail image', exc_info=True)
 
 
 def generate_ion_thumbnail_lithops(
-    executor: Executor,
-    db,
-    sm_config: Dict,
-    ds: Dataset,
-    only_if_needed=False,
-    algorithm=DEFAULT_ALGORITHM,
+    executor: Executor, db, ds: Dataset, only_if_needed=False, algorithm=DEFAULT_ALGORITHM,
 ):
-    img_service_private_url = sm_config['services']['img_service_url']
-    img_service_public_url = sm_config['services']['img_service_public_url']
-
     def generate(annotation_rows):
-        # Use web_app_url to get the publicly-exposed storage server address, because
-        # Functions can't use the private address
-        public_img_store = ImageStoreServiceWrapper(img_service_public_url)
-        return _generate_ion_thumbnail_image(annotation_rows, public_img_store, algorithm)
+        return _generate_ion_thumbnail_image(ds.id, annotation_rows, algorithm)
 
     try:
         (existing_thumb_id,) = db.select_one(THUMB_SEL, [ds.id])
@@ -253,12 +241,11 @@ def generate_ion_thumbnail_lithops(
             generate, (annotation_rows,), runtime_memory=2048, include_modules=['png']
         )
 
-        img_store = ImageStoreServiceWrapper(img_service_private_url)
-        image_id = _save_ion_thumbnail_image(img_store, thumbnail)
+        image_id = _save_ion_thumbnail_image(ds.id, thumbnail)
         db.alter(THUMB_UPD, [image_id, ds.id])
 
         if existing_thumb_id:
-            img_store.delete_image_by_id('ion_thumbnail', existing_thumb_id)
+            image_storage.delete_image(image_storage.THUMB, ds.id, existing_thumb_id)
 
     except Exception:
         logger.error('Error generating ion thumbnail image', exc_info=True)

--- a/metaspace/engine/sm/engine/postprocessing/ion_thumbnail.py
+++ b/metaspace/engine/sm/engine/postprocessing/ion_thumbnail.py
@@ -10,6 +10,7 @@ from sklearn.cluster import KMeans
 from sm.engine import image_storage
 from sm.engine.annotation_lithops.executor import Executor
 from sm.engine.dataset import Dataset
+from sm.engine.db import DB
 
 ISO_IMAGE_SEL = (
     "SELECT iso_image_ids[1] "
@@ -217,6 +218,12 @@ def generate_ion_thumbnail(db, ds, only_if_needed=False, algorithm=DEFAULT_ALGOR
 
     except Exception:
         logger.error('Error generating ion thumbnail image', exc_info=True)
+
+
+def delete_ion_thumbnail(db: DB, ds: Dataset):
+    (thumb_id,) = db.select_one(THUMB_SEL, [ds.id])
+    if thumb_id:
+        image_storage.delete_image(image_storage.THUMB, ds.id, thumb_id)
 
 
 def generate_ion_thumbnail_lithops(

--- a/metaspace/engine/sm/engine/postprocessing/off_sample_wrapper.py
+++ b/metaspace/engine/sm/engine/postprocessing/off_sample_wrapper.py
@@ -108,7 +108,7 @@ def classify_dataset_ion_images(db, ds, services_config, overwrite_existing=Fals
     """
     off_sample_api_endpoint = services_config['off_sample']
 
-    get_image_by_id = partial(image_storage.get_image, image_storage.ImageType.ISO, ds.id)
+    get_image_by_id = partial(image_storage.get_image, image_storage.ISO, ds.id)
 
     annotations = db.select_with_fields(SEL_ION_IMAGES, (ds.id, overwrite_existing))
     image_ids = [a['img_id'] for a in annotations]

--- a/metaspace/engine/sm/engine/storage.py
+++ b/metaspace/engine/sm/engine/storage.py
@@ -30,7 +30,8 @@ def get_s3_resource():
     return boto3.resource('s3', **_boto_client_kwargs())
 
 
-def create_bucket(s3_client, bucket_name: str):
+def create_bucket(bucket_name: str):
+    s3_client = get_s3_client()
     try:
         s3_client.head_bucket(Bucket=bucket_name)
     except botocore.exceptions.ClientError as e:

--- a/metaspace/engine/sm/engine/storage.py
+++ b/metaspace/engine/sm/engine/storage.py
@@ -30,13 +30,12 @@ def get_s3_resource():
     return boto3.resource('s3', **_boto_client_kwargs())
 
 
-def create_bucket(bucket_name: str):
-    s3 = get_s3_client()
+def create_bucket(s3_client, bucket_name: str):
     try:
-        s3.head_bucket(Bucket=bucket_name)
+        s3_client.head_bucket(Bucket=bucket_name)
     except botocore.exceptions.ClientError as e:
-        if e.response["Error"]["Code"] == "404":
-            s3.create_bucket(Bucket=bucket_name)
+        if e.response['Error']['Code'] == '404':
+            s3_client.create_bucket(Bucket=bucket_name)
         else:
             raise
 

--- a/metaspace/engine/sm/engine/util.py
+++ b/metaspace/engine/sm/engine/util.py
@@ -34,17 +34,6 @@ def find_file_by_ext(path, ext):
     return next(str(p) for p in Path(path).iterdir() if str(p).lower().endswith(ext))
 
 
-def bootstrap_and_run(config_path, func):
-    from sm.engine.db import ConnectionPool  # pylint: disable=import-outside-toplevel
-
-    SMConfig.set_path(config_path)
-    sm_config = SMConfig.get_conf()
-    init_loggers(sm_config['logs'])
-
-    with ConnectionPool(sm_config['db']):
-        func(sm_config)
-
-
 def populate_aws_env_vars(aws_config):
     for env_var, val in aws_config.items():
         os.environ.setdefault(env_var.upper(), val)
@@ -68,7 +57,6 @@ class GlobalInit:
         from sm.engine.db import ConnectionPool  # pylint: disable=import-outside-toplevel
 
         self.sm_config = on_startup(config_path)
-
         self.pool = ConnectionPool(self.sm_config['db'])
 
     def __enter__(self):

--- a/metaspace/engine/sm/engine/util.py
+++ b/metaspace/engine/sm/engine/util.py
@@ -47,7 +47,7 @@ def on_startup(config_path: str) -> Dict:
     if 'aws' in sm_config:
         populate_aws_env_vars(sm_config['aws'])
 
-    image_storage.init(sm_config['image_storage'])
+    image_storage.init()
 
     return sm_config
 

--- a/metaspace/engine/sm/rest/databases.py
+++ b/metaspace/engine/sm/rest/databases.py
@@ -52,7 +52,7 @@ def create():
         logger.info(f'Creating molecular database. Params: {params}')
 
         required_fields = ['name', 'version', 'group_id', 'file_path']
-        if not all([field in params for field in required_fields]):
+        if not all(field in params for field in required_fields):
             return make_response(WRONG_PARAMETERS, errors=[f'Required fields: {required_fields}'])
 
         moldb = molecular_db.create(**params)

--- a/metaspace/engine/tests/conftest.py
+++ b/metaspace/engine/tests/conftest.py
@@ -42,7 +42,7 @@ def global_setup(sm_config):
     if 'aws' in sm_config:
         populate_aws_env_vars(sm_config['aws'])
 
-    image_storage.init(sm_config['image_storage'])
+    image_storage.init()
 
 
 @pytest.fixture()

--- a/metaspace/engine/tests/sci_test/spheroid.py
+++ b/metaspace/engine/tests/sci_test/spheroid.py
@@ -128,7 +128,7 @@ class SciTester:
     @classmethod
     def _patch_image_storage(cls):
         class ImageStorageMock:
-            Type = image_storage.ImageType
+            ISO = image_storage.ISO
 
             def __init__(self, *args, **kwargs):
                 pass

--- a/metaspace/engine/tests/sci_test/spheroid.py
+++ b/metaspace/engine/tests/sci_test/spheroid.py
@@ -127,7 +127,7 @@ class SciTester:
 
     @classmethod
     def _patch_image_storage(cls):
-        class ImageStoreMock:
+        class ImageStorageMock:
             Type = image_storage.ImageType
 
             def __init__(self, *args, **kwargs):
@@ -138,7 +138,7 @@ class SciTester:
 
         from sm.engine.annotation_spark import search_results
 
-        search_results.ImageStorage = ImageStoreMock
+        search_results.ImageStorage = ImageStorageMock
 
     def run_search(self, mock_image_storage=False, use_lithops=False):
         if mock_image_storage:

--- a/metaspace/engine/tests/test_api_databases.py
+++ b/metaspace/engine/tests/test_api_databases.py
@@ -39,7 +39,7 @@ class MoldbFiles(Enum):
 @pytest.fixture(autouse=True, scope='module')
 def fill_storage():
     s3 = get_s3_client()
-    create_bucket(s3, BUCKET_NAME)
+    create_bucket(BUCKET_NAME)
 
     for file in MoldbFiles:
         s3.upload_file(

--- a/metaspace/engine/tests/test_api_databases.py
+++ b/metaspace/engine/tests/test_api_databases.py
@@ -39,7 +39,7 @@ class MoldbFiles(Enum):
 @pytest.fixture(autouse=True, scope='module')
 def fill_storage():
     s3 = get_s3_client()
-    create_bucket(BUCKET_NAME)
+    create_bucket(s3, BUCKET_NAME)
 
     for file in MoldbFiles:
         s3.upload_file(

--- a/metaspace/engine/tests/test_colocalization.py
+++ b/metaspace/engine/tests/test_colocalization.py
@@ -67,10 +67,10 @@ def test_new_ds_saves_to_db(test_db, metadata, ds_config):
         [(job_id, r.formula, r.adduct, r.fdr, [r.image_id]) for i, r in ion_metrics_df.iterrows()],
     )
 
-    with patch('sm.engine.postprocessing.colocalization.image_storage') as image_storage_mock:
-        image_storage_mock.get_ion_images_for_analysis.side_effect = (
-            mock_get_ion_images_for_analysis
-        )
+    with patch(
+        'sm.engine.postprocessing.colocalization.ImageStorage.get_ion_images_for_analysis'
+    ) as get_ion_images_for_analysis_mock:
+        get_ion_images_for_analysis_mock.side_effect = mock_get_ion_images_for_analysis
 
         Colocalization(db).run_coloc_job(ds)
 

--- a/metaspace/engine/tests/test_es_export.py
+++ b/metaspace/engine/tests/test_es_export.py
@@ -132,6 +132,7 @@ def test_index_ds_works(sm_config, test_db, es_dsl_search, sm_index, ds_config, 
         'ds_group_id': group_id,
         'ds_group_name': 'group name',
         'ds_group_short_name': 'grp',
+        'ds_ion_thumbnail': 'thumb-id',
         'ds_ion_thumbnail_url': (
             f'http://localhost:9000/{sm_config["image_storage"]["bucket"]}/thumb/{ds_id}/thumb-id'
         ),

--- a/metaspace/engine/tests/test_es_export.py
+++ b/metaspace/engine/tests/test_es_export.py
@@ -132,7 +132,9 @@ def test_index_ds_works(sm_config, test_db, es_dsl_search, sm_index, ds_config, 
         'ds_group_id': group_id,
         'ds_group_name': 'group name',
         'ds_group_short_name': 'grp',
-        'ds_ion_thumbnail_url': 'http://localhost:9000/thumb/2000-01-01_00h00m/thumb-id',
+        'ds_ion_thumbnail_url': (
+            f'http://localhost:9000/{sm_config["image_storage"]["bucket"]}/thumb/{ds_id}/thumb-id'
+        ),
     }
     assert ds_d == {
         **expected_ds_fields,
@@ -167,7 +169,10 @@ def test_index_ds_works(sm_config, test_db, es_dsl_search, sm_index, ds_config, 
         'ion_formula': 'HO2',
         'total_iso_ints': 100,
         'centroid_mzs': [100.0, 200.0, 300.0],
-        'iso_image_ids': ['iso_img_id_1', 'iso_img_id_2'],
+        'iso_image_urls': [
+            f'http://localhost:9000/{sm_config["image_storage"]["bucket"]}/iso/{ds_id}/iso_img_id_1',
+            f'http://localhost:9000/{sm_config["image_storage"]["bucket"]}/iso/{ds_id}/iso_img_id_2',
+        ],
         'isobars': [],
         'isomer_ions': [],
         'polarity': '+',
@@ -204,7 +209,10 @@ def test_index_ds_works(sm_config, test_db, es_dsl_search, sm_index, ds_config, 
         'ion_formula': 'HAu',
         'total_iso_ints': 100,
         'centroid_mzs': [10.0, 20.0],
-        'iso_image_ids': ['iso_img_id_1', 'iso_img_id_2'],
+        'iso_image_urls': [
+            f'http://localhost:9000/{sm_config["image_storage"]["bucket"]}/iso/{ds_id}/iso_img_id_1',
+            f'http://localhost:9000/{sm_config["image_storage"]["bucket"]}/iso/{ds_id}/iso_img_id_2',
+        ],
         'isobars': [],
         'isomer_ions': [],
         'polarity': '+',
@@ -254,7 +262,7 @@ def test_add_isobar_fields_to_anns(ds_config):
         {
             'annotation_id': 'Base annotation',
             'centroid_mzs': [100, 101, 102, 103],
-            'iso_image_ids': ['img1', 'img2', 'img3', 'img4'],
+            'iso_image_urls': ['img1', 'img2', 'img3', 'img4'],
             'msm': 0.5,
             'ion': 'H1+',
             'ion_formula': 'H1',
@@ -262,7 +270,7 @@ def test_add_isobar_fields_to_anns(ds_config):
         {
             'annotation_id': "Base's 1st centroid overlaps 1st",
             'centroid_mzs': [100.0002, 101.1, 102.1, 103.1],
-            'iso_image_ids': ['img1', 'img2', 'img3', 'img4'],
+            'iso_image_urls': ['img1', 'img2', 'img3', 'img4'],
             'msm': 0.6,
             'ion': 'H2+',
             'ion_formula': 'H2',
@@ -270,7 +278,7 @@ def test_add_isobar_fields_to_anns(ds_config):
         {
             'annotation_id': "Base's 1st centroid overlaps 2nd (shouldn't be reported)",
             'centroid_mzs': [98, 100.0002, 101.2, 102.2],
-            'iso_image_ids': ['img1', 'img2', 'img3', 'img4'],
+            'iso_image_urls': ['img1', 'img2', 'img3', 'img4'],
             'msm': 0.7,
             'ion': 'H3+',
             'ion_formula': 'H3',
@@ -278,7 +286,7 @@ def test_add_isobar_fields_to_anns(ds_config):
         {
             'annotation_id': "Base's 2nd and 3rd centroid overlap 3rd and 4th",
             'centroid_mzs': [96, 97, 101, 102],
-            'iso_image_ids': ['img1', 'img2', 'img3', 'img4'],
+            'iso_image_urls': ['img1', 'img2', 'img3', 'img4'],
             'msm': 0.8,
             'ion': 'H4+',
             'ion_formula': 'H4',

--- a/metaspace/engine/tests/test_image_storage.py
+++ b/metaspace/engine/tests/test_image_storage.py
@@ -27,14 +27,14 @@ def make_test_image_bytes() -> bytes:
 def test_post_get_image_success():
     test_image_bytes = make_test_image_bytes()
 
-    image_id = image_storage.post_image(image_storage.ImageType.ISO, "ds-id", test_image_bytes)
-    fetched_image_bytes = image_storage.get_image(image_storage.ImageType.ISO, "ds-id", image_id)
+    image_id = image_storage.post_image(image_storage.ISO, "ds-id", test_image_bytes)
+    fetched_image_bytes = image_storage.get_image(image_storage.ISO, "ds-id", image_id)
 
     assert fetched_image_bytes == test_image_bytes
 
 
 def test_get_image_wrong_key():
     try:
-        image_storage.get_image(image_storage.ImageType.ISO, "ds-id", 'wrong-id')
+        image_storage.get_image(image_storage.ISO, "ds-id", 'wrong-id')
     except botocore.exceptions.ClientError as error:
         assert error.response['Error']['Code'] == 'NoSuchKey'

--- a/metaspace/graphql/esConnector.ts
+++ b/metaspace/graphql/esConnector.ts
@@ -75,7 +75,7 @@ export interface ESAnnotationSource extends ESDatasetSource {
 
   mz: number;
   centroid_mzs: number[];
-  iso_image_ids: (string|null)[];
+  iso_image_urls: (string|null)[];
   total_iso_ints: number[];
   min_iso_ints: number[];
   max_iso_ints: number[];

--- a/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
+++ b/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
@@ -125,14 +125,12 @@ const Annotation: FieldResolversFor<Annotation, ESAnnotation | ESAnnotationWithC
   },
 
   isotopeImages(hit) {
-    const { iso_image_ids, centroid_mzs, total_iso_ints, min_iso_ints, max_iso_ints } = hit._source
+    const { iso_image_urls, centroid_mzs, total_iso_ints, min_iso_ints, max_iso_ints } = hit._source
     return centroid_mzs
       .map(function(mz, i) {
         return {
           mz: parseFloat(mz as any),
-          url: iso_image_ids[i] !== null
-            ? `/${hit._source.ds_ion_img_storage}${config.img_upload.categories.iso_image.path}${iso_image_ids[i]}`
-            : null,
+          url: iso_image_urls[i],
           totalIntensity: total_iso_ints[i],
           minIntensity: min_iso_ints[i],
           maxIntensity: max_iso_ints[i],


### PR DESCRIPTION
* Export iso image URLs to ES.
* Make image storage work with lithops.
* Remove dataset indexing from `ServerAnnotationJob`.
* Configure policy for image storage bucket on startup.
* Fix sci-test.
* Remove deprecated `bootstrap_and_run`, refactor dependent scripts.
* Update graphql `Annotation` resolver.
* Handle `pylint==2.7.0` complaints.