### PR TITLE
Lithops hotfixes

### DIFF
--- a/ansible/roles/sm_lithops_daemon/templates/sm-lithops-daemon.supervisor.j2
+++ b/ansible/roles/sm_lithops_daemon/templates/sm-lithops-daemon.supervisor.j2
@@ -4,7 +4,7 @@
 process_name = {{ sm_lithops_daemon_app_name }}-%(process_num)s
 environment = PATH="{{ miniconda_prefix }}/envs/{{ miniconda_env.name }}/bin"
 directory = {{ sm_home }}
-command = {{ miniconda_prefix }}/envs/{{ miniconda_env.name }}/bin/python scripts/run_sm_daemon.py --name=lithops
+command = {{ miniconda_prefix }}/envs/{{ miniconda_env.name }}/bin/python scripts/run_sm_daemon.py --name=lithops --exit-after 86400
 redirect_stderr = true
 stdout_logfile = {{ sm_home }}/logs/{{ sm_lithops_daemon_app_name }}-%(process_num)s.log
 numprocs = {{ sm_lithops_daemon_nprocs }}

--- a/metaspace/engine/sm/engine/daemons/lithops.py
+++ b/metaspace/engine/sm/engine/daemons/lithops.py
@@ -45,7 +45,7 @@ class LithopsDaemon:
 
     def _on_failure(self, msg, e):
         if isinstance(e, LithopsStalledException):
-            # Requeue the message so it retries, then exit the process
+            # Requeue the message so it retries, then exit the process and let supervisor restart it
             if msg.get('retry_attempt', 0) < 1:
                 self.logger.info('Lithops stalled. Retrying')
                 self._lithops_queue_pub.publish(

--- a/metaspace/engine/sm/engine/queue.py
+++ b/metaspace/engine/sm/engine/queue.py
@@ -1,5 +1,7 @@
 import logging
 import json
+import os
+import signal
 from threading import Event, Thread
 from time import sleep
 import pika
@@ -433,6 +435,9 @@ class QueueConsumer(Thread):
                     self._on_failure(msg or body, e)
                 except BaseException:
                     self.logger.error(' [x] Failed in _on_failure: {}'.format(body), exc_info=True)
+                    # Shut down the process, because this is likely an unrecoverable error
+                    # e.g. a broken postgres connection or Lithops invoker
+                    os.kill(os.getpid(), signal.SIGINT)
             else:
                 self.logger.info(' [v] Succeeded: {}'.format(body))
                 try:


### PR DESCRIPTION
This fixes several mostly Lithops-related issues:

#### `IOError: Too many open files` and `psycopg2.OperationalError: SSL connection has been closed unexpectedly` exceptions
Fixes #771

This raises the open file limit for the process on startup. I initially tried setting this on the server with `ulimit -n 127128`, but it appears that only sets it for the current terminal session. I decided to move this into the process as it's easier to manage code than infrastructure, and it affects only the Lithops daemon.

Additionally, I added code to `QueueConsumer` to exit the process if there is an error in the failure handler (i.e. there was an exception in the main task AND an exception handling the previous exception). `IOError: Too many open files` is actually the 2nd unrecoverable error we've seen. The first was `psycopg2.OperationalError: SSL connection has been closed unexpectedly`. It happens every time Postgres restarts (usually due to Ubuntu automatic updates), and every psycopg2 DB connection just stays in a broken state, raising exceptions on every call.

#### High long-term memory usage
Fixes #770

When large datasets are processed, the lithops-daemon process seems to grow to ~2GB and not shrink again after finishing. I added an optional `--exit-after` command-line parameter that stops the daemon after the specified number of seconds. Supervisorctl then restarts the daemon.

I also suspect that Lithops doesn't correctly clean up the background threads when there have been execution errors. Restarting periodically should prevent these threads from accumulating and becoming a problem.

To test this I ran it in Docker with `--exit-after 10` and verified that it shut down after 10s.

#### Increase the IBM COS multipart upload part size
Fixes #774 

Multipart uploads can have a maximum of 10000 parts. `upload_fileobj` doesn't know the file size, so it just guesses and uses 8MB parts, meaning the maximum file size that could be transferred from S3 to IBM COS is ~80GB. This change increases it to 20MB per part, so ~200GB maximum.

Additionally I increased some of the parameters for upload - parallelism from 10 to 20, and the read/write chunksize from 256k to 1MB. Hopefully this increases transfer speed.

To test this I uploaded a 300MB dataset on Staging and watched the logs to make sure there were no errors while it was transferring.