### PR TITLE
File upload fixes

### DIFF
--- a/metaspace/webapp/src/lib/util.ts
+++ b/metaspace/webapp/src/lib/util.ts
@@ -112,10 +112,21 @@ export function getOS() {
   return os
 }
 
-// not bulletproof but should do the job, local S3 uses path-style urls
-export const getS3Bucket = (parsedUrl: URL) => {
+export const parseS3Url = (parsedUrl: URL) => {
   if (parsedUrl.host.includes('.')) {
-    return parsedUrl.host.split('.')[0]
+    // When using S3, the bucket appears in the subdomain e.g. https://sm-engine-upload.s3.eu-west-1.amazonaws.com/
+    const bucket = parsedUrl.host.split('.')[0]
+    const key = parsedUrl.pathname.slice(1)
+    return { bucket, key }
+  } else {
+    // When using Minio, the bucket is the first path item, e.g. http://localhost:9000/sm-engine-dev/
+    const bucket = parsedUrl.pathname.split('/')[1]
+    const key = parsedUrl.pathname.split('/').slice(2).join('/')
+    return { bucket, key }
   }
-  return parsedUrl.pathname.split('/')[1]
+}
+
+export const convertUploadUrlToS3Path = (url: string) => {
+  const { bucket, key } = parseS3Url(new URL(url))
+  return `s3://${bucket}/${key}`
 }

--- a/metaspace/webapp/src/modules/MetadataEditor/UploadPage.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/UploadPage.vue
@@ -114,12 +114,12 @@ import { getSystemHealthQuery, getSystemHealthSubscribeToMore } from '../../api/
 import get from 'lodash-es/get'
 import { currentUserIdQuery } from '../../api/user'
 import reportError from '../../lib/reportError'
-import { getS3Bucket } from '../../lib/util'
+import { parseS3Url } from '../../lib/util'
 import config from '../../lib/config'
 
 const createInputPath = (url, uuid) => {
   const parsedUrl = new URL(url)
-  const bucket = getS3Bucket(parsedUrl)
+  const { bucket } = parseS3Url(parsedUrl)
   return `s3a://${bucket}/${uuid}`
 }
 

--- a/metaspace/webapp/src/modules/MolecularDatabases/UploadDialog.tsx
+++ b/metaspace/webapp/src/modules/MolecularDatabases/UploadDialog.tsx
@@ -11,14 +11,7 @@ import FadeTransition from '../../components/FadeTransition'
 import { createDatabaseQuery, MolecularDBDetails } from '../../api/moldb'
 import safeJsonParse from '../../lib/safeJsonParse'
 import reportError from '../../lib/reportError'
-import { getS3Bucket } from '../../lib/util'
-
-const convertToS3 = (url: string) => {
-  const parsedUrl = new URL(url)
-  const bucket = getS3Bucket(parsedUrl)
-  const path = decodeURIComponent(parsedUrl.pathname.slice(1))
-  return `s3://${bucket}/${path}`
-}
+import { convertUploadUrlToS3Path } from '../../lib/util'
 
 const uppyOptions : UppyOptions = {
   debug: true,
@@ -110,7 +103,7 @@ const UploadDialog = defineComponent<Props>({
     const handleUploadComplete = (result: UploadResult) => {
       if (result.successful.length) {
         const [file] = result.successful
-        state.model.filePath = convertToS3(file.uploadURL)
+        state.model.filePath = convertUploadUrlToS3Path(file.uploadURL)
         if (!state.model.name) {
           state.model.name = file.name.substr(0, file.name.lastIndexOf('.')) || file.name
         }

--- a/metaspace/webapp/src/router.ts
+++ b/metaspace/webapp/src/router.ts
@@ -34,11 +34,11 @@ const asyncPagesFreelyTyped = {
   ViewProjectPage: () => import(/* webpackPrefetch: true, webpackChunkName: "Bundle2" */ './modules/Project/ViewProjectPage.vue'),
 
   // Separate bundle for design docs
-  DesignTOC: () => import(/* webpackPrefetch: false, webpackChunkName: "DesignBundle" */ './design/TOCPage.vue'),
-  DesignStyleGuide: () => import(/* webpackPrefetch: false, webpackChunkName: "DesignBundle" */ './design/StyleGuidePage.vue'),
-  DesignIcons: () => import(/* webpackPrefetch: false, webpackChunkName: "DesignBundle" */ './design/IconsPage.vue'),
-  DesignComponents: () => import(/* webpackPrefetch: false, webpackChunkName: "DesignBundle" */ './design/ComponentsPage.vue'),
-  DesignForms: () => import(/* webpackPrefetch: false, webpackChunkName: "DesignBundle" */ './design/FormsPage.vue'),
+  DesignTOC: () => import(/* webpackChunkName: "DesignBundle" */ './design/TOCPage.vue'),
+  DesignStyleGuide: () => import(/* webpackChunkName: "DesignBundle" */ './design/StyleGuidePage.vue'),
+  DesignIcons: () => import(/* webpackChunkName: "DesignBundle" */ './design/IconsPage.vue'),
+  DesignComponents: () => import(/* webpackChunkName: "DesignBundle" */ './design/ComponentsPage.vue'),
+  DesignForms: () => import(/* webpackChunkName: "DesignBundle" */ './design/FormsPage.vue'),
 }
 const asyncPages = asyncPagesFreelyTyped as Record<keyof typeof asyncPagesFreelyTyped, AsyncComponent>
 


### PR DESCRIPTION
3 separate bug fixes - see individual commits to view them in isolation.

#### Fix uploading molecular DBs to minio

The only way to know the S3 Key (needed by the back-end) is to parse the `file.uploadURL` provided by Uppy. The URL format is different depending on whether you're targeting S3 or Minio. The Upload page handled both, but the Molecular Database Upload only handled S3 formats. 

I consolidated the URL parsing code so that both can handle both formats.

#### Prevent Uppy from uploading dataset files with different filenames to the same S3 prefix

Fixes #758 

If a user uploads a dataset, then removes the files and re-uploads some files with a different filename, the files with the old filename still exists in S3 under the same UUID prefix, which causes a problem when the engine tries to determine which file to use.

I've seen this ~5 times since Uppy was deployed - roughly once per week. It causes the dataset to fail to process, which is a bad experience for the users.

This change gets a new UUID prefix if files have been added but then all files are removed. For cases where not all files are removed, there is already an error if you try to upload a filename that's different to the existing file.

#### Remove "webpackPrefetch: false" as it causes compile warnings

Webpack was spamming warnings in the console that `false` is an invalid value for that setting. `webpackPrefetch` is off by default, so I just removed that setting.