### PR TITLE
Image storage deployment fixes

### DIFF
--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -196,5 +196,8 @@ The Prefix is necessary and should not have a leading or trailing slash
   },
   "ds_config_defaults": {
     "adducts": {{ sm_default_adducts | to_json }}
+  },
+  "image_storage": {
+    "bucket": "{{ sm_image_storage_bucket }}"
   }
 }

--- a/metaspace/engine/conf/test_config.json
+++ b/metaspace/engine/conf/test_config.json
@@ -171,6 +171,6 @@
     "secret_access_key": "minioadmin"
   },
   "image_storage": {
-    "bucket": "sm-image-storage-tests"
+    "bucket": "sm-image-storage-test"
   }
 }

--- a/metaspace/engine/docker/lithops_ibm_cf/Dockerfile
+++ b/metaspace/engine/docker/lithops_ibm_cf/Dockerfile
@@ -24,7 +24,7 @@ RUN pip install --no-cache-dir --upgrade pip setuptools six \
         namegenerator==1.0.6
 
 COPY requirements.txt /tmp/requirements.txt
-RUN grep -E "^(c?pyMSpec|c?pyImagingMSpec|numpy|scipy|pandas|msgpack|pyimzML|pyarrow|scikit-learn|Pillow)" /tmp/requirements.txt > /tmp/requirements-lithops.txt
+RUN grep -E "^(c?pyMSpec|c?pyImagingMSpec|numpy|scipy|pandas|msgpack|pyimzML|pyarrow|scikit-learn|Pillow|boto3)" /tmp/requirements.txt > /tmp/requirements-lithops.txt
 RUN pip install --no-cache-dir -r /tmp/requirements-lithops.txt
 
 # create action working directory

--- a/metaspace/engine/sm/engine/annotation/job.py
+++ b/metaspace/engine/sm/engine/annotation/job.py
@@ -50,16 +50,11 @@ def del_jobs(ds: Dataset, moldb_ids: Optional[Iterable[int]] = None):
                 (ds.id, moldb.id),
             )
 
-            # for _ in executor.map(
-            #     lambda img_id: image_storage.delete_image(image_storage.ISO, ds.id, img_id),
-            #     (img_id for img_ids in img_id_rows for img_id in img_ids if img_id is not None),
-            # ):
-            #     pass
-
-            for img_ids in img_id_rows:
-                for img_id in img_ids:
-                    if img_id is not None:
-                        image_storage.delete_image(image_storage.ISO, ds.id, img_id)
+            for _ in executor.map(
+                lambda img_id: image_storage.delete_image(image_storage.ISO, ds.id, img_id),
+                (img_id for img_ids in img_id_rows for img_id in img_ids if img_id is not None),
+            ):
+                pass
 
             logger.info(f"Deleting job results: ds_id={ds.id} ds_name={ds.name} moldb={moldb}")
             db.alter('DELETE FROM job WHERE ds_id = %s and moldb_id = %s', (ds.id, moldb.id))

--- a/metaspace/engine/sm/engine/annotation/job.py
+++ b/metaspace/engine/sm/engine/annotation/job.py
@@ -50,11 +50,16 @@ def del_jobs(ds: Dataset, moldb_ids: Optional[Iterable[int]] = None):
                 (ds.id, moldb.id),
             )
 
-            for _ in executor.map(
-                lambda img_id: image_storage.delete_image(image_storage.ISO, ds.id, img_id),
-                (img_id for img_ids in img_id_rows for img_id in img_ids if img_id is not None),
-            ):
-                pass
+            # for _ in executor.map(
+            #     lambda img_id: image_storage.delete_image(image_storage.ISO, ds.id, img_id),
+            #     (img_id for img_ids in img_id_rows for img_id in img_ids if img_id is not None),
+            # ):
+            #     pass
+
+            for img_ids in img_id_rows:
+                for img_id in img_ids:
+                    if img_id is not None:
+                        image_storage.delete_image(image_storage.ISO, ds.id, img_id)
 
             logger.info(f"Deleting job results: ds_id={ds.id} ds_name={ds.name} moldb={moldb}")
             db.alter('DELETE FROM job WHERE ds_id = %s and moldb_id = %s', (ds.id, moldb.id))

--- a/metaspace/engine/sm/engine/annotation_lithops/executor.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/executor.py
@@ -24,7 +24,7 @@ TRet = TypeVar('TRet')
 #: manually updating their config files every time it changes. The image must be public on
 #: Docker Hub, and can be rebuilt using the scripts/Dockerfile in `engine/docker/lithops_ibm_cf`.
 #: Note: sci-test changes this constant to force local execution without docker
-RUNTIME_DOCKER_IMAGE = 'metaspace2020/metaspace-lithops:1.8.3'
+RUNTIME_DOCKER_IMAGE = 'metaspace2020/metaspace-lithops:1.8.4'
 MEM_LIMITS = {
     'localhost': 32768,
     'ibm_cf': 4096,

--- a/metaspace/engine/sm/engine/annotation_spark/annotation_job.py
+++ b/metaspace/engine/sm/engine/annotation_spark/annotation_job.py
@@ -132,7 +132,7 @@ class AnnotationJob:
             self._ds_data_path.mkdir(parents=True, exist_ok=True)
 
             bucket_name, key = split_s3_path(ds.input_path)
-            bucket = storage.get_s3_bucket(bucket_name)
+            bucket = storage.get_s3_bucket(bucket_name, self._sm_config)
             for obj_sum in bucket.objects.filter(Prefix=key):
                 local_file = str(self._ds_data_path / Path(obj_sum.key).name)
                 logger.debug(f'Downloading s3a://{bucket_name}/{obj_sum.key} -> {local_file}')

--- a/metaspace/engine/sm/engine/annotation_spark/search_results.py
+++ b/metaspace/engine/sm/engine/annotation_spark/search_results.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import pyspark
 
+from sm.engine.config import SMConfig
 from sm.engine.image_storage import ImageStorage
 from sm.engine.db import DB
 from sm.engine.ion_mapping import get_ion_id_mapping
@@ -77,9 +78,10 @@ class SearchResults:
         logger.info('Posting iso images to image store')
         png_generator = PngGenerator(alpha_channel, greyscale=True)
         ds_id = self.ds_id
+        sm_config = SMConfig.get_conf()
 
         def generate_png_and_post(partition):
-            image_storage = ImageStorage()
+            image_storage = ImageStorage(sm_config)
 
             for formula_i, imgs in partition:
                 iso_image_ids = [None] * n_peaks

--- a/metaspace/engine/sm/engine/daemons/dataset_manager.py
+++ b/metaspace/engine/sm/engine/daemons/dataset_manager.py
@@ -147,7 +147,8 @@ class DatasetManager:
         self._es.update_ds(ds.id, fields)
 
     def delete(self, ds):
-        """ Delete all dataset related data from the DB """
+        """Delete all dataset related data."""
+
         self.logger.info(f'Deleting dataset: {ds.id}')
         del_jobs(ds)
         del_optical_image(self._db, ds.id)

--- a/metaspace/engine/sm/engine/daemons/update.py
+++ b/metaspace/engine/sm/engine/daemons/update.py
@@ -3,6 +3,7 @@ import logging
 from traceback import format_exc
 
 from sm.engine.daemons.actions import DaemonAction, DaemonActionStage
+from sm.engine.daemons.dataset_manager import DatasetManager
 from sm.engine.dataset import DatasetStatus
 from sm.engine.errors import UnknownDSID, SMError, IndexUpdateError
 
@@ -13,7 +14,7 @@ class SMUpdateDaemon:
 
     logger = logging.getLogger('update-daemon')
 
-    def __init__(self, manager, make_update_queue_cons):
+    def __init__(self, manager: DatasetManager, make_update_queue_cons):
         self._manager = manager
         self._update_queue_cons = make_update_queue_cons(
             callback=self._callback, on_success=self._on_success, on_failure=self._on_failure

--- a/metaspace/engine/sm/engine/image_storage.py
+++ b/metaspace/engine/sm/engine/image_storage.py
@@ -184,7 +184,8 @@ def _configure_bucket():
     bucket_name = sm_config['image_storage']['bucket']
     logger.info(f'Configuring image storage bucket: {bucket_name}')
 
-    create_bucket(bucket_name, sm_config)
+    s3_client = get_s3_client(sm_config)
+    create_bucket(bucket_name, s3_client)
     bucket_policy = {
         'Version': '2012-10-17',
         'Statement': [
@@ -196,7 +197,6 @@ def _configure_bucket():
             }
         ],
     }
-    s3_client = get_s3_client()
     s3_client.put_bucket_policy(Bucket=bucket_name, Policy=json.dumps(bucket_policy))
     cors_configuration = {
         'CORSRules': [

--- a/metaspace/engine/sm/engine/image_storage.py
+++ b/metaspace/engine/sm/engine/image_storage.py
@@ -4,7 +4,7 @@ import logging
 import uuid
 from concurrent.futures.thread import ThreadPoolExecutor
 from enum import Enum
-from typing import List, Tuple, Callable
+from typing import List, Tuple, Callable, Dict
 
 import numpy as np
 from scipy.ndimage import zoom
@@ -34,8 +34,8 @@ class ImageStorage:
     OPTICAL = ImageType.OPTICAL
     THUMB = ImageType.THUMB
 
-    def __init__(self):
-        sm_config = SMConfig.get_conf()
+    def __init__(self, sm_config: Dict = None):
+        sm_config = sm_config or SMConfig.get_conf()
         logger.info(f'Initializing image storage from config: {sm_config["image_storage"]}')
         self.s3: S3ServiceResource = get_s3_resource()
         self.s3_client: S3Client = self.s3.meta.client

--- a/metaspace/engine/sm/engine/image_storage.py
+++ b/metaspace/engine/sm/engine/image_storage.py
@@ -186,20 +186,21 @@ def _configure_bucket(sm_config: Dict):
     s3_client = get_s3_client(sm_config)
     create_bucket(bucket_name, s3_client)
 
+    bucket_policy = {
+        'Version': '2012-10-17',
+        'Statement': [
+            {
+                'Effect': 'Allow',
+                'Principal': {'AWS': ['*']},
+                'Action': ['s3:GetObject'],
+                'Resource': [f'arn:aws:s3:::{bucket_name}/*'],
+            }
+        ],
+    }
+    s3_client.put_bucket_policy(Bucket=bucket_name, Policy=json.dumps(bucket_policy))
+
     is_s3_bucket = 'aws' in sm_config  # False when minio is used instead of AWS S3
     if is_s3_bucket:
-        bucket_policy = {
-            'Version': '2012-10-17',
-            'Statement': [
-                {
-                    'Effect': 'Allow',
-                    'Principal': {'AWS': ['*']},
-                    'Action': ['s3:GetObject'],
-                    'Resource': [f'arn:aws:s3:::{bucket_name}/*'],
-                }
-            ],
-        }
-        s3_client.put_bucket_policy(Bucket=bucket_name, Policy=json.dumps(bucket_policy))
         cors_configuration = {
             'CORSRules': [
                 {

--- a/metaspace/engine/sm/engine/image_storage.py
+++ b/metaspace/engine/sm/engine/image_storage.py
@@ -37,7 +37,7 @@ class ImageStorage:
     def __init__(self, sm_config: Dict = None):
         sm_config = sm_config or SMConfig.get_conf()
         logger.info(f'Initializing image storage from config: {sm_config["image_storage"]}')
-        self.s3: S3ServiceResource = get_s3_resource()
+        self.s3: S3ServiceResource = get_s3_resource(sm_config)
         self.s3_client: S3Client = self.s3.meta.client
         self.bucket = self.s3.Bucket(sm_config['image_storage']['bucket'])
 
@@ -180,9 +180,10 @@ get_ion_images_for_analysis = None
 
 
 def _configure_bucket():
-    bucket_name = SMConfig.get_conf()['image_storage']['bucket']
+    sm_config = SMConfig.get_conf()
+    bucket_name = sm_config['image_storage']['bucket']
     logger.info(f'Configuring image storage bucket: {bucket_name}')
-    create_bucket(bucket_name)
+    create_bucket(bucket_name, sm_config)
     bucket_policy = {
         'Version': '2012-10-17',
         'Statement': [

--- a/metaspace/engine/sm/engine/image_storage.py
+++ b/metaspace/engine/sm/engine/image_storage.py
@@ -183,6 +183,7 @@ def _configure_bucket():
     sm_config = SMConfig.get_conf()
     bucket_name = sm_config['image_storage']['bucket']
     logger.info(f'Configuring image storage bucket: {bucket_name}')
+
     create_bucket(bucket_name, sm_config)
     bucket_policy = {
         'Version': '2012-10-17',
@@ -195,7 +196,19 @@ def _configure_bucket():
             }
         ],
     }
-    get_s3_client().put_bucket_policy(Bucket=bucket_name, Policy=json.dumps(bucket_policy))
+    s3_client = get_s3_client()
+    s3_client.put_bucket_policy(Bucket=bucket_name, Policy=json.dumps(bucket_policy))
+    cors_configuration = {
+        'CORSRules': [
+            {
+                'AllowedHeaders': ['*'],
+                'AllowedMethods': ['GET'],
+                'AllowedOrigins': ['*'],
+                'MaxAgeSeconds': 3000,
+            }
+        ]
+    }
+    s3_client.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=cors_configuration)
 
 
 def init():

--- a/metaspace/engine/sm/engine/molecular_db.py
+++ b/metaspace/engine/sm/engine/molecular_db.py
@@ -9,6 +9,7 @@ import pandas as pd
 from pyMSpec.pyisocalc.canopy.sum_formula_actions import InvalidFormulaError
 from pyMSpec.pyisocalc.pyisocalc import parseSumFormula
 
+from sm.engine.config import SMConfig
 from sm.engine.db import DB, transaction_context
 from sm.engine.errors import SMError
 from sm.engine.storage import get_s3_bucket
@@ -78,7 +79,8 @@ def read_moldb_file(file_path):
     try:
         if re.findall(r'^s3a?://', file_path):
             bucket_name, key = split_s3_path(file_path)
-            buffer = get_s3_bucket(bucket_name).Object(key).get()['Body']
+            sm_config = SMConfig.get_conf()
+            buffer = get_s3_bucket(bucket_name, sm_config).Object(key).get()['Body']
         else:
             buffer = Path(file_path).open()
         moldb_df = pd.read_csv(buffer, sep='\t', dtype=object, na_filter=False)

--- a/metaspace/engine/sm/engine/optical_image.py
+++ b/metaspace/engine/sm/engine/optical_image.py
@@ -201,7 +201,7 @@ def del_optical_image(db, ds_id):
     """Delete raw and zoomed optical images from DB and FS."""
 
     ds = Dataset.load(db, ds_id)
-    logger.info(f'Deleting optical image to "{ds.id}" dataset')
+    logger.info(f'Deleting optical image of "{ds.id}" dataset')
     (raw_img_id,) = db.select_one(SEL_DATASET_RAW_OPTICAL_IMAGE, params=(ds.id,))
     if raw_img_id:
         image_storage.delete_image(image_storage.OPTICAL, ds_id, raw_img_id)

--- a/metaspace/engine/sm/engine/postprocessing/colocalization.py
+++ b/metaspace/engine/sm/engine/postprocessing/colocalization.py
@@ -441,7 +441,7 @@ class Colocalization:
             tasks,
             cost_factors=cost_factors,
             runtime_memory=4096,
-            include_modules=['boto3'],
+            include_modules=['boto3', 'botocore'],
         )
 
         for job in iter_cobjs_with_prefetch(fexec.storage, job_cobjs):

--- a/metaspace/engine/sm/engine/postprocessing/colocalization.py
+++ b/metaspace/engine/sm/engine/postprocessing/colocalization.py
@@ -424,11 +424,12 @@ class Colocalization:
         # Extract required fields to avoid pickling Dataset, because unpickling Dataset tries to
         # import psycopg2 and fails inside Functions
         ds_id = ds.id
+        sm_config = self._sm_config
 
         def run_coloc_job(moldb_id, image_ids, ion_ids, fdrs, *, storage):
             # Use web_app_url to get the publicly-exposed storage server address, because
             # Functions can't use the private address
-            images, h, w = _get_images(ImageStorage(), ds_id, image_ids)
+            images, h, w = _get_images(ImageStorage(sm_config), ds_id, image_ids)
             cobjs = []
             for job in analyze_colocalization(ds_id, moldb_id, images, ion_ids, fdrs, h, w):
                 cobjs.append(save_cobj(storage, job))

--- a/metaspace/engine/sm/engine/postprocessing/colocalization.py
+++ b/metaspace/engine/sm/engine/postprocessing/colocalization.py
@@ -438,11 +438,7 @@ class Colocalization:
         tasks = list(self._iter_pending_coloc_tasks(ds.id, reprocess))
         cost_factors = pd.DataFrame({'n_images': [len(task[1]) for task in tasks]})
         job_cobjs = fexec.map_concat(
-            run_coloc_job,
-            tasks,
-            cost_factors=cost_factors,
-            runtime_memory=4096,
-            include_modules=['boto3', 'botocore'],
+            run_coloc_job, tasks, cost_factors=cost_factors, runtime_memory=4096
         )
 
         for job in iter_cobjs_with_prefetch(fexec.storage, job_cobjs):

--- a/metaspace/engine/sm/engine/postprocessing/colocalization.py
+++ b/metaspace/engine/sm/engine/postprocessing/colocalization.py
@@ -437,7 +437,11 @@ class Colocalization:
         tasks = list(self._iter_pending_coloc_tasks(ds.id, reprocess))
         cost_factors = pd.DataFrame({'n_images': [len(task[1]) for task in tasks]})
         job_cobjs = fexec.map_concat(
-            run_coloc_job, tasks, cost_factors=cost_factors, runtime_memory=4096
+            run_coloc_job,
+            tasks,
+            cost_factors=cost_factors,
+            runtime_memory=4096,
+            include_modules=['boto3'],
         )
 
         for job in iter_cobjs_with_prefetch(fexec.storage, job_cobjs):

--- a/metaspace/engine/sm/engine/postprocessing/ion_thumbnail.py
+++ b/metaspace/engine/sm/engine/postprocessing/ion_thumbnail.py
@@ -9,7 +9,6 @@ from scipy.spatial.distance import cdist
 from sklearn.cluster import KMeans
 from sm.engine.annotation_lithops.executor import Executor
 from sm.engine.dataset import Dataset
-from sm.engine.db import DB
 from sm.engine import image_storage
 
 ISO_IMAGE_SEL = (
@@ -221,14 +220,14 @@ def generate_ion_thumbnail(db, ds, only_if_needed=False, algorithm=DEFAULT_ALGOR
         logger.error('Error generating ion thumbnail image', exc_info=True)
 
 
-def delete_ion_thumbnail(db: DB, ds: Dataset):
+def delete_ion_thumbnail(db, ds: Dataset):
     (thumb_id,) = db.select_one(THUMB_SEL, [ds.id])
     if thumb_id:
         image_storage.delete_image(image_storage.THUMB, ds.id, thumb_id)
 
 
 def generate_ion_thumbnail_lithops(
-    executor: Executor, db: DB, ds: Dataset, only_if_needed=False, algorithm=DEFAULT_ALGORITHM,
+    executor: Executor, db, ds: Dataset, only_if_needed=False, algorithm=DEFAULT_ALGORITHM,
 ):
     try:
         (existing_thumb_id,) = db.select_one(THUMB_SEL, [ds.id])

--- a/metaspace/engine/sm/engine/postprocessing/ion_thumbnail.py
+++ b/metaspace/engine/sm/engine/postprocessing/ion_thumbnail.py
@@ -8,6 +8,7 @@ import png
 from scipy.spatial.distance import cdist
 from sklearn.cluster import KMeans
 from sm.engine.annotation_lithops.executor import Executor
+from sm.engine.config import SMConfig
 from sm.engine.dataset import Dataset
 from sm.engine import image_storage
 
@@ -242,10 +243,11 @@ def generate_ion_thumbnail_lithops(
             return
 
         ds_id = ds.id
+        sm_config = SMConfig.get_conf()
 
         def generate(annotation_rows):
             return _generate_ion_thumbnail_image(
-                image_storage.ImageStorage(), ds_id, annotation_rows, algorithm
+                image_storage.ImageStorage(sm_config), ds_id, annotation_rows, algorithm
             )
 
         thumbnail = executor.call(

--- a/metaspace/engine/sm/engine/postprocessing/off_sample_wrapper.py
+++ b/metaspace/engine/sm/engine/postprocessing/off_sample_wrapper.py
@@ -2,8 +2,7 @@ import base64
 import json
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from functools import partial
-from io import BytesIO
+
 from PIL import Image
 from requests import post, get
 import numpy as np
@@ -20,13 +19,6 @@ def make_chunk_gen(items, chunk_size):
     chunks = [items[i * chunk_size : (i + 1) * chunk_size] for i in range(chunk_n)]
     for image_path_chunk in chunks:
         yield image_path_chunk
-
-
-def encode_image_as_base64(img):
-    fp = BytesIO()
-    img.save(fp, format='PNG')
-    fp.seek(0)
-    return base64.b64encode(fp.read()).decode()
 
 
 def base64_images_to_doc(images):
@@ -73,14 +65,15 @@ def call_api(url='', doc=None):
     raise SMError(resp.content or resp)
 
 
-def make_classify_images(api_endpoint, get_image):
+def make_classify_images(api_endpoint, ds_id):
     def classify(chunk):
         logger.debug(f'Classifying chunk of {len(chunk)} images')
 
         base64_images = []
-        for elem in chunk:
-            img = get_image(elem)
-            base64_images.append(encode_image_as_base64(img))
+        for img_id in chunk:
+            img_bytes = image_storage.get_image(image_storage.ISO, ds_id, img_id)
+            img_base64 = base64.b64encode(img_bytes).decode()
+            base64_images.append(img_base64)
 
         images_doc = base64_images_to_doc(base64_images)
         pred_doc = call_api(api_endpoint + '/predict', doc=images_doc)
@@ -108,12 +101,10 @@ def classify_dataset_ion_images(db, ds, services_config, overwrite_existing=Fals
     """
     off_sample_api_endpoint = services_config['off_sample']
 
-    get_image_by_id = partial(image_storage.get_image, image_storage.ISO, ds.id)
-
     annotations = db.select_with_fields(SEL_ION_IMAGES, (ds.id, overwrite_existing))
     image_ids = [a['img_id'] for a in annotations]
 
-    classify_images = make_classify_images(off_sample_api_endpoint, get_image_by_id)
+    classify_images = make_classify_images(off_sample_api_endpoint, ds.id)
     image_predictions = classify_images(image_ids)
 
     rows = [(ann['ann_id'], json.dumps(pred)) for ann, pred in zip(annotations, image_predictions)]

--- a/metaspace/engine/sm/engine/storage.py
+++ b/metaspace/engine/sm/engine/storage.py
@@ -44,5 +44,5 @@ def create_bucket(bucket_name: str, s3_client=None):
             raise
 
 
-def get_s3_bucket(bucket_name: str):
-    return get_s3_resource().Bucket(bucket_name)
+def get_s3_bucket(bucket_name: str, sm_config: Dict):
+    return get_s3_resource(sm_config).Bucket(bucket_name)

--- a/metaspace/engine/sm/engine/storage.py
+++ b/metaspace/engine/sm/engine/storage.py
@@ -31,12 +31,18 @@ def get_s3_resource():
 
 
 def create_bucket(bucket_name: str):
+    sm_config = SMConfig.get_conf()
     s3_client = get_s3_client()
     try:
         s3_client.head_bucket(Bucket=bucket_name)
     except botocore.exceptions.ClientError as e:
         if e.response['Error']['Code'] == '404':
-            s3_client.create_bucket(Bucket=bucket_name)
+            s3_client.create_bucket(
+                Bucket=bucket_name,
+                CreateBucketConfiguration={
+                    'LocationConstraint': sm_config['aws']['aws_default_region']
+                },
+            )
         else:
             raise
 

--- a/metaspace/engine/sm/engine/storage.py
+++ b/metaspace/engine/sm/engine/storage.py
@@ -31,16 +31,14 @@ def get_s3_resource(sm_config: Dict = None):
     return boto3.resource('s3', **_boto_client_kwargs(sm_config or SMConfig.get_conf()))
 
 
-def create_bucket(bucket_name: str, sm_config: Dict = None):
-    sm_config = sm_config or SMConfig.get_conf()
-    region_name = sm_config['aws']['aws_default_region'] if 'aws' in sm_config else ''
-    s3_client = get_s3_client(sm_config)
+def create_bucket(bucket_name: str, s3_client=None):
     try:
         s3_client.head_bucket(Bucket=bucket_name)
     except botocore.exceptions.ClientError as e:
         if e.response['Error']['Code'] == '404':
             s3_client.create_bucket(
-                Bucket=bucket_name, CreateBucketConfiguration={'LocationConstraint': region_name},
+                Bucket=bucket_name,
+                CreateBucketConfiguration={'LocationConstraint': s3_client.meta.region_name},
             )
         else:
             raise

--- a/metaspace/engine/sm/engine/storage.py
+++ b/metaspace/engine/sm/engine/storage.py
@@ -32,16 +32,14 @@ def get_s3_resource():
 
 def create_bucket(bucket_name: str):
     sm_config = SMConfig.get_conf()
+    region_name = sm_config['aws']['aws_default_region'] if 'aws' in sm_config else ''
     s3_client = get_s3_client()
     try:
         s3_client.head_bucket(Bucket=bucket_name)
     except botocore.exceptions.ClientError as e:
         if e.response['Error']['Code'] == '404':
             s3_client.create_bucket(
-                Bucket=bucket_name,
-                CreateBucketConfiguration={
-                    'LocationConstraint': sm_config['aws']['aws_default_region']
-                },
+                Bucket=bucket_name, CreateBucketConfiguration={'LocationConstraint': region_name},
             )
         else:
             raise

--- a/metaspace/engine/sm/engine/storage.py
+++ b/metaspace/engine/sm/engine/storage.py
@@ -1,11 +1,12 @@
+from typing import Dict
+
 import boto3
 import botocore.exceptions
 
 from sm.engine.config import SMConfig
 
 
-def _boto_client_kwargs():
-    sm_config = SMConfig.get_conf()
+def _boto_client_kwargs(sm_config: Dict):
     boto_config = boto3.session.Config(signature_version='s3v4')
     if 'aws' in sm_config:
         return dict(
@@ -22,18 +23,18 @@ def _boto_client_kwargs():
     )
 
 
-def get_s3_client():
-    return boto3.client('s3', **_boto_client_kwargs())
+def get_s3_client(sm_config: Dict = None):
+    return boto3.client('s3', **_boto_client_kwargs(sm_config or SMConfig.get_conf()))
 
 
-def get_s3_resource():
-    return boto3.resource('s3', **_boto_client_kwargs())
+def get_s3_resource(sm_config: Dict = None):
+    return boto3.resource('s3', **_boto_client_kwargs(sm_config or SMConfig.get_conf()))
 
 
-def create_bucket(bucket_name: str):
-    sm_config = SMConfig.get_conf()
+def create_bucket(bucket_name: str, sm_config: Dict = None):
+    sm_config = sm_config or SMConfig.get_conf()
     region_name = sm_config['aws']['aws_default_region'] if 'aws' in sm_config else ''
-    s3_client = get_s3_client()
+    s3_client = get_s3_client(sm_config)
     try:
         s3_client.head_bucket(Bucket=bucket_name)
     except botocore.exceptions.ClientError as e:

--- a/metaspace/engine/sm/engine/util.py
+++ b/metaspace/engine/sm/engine/util.py
@@ -47,7 +47,7 @@ def on_startup(config_path: str) -> Dict:
     if 'aws' in sm_config:
         populate_aws_env_vars(sm_config['aws'])
 
-    image_storage.init()
+    image_storage.init(sm_config)
 
     return sm_config
 

--- a/metaspace/engine/tests/conftest.py
+++ b/metaspace/engine/tests/conftest.py
@@ -42,7 +42,7 @@ def global_setup(sm_config):
     if 'aws' in sm_config:
         populate_aws_env_vars(sm_config['aws'])
 
-    image_storage.init()
+    image_storage.init(sm_config)
 
 
 @pytest.fixture()

--- a/metaspace/engine/tests/test_api_databases.py
+++ b/metaspace/engine/tests/test_api_databases.py
@@ -38,18 +38,18 @@ class MoldbFiles(Enum):
 
 @pytest.fixture(autouse=True, scope='module')
 def fill_storage():
-    s3 = get_s3_client()
-    create_bucket(BUCKET_NAME)
+    s3_client = get_s3_client()
+    create_bucket(BUCKET_NAME, s3_client)
 
     for file in MoldbFiles:
-        s3.upload_file(
+        s3_client.upload_file(
             Filename=f'tests/data/moldbs/{file.value}', Bucket=BUCKET_NAME, Key=file.value
         )
 
     yield
 
     for file in MoldbFiles:
-        s3.delete_object(Bucket=BUCKET_NAME, Key=file.value)
+        s3_client.delete_object(Bucket=BUCKET_NAME, Key=file.value)
 
 
 def moldb_input_doc(**kwargs):

--- a/metaspace/engine/tests/test_off_sample_wrapper.py
+++ b/metaspace/engine/tests/test_off_sample_wrapper.py
@@ -1,3 +1,4 @@
+import io
 from collections import defaultdict
 
 from PIL import Image
@@ -14,7 +15,12 @@ def test_classify_ion_images_preds_saved(call_api_mock, image_storage_mock, fill
     call_api_mock.return_value = {
         'predictions': [{'prob': 0.1, 'label': 'on'}, {'prob': 0.9, 'label': 'off'}]
     }
-    image_storage_mock.get_image.return_value = Image.new('RGBA', (10, 10))
+
+    fp = io.BytesIO()
+    Image.new('RGBA', (10, 10)).save(fp, format='PNG')
+    fp.seek(0)
+    img_bytes = fp.read()
+    image_storage_mock.get_image.return_value = img_bytes
 
     db = DB()
     ds_id = '2000-01-01'

--- a/metaspace/graphql/esConnector.ts
+++ b/metaspace/graphql/esConnector.ts
@@ -76,7 +76,7 @@ export interface ESAnnotationSource extends ESDatasetSource {
   mz: number;
   centroid_mzs: number[];
   iso_image_ids: (string|null)[]; // FIXME: remove after data migration
-  iso_image_urls: (string|null)[];
+  iso_image_urls?: (string|null)[];
   total_iso_ints: number[];
   min_iso_ints: number[];
   max_iso_ints: number[];

--- a/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
+++ b/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
@@ -128,11 +128,15 @@ const Annotation: FieldResolversFor<Annotation, ESAnnotation | ESAnnotationWithC
     const { iso_image_ids, iso_image_urls, centroid_mzs, total_iso_ints, min_iso_ints, max_iso_ints } = hit._source
     return centroid_mzs
       .map(function(mz, i) {
+        let url
+        if (iso_image_urls != null) {
+          url = iso_image_urls[i]
+        } else { // FIXME: remove after data migration
+          url = `/${hit._source.ds_ion_img_storage}${config.img_upload.categories.iso_image.path}${iso_image_ids[i]}`
+        }
         return {
           mz: parseFloat(mz as any),
-          // FIXME: remove after data migration
-          url: iso_image_urls[i]
-            || `/${hit._source.ds_ion_img_storage}${config.img_upload.categories.iso_image.path}${iso_image_ids[i]}`,
+          url,
           totalIntensity: total_iso_ints[i],
           minIntensity: min_iso_ints[i],
           maxIntensity: max_iso_ints[i],


### PR DESCRIPTION
This is a collection of fixes that I had to do after the feature was deployed to staging. The key problem was that all the changes were tested only locally and moving from minio to S3 and local threads to Cloud Functions uncovered lots of hidden bugs or incompatibilities.

**Key changes:**
* Add `boto3` to the lithops runtime, bump its version.
* Explicitly initialize image storage objects using `sm_config` to avoid initialization issues inside cloud functions.
* Perform different bucket configuration depending on whether minio or S3 is being used.
* Fix `off_sample_wrapper.py`: treat values returned by image storage as bytes and not PIL image.