### PR TITLE
[DatasetTable|SortDropdown] set flex pagination container|min width d…

### DIFF
--- a/metaspace/webapp/src/components/SortDropdown/SortDropdown.css
+++ b/metaspace/webapp/src/components/SortDropdown/SortDropdown.css
@@ -1,0 +1,3 @@
+.sort-dp-container{
+    min-width: 200px;
+}

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
@@ -77,6 +77,7 @@
     <div class="mb-8 p-2 flex flex-row justify-end">
       <el-pagination
         v-if="totalCount > 0"
+        class="flex"
         hide-on-single-page
         :total="totalCount"
         :current-page.sync="currentPage"

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -928,6 +928,7 @@ exports[`DatasetTable should match snapshot 1`] = `
     class="mb-8 p-2 flex flex-row justify-end"
   >
     <mock-el-pagination
+      class="flex"
       current-page="1"
       hide-on-single-page=""
       layout="prev, pager, next"


### PR DESCRIPTION
In order to fix the dataset page's pagination and sorting input that were being truncated on zoomed pages, a min-width was added to the sorting input, and the pagination display was changed to flex, so it could match the pages width.

