### PR TITLE
Update python-client to handle the new image URLs served by graphql

### DIFF
--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.8.3'
+__version__ = '1.8.4'
 
 from metaspace.sm_annotation_utils import (
     SMInstance,


### PR DESCRIPTION
As discussed in Slack

To test this I queried the ion images of datasets from Prod (where data has been migrated) and Beta (where it hasn't been migrated). I also checked that optical images on prod still work (they haven't been migrated yet - waiting for #803) and ran the relevant unit tests locally.

As this is urgent, I'll publish the package after opening this PR, however this should still be reviewed and if there's any feedback I'll publish again with the fixes.