### PR TITLE
Fix database upload

### DIFF
--- a/metaspace/webapp/src/modules/MolecularDatabases/UploadDialog.tsx
+++ b/metaspace/webapp/src/modules/MolecularDatabases/UploadDialog.tsx
@@ -103,7 +103,9 @@ const UploadDialog = defineComponent<Props>({
     const handleUploadComplete = (result: UploadResult) => {
       if (result.successful.length) {
         const [file] = result.successful
-        state.model.filePath = convertUploadUrlToS3Path(file.uploadURL)
+        // The path part of file.uploadURL is double-URI-encoded for some reason (slashes in the path are %2F,
+        // spaces in the filename are %2520). Pass it through decodeURI to get a regular encoded URI (spaces are %20).
+        state.model.filePath = convertUploadUrlToS3Path(decodeURIComponent(file.uploadURL))
         if (!state.model.name) {
           state.model.name = file.name.substr(0, file.name.lastIndexOf('.')) || file.name
         }

--- a/metaspace/webapp/src/modules/MolecularDatabases/UploadDialog.tsx
+++ b/metaspace/webapp/src/modules/MolecularDatabases/UploadDialog.tsx
@@ -104,7 +104,7 @@ const UploadDialog = defineComponent<Props>({
       if (result.successful.length) {
         const [file] = result.successful
         // The path part of file.uploadURL is double-URI-encoded for some reason (slashes in the path are %2F,
-        // spaces in the filename are %2520). Pass it through decodeURI to get a regular encoded URI (spaces are %20).
+        // spaces in the filename are %2520). Decode it once to get a regular URI (slashes are /, spaces are %20).
         state.model.filePath = convertUploadUrlToS3Path(decodeURIComponent(file.uploadURL))
         if (!state.model.name) {
           state.model.name = file.name.substr(0, file.name.lastIndexOf('.')) || file.name


### PR DESCRIPTION
Fixes a bug raised in #metaspace in Slack. This bug was introduced in my prior PR #787. For some reason, `file.uploadURL` from Uppy is double-URI-encoded. e.g. `https://sm-engine-upload-staging.s3.eu-west-1.amazonaws.com/databases%2F04f2f048-4928-455e-a627-44218dbf7015%2Ftest%2520data%2520base%2520with%2520spaces%2520and%2520%252B%2520%2525.tsv`

The dataset upload page isn't affected as it only uses the bucket from `uploadURL` and discards the rest of the string.

Tested locally against minio & on staging against S3. 