### PR TITLE
Feat/bulk add rem datasets

### DIFF
--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -284,6 +284,11 @@ type Query {
               filter: DatasetFilter = {}, simpleQuery: String,
               offset: Int = 0, limit: Int = 10): [Dataset!]
 
+  allProjectDatasets(orderBy: DatasetOrderBy = ORDER_BY_DATE,
+              sortingOrder: SortingOrder = DESCENDING,
+              filter: DatasetFilter = {}, simpleQuery: String
+  ): [Dataset!]
+
   countDatasets(filter: DatasetFilter = {}, simpleQuery: String): Int!
 
   countDatasetsPerGroup(query: DatasetCountPerGroupInput!): DatasetCountPerGroup!

--- a/metaspace/graphql/schemas/project.graphql
+++ b/metaspace/graphql/schemas/project.graphql
@@ -93,7 +93,7 @@ type Mutation {
 
   updateUserProject(projectId: ID!, userId: ID!, update: UpdateUserProjectInput!): Boolean!
 
-  importDatasetsIntoProject(projectId: ID!, datasetIds: [ID!]!): Boolean!
+  importDatasetsIntoProject(projectId: ID!, datasetIds: [ID!], removedDatasetIds: [ID!]): Boolean!
 
   # Managing review links
   createReviewLink(projectId: ID!): Project!

--- a/metaspace/graphql/src/modules/dataset/controller/Query.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Query.ts
@@ -43,6 +43,15 @@ const QueryResolvers: FieldResolversFor<Query, void> = {
     return await esSearchResults(filteredArgs, 'dataset', ctx.user)
   },
 
+  async allProjectDatasets(source, args, ctx): Promise<DatasetSource[]> {
+    const { args: filteredArgs } = await applyQueryFilters(ctx, {
+      ...args,
+      datasetFilter: args.filter,
+      filter: {},
+    })
+    return await esSearchResults(filteredArgs, 'dataset', ctx.user)
+  },
+
   async countDatasets(source, args, ctx): Promise<number> {
     const { args: filteredArgs } = await applyQueryFilters(ctx, {
       ...args,

--- a/metaspace/graphql/src/modules/dataset/operation/getDatasetFromProjectForEditing.ts
+++ b/metaspace/graphql/src/modules/dataset/operation/getDatasetFromProjectForEditing.ts
@@ -1,0 +1,48 @@
+import { EntityManager } from 'typeorm'
+import { ContextUser } from '../../../context'
+import { UserError } from 'graphql-errors'
+import { Dataset as DatasetModel, DatasetProject } from '../model'
+
+export const getDatasetFromProjectForEditing = async(entityManager: EntityManager,
+  user: ContextUser, dsId: string, projectId: string, userProjectRole: string, isForRemoval: boolean) => {
+  if (!user.id) {
+    throw new UserError('Access denied')
+  }
+
+  if (!dsId) {
+    throw new UserError('Dataset id not provided')
+  }
+
+  if (!projectId) {
+    throw new UserError('Project id not provided')
+  }
+
+  const dataset = await entityManager.getRepository(DatasetModel).findOne({
+    id: dsId,
+  })
+  if (!dataset) {
+    throw new UserError(`Dataset ${dsId} does not exist`)
+  }
+
+  if (userProjectRole !== 'MANAGER' && user.id !== dataset.userId && user.role !== 'admin') {
+    throw new UserError('Access denied')
+  }
+
+  // do not allow managers to add datasets that they do not own
+  if (!isForRemoval && userProjectRole === 'MANAGER' && user.id !== dataset.userId && user.role !== 'admin') {
+    throw new UserError('Access denied')
+  }
+
+  if (isForRemoval) { // do not allow removal of datasets that are not from project
+    const dsProject = await entityManager.getRepository(DatasetProject).findOne({
+      datasetId: dsId,
+      projectId: projectId,
+    })
+
+    if (!dsProject) {
+      throw new UserError('Access denied')
+    }
+  }
+
+  return dataset
+}

--- a/metaspace/graphql/src/modules/project/operation/updateProjectDatasets.ts
+++ b/metaspace/graphql/src/modules/project/operation/updateProjectDatasets.ts
@@ -8,7 +8,7 @@ export default async function(ctx: Context, projectId: string, datasetIds: strin
   removedDatasetIds: string[], approved: boolean | null,
   asyncEsUpdate = true) {
   // add and update
-  if (Array.isArray(datasetIds) && datasetIds.length > 0) {
+  if (datasetIds != null && datasetIds.length > 0) {
     const datasetProjectRepository = ctx.entityManager.getRepository(DatasetProjectModel)
     const datasets = await ctx.entityManager.getRepository(DatasetModel)
       .find({
@@ -16,8 +16,8 @@ export default async function(ctx: Context, projectId: string, datasetIds: strin
         relations: ['datasetProjects'],
       })
 
-    const promises = datasets.map(async dataset => {
-      const existingDatasetProject = dataset.datasetProjects.find(dp => dp.projectId === projectId)
+    const promises = datasets.map(async(dataset: any) => {
+      const existingDatasetProject = dataset.datasetProjects.find((dp: any) => dp.projectId === projectId)
       const datasetId = dataset.id
       if (approved == null) {
         if (existingDatasetProject != null) {
@@ -35,7 +35,7 @@ export default async function(ctx: Context, projectId: string, datasetIds: strin
         }
       }
 
-      const projectIds = dataset.datasetProjects.map(dp => dp.projectId)
+      const projectIds = dataset.datasetProjects.map((dp : any) => dp.projectId)
       if (approved === true) {
         projectIds.push(projectId)
       } else {
@@ -49,7 +49,7 @@ export default async function(ctx: Context, projectId: string, datasetIds: strin
   }
 
   // remove relationships
-  if (Array.isArray(removedDatasetIds) && removedDatasetIds.length > 0) {
+  if (removedDatasetIds != null && removedDatasetIds.length > 0) {
     const datasetProjectRepository = ctx.entityManager.getRepository(DatasetProjectModel)
     const datasets = await ctx.entityManager.getRepository(DatasetModel)
       .find({
@@ -57,17 +57,14 @@ export default async function(ctx: Context, projectId: string, datasetIds: strin
         relations: ['datasetProjects'],
       })
 
-    console.log('TO REMOV', datasets.length, JSON.stringify(datasets))
-
-    const promises = datasets.map(async dataset => {
-      const existingDatasetProject = dataset.datasetProjects.find(dp => dp.projectId === projectId)
+    const promises = datasets.map(async(dataset : any) => {
+      const existingDatasetProject = dataset.datasetProjects.find((dp : any) => dp.projectId === projectId)
       const datasetId = dataset.id
 
-      console.log('existingDatasetProject', existingDatasetProject)
       if (existingDatasetProject) {
         await datasetProjectRepository.delete({ projectId, datasetId })
 
-        const projectIds = dataset.datasetProjects.map(dp => dp.projectId)
+        const projectIds = dataset.datasetProjects.map((dp : any) => dp.projectId)
         _.pull(projectIds, projectId)
 
         await smApiUpdateDataset(datasetId, { projectIds }, { asyncEsUpdate })

--- a/metaspace/graphql/src/modules/project/operation/updateProjectDatasets.ts
+++ b/metaspace/graphql/src/modules/project/operation/updateProjectDatasets.ts
@@ -4,42 +4,76 @@ import { Dataset as DatasetModel, DatasetProject as DatasetProjectModel } from '
 import { In } from 'typeorm'
 import { smApiUpdateDataset } from '../../../utils/smApi/datasets'
 
-export default async function(ctx: Context, projectId: string, datasetIds: string[], approved: boolean | null) {
-  const datasetProjectRepository = ctx.entityManager.getRepository(DatasetProjectModel)
-  const datasets = await ctx.entityManager.getRepository(DatasetModel)
-    .find({
-      where: { id: In(datasetIds) },
-      relations: ['datasetProjects'],
+export default async function(ctx: Context, projectId: string, datasetIds: string[],
+  removedDatasetIds: string[], approved: boolean | null,
+  asyncEsUpdate = true) {
+  // add and update
+  if (Array.isArray(datasetIds) && datasetIds.length > 0) {
+    const datasetProjectRepository = ctx.entityManager.getRepository(DatasetProjectModel)
+    const datasets = await ctx.entityManager.getRepository(DatasetModel)
+      .find({
+        where: { id: In(datasetIds) },
+        relations: ['datasetProjects'],
+      })
+
+    const promises = datasets.map(async dataset => {
+      const existingDatasetProject = dataset.datasetProjects.find(dp => dp.projectId === projectId)
+      const datasetId = dataset.id
+      if (approved == null) {
+        if (existingDatasetProject != null) {
+          await datasetProjectRepository.delete({ projectId, datasetId })
+        } else {
+          return // No change needed
+        }
+      } else {
+        if (existingDatasetProject != null && approved !== existingDatasetProject.approved) {
+          await datasetProjectRepository.update({ projectId, datasetId }, { approved })
+        } else if (existingDatasetProject == null) {
+          await datasetProjectRepository.insert({ projectId, datasetId, approved })
+        } else if (existingDatasetProject != null) {
+          return // No change needed
+        }
+      }
+
+      const projectIds = dataset.datasetProjects.map(dp => dp.projectId)
+      if (approved === true) {
+        projectIds.push(projectId)
+      } else {
+        _.pull(projectIds, projectId)
+      }
+
+      await smApiUpdateDataset(datasetId, { projectIds }, { asyncEsUpdate })
     })
 
-  const promises = datasets.map(async dataset => {
-    const existingDatasetProject = dataset.datasetProjects.find(dp => dp.projectId === projectId)
-    const datasetId = dataset.id
-    if (approved == null) {
-      if (existingDatasetProject != null) {
+    await Promise.all(promises)
+  }
+
+  // remove relationships
+  if (Array.isArray(removedDatasetIds) && removedDatasetIds.length > 0) {
+    const datasetProjectRepository = ctx.entityManager.getRepository(DatasetProjectModel)
+    const datasets = await ctx.entityManager.getRepository(DatasetModel)
+      .find({
+        where: { id: In(removedDatasetIds) },
+        relations: ['datasetProjects'],
+      })
+
+    console.log('TO REMOV', datasets.length, JSON.stringify(datasets))
+
+    const promises = datasets.map(async dataset => {
+      const existingDatasetProject = dataset.datasetProjects.find(dp => dp.projectId === projectId)
+      const datasetId = dataset.id
+
+      console.log('existingDatasetProject', existingDatasetProject)
+      if (existingDatasetProject) {
         await datasetProjectRepository.delete({ projectId, datasetId })
-      } else {
-        return // No change needed
+
+        const projectIds = dataset.datasetProjects.map(dp => dp.projectId)
+        _.pull(projectIds, projectId)
+
+        await smApiUpdateDataset(datasetId, { projectIds }, { asyncEsUpdate })
       }
-    } else {
-      if (existingDatasetProject != null && approved !== existingDatasetProject.approved) {
-        await datasetProjectRepository.update({ projectId, datasetId }, { approved })
-      } else if (existingDatasetProject == null) {
-        await datasetProjectRepository.insert({ projectId, datasetId, approved })
-      } else if (existingDatasetProject != null) {
-        return // No change needed
-      }
-    }
+    })
 
-    const projectIds = dataset.datasetProjects.map(dp => dp.projectId)
-    if (approved === true) {
-      projectIds.push(projectId)
-    } else {
-      _.pull(projectIds, projectId)
-    }
-
-    await smApiUpdateDataset(datasetId, { projectIds }, { asyncEsUpdate: true })
-  })
-
-  await Promise.all(promises)
+    await Promise.all(promises)
+  }
 }

--- a/metaspace/graphql/src/modules/project/operation/updateUserProjectRole.ts
+++ b/metaspace/graphql/src/modules/project/operation/updateUserProjectRole.ts
@@ -75,6 +75,6 @@ export default async(ctx: Context, userId: string, projectId: string, newRole: U
     const approved = newRole == null
       ? null
       : [UPRO.MANAGER, UPRO.MEMBER].includes(newRole)
-    await updateProjectDatasets(ctx, projectId, datasetIds, approved)
+    await updateProjectDatasets(ctx, projectId, datasetIds, [], approved)
   }
 }

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -145,6 +145,15 @@ export const datasetListItemsQuery =
     }
   }`
 
+export const projectDatasetListItemsQuery =
+  gql`query GetProjectDatasets($dFilter: DatasetFilter, $query: String) {
+    allProjectDatasets(filter: $dFilter, simpleQuery: $query) {
+      id
+      name
+      uploadDT
+    }
+  }`
+
 export type OpticalImageType = 'SCALED' | 'CLIPPED_TO_ION_IMAGE';
 
 export interface OpticalImage {

--- a/metaspace/webapp/src/api/project.ts
+++ b/metaspace/webapp/src/api/project.ts
@@ -99,8 +99,8 @@ export const updateUserProjectMutation =
   }`
 
 export const importDatasetsIntoProjectMutation =
-  gql`mutation($projectId: ID!, $datasetIds: [ID!]!) {
-    importDatasetsIntoProject(projectId: $projectId, datasetIds: $datasetIds)
+  gql`mutation($projectId: ID!, $datasetIds: [ID!], $removedDatasetIds: [ID!]) {
+    importDatasetsIntoProject(projectId: $projectId, datasetIds: $datasetIds, removedDatasetIds: $removedDatasetIds)
   }`
 
 export const createReviewLinkMutation =

--- a/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.scss
+++ b/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.scss
@@ -1,0 +1,51 @@
+.project-datasets-dialog {
+  .el-dialog {
+    @apply max-w-lg;
+
+    .el-form-item {
+      margin-bottom: 10px;
+    }
+    .el-form-item__label {
+      line-height: 1.2em;
+    }
+  }
+
+  .el-dialog__header {
+    padding-bottom: 0;
+  }
+
+  .el-dialog__body {
+    padding: 20px;
+  }
+
+  .dataset-checkbox-list {
+    margin: 12px 0;
+    max-height: 50vh;
+    overflow: auto;
+    box-shadow: inset 0 -10px 7px -10px lightgrey;
+  }
+  .select-buttons {
+    margin: 12px 0;
+  }
+  .el-checkbox__label {
+    @apply inline-flex flex-grow justify-between items-baseline overflow-hidden;
+  }
+
+
+  .button-bar {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    margin-top: 20px;
+  }
+
+  .select-link{
+    @apply cursor-pointer underline;
+    color: hsl(208, 93%, 44%);
+  }
+
+  .el-checkbox:last-of-type {
+    @apply mx-2;
+  }
+}
+

--- a/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.spec.ts
+++ b/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.spec.ts
@@ -1,0 +1,233 @@
+import { mount } from '@vue/test-utils'
+import router from '../../router'
+import store from '../../store/index'
+import Vue from 'vue'
+import Vuex from 'vuex'
+import { sync } from 'vuex-router-sync'
+import { ProjectDatasetsDialog } from './ProjectDatasetsDialog'
+import { initMockGraphqlClient, apolloProvider } from '../../../tests/utils/mockGraphqlClient'
+
+Vue.use(Vuex)
+sync(store, router)
+
+describe('ProjectDatasetsDialog', () => {
+  const propsData = {
+    project: {
+      id: '05c6519a-8049-11eb-927e-6bf28a9b25ae',
+      name: 'Test',
+      currentUserRole: 'MANAGER',
+    },
+    currentUserId: '039801c8-919e-11eb-908e-3b2b8e672707',
+    dialogLabel: 'Would you like to include/remove previously submitted datasets?',
+    saveBtnLabel: 'Update',
+    cancelBtnLabel: 'Cancel',
+    selectAllLabel: 'Select all',
+    selectNoneLabel: 'Select none',
+    noDatasetsLabel: 'No datasets available',
+    visible: true,
+    isAdmin: true,
+    refreshData: () => {},
+    projectDatasets: [
+      {
+        id: '2021-03-31_11h02m28s',
+        name: 'New 3 (1)',
+        status: 'FINISHED',
+        canDownload: true,
+        uploadDT: '2021-03-31T14:02:28.722Z',
+      },
+      {
+        id: '2021-03-30_18h25m18s',
+        name: 'Untreated_3_434_super_lite_19_31 (1)',
+        status: 'FINISHED',
+        statusUpdateDT: '2021-03-30T21:29:02.043Z',
+        uploadDT: '2021-03-30T21:25:18.473Z',
+      },
+    ],
+  }
+  const propsDataNoDsSelected = {
+    project: {
+      id: '05c6519a-8049-11eb-927e-6bf28a9b25ae',
+      name: 'Test',
+      currentUserRole: 'MANAGER',
+    },
+    currentUserId: '039801c8-919e-11eb-908e-3b2b8e672707',
+    dialogLabel: 'Would you like to include/remove previously submitted datasets?',
+    saveBtnLabel: 'Update',
+    cancelBtnLabel: 'Cancel',
+    selectAllLabel: 'Select all',
+    selectNoneLabel: 'Select none',
+    noDatasetsLabel: 'No datasets available',
+    visible: true,
+    isAdmin: true,
+    refreshData: () => {},
+    projectDatasets: [],
+  }
+
+  const testHarness = Vue.extend({
+    components: {
+      ProjectDatasetsDialog,
+    },
+    render(h) {
+      return h(ProjectDatasetsDialog, { props: this.$attrs })
+    },
+  })
+  const graphqlWithData = () => {
+    initMockGraphqlClient({
+      Query: () => ({
+        allDatasets: () => {
+          return [{
+            id: '2021-03-31_11h02m28s',
+            name: 'New 3 (1)',
+            uploadDT: '2021-03-31T14:02:28.722Z',
+            __typename: 'Dataset',
+          }, {
+            id: '2021-03-30_18h25m18s',
+            name: 'Untreated_3_434_super_lite_19_31 (1)',
+            uploadDT: '2021-03-30T21:25:18.473Z',
+            __typename: 'Dataset',
+          }]
+        },
+      }),
+    })
+  }
+  const graphqlWithNoData = () => {
+    initMockGraphqlClient({
+      Query: () => ({
+        allDatasets: () => {
+          return []
+        },
+      }),
+    })
+  }
+
+  it('it should match snapshot', async() => {
+    graphqlWithData()
+    const wrapper = mount(testHarness, { store, router, propsData })
+    await Vue.nextTick()
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('it should match no dataset snapshot', async() => {
+    graphqlWithNoData()
+    const wrapper = mount(testHarness, { store, router, propsData })
+    await Vue.nextTick()
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('it should have disabled update button when no data available', async() => {
+    graphqlWithNoData()
+    const wrapper = mount(testHarness, { store, router, propsData })
+    await Vue.nextTick()
+
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(true)
+  })
+
+  it('it should have disabled update button when no dataset selection has changed', async() => {
+    graphqlWithData()
+    const wrapper = mount(testHarness, { store, router, propsData })
+    await Vue.nextTick()
+
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(true)
+  })
+
+  it('it should uncheck all datasets when clicking select none', async() => {
+    graphqlWithData()
+    const wrapper = mount(testHarness, { store, router, propsData })
+    await Vue.nextTick()
+
+    const selectNone = wrapper.findAll('.select-link').at(0)
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(true)
+    selectNone.trigger('click')
+    await Vue.nextTick()
+
+    wrapper.findAll('.el-checkbox').wrappers.forEach((checkBox) => {
+      expect(checkBox.classes('is-checked')).toBe(false)
+    })
+
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(false)
+  })
+
+  it('it should check all datasets when clicking select all', async() => {
+    graphqlWithData()
+    const wrapper = mount(testHarness, { store, router, propsData })
+    await Vue.nextTick()
+
+    const selectAll = wrapper.findAll('.select-link').at(1)
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(true)
+    selectAll.trigger('click')
+    await Vue.nextTick()
+
+    wrapper.findAll('.el-checkbox').wrappers.forEach((checkBox) => {
+      expect(checkBox.classes('is-checked')).toBe(true)
+    })
+
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(false)
+  })
+
+  it('it should check all datasets when clicking select all', async() => {
+    graphqlWithData()
+    const wrapper = mount(testHarness, { store, router, propsData })
+    await Vue.nextTick()
+
+    const selectAll = wrapper.findAll('.select-link').at(1)
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(true)
+    selectAll.trigger('click')
+    await Vue.nextTick()
+
+    wrapper.findAll('.el-checkbox').wrappers.forEach((checkBox) => {
+      expect(checkBox.classes('is-checked')).toBe(true)
+    })
+
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(false)
+  })
+
+  it('it should check one dataset and hit update', async() => {
+    graphqlWithData()
+
+    const wrapper = mount(testHarness, {
+      store,
+      router,
+      propsData: {
+        ...propsDataNoDsSelected,
+      },
+    })
+    await Vue.nextTick()
+
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(true)
+
+    wrapper.findAll('.el-checkbox').wrappers.forEach((checkBox) => {
+      expect(checkBox.classes('is-checked')).toBe(false)
+    })
+
+    wrapper.findAll('.el-checkbox').at(0).trigger('click')
+    await Vue.nextTick()
+
+    expect(wrapper.findAll('.el-checkbox').at(0).classes('is-checked')).toBe(true)
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(false)
+  })
+
+  it('it should uncheck one dataset and hit update', async() => {
+    graphqlWithData()
+
+    const wrapper = mount(testHarness, {
+      store,
+      router,
+      propsData,
+    })
+    await Vue.nextTick()
+
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(true)
+
+    wrapper.findAll('.el-checkbox').wrappers.forEach((checkBox) => {
+      expect(checkBox.classes('is-checked')).toBe(true)
+    })
+
+    wrapper.findAll('.el-checkbox').at(0).trigger('click')
+    await Vue.nextTick()
+
+    expect(wrapper.findAll('.el-checkbox').at(0).classes('is-checked')).toBe(false)
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(false)
+  })
+})

--- a/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.tsx
+++ b/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.tsx
@@ -1,0 +1,218 @@
+import { defineComponent, computed, reactive } from '@vue/composition-api'
+import { importDatasetsIntoProjectMutation, ProjectsListProject } from '../../api/project'
+import { Dialog, Checkbox, Button } from '../../lib/element-ui'
+import { uniqBy } from 'lodash'
+import './ProjectDatasetsDialog.scss'
+import { DatasetListItem, datasetListItemsQuery } from '../../api/dataset'
+import { useQuery } from '@vue/apollo-composable'
+import ElapsedTime from '../../components/ElapsedTime'
+import reportError from '../../lib/reportError'
+
+interface CheckOptions {
+  [key: string]: boolean
+}
+
+interface ProjectDatasetsDialogState {
+  selectedDatasets: CheckOptions
+  isSubmitting: boolean
+  hasChanged: boolean
+}
+
+interface ProjectDatasetsDialogProps {
+  project: ProjectsListProject
+  currentUserId: string
+  visible: boolean
+  isAdmin: boolean
+  projectDatasets: string[]
+  dialogLabel: string
+  saveBtnLabel: string
+  cancelBtnLabel: string
+  selectAllLabel: string
+  selectNoneLabel: string
+  noDatasetsLabel: string
+  refreshData: () => Promise<any>
+}
+
+export const ProjectDatasetsDialog = defineComponent<ProjectDatasetsDialogProps>({
+  name: 'ProjectDatasetsDialog',
+  props: {
+    project: { type: Object, default: undefined },
+    currentUserId: { type: String, default: undefined },
+    dialogLabel: { type: String, default: 'Would you like to include/remove previously submitted datasets?' },
+    saveBtnLabel: { type: String, default: 'Update' },
+    cancelBtnLabel: { type: String, default: 'Cancel' },
+    selectAllLabel: { type: String, default: 'Select all' },
+    selectNoneLabel: { type: String, default: 'Select none' },
+    noDatasetsLabel: { type: String, default: 'No datasets available' },
+    visible: { type: Boolean, default: true },
+    isAdmin: { type: Boolean, default: false },
+    projectDatasets: { type: Array, default: () => [] },
+    refreshData: { type: Function, required: true },
+  },
+  setup(props, ctx) {
+    const { emit, root } = ctx
+    const { $apollo } = root
+    const getProjectDatasets = () => {
+      const defaultDatasets = {} as CheckOptions
+      if (Array.isArray(props.projectDatasets)) {
+        props.projectDatasets.forEach((ds: any) => {
+          defaultDatasets[ds.id] = true
+        })
+      }
+      return defaultDatasets
+    }
+    const state = reactive<ProjectDatasetsDialogState>({
+      selectedDatasets: getProjectDatasets(),
+      isSubmitting: false,
+      hasChanged: false,
+    })
+    const {
+      result: datasetsResult,
+      loading,
+    } = useQuery<{allDatasets: DatasetListItem[]}>(datasetListItemsQuery, {
+      dFilter: {
+        submitter: props?.currentUserId,
+      },
+    })
+    const datasets = computed(() => datasetsResult.value != null
+      ? datasetsResult.value.allDatasets as DatasetListItem[] : null)
+
+    const getAvailableDatasets = (datasets: any) => {
+      if (!props?.isAdmin) {
+        return datasets
+      }
+
+      if (Array.isArray(datasets) && Array.isArray(props.projectDatasets)) {
+        // show not owned datasets if admin, so it can be removed
+        return uniqBy(datasets.concat(props.projectDatasets), 'id')
+      }
+
+      return []
+    }
+
+    const handleClose = () => {
+      emit('close')
+    }
+
+    const handleDatasetCheck = (value: boolean, key: string) => {
+      state.selectedDatasets[key] = value
+      if (!state.hasChanged) {
+        state.hasChanged = true
+      }
+    }
+
+    const handleSelectNone = () => {
+      const availableDatasets = getAvailableDatasets(datasets?.value).map((ds: any) => ds.id)
+      availableDatasets.forEach((key: string) => { state.selectedDatasets[key] = false })
+    }
+
+    const handleSelectAll = () => {
+      const availableDatasets = getAvailableDatasets(datasets?.value).map((ds: any) => ds.id)
+      availableDatasets.forEach((key: string) => { state.selectedDatasets[key] = true })
+    }
+
+    const handleProjectDatasetsUpdate = async() => {
+      const previousDatasets = getProjectDatasets()
+      const removedDatasetIds: string[] = []
+      const addedDatasetIds: string[] = []
+      state.isSubmitting = true
+      Object.keys(state.selectedDatasets).forEach((key: string) => {
+        if (previousDatasets[key] && !state.selectedDatasets[key]) { // remove ds
+          removedDatasetIds.push(key)
+        } else if (!previousDatasets[key] && state.selectedDatasets[key]) { // new ds * do not add already
+          addedDatasetIds.push(key)
+        }
+      })
+
+      try {
+        if (addedDatasetIds.length > 0 || removedDatasetIds.length > 0) {
+          await $apollo.mutate({
+            mutation: importDatasetsIntoProjectMutation,
+            variables: { projectId: props?.project?.id, datasetIds: addedDatasetIds, removedDatasetIds },
+          })
+        }
+        await props?.refreshData()
+        emit('update')
+      } catch (err) {
+        reportError(err)
+      } finally {
+        state.isSubmitting = false
+      }
+    }
+
+    return () => {
+      const {
+        visible, project, dialogLabel, saveBtnLabel, cancelBtnLabel,
+        selectAllLabel, selectNoneLabel, noDatasetsLabel,
+      } = props
+      const { name } = project
+      const availableDatasets = getAvailableDatasets(datasets?.value)
+
+      return (
+        <Dialog
+          class='project-datasets-dialog'
+          visible={visible}
+          append-to-body
+          title={`Manage ${name}\`s datasets`}
+          lockScroll={false}
+          onClose={handleClose}>
+          <div class="mt-6">
+            <h4 class="m-0">
+              {dialogLabel}
+            </h4>
+            {
+              Array.isArray(availableDatasets) && availableDatasets.length > 0
+                && <div class="dataset-checkbox-list leading-6">
+                  <div class="mb-2">
+                    <span
+                      class="select-link"
+                      onClick={handleSelectNone}>{selectNoneLabel}</span>
+                    <span> | </span>
+                    <span
+                      class="select-link"
+                      onClick={handleSelectAll}>{selectAllLabel}</span>
+                  </div>
+                  {
+                    availableDatasets.map((dataset) => <Checkbox
+                      class="flex h-6 items-center m-0 mx-2"
+                      key={dataset.id}
+                      value={state?.selectedDatasets[dataset.id]}
+                      disabled={state?.isSubmitting}
+                      onChange={(value: boolean) => handleDatasetCheck(value, dataset.id)}
+                      label={dataset.name}>
+                      <span class="truncate">
+                        { dataset?.name }
+                      </span>
+                      <span class="text-gray-700 text-xs tracking-wide pl-1">
+                        <ElapsedTime date={dataset?.uploadDT} />
+                      </span>
+                    </Checkbox>)
+                  }
+                </div>
+            }
+            {
+              Array.isArray(availableDatasets) && availableDatasets.length === 0
+                && <div class="flex items-center justify-center leading-6">
+                  <div>{noDatasetsLabel}</div>
+                </div>
+            }
+
+            <div class="button-bar">
+              <Button onClick={handleClose}>
+                {cancelBtnLabel}
+              </Button>
+              <Button
+                class='w-32'
+                loading={state?.isSubmitting}
+                disabled={!state?.hasChanged}
+                type="primary"
+                onClick={handleProjectDatasetsUpdate}>
+                {saveBtnLabel}
+              </Button>
+            </div>
+          </div>
+        </Dialog>
+      )
+    }
+  },
+})

--- a/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.tsx
+++ b/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.tsx
@@ -71,14 +71,14 @@ export const ProjectDatasetsDialog = defineComponent<ProjectDatasetsDialogProps>
       loading,
     } = useQuery<{allDatasets: DatasetListItem[]}>(datasetListItemsQuery, {
       dFilter: {
-        submitter: props?.currentUserId,
+        submitter: props.currentUserId,
       },
     })
     const datasets = computed(() => datasetsResult.value != null
       ? datasetsResult.value.allDatasets as DatasetListItem[] : null)
 
     const getAvailableDatasets = (datasets: any) => {
-      if (!props?.isAdmin) {
+      if (!props.isAdmin) {
         return datasets
       }
 
@@ -104,11 +104,17 @@ export const ProjectDatasetsDialog = defineComponent<ProjectDatasetsDialogProps>
     const handleSelectNone = () => {
       const availableDatasets = getAvailableDatasets(datasets?.value).map((ds: any) => ds.id)
       availableDatasets.forEach((key: string) => { state.selectedDatasets[key] = false })
+      if (!state.hasChanged) {
+        state.hasChanged = true
+      }
     }
 
     const handleSelectAll = () => {
       const availableDatasets = getAvailableDatasets(datasets?.value).map((ds: any) => ds.id)
       availableDatasets.forEach((key: string) => { state.selectedDatasets[key] = true })
+      if (!state.hasChanged) {
+        state.hasChanged = true
+      }
     }
 
     const handleProjectDatasetsUpdate = async() => {
@@ -128,10 +134,10 @@ export const ProjectDatasetsDialog = defineComponent<ProjectDatasetsDialogProps>
         if (addedDatasetIds.length > 0 || removedDatasetIds.length > 0) {
           await $apollo.mutate({
             mutation: importDatasetsIntoProjectMutation,
-            variables: { projectId: props?.project?.id, datasetIds: addedDatasetIds, removedDatasetIds },
+            variables: { projectId: props.project?.id, datasetIds: addedDatasetIds, removedDatasetIds },
           })
         }
-        await props?.refreshData()
+        await props.refreshData()
         emit('update')
       } catch (err) {
         reportError(err)

--- a/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
+++ b/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
@@ -11,8 +11,7 @@
         :visible="showProjectDatasetsDialog && currentUser != null"
         :current-user-id="currentUser && currentUser.id"
         :project="project"
-        :is-admin="isManager"
-        :project-datasets="projectDatasets"
+        :is-manager="isManager"
         :refresh-data="refetch"
         @close="handleCloseProjectDatasetsDialog"
         @update="handleCloseProjectDatasetsDialog"
@@ -349,11 +348,6 @@ export default class ViewProjectPage extends Vue {
       return (this.data && this.data.allDatasets || []).filter(ds => ds.status !== 'FAILED')
     }
 
-    get projectUserDatasetsIds(): string[] {
-      return (this.data && this.data.allDatasets || []).filter(ds => ds.status !== 'FAILED'
-        && ds.submitter && ds.submitter.id === this.currentUser?.id).map((ds) => ds.id)
-    }
-
     get countDatasets(): number { return this.data && this.data.countDatasets || 0 }
     get members() { return this.project && this.project.members || [] }
     get countMembers() { return this.project && this.project.numMembers }
@@ -560,6 +554,7 @@ export default class ViewProjectPage extends Vue {
 
     handleOpenProjectDatasetsDialog() {
       this.showProjectDatasetsDialog = true
+      hideFeatureBadge('manage_project_datasets')
     }
 
     handleCloseProjectDatasetsDialog() {

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectDatasetsDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectDatasetsDialog.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProjectDatasetsDialog it should match no dataset snapshot 1`] = `
-<transition-stub name="dialog-fade" class="project-datasets-dialog" project="[object Object]" currentuserid="039801c8-919e-11eb-908e-3b2b8e672707" dialoglabel="Would you like to include/remove previously submitted datasets?" savebtnlabel="Update" cancelbtnlabel="Cancel" selectalllabel="Select all" selectnonelabel="Select none" nodatasetslabel="No datasets available" visible="true" isadmin="true" refreshdata="function () {}" projectdatasets="[object Object],[object Object]" style="z-index: 2003;">
+<transition-stub name="dialog-fade" class="project-datasets-dialog" project="[object Object]" currentuserid="039801c8-919e-11eb-908e-3b2b8e672707" visible="true" ismanager="true" refreshdata="function () {}" style="z-index: 2003;">
   <div class="el-dialog__wrapper">
     <div role="dialog" aria-modal="true" aria-label="Manage Test\`s datasets" class="el-dialog" style="margin-top: 15vh;">
       <div class="el-dialog__header"><span class="el-dialog__title">Manage Test\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
@@ -9,8 +9,8 @@ exports[`ProjectDatasetsDialog it should match no dataset snapshot 1`] = `
         <div class="mt-6">
           <h4 class="m-0">Would you like to include/remove previously submitted datasets?</h4>
           <div class="dataset-checkbox-list leading-6">
-            <div class="mb-2"><span class="select-link">Select none</span><span> | </span><span class="select-link">Select all</span></div><label class="el-checkbox is-checked flex h-6 items-center m-0 mx-2"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="New 3 (1)"></span><span class="el-checkbox__label"><span class="truncate">New 3 (1)</span><span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="2021-03-31T14:02:28.722Z"></mock-elapsed-time></span>
-              <!----></span></label><label class="el-checkbox is-checked flex h-6 items-center m-0 mx-2"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="Untreated_3_434_super_lite_19_31 (1)"></span><span class="el-checkbox__label"><span class="truncate">Untreated_3_434_super_lite_19_31 (1)</span><span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="2021-03-30T21:25:18.473Z"></mock-elapsed-time></span>
+            <div class="mb-2"><span class="select-link">Select none</span><span> | </span><span class="select-link">Select all</span></div><label class="el-checkbox flex h-6 items-center m-0 mx-2"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="allDatasets.0.name"></span><span class="el-checkbox__label"><span class="truncate">allDatasets.0.name</span><span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="allDatasets.0.uploadDT"></mock-elapsed-time></span>
+              <!----></span></label><label class="el-checkbox flex h-6 items-center m-0 mx-2"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="allDatasets.1.name"></span><span class="el-checkbox__label"><span class="truncate">allDatasets.1.name</span><span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="allDatasets.1.uploadDT"></mock-elapsed-time></span>
               <!----></span></label>
           </div>
           <div class="button-bar"><button type="button" class="el-button el-button--default">
@@ -27,7 +27,7 @@ exports[`ProjectDatasetsDialog it should match no dataset snapshot 1`] = `
 `;
 
 exports[`ProjectDatasetsDialog it should match snapshot 1`] = `
-<transition-stub name="dialog-fade" class="project-datasets-dialog" project="[object Object]" currentuserid="039801c8-919e-11eb-908e-3b2b8e672707" dialoglabel="Would you like to include/remove previously submitted datasets?" savebtnlabel="Update" cancelbtnlabel="Cancel" selectalllabel="Select all" selectnonelabel="Select none" nodatasetslabel="No datasets available" visible="true" isadmin="true" refreshdata="function () {}" projectdatasets="[object Object],[object Object]" style="z-index: 2001;">
+<transition-stub name="dialog-fade" class="project-datasets-dialog" project="[object Object]" currentuserid="039801c8-919e-11eb-908e-3b2b8e672707" visible="true" ismanager="true" refreshdata="function () {}" style="z-index: 2001;">
   <div class="el-dialog__wrapper">
     <div role="dialog" aria-modal="true" aria-label="Manage Test\`s datasets" class="el-dialog" style="margin-top: 15vh;">
       <div class="el-dialog__header"><span class="el-dialog__title">Manage Test\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectDatasetsDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectDatasetsDialog.spec.ts.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProjectDatasetsDialog it should match no dataset snapshot 1`] = `
+<transition-stub name="dialog-fade" class="project-datasets-dialog" project="[object Object]" currentuserid="039801c8-919e-11eb-908e-3b2b8e672707" dialoglabel="Would you like to include/remove previously submitted datasets?" savebtnlabel="Update" cancelbtnlabel="Cancel" selectalllabel="Select all" selectnonelabel="Select none" nodatasetslabel="No datasets available" visible="true" isadmin="true" refreshdata="function () {}" projectdatasets="[object Object],[object Object]" style="z-index: 2003;">
+  <div class="el-dialog__wrapper">
+    <div role="dialog" aria-modal="true" aria-label="Manage Test\`s datasets" class="el-dialog" style="margin-top: 15vh;">
+      <div class="el-dialog__header"><span class="el-dialog__title">Manage Test\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+      <div class="el-dialog__body">
+        <div class="mt-6">
+          <h4 class="m-0">Would you like to include/remove previously submitted datasets?</h4>
+          <div class="dataset-checkbox-list leading-6">
+            <div class="mb-2"><span class="select-link">Select none</span><span> | </span><span class="select-link">Select all</span></div><label class="el-checkbox is-checked flex h-6 items-center m-0 mx-2"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="New 3 (1)"></span><span class="el-checkbox__label"><span class="truncate">New 3 (1)</span><span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="2021-03-31T14:02:28.722Z"></mock-elapsed-time></span>
+              <!----></span></label><label class="el-checkbox is-checked flex h-6 items-center m-0 mx-2"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="Untreated_3_434_super_lite_19_31 (1)"></span><span class="el-checkbox__label"><span class="truncate">Untreated_3_434_super_lite_19_31 (1)</span><span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="2021-03-30T21:25:18.473Z"></mock-elapsed-time></span>
+              <!----></span></label>
+          </div>
+          <div class="button-bar"><button type="button" class="el-button el-button--default">
+              <!---->
+              <!----><span>Cancel</span></button><button disabled="disabled" type="button" class="el-button el-button--primary is-disabled w-32">
+              <!---->
+              <!----><span>Update</span></button></div>
+        </div>
+      </div>
+      <!---->
+    </div>
+  </div>
+</transition-stub>
+`;
+
+exports[`ProjectDatasetsDialog it should match snapshot 1`] = `
+<transition-stub name="dialog-fade" class="project-datasets-dialog" project="[object Object]" currentuserid="039801c8-919e-11eb-908e-3b2b8e672707" dialoglabel="Would you like to include/remove previously submitted datasets?" savebtnlabel="Update" cancelbtnlabel="Cancel" selectalllabel="Select all" selectnonelabel="Select none" nodatasetslabel="No datasets available" visible="true" isadmin="true" refreshdata="function () {}" projectdatasets="[object Object],[object Object]" style="z-index: 2001;">
+  <div class="el-dialog__wrapper">
+    <div role="dialog" aria-modal="true" aria-label="Manage Test\`s datasets" class="el-dialog" style="margin-top: 15vh;">
+      <div class="el-dialog__header"><span class="el-dialog__title">Manage Test\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+      <div class="el-dialog__body">
+        <div class="mt-6">
+          <h4 class="m-0">Would you like to include/remove previously submitted datasets?</h4>
+          <div class="dataset-checkbox-list leading-6">
+            <div class="mb-2"><span class="select-link">Select none</span><span> | </span><span class="select-link">Select all</span></div><label class="el-checkbox is-checked flex h-6 items-center m-0 mx-2"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="New 3 (1)"></span><span class="el-checkbox__label"><span class="truncate">New 3 (1)</span><span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="2021-03-31T14:02:28.722Z"></mock-elapsed-time></span>
+              <!----></span></label><label class="el-checkbox is-checked flex h-6 items-center m-0 mx-2"><span class="el-checkbox__input is-checked"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="Untreated_3_434_super_lite_19_31 (1)"></span><span class="el-checkbox__label"><span class="truncate">Untreated_3_434_super_lite_19_31 (1)</span><span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="2021-03-30T21:25:18.473Z"></mock-elapsed-time></span>
+              <!----></span></label>
+          </div>
+          <div class="button-bar"><button type="button" class="el-button el-button--default">
+              <!---->
+              <!----><span>Cancel</span></button><button disabled="disabled" type="button" class="el-button el-button--primary is-disabled w-32">
+              <!---->
+              <!----><span>Update</span></button></div>
+        </div>
+      </div>
+      <!---->
+    </div>
+  </div>
+</transition-stub>
+`;

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
@@ -3,6 +3,15 @@
 exports[`ViewProjectPage datasets tab should match snapshot (non-member) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
+    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1 class="py-1 leading-tight">
@@ -15,6 +24,7 @@ exports[`ViewProjectPage datasets tab should match snapshot (non-member) 1`] = `
           <!----><span>
           Request access
         </span></button>
+        <!---->
         <!---->
       </div>
       <!---->
@@ -59,6 +69,15 @@ exports[`ViewProjectPage datasets tab should match snapshot (non-member) 1`] = `
 exports[`ViewProjectPage members tab should match snapshot (invited) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
+    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1 class="py-1 leading-tight">
@@ -67,6 +86,7 @@ exports[`ViewProjectPage members tab should match snapshot (invited) 1`] = `
         <!---->
       </div>
       <div class="header-buttons">
+        <!---->
         <!---->
         <!---->
       </div>
@@ -132,6 +152,15 @@ exports[`ViewProjectPage members tab should match snapshot (invited) 1`] = `
 exports[`ViewProjectPage members tab should match snapshot (manager, including table) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
+    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1 class="py-1 leading-tight">
@@ -140,6 +169,7 @@ exports[`ViewProjectPage members tab should match snapshot (manager, including t
         <!---->
       </div>
       <div class="header-buttons">
+        <!---->
         <!---->
         <!---->
       </div>
@@ -386,6 +416,15 @@ exports[`ViewProjectPage members tab should match snapshot (manager, including t
 exports[`ViewProjectPage members tab should match snapshot (member) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
+    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1 class="py-1 leading-tight">
@@ -394,6 +433,7 @@ exports[`ViewProjectPage members tab should match snapshot (member) 1`] = `
         <!---->
       </div>
       <div class="header-buttons">
+        <!---->
         <!---->
         <!---->
       </div>
@@ -434,6 +474,15 @@ exports[`ViewProjectPage members tab should match snapshot (member) 1`] = `
 exports[`ViewProjectPage members tab should match snapshot (non-member) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
+    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1 class="py-1 leading-tight">
@@ -446,6 +495,7 @@ exports[`ViewProjectPage members tab should match snapshot (non-member) 1`] = `
           <!----><span>
           Request access
         </span></button>
+        <!---->
         <!---->
       </div>
       <!---->
@@ -487,6 +537,15 @@ exports[`ViewProjectPage members tab should match snapshot (non-member) 1`] = `
 exports[`ViewProjectPage publishing tab should match snapshot (published) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
+    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1 class="py-1 leading-tight">
@@ -495,6 +554,7 @@ exports[`ViewProjectPage publishing tab should match snapshot (published) 1`] = 
         <!---->
       </div>
       <div class="header-buttons">
+        <!---->
         <!---->
         <!---->
       </div>
@@ -542,6 +602,15 @@ exports[`ViewProjectPage publishing tab should match snapshot (published) 1`] = 
 exports[`ViewProjectPage publishing tab should match snapshot (under review) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
+    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1 class="py-1 leading-tight">
@@ -550,6 +619,7 @@ exports[`ViewProjectPage publishing tab should match snapshot (under review) 1`]
         <!---->
       </div>
       <div class="header-buttons">
+        <!---->
         <!---->
         <!---->
       </div>
@@ -650,6 +720,15 @@ exports[`ViewProjectPage publishing tab should match snapshot (under review) 1`]
 exports[`ViewProjectPage publishing tab should match snapshot (unpublished) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
+    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1 class="py-1 leading-tight">
@@ -658,6 +737,7 @@ exports[`ViewProjectPage publishing tab should match snapshot (unpublished) 1`] 
         <!---->
       </div>
       <div class="header-buttons">
+        <!---->
         <!---->
         <!---->
       </div>
@@ -746,6 +826,15 @@ exports[`ViewProjectPage publishing tab should match snapshot (unpublished) 1`] 
 exports[`ViewProjectPage settings tab should disable actions when published 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
+    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1 class="py-1 leading-tight">
@@ -754,6 +843,7 @@ exports[`ViewProjectPage settings tab should disable actions when published 1`] 
         <!---->
       </div>
       <div class="header-buttons">
+        <!---->
         <!---->
         <!---->
       </div>
@@ -847,6 +937,15 @@ exports[`ViewProjectPage settings tab should disable actions when published 1`] 
 exports[`ViewProjectPage settings tab should disable actions when under review 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
+    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1 class="py-1 leading-tight">
@@ -855,6 +954,7 @@ exports[`ViewProjectPage settings tab should disable actions when under review 1
         <!---->
       </div>
       <div class="header-buttons">
+        <!---->
         <!---->
         <!---->
       </div>
@@ -941,6 +1041,15 @@ exports[`ViewProjectPage settings tab should disable actions when under review 1
 exports[`ViewProjectPage settings tab should match snapshot 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
+    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1 class="py-1 leading-tight">
@@ -949,6 +1058,7 @@ exports[`ViewProjectPage settings tab should match snapshot 1`] = `
         <!---->
       </div>
       <div class="header-buttons">
+        <!---->
         <!---->
         <!---->
       </div>


### PR DESCRIPTION
### Description

In order to improve user experience and allow the project managers to bulk add/remove the datasets related to the project, a modal component was created to perform this task.

Issue #807 

#### Changes

##### Front end

###### View project page
- [x] Added "Manage datasets" button on datasets tab
- [x] Added NewFeaturePopup tp manage datasets so the user can note the new feature

###### Project Datasets Dialog Component
- [x] Created component to list datasets for bulk add/remove
- [x] Enable Managers to remove datasets from other users
- [x] Enable Users to add/remove their datasets from the project

***Note
Although there was already a component used to add/remove datasets from projects, as the component created the project itself, and did not enable remove, a new component was created as the main function of the components differ. The new component also was written in ts and with test, so it fits the new project standards. If you understand both components should be one, I can add a few props flags to enable both as one.

##### Graphql

###### Update Dataset projects
- [x] Added asyncEsUpdate flag option to update datasets function 
- [x] Added removedDatasetIds param, in order to receive dataset ids to be removed from project association
- [x] Removed datasetIds as mandatory param, as it is possible to have situations where there are only datasets to be removed. If no datasetIds and no removeDatasetIds is passed, nothing happens.

 
 #### Tests
 
 ##### Front end
 
- [x] Unit Test
- [ ] e2e Test
 
 ###### Browsers and resolutions
- [x] Chrome
- [x]  Safari
- [x] sm, md, lg, xl, lg


<img width="1790" alt="Screenshot 2021-04-06 at 06 36 59" src="https://user-images.githubusercontent.com/35172605/113693276-cfcc2e80-96a4-11eb-9a81-c5c5b9647bf9.png">
<img width="1792" alt="Screenshot 2021-04-06 at 06 35 43" src="https://user-images.githubusercontent.com/35172605/113693300-d5297900-96a4-11eb-9c50-bd7a93a215ab.png">
