### PR TITLE
Feat/plus one overlay

### DIFF
--- a/metaspace/webapp/src/components/IonImageViewer.tsx
+++ b/metaspace/webapp/src/components/IonImageViewer.tsx
@@ -339,6 +339,7 @@ const useBufferedOpticalImage = (props: Props) => {
       {opticalImageUrl.value
       && <img
         key={state.loadedOpticalImageUrl}
+        crossOrigin="anonymous"
         src={state.loadedOpticalImageUrl}
         class="absolute top-0 left-0 -z-10 origin-top-left"
         style={{
@@ -352,6 +353,7 @@ const useBufferedOpticalImage = (props: Props) => {
       && state.loadedOpticalImageUrl !== opticalImageUrl.value
       && <img
         key={opticalImageUrl.value}
+        crossOrigin="anonymous"
         src={opticalImageUrl.value}
         class="absolute top-0 left-0 -z-20 origin-top-left opacity-1"
         style={{

--- a/metaspace/webapp/src/components/IonImageViewer.tsx
+++ b/metaspace/webapp/src/components/IonImageViewer.tsx
@@ -35,6 +35,7 @@ interface Props {
   xOffset: number
   yOffset: number
   opticalSrc: string | null
+  opticalOpacity: number
   ionImageTransform: number[][]
   opticalTransform: number[][]
   scrollBlock: boolean
@@ -340,7 +341,11 @@ const useBufferedOpticalImage = (props: Props) => {
         key={state.loadedOpticalImageUrl}
         src={state.loadedOpticalImageUrl}
         class="absolute top-0 left-0 -z-10 origin-top-left"
-        style={state.loadedOpticalImageStyle}
+        style={{
+          ...state.loadedOpticalImageStyle,
+          filter: props.opticalOpacity !== undefined ? `brightness(${100 - ((1 - props.opticalOpacity) * 100
+              * 0.75)}%) grayscale(${(1 - (props.opticalOpacity || 0)) * 100}%)` : '',
+        }}
       />}
 
       {opticalImageUrl.value
@@ -349,7 +354,11 @@ const useBufferedOpticalImage = (props: Props) => {
         key={opticalImageUrl.value}
         src={opticalImageUrl.value}
         class="absolute top-0 left-0 -z-20 origin-top-left opacity-1"
-        style={opticalImageStyle.value}
+        style={{
+          ...opticalImageStyle.value,
+          filter: props.opticalOpacity !== undefined ? `brightness(${100 - ((1 - props.opticalOpacity) * 100
+              * 0.75)}%) grayscale(${(1 - (props.opticalOpacity || 0)) * 100}%)` : '',
+        }}
         onLoad={onOpticalImageLoaded}
       />}
     </div>)
@@ -420,6 +429,7 @@ export default defineComponent<Props>({
     xOffset: { type: Number, required: true },
     yOffset: { type: Number, required: true },
     opticalSrc: { type: String, default: null },
+    opticalOpacity: { type: Number, default: 1 },
 
     // 3x3 matrix mapping ion-image pixel coordinates into new ion-image pixel coordinates independent from
     // zoom/offset props, e.g. This ionImageTransform:

--- a/metaspace/webapp/src/components/__snapshots__/ImageLoader.spec.ts.snap
+++ b/metaspace/webapp/src/components/__snapshots__/ImageLoader.spec.ts.snap
@@ -44,6 +44,7 @@ exports[`ImageLoader should match snapshot (with everything turned on) 1`] = `
       <div>
         <img
           class="absolute top-0 left-0 -z-10 origin-top-left"
+          crossorigin="anonymous"
           src="http://placekitten.com/200/300"
           style="transform: matrix3d(1, 4, 0, 7,
              2, 5, 0, 8,

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
@@ -51,6 +51,7 @@ const { settings: ionImageSettings } = useIonImageSettings()
    opticalSrc: string | null
    opticalTransform: number[][] | null
    pixelAspectRatio: number
+   opticalOpacity: number
    // scaleType is deliberately not included here, because every time it changes some slow computation occurs,
    // and the computed getters were being triggered by any part of the ImageSettings object changing, such as opacity,
    // causing a lot of jank.
@@ -207,6 +208,7 @@ export default class AnnotationView extends Vue {
 
      return {
        annotImageOpacity: (this.showOpticalImage && hasOpticalImages) ? this.opacity : 1.0,
+       opticalOpacity: this.showOpticalImage ? this.opticalOpacity : 1.0,
        opacityMode: this.imageOpacityMode,
        imagePosition: this.imagePosition,
        opticalSrc: this.showOpticalImage && optImg && optImg.url || null,
@@ -270,6 +272,14 @@ export default class AnnotationView extends Vue {
 
    set opacity(value: number) {
      ionImageSettings.opacity = value
+   }
+
+   get opticalOpacity() {
+     return ionImageSettings.opticalOpacity
+   }
+
+   set opticalOpacity(value: number) {
+     ionImageSettings.opticalOpacity = value
    }
 
    get imagePosition() {

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.vue
@@ -122,6 +122,7 @@
             :annotation="annotation"
             :colormap="colormap"
             :opacity="opacity"
+            :optical-opacity="opticalOpacity"
             :image-position="imagePosition"
             :image-loader-settings="imageLoaderSettings"
             :apply-image-move="onImageMove"
@@ -131,6 +132,7 @@
             :scale-bar-color="scaleBarColor"
             :scale-type="scaleType"
             @opacity="newVal => opacity = newVal"
+            @opticalOpacity="newVal => opticalOpacity = newVal"
           />
         </el-collapse-item>
 

--- a/metaspace/webapp/src/modules/ImageViewer/ImageViewer.vue
+++ b/metaspace/webapp/src/modules/ImageViewer/ImageViewer.vue
@@ -43,25 +43,54 @@
           v-bind="singleIonImageControls"
         />
       </fade-transition>
-      <fade-transition>
-        <opacity-settings
-          v-if="openMenu === 'ION' && hasOpticalImage"
-          key="opacity"
-          class="sm-leading-trim mt-auto"
-          :opacity="opacity"
-          @opacity="emitOpacity"
-        />
-      </fade-transition>
-      <fade-transition v-if="lockIntensityEnabled">
-        <intensity-settings
-          v-if="openMenu === 'ION'"
-          key="ion-settings"
-          class="sm-leading-trim"
-          :has-optical-image="hasOpticalImage"
-          :opacity="opacity"
-          @opacity="emitOpacity"
-        />
-      </fade-transition>
+      <div
+        v-if="openMenu === 'ION'"
+        class="ion-slider-wrapper"
+      >
+        <div
+          v-if="hasOpticalImage"
+          class="ion-slider-holder"
+        >
+          <fade-transition class="w-full">
+            <opacity-settings
+              key="opticalOpacity"
+              label="Optical image color scale"
+              class="sm-leading-trim mt-auto"
+              :opacity="opticalOpacity"
+              @opacity="emitOpticalOpacity"
+            />
+          </fade-transition>
+        </div>
+        <div
+          v-if="hasOpticalImage"
+          class="ion-slider-holder"
+        >
+          <fade-transition class="w-full">
+            <opacity-settings
+              key="opacity"
+              label="Ion overlay opacity"
+              class="sm-leading-trim mt-auto"
+              :opacity="opacity"
+              @opacity="emitOpacity"
+            />
+          </fade-transition>
+        </div>
+        <div
+          v-if="lockIntensityEnabled"
+          class="ion-slider-holder"
+        >
+          <fade-transition>
+            <intensity-settings
+              v-if="openMenu === 'ION'"
+              key="ion-settings"
+              class="sm-leading-trim"
+              :has-optical-image="hasOpticalImage"
+              :opacity="opacity"
+              @opacity="emitOpacity"
+            />
+          </fade-transition>
+        </div>
+      </div>
     </div>
     <image-saver
       class="absolute top-0 left-0 mt-3 ml-3"
@@ -119,6 +148,7 @@ const ImageViewer = defineComponent<Props>({
     annotation: { required: true, type: Object },
     colormap: { required: true, type: String },
     opacity: { required: true, type: Number },
+    opticalOpacity: { type: Number },
     imageLoaderSettings: { required: true, type: Object },
     applyImageMove: { required: true, type: Function },
     pixelSizeX: { type: Number },
@@ -191,6 +221,9 @@ const ImageViewer = defineComponent<Props>({
       emitOpacity(value: number) {
         emit('opacity', value)
       },
+      emitOpticalOpacity(value: number) {
+        emit('opticalOpacity', value)
+      },
       hasOpticalImage: computed(() => !!props.imageLoaderSettings.opticalSrc),
       lockIntensityEnabled: config.features.lock_intensity,
     }
@@ -206,5 +239,21 @@ export default ImageViewer
 
 .sm-leading-trim > :first-child {
   margin-top: calc(-1 * theme('spacing.3') / 2); /* hacking */
+}
+
+.ion-slider-wrapper{
+  display: flex;
+  flex-wrap: wrap;
+}
+.ion-slider-holder{
+  display: flex;
+  flex-wrap: wrap;
+  width: 240px;
+  @apply mt-2 ml-2;
+}
+@media (min-width: 768px) {
+  .ion-slider-wrapper{
+    min-width: max-content;
+  }
 }
 </style>

--- a/metaspace/webapp/src/modules/ImageViewer/ImageViewer.vue
+++ b/metaspace/webapp/src/modules/ImageViewer/ImageViewer.vue
@@ -48,13 +48,13 @@
         class="ion-slider-wrapper"
       >
         <div
-          v-if="hasOpticalImage"
+          v-if="hasOpticalImage && !isIE"
           class="ion-slider-holder"
         >
           <fade-transition class="w-full">
             <opacity-settings
               key="opticalOpacity"
-              label="Optical image color scale"
+              label="Optical image visibility"
               class="sm-leading-trim mt-auto"
               :opacity="opticalOpacity"
               @opacity="emitOpticalOpacity"
@@ -68,7 +68,7 @@
           <fade-transition class="w-full">
             <opacity-settings
               key="opacity"
-              label="Ion overlay opacity"
+              label="Ion image opacity"
               class="sm-leading-trim mt-auto"
               :opacity="opacity"
               @opacity="emitOpacity"
@@ -199,12 +199,18 @@ const ImageViewer = defineComponent<Props>({
       })
     })
 
+    const isIE = computed(() => {
+      // IE 10 and IE 11
+      return /Trident\/|MSIE/.test(window.navigator.userAgent)
+    })
+
     return {
       imageArea,
       dimensions,
       ionImageDimensions,
       imageFit,
       onResize,
+      isIE,
       ionImageLayers,
       ionImageMenuItems,
       singleIonImageControls,

--- a/metaspace/webapp/src/modules/ImageViewer/OpacitySettings.vue
+++ b/metaspace/webapp/src/modules/ImageViewer/OpacitySettings.vue
@@ -4,7 +4,7 @@
   >
     <p class="leading-6 m-0 flex justify-between">
       <span class="text-gray-700 font-medium">
-        Opacity
+        {{ opacityLabel }}
       </span>
       <span>
         {{ percentage }}%
@@ -33,10 +33,12 @@ export default defineComponent({
   },
   props: {
     opacity: { type: Number, required: true },
+    label: { type: String, default: 'Opacity' },
   },
   setup(props, { emit }) {
     return {
       percentage: computed(() => Math.round(props.opacity * 100)),
+      opacityLabel: computed(() => props.label),
       emitOpacity(value: number) {
         emit('opacity', value / 100)
       },

--- a/metaspace/webapp/src/modules/ImageViewer/ionImageState.ts
+++ b/metaspace/webapp/src/modules/ImageViewer/ionImageState.ts
@@ -58,6 +58,7 @@ interface Settings {
   lockMaxScale: number
   isLockActive: boolean
   opacity: number
+  opticalOpacity: number
 }
 
 const channels = ['magenta', 'green', 'blue', 'red', 'yellow', 'cyan', 'orange', 'violet']
@@ -73,6 +74,7 @@ const settings = reactive<Settings>({
   lockMaxScale: 1,
   isLockActive: true,
   opacity: 1,
+  opticalOpacity: 1,
 })
 const activeAnnotation = ref<string>() // local copy of prop value to allow watcher to run
 
@@ -165,6 +167,7 @@ export function resetIonImageState() {
     lockMaxScale: 1,
     isLockActive: true,
     opacity: 1,
+    opticalOpacity: 1,
   })
 }
 


### PR DESCRIPTION
### Description

In some cases, at the annotation viewer, it is difficult to see the ion image given some unique features from the correspondent optical image. In order to improve user experience, a new slider that can change the optical image visibility was added.

Issue #812

#### Changes

##### Front end

###### ImageViewer page
- [x] Added "Optical image visibility" slider
- [x] Changed "Opacity" slider label to "Ion image opacity"
- [x] Changed Sliders disposition. Opacity, visibility and lockIntensity sliders in a row disposition and as column on small screen
- [x] Hid "Optical image visibility" slider in IE, as the filter props do not work on it.

###### IonImageViewerComponent
- [x] Added crossOrigin props on optical img tag to enable download from s3 without cors problems
- [x] Added opticalOpacity props, which changes visibility of the optical image. The formula changes the image to grayscale and reduces the brightness with 75% of the correspondent grayscale percentage value

***Note
Although there is a code repeat on the filter opticalOpacity formula formula on both optical images tags. This was done so the props changes can be listened without needing a specific listener.

 #### Tests
 
 ##### Front end
 
- [ ] Unit Test
- [ ] e2e Test
 
 ###### Browsers and resolutions
- [x] Chrome
- [x] Safari
- [x] sm, md, lg, xl, lg
* Not supported on IE11

![image](https://user-images.githubusercontent.com/35172605/113910209-f24a6e80-97ae-11eb-8279-4ba267a9489e.png)
![image](https://user-images.githubusercontent.com/35172605/113910399-2d4ca200-97af-11eb-99b6-0842a55127eb.png)
