### PR TITLE
Create placeholder action for testing recalibration package compilation

### DIFF
--- a/.github/workflowsmsi_recal_publish.yml
+++ b/.github/workflowsmsi_recal_publish.yml
@@ -1,0 +1,13 @@
+# This is a placeholder action file, because manually triggered actions need a file in the master branch to be run on any branch.
+# The real action template will come in a PR
+name: Build msi_recal wheels
+
+on:
+  workflow_dispatch:
+
+jobs:
+  hello_world:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Hello world
+        run: echo "Hello world"


### PR DESCRIPTION
This is a placeholder action file. Manually triggered actions can't be run against other branches unless they already exist in the master branch. 

I'm going to use this so I can test [an action in a branch that's not yet ready for PR](https://github.com/metaspace2020/metaspace/blob/feat/recalibration/.github/workflows/msi_recal_publish.yml). 

I'm going to merge this without review, as this change shouldn't affect anything, and will be overwritten by a properly-reviewed PR when this feature is ready.