### PR TITLE
Python client update_dataset support + docs improvements

### DIFF
--- a/metaspace/python-client/docs/requirements.txt
+++ b/metaspace/python-client/docs/requirements.txt
@@ -2,3 +2,4 @@ metaspace/python-client/
 Sphinx==3.3.1
 sphinx-rtd-theme==0.5.0
 nbsphinx
+sphinx_autodoc_typehints

--- a/metaspace/python-client/docs/source/conf.py
+++ b/metaspace/python-client/docs/source/conf.py
@@ -34,6 +34,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'nbsphinx',
     'sphinx_rtd_theme',
+    'sphinx_autodoc_typehints',
 ]
 
 source_suffix = ['.rst', '.ipynb']

--- a/metaspace/python-client/docs/source/content/apireference/projects_client.rst
+++ b/metaspace/python-client/docs/source/content/apireference/projects_client.rst
@@ -2,5 +2,7 @@ metaspace.projects_client
 =============================
 
 .. automodule:: metaspace.projects_client
-   :members:
-   :undoc-members:
+    :member-order: bysource
+    :exclude-members: PROJECT_FIELDS
+    :members:
+    :undoc-members:

--- a/metaspace/python-client/docs/source/content/apireference/sm_annotation_utils.rst
+++ b/metaspace/python-client/docs/source/content/apireference/sm_annotation_utils.rst
@@ -2,5 +2,7 @@ metaspace.sm_annotation_utils
 =============================
 
 .. automodule:: metaspace.sm_annotation_utils
-   :members:
-   :undoc-members:
+    :member-order: bysource
+    :exclude-members: DataframeNode, DataframeTree, get_config, multipart_upload, plot_diff, DATASET_FIELDS, ANNOTATION_FIELDS
+    :members:
+    :undoc-members:

--- a/metaspace/python-client/docs/source/content/apireference/types.rst
+++ b/metaspace/python-client/docs/source/content/apireference/types.rst
@@ -1,0 +1,10 @@
+metaspace.types
+=============================
+
+This module contains type annotations for data structures so that IDEs such as PyCharm can assist when
+accessing structures such as :py:attr:`metaspace.sm_annotation_utils.SMDataset.metadata`
+
+.. automodule:: metaspace.types
+    :exclude-members: MetadataContainer, make_metadata
+    :members:
+    :undoc-members:

--- a/metaspace/python-client/docs/source/index.rst
+++ b/metaspace/python-client/docs/source/index.rst
@@ -35,6 +35,7 @@ Applications:
    content/apireference/sm_annotation_utils
    content/apireference/image_processing
    content/apireference/projects_client
+   content/apireference/types
 
 Indices and tables
 ------------------

--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.8.6'
+__version__ = '1.8.7'
 
 from metaspace.sm_annotation_utils import (
     SMInstance,

--- a/metaspace/python-client/metaspace/projects_client.py
+++ b/metaspace/python-client/metaspace/projects_client.py
@@ -128,3 +128,11 @@ class ProjectsClient:
             {'projectId': project_id, 'provider': provider, 'link': link},
         )
         return result['removeProjectExternalLink']['externalLinks']
+
+
+# Specify __all__ so that Sphinx documents everything in order from most to least interesting
+__all__ = [
+    'ProjectsClient',
+    'ProjectDict',
+    'ExternalLink',
+]

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -1360,7 +1360,7 @@ class SMInstance(object):
         if project_id is not None:
             datasetFilter['project'] = project_id
         if polarity is not None:
-            datasetFilter['polarity'] = polarity
+            datasetFilter['polarity'] = polarity.upper()
         if ionisation_source is not None:
             datasetFilter['ionisationSource'] = ionisation_source
         if analyzer_type is not None:

--- a/metaspace/python-client/metaspace/tests/test_sm_instance.py
+++ b/metaspace/python-client/metaspace/tests/test_sm_instance.py
@@ -52,6 +52,25 @@ def test_datasets_by_project(sm):
     assert len(result) > 0
 
 
+def test_datasets_by_all_fields(sm: SMInstance):
+    project_id = [p['id'] for p in sm.projects.get_all_projects() if p['numDatasets'] > 0][0]
+
+    # If anything is broken with the GraphQL mapping, this will throw an exception
+    sm.datasets(
+        nameMask='foo',
+        idMask='foo',
+        submitter_id=sm.current_user_id(),
+        group_id=sm._gqclient.get_primary_group_id(),
+        project=project_id,
+        polarity='Positive',
+        ionisation_source='MALDI',
+        analyzer_type='Orbitrap',
+        maldi_matrix='DHB',
+        organism='Human',
+        organismPart='Cells',
+    )
+
+
 def test_update_dataset_without_reprocessing(sm: SMInstance, my_ds_id):
     old_ds = sm.dataset(id=my_ds_id)
     new_name = 'foo' if old_ds.name != 'foo' else 'bar'

--- a/metaspace/python-client/metaspace/tests/test_sm_instance.py
+++ b/metaspace/python-client/metaspace/tests/test_sm_instance.py
@@ -88,7 +88,7 @@ def test_update_dataset_without_reprocessing(sm: SMInstance, my_ds_id):
     assert sm.dataset(id=my_ds_id).name == new_name
 
 
-# @pytest.mark.skip('This test triggers reprocessing and should only be run manually')
+@pytest.mark.skip('This test triggers reprocessing and should only be run manually')
 def test_update_dataset_with_auto_reprocessing(sm: SMInstance, my_ds_id):
     old_ds = sm.dataset(id=my_ds_id)
     new_adducts = ['+H'] if old_ds.adducts != ['+H'] else ['+K']

--- a/metaspace/python-client/metaspace/tests/test_sm_instance.py
+++ b/metaspace/python-client/metaspace/tests/test_sm_instance.py
@@ -1,4 +1,8 @@
+import time
+
 import pytest
+
+from metaspace import SMInstance
 from metaspace.tests.utils import sm, my_ds_id
 
 
@@ -45,3 +49,35 @@ def test_datasets_by_project(sm):
 
     print(result)
     assert len(result) > 0
+
+
+def test_update_dataset_without_reprocessing(sm: SMInstance, my_ds_id):
+    old_ds = sm.dataset(id=my_ds_id)
+    new_name = 'foo' if old_ds.name != 'foo' else 'bar'
+    metadata = old_ds.metadata.json
+
+    sm.update_dataset(id=my_ds_id, name=new_name)
+
+    # Wait for reindexing, as dataset updates are async
+    attempts = 0
+    while sm.dataset(id=my_ds_id).name != new_name and attempts < 10:
+        time.sleep(1)
+
+    assert sm.dataset(id=my_ds_id).name == new_name
+
+
+@pytest.mark.skip('This test triggers reprocessing and should only be run manually')
+def test_update_dataset_with_auto_reprocessing(sm: SMInstance, my_ds_id):
+    old_ds = sm.dataset(id=my_ds_id)
+    new_adducts = ['+H'] if old_ds.adducts != ['+H'] else ['+K']
+
+    assert old_ds.status == 'FINISHED'
+
+    sm.update_dataset(id=my_ds_id, adducts=new_adducts)
+
+    # Wait for dataset to change status
+    attempts = 0
+    while sm.dataset(id=my_ds_id).status != 'FINISHED' and attempts < 10:
+        time.sleep(1)
+
+    assert sm.dataset(id=my_ds_id).status in ('QUEUED', 'ANNOTATING')

--- a/metaspace/python-client/metaspace/types.py
+++ b/metaspace/python-client/metaspace/types.py
@@ -1,0 +1,144 @@
+import json
+from typing import Optional, cast, List
+
+# NOTE: Python-client needs to support Python versions as low as Python 3.6.
+# Make sure to run PyCharm's "Code Compatibility" inspection when touching any imports from typing
+try:
+    from typing import TypedDict, Literal  # Python 3.8+
+
+    Polarity = Literal['Positive', 'Negative']
+    MetadataDataType = Literal['Imaging MS']
+except ImportError:
+    try:
+        from typing_extensions import TypedDict, Literal
+
+        Polarity = Literal['Positive', 'Negative']
+        MetadataDataType = Literal['Imaging MS']
+    except ImportError:
+        Polarity = str
+        MetadataDataType = str
+        TypedDict = dict
+
+
+class MetadataSampleInformation(TypedDict):
+    Organism: str
+    Organism_Part: str
+    Condition: str
+    Sample_Growth_Conditions: Optional[str]
+
+
+class MetadataSamplePreparation(TypedDict):
+    Sample_Stabilisation: str
+    Tissue_Modification: str
+    MALDI_Matrix: str
+    MALDI_Matrix_Application: str
+    Solvent: Optional[str]
+
+
+class MetadataResolvingPower(TypedDict):
+    mz: float
+    Resolving_Power: float
+
+
+class MetadataPixelSize(TypedDict):
+    Xaxis: float
+    Yaxis: float
+
+
+class MetadataMSAnalysis(TypedDict):
+    Polarity: Polarity
+    Ionisation_Source: str
+    Analyzer: str
+    Detector_Resolving_Power: MetadataResolvingPower
+    Pixel_Size: str
+
+
+class Metadata(TypedDict):
+    Data_Type: str  # Should always be 'Imaging MS'
+    Sample_Information: MetadataSampleInformation
+    Sample_Preparation: MetadataSamplePreparation
+    MS_Analysis: MetadataMSAnalysis
+
+
+class MetadataContainer(dict):
+    def __init__(self, json_metadata):
+        super().__init__(json.loads(json_metadata))
+        self._json = json_metadata
+
+    @property
+    def json(self):
+        return self._json
+
+
+def make_metadata(json_metadata):
+    """
+    It's more user-friendly to access metadata as a TypedDict, but for backwards compatibility,
+    it's necessary to provide the metadata.json property. TypedDicts don't seem to support
+    custom constructors or non-dictionary properties at all.
+    As a compromise, cast to `MetadataDict` so that users with type checking can access it as a
+    TypedDict, but the .json property is still available as the instance type is a regular dict.
+    """
+    return cast(Metadata, MetadataContainer(json_metadata))
+
+
+# Should match metaspace/engine/sm/engine/ds_config.py
+# noinspection DuplicatedCode
+class DSConfigIsotopeGeneration(TypedDict):
+    adducts: List[str]
+    charge: int
+    isocalc_sigma: float
+    instrument: str
+    n_peaks: int
+    neutral_losses: List[str]
+    chem_mods: List[str]
+
+
+# noinspection DuplicatedCode
+class DSConfigFDR(TypedDict):
+    decoy_sample_size: int
+
+
+# noinspection DuplicatedCode
+class DSConfigImageGeneration(TypedDict):
+    ppm: int
+    n_levels: int
+    min_px: int
+
+
+# noinspection DuplicatedCode
+class DSConfig(TypedDict):
+    database_ids: List[int]
+    analysis_version: int
+    isotope_generation: DSConfigIsotopeGeneration
+    fdr: DSConfigFDR
+    image_generation: DSConfigImageGeneration
+
+
+class DatabaseDetails(TypedDict):
+    id: int
+    name: str
+    version: str
+    isPublic: bool
+    archived: bool
+
+
+class DatasetDownloadLicense(TypedDict):
+    code: str
+    name: str
+    link: Optional[str]
+
+
+class DatasetDownloadContributor(TypedDict):
+    name: Optional[str]
+    institution: Optional[str]
+
+
+class DatasetDownloadFile(TypedDict):
+    filename: str
+    link: str
+
+
+class DatasetDownload(TypedDict):
+    license: DatasetDownloadLicense
+    contributors: List[DatasetDownloadContributor]
+    files: List[DatasetDownloadFile]

--- a/metaspace/python-client/metaspace/types.py
+++ b/metaspace/python-client/metaspace/types.py
@@ -54,6 +54,12 @@ class MetadataMSAnalysis(TypedDict):
 
 
 class Metadata(TypedDict):
+    """
+    SMDataset.metadata should be accessed as a Python dict, e.g.
+
+    >>> organism = dataset.metadata['Sample_Information']['Organism']
+    """
+
     Data_Type: str  # Should always be 'Imaging MS'
     Sample_Information: MetadataSampleInformation
     Sample_Preparation: MetadataSamplePreparation
@@ -107,6 +113,12 @@ class DSConfigImageGeneration(TypedDict):
 
 # noinspection DuplicatedCode
 class DSConfig(TypedDict):
+    """
+    SMDataset.config should be accessed as a Python dict, e.g.
+
+    >>> instrument = dataset.config['isotope_generation']['instrument']
+    """
+
     database_ids: List[int]
     analysis_version: int
     isotope_generation: DSConfigIsotopeGeneration

--- a/metaspace/python-client/setup.py
+++ b/metaspace/python-client/setup.py
@@ -19,14 +19,7 @@ setup(
     author='Alexandrov Team, EMBL',
     author_email='contact@metaspace2020.eu',
     packages=find_packages(exclude=['*tests*']),
-    install_requires=[
-        'pandas',
-        'plotly>=1.12',
-        'numpy',
-        'matplotlib',
-        'pillow',
-        'requests',
-    ],
+    install_requires=['pandas', 'plotly>=1.12', 'numpy', 'matplotlib', 'pillow', 'requests'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/metaspace/python-client/setup.py
+++ b/metaspace/python-client/setup.py
@@ -24,7 +24,6 @@ setup(
         'plotly>=1.12',
         'numpy',
         'matplotlib',
-        'pyMSpec',
         'pillow',
         'requests',
     ],


### PR DESCRIPTION
* Added `SMInstance.update_dataset` to make it possible to edit datasets' neutral losses, etc.
* Change `SMDataset.metadata` to be accessible as a dictionary. Previously it just held a property `Metadata.json` that returned the JSON string. I had to do some hackery to get it working as a TypedDict that also retained the `.json` property for backwards compatibility.
* Add `TypedDict` declarations for `SMDataset.config`
* Moved the `DatasetDownload` `TypedDict` declarations into `metaspace.types`, alongside the new `Metadata` and `DSConfig` declarations
* Explicitly declare most of the available arguments to `SMInstance.datasets`, because it's one of the main APIs new users will look at, and it wasn't generating useful documentation.
* Tidy up the docs by reordering module members and excluding a bunch of private methods & data
* Remove non-functional/unused `ion` function, `SMInstance.adducts` method, and `NYI` exception from `sm_annotation_utils`

As a team member is waiting for the `SMInstance.update_dataset` change, I've released this to PyPI already.