### PR TITLE
Set useLithops True for GraphQL API

### DIFF
--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -323,7 +323,7 @@ type Mutation {
     id: String,
     input: DatasetCreateInput!,
     priority: Int=0,
-    useLithops: Boolean=false
+    useLithops: Boolean=true
   ): String!
 
   # Throws errors of types: "under_review_or_published", "reprocessing_needed", "failed_validation"
@@ -335,7 +335,7 @@ type Mutation {
     skipValidation: Boolean=false, # ignored for non-admins
     force: Boolean=false,
     priority: Int=0,
-    useLithops: Boolean=false
+    useLithops: Boolean=true
   ): String!
 
   # Throws errors of types: "under_review_or_published"
@@ -346,7 +346,7 @@ type Mutation {
     id: String,
     priority: Int=0,
     delFirst: Boolean=false,
-    useLithops: Boolean=false
+    useLithops: Boolean=true
   ): String!
 
   addOpticalImage(input: AddOpticalImageInput!): String!

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -667,7 +667,12 @@ class GraphQLClient(object):
         return self.query(query, variables)
 
     def update_dataset(
-        self, ds_id, input=None, reprocess=False, force=False, priority=1,
+        self,
+        ds_id,
+        input=None,
+        reprocess=False,
+        force=False,
+        priority=1,
     ):
         query = """
             mutation updateMetadataDatabases($id: String!, $reprocess: Boolean,


### PR DESCRIPTION
At the moment, all clients of the GraphQL API used useLithops=false by default. In this regard, we have to explicitly register the processing of datasets through Lithops in the python-client, metaspace site, ... Since we do not see any obvious problems with the use of Lithops, it was decided to switch used to Lithops by default.