### PR TITLE
Feat/project sorting

### DIFF
--- a/metaspace/graphql/schemas/project.graphql
+++ b/metaspace/graphql/schemas/project.graphql
@@ -53,6 +53,16 @@ type UserProject {
   numDatasets: Int!
 }
 
+enum ProjectOrderBy {
+  ORDER_BY_DATE
+  ORDER_BY_POPULARITY
+  ORDER_BY_NAME
+  ORDER_BY_UP_DATE
+  ORDER_BY_MANAGER_NAME
+  ORDER_BY_DATASETS_COUNT
+  ORDER_BY_MEMBERS_COUNT
+}
+
 enum UserProjectRole {
   INVITED    # User was invited into the project but hasn't confirmed it yet
   PENDING    # User requested to join the project but the PI hasn't confirmed it yet
@@ -64,7 +74,9 @@ enum UserProjectRole {
 type Query {
   project(projectId: ID!): Project
   projectByUrlSlug(urlSlug: String!): Project
-  allProjects(query: String, offset: Int = 0, limit: Int = 10): [Project!]!
+  allProjects(orderBy: ProjectOrderBy = ORDER_BY_POPULARITY,
+              sortingOrder: SortingOrder = DESCENDING,
+              query: String, offset: Int = 0, limit: Int = 10): [Project!]!
   projectsCount(query: String): Int!
 
   projectUrlSlugIsValid(urlSlug: String!, existingProjectId: ID): Boolean! # Throws error if invalid, consistent with updateProject

--- a/metaspace/graphql/src/modules/project/controller/Query.spec.ts
+++ b/metaspace/graphql/src/modules/project/controller/Query.spec.ts
@@ -281,7 +281,8 @@ describe('modules/project/controller (queries)', () => {
           const project = await createTestProject({
             name: `test${pIdx}`,
             createdDT: moment().add(pIdx, 'seconds'),
-            publishedDT: moment().add(pIdx, 'seconds'),
+            publishedDT: pIdx === 0 ? null : moment().add(pIdx, 'seconds'), // adds null to first to check if it
+            // is removed
           })
           const members = await Promise.all(_.range(idx + 1)
             .map((mIdx) => createTestUser({ name: `user${pIdx}-${mIdx}` })))
@@ -388,17 +389,35 @@ describe('modules/project/controller (queries)', () => {
             return 0
           }).map((pj: any) => pj.id))
         expect(resultSortedByPubDateAsc.map((pj: any) => pj.id))
+          .not
           .toEqual(projects.sort((a: any, b: any) => {
-            if (a.publishedDT.isBefore(b.publishedDT)) { return -1 }
-            if (a.publishedDT.isAfter(b.publishedDT)) { return 1 }
+            if (a.publishedDT?.isBefore(b.publishedDT)) { return -1 }
+            if (a.publishedDT?.isAfter(b.publishedDT)) { return 1 }
             return 0
           }).map((pj: any) => pj.id))
         expect(resultSortedByPubDateDesc.map((pj: any) => pj.id))
+          .not
           .toEqual(projects.sort((a: any, b: any) => {
-            if (a.publishedDT.isBefore(b.publishedDT)) { return 1 }
-            if (a.publishedDT.isAfter(b.publishedDT)) { return -1 }
+            if (a.publishedDT?.isBefore(b.publishedDT)) { return 1 }
+            if (a.publishedDT?.isAfter(b.publishedDT)) { return -1 }
             return 0
           }).map((pj: any) => pj.id))
+        expect(resultSortedByPubDateAsc.map((pj: any) => pj.id))
+          .toEqual(projects
+            .filter((pj: any) => pj.publishedDT !== null)
+            .sort((a: any, b: any) => {
+              if (a.publishedDT?.isBefore(b.publishedDT)) { return -1 }
+              if (a.publishedDT?.isAfter(b.publishedDT)) { return 1 }
+              return 0
+            }).map((pj: any) => pj.id))
+        expect(resultSortedByPubDateDesc.map((pj: any) => pj.id))
+          .toEqual(projects
+            .filter((pj: any) => pj.publishedDT !== null)
+            .sort((a: any, b: any) => {
+              if (a.publishedDT?.isBefore(b.publishedDT)) { return 1 }
+              if (a.publishedDT?.isAfter(b.publishedDT)) { return -1 }
+              return 0
+            }).map((pj: any) => pj.id))
         expect(resultSortedByDsCountAsc.map((pj: any) => pj.id))
           .toEqual(projects
             .sort((a: any, b: any) => a.numDatasets - b.numDatasets)

--- a/metaspace/graphql/src/modules/project/controller/Query.ts
+++ b/metaspace/graphql/src/modules/project/controller/Query.ts
@@ -13,9 +13,12 @@ const QueryResolvers: FieldResolversFor<Query, void> = {
     return await ctx.entityManager.getCustomRepository(ProjectSourceRepository)
       .findProjectByUrlSlug(ctx.user, urlSlug)
   },
-  async allProjects(source, { query, offset, limit }, ctx): Promise<ProjectSource[]> {
+  async allProjects(source, {
+    orderBy, sortingOrder,
+    query, offset, limit,
+  }, ctx): Promise<ProjectSource[]> {
     return await ctx.entityManager.getCustomRepository(ProjectSourceRepository)
-      .findProjectsByQuery(ctx.user, query, offset, limit)
+      .findProjectsByQuery(ctx.user, query, offset, limit, orderBy, sortingOrder)
   },
   async projectsCount(source, { query }, ctx): Promise<number> {
     return await ctx.entityManager.getCustomRepository(ProjectSourceRepository)

--- a/metaspace/webapp/src/api/project.ts
+++ b/metaspace/webapp/src/api/project.ts
@@ -207,8 +207,10 @@ const projectsListItemFragment =
     }`
 
 export const projectsListQuery =
-  gql`query ProjectsListQuery($query: String!, $offset: Int = 0, $limit: Int = 10) {
-    allProjects(query: $query, offset: $offset, limit: $limit) {
+  gql`query ProjectsListQuery($query: String!, $offset: Int = 0, $limit: Int = 10,
+    $orderBy: ProjectOrderBy = ORDER_BY_POPULARITY, $sortingOrder: SortingOrder = DESCENDING) {
+    allProjects(orderBy: $orderBy, sortingOrder: $sortingOrder, query: $query,
+      offset: $offset, limit: $limit) {
       ...ProjectsListItem
     }
   }

--- a/metaspace/webapp/src/components/SortDropdown/SortDropdown.tsx
+++ b/metaspace/webapp/src/components/SortDropdown/SortDropdown.tsx
@@ -11,6 +11,7 @@ const enum SortingOrder {
 
 interface Props {
   options: Option[]
+  size: string
   onSortChange(value: any, orderBy: SortingOrder): any
 }
 
@@ -50,6 +51,10 @@ export const SortDropdown = defineComponent<Props>({
       type: Function,
       default: () => {},
     },
+    size: {
+      type: String,
+      default: 'small',
+    },
   },
   // Last reprocessed date (as currently)/Upload date/Number of annotations for FDR 10%/User name/Dataset name
   setup(props) {
@@ -75,7 +80,7 @@ export const SortDropdown = defineComponent<Props>({
 
     return () => (
       <div class="flex flex-row sort-dp-container">
-        <el-select size="small" value={state.value} placeholder="Sort by" onChange={handleSelect} clearable>
+        <el-select size={props.size} value={state.value} placeholder="Sort by" onChange={handleSelect} clearable>
           {
             props.options.map((opt) => {
               return <el-option

--- a/metaspace/webapp/src/modules/Project/ProjectsListPage.vue
+++ b/metaspace/webapp/src/modules/Project/ProjectsListPage.vue
@@ -7,19 +7,35 @@
       @create="handleProjectCreated"
     />
     <div class="page-content">
-      <div class="header-row">
-        <filter-panel
-          level="projects"
-          :simple-filter-options="simpleFilterOptions"
-        />
-        <div style="flex-grow: 1" />
+      <div
+        v-if="currentUser"
+        class="flex flex-row items-center justify-end flex-1 w-full py-4"
+      >
         <el-button
-          v-if="currentUser"
+          type="primary"
+          size="small"
           @click="handleOpenCreateProject"
         >
           Create project
         </el-button>
       </div>
+      <div class="header-row">
+        <filter-panel
+          level="projects"
+          :simple-filter-options="simpleFilterOptions"
+        />
+        <div
+          class="flex flex-row items-center justify-end flex-1"
+        >
+          <sort-dropdown
+            class="pb-2"
+            size="default"
+            :options="sortingOptions"
+            :on-sort-change="handleSortChange"
+          />
+        </div>
+      </div>
+
       <div class="clearfix" />
       <div
         v-loading="loading !== 0"
@@ -62,6 +78,7 @@ import { FilterPanel } from '../Filters'
 import QuickFilterBox from '../Filters/filter-components/SimpleFilterBox.vue'
 import ProjectsListItem from './ProjectsListItem.vue'
 import CreateProjectDialog from './CreateProjectDialog.vue'
+import { SortDropdown } from '../../components/SortDropdown/SortDropdown'
 
   @Component<ProjectsListPage>({
     components: {
@@ -69,6 +86,7 @@ import CreateProjectDialog from './CreateProjectDialog.vue'
       ProjectsListItem,
       CreateProjectDialog,
       QuickFilterBox,
+      SortDropdown,
     },
     apollo: {
       currentUser: {
@@ -87,6 +105,8 @@ import CreateProjectDialog from './CreateProjectDialog.vue'
             query: this.query,
             offset: (this.page - 1) * this.pageSize,
             limit: this.pageSize,
+            orderBy: this.orderBy,
+            sortingOrder: this.sortingOrder,
           }
         },
       },
@@ -124,6 +144,38 @@ export default class ProjectsListPage extends Vue {
     allProjects: ProjectsListProject[] | null = null;
     myProjects: ProjectsListProject[] | null = null;
     allProjectsCount = 0;
+    orderBy : string = 'ORDER_BY_POPULARITY';
+    sortingOrder : string = 'DESCENDING';
+    sortingOptions: any[] = [
+      {
+        value: 'ORDER_BY_POPULARITY',
+        label: 'Popularity',
+      },
+      {
+        value: 'ORDER_BY_DATE',
+        label: 'Last updated',
+      },
+      {
+        value: 'ORDER_BY_UP_DATE',
+        label: 'Upload date',
+      },
+      {
+        value: 'ORDER_BY_NAME',
+        label: 'Project name',
+      },
+      {
+        value: 'ORDER_BY_MANAGER_NAME',
+        label: 'Manager name',
+      },
+      {
+        value: 'ORDER_BY_DATASETS_COUNT',
+        label: 'Number of datasets',
+      },
+      {
+        value: 'ORDER_BY_MEMBERS_COUNT',
+        label: 'Number of members',
+      },
+    ]
 
     showCreateProjectDialog = false;
     page = 1;
@@ -197,6 +249,11 @@ export default class ProjectsListPage extends Vue {
 
     handleCloseCreateProject() {
       this.showCreateProjectDialog = false
+    }
+
+    handleSortChange(value: string, sortingOrder: string) {
+      this.orderBy = !value ? 'ORDER_BY_POPULARITY' : value
+      this.sortingOrder = !sortingOrder ? 'DESCENDING' : sortingOrder
     }
 
     handleProjectCreated({ id }: {id: string}) {

--- a/metaspace/webapp/src/modules/Project/ProjectsListPage.vue
+++ b/metaspace/webapp/src/modules/Project/ProjectsListPage.vue
@@ -149,15 +149,15 @@ export default class ProjectsListPage extends Vue {
     sortingOptions: any[] = [
       {
         value: 'ORDER_BY_POPULARITY',
-        label: 'Popularity',
+        label: 'Project size',
       },
       {
         value: 'ORDER_BY_DATE',
-        label: 'Last updated',
+        label: 'Creation date',
       },
       {
         value: 'ORDER_BY_UP_DATE',
-        label: 'Upload date',
+        label: 'Publication date',
       },
       {
         value: 'ORDER_BY_NAME',

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -75,9 +75,9 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
       <div class="flex flex-row items-center justify-end flex-1">
         <div class="pb-2 flex flex-row sort-dp-container">
           <mock-el-select size="default" value="" placeholder="Sort by" clearable="true">
-            <mock-el-option label="Popularity" value="ORDER_BY_POPULARITY"></mock-el-option>
-            <mock-el-option label="Last updated" value="ORDER_BY_DATE"></mock-el-option>
-            <mock-el-option label="Upload date" value="ORDER_BY_UP_DATE"></mock-el-option>
+            <mock-el-option label="Project size" value="ORDER_BY_POPULARITY"></mock-el-option>
+            <mock-el-option label="Creation date" value="ORDER_BY_DATE"></mock-el-option>
+            <mock-el-option label="Publication date" value="ORDER_BY_UP_DATE"></mock-el-option>
             <mock-el-option label="Project name" value="ORDER_BY_NAME"></mock-el-option>
             <mock-el-option label="Manager name" value="ORDER_BY_MANAGER_NAME"></mock-el-option>
             <mock-el-option label="Number of datasets" value="ORDER_BY_DATASETS_COUNT"></mock-el-option>
@@ -239,9 +239,9 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
       <div class="flex flex-row items-center justify-end flex-1">
         <div class="pb-2 flex flex-row sort-dp-container">
           <mock-el-select size="default" value="" placeholder="Sort by" clearable="true">
-            <mock-el-option label="Popularity" value="ORDER_BY_POPULARITY"></mock-el-option>
-            <mock-el-option label="Last updated" value="ORDER_BY_DATE"></mock-el-option>
-            <mock-el-option label="Upload date" value="ORDER_BY_UP_DATE"></mock-el-option>
+            <mock-el-option label="Project size" value="ORDER_BY_POPULARITY"></mock-el-option>
+            <mock-el-option label="Creation date" value="ORDER_BY_DATE"></mock-el-option>
+            <mock-el-option label="Publication date" value="ORDER_BY_UP_DATE"></mock-el-option>
             <mock-el-option label="Project name" value="ORDER_BY_NAME"></mock-el-option>
             <mock-el-option label="Manager name" value="ORDER_BY_MANAGER_NAME"></mock-el-option>
             <mock-el-option label="Number of datasets" value="ORDER_BY_DATASETS_COUNT"></mock-el-option>
@@ -402,9 +402,9 @@ exports[`ProjectsListPage should match snapshot 1`] = `
       <div class="flex flex-row items-center justify-end flex-1">
         <div class="pb-2 flex flex-row sort-dp-container">
           <mock-el-select size="default" value="" placeholder="Sort by" clearable="true">
-            <mock-el-option label="Popularity" value="ORDER_BY_POPULARITY"></mock-el-option>
-            <mock-el-option label="Last updated" value="ORDER_BY_DATE"></mock-el-option>
-            <mock-el-option label="Upload date" value="ORDER_BY_UP_DATE"></mock-el-option>
+            <mock-el-option label="Project size" value="ORDER_BY_POPULARITY"></mock-el-option>
+            <mock-el-option label="Creation date" value="ORDER_BY_DATE"></mock-el-option>
+            <mock-el-option label="Publication date" value="ORDER_BY_UP_DATE"></mock-el-option>
             <mock-el-option label="Project name" value="ORDER_BY_NAME"></mock-el-option>
             <mock-el-option label="Manager name" value="ORDER_BY_MANAGER_NAME"></mock-el-option>
             <mock-el-option label="Number of datasets" value="ORDER_BY_DATASETS_COUNT"></mock-el-option>

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -52,6 +52,11 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
     </div>
   </mock-el-dialog>
   <div class="page-content">
+    <div class="flex flex-row items-center justify-end flex-1 w-full py-4"><button type="button" class="el-button el-button--primary el-button--small">
+        <!---->
+        <!----><span>
+        Create project
+      </span></button></div>
     <div class="header-row">
       <div class="filter-panel">
         <!---->
@@ -67,13 +72,26 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
           <!---->
         </div>
       </div>
-      <div style="flex-grow: 1;"></div> <button type="button" class="el-button el-button--default">
-        <!---->
-        <!----><span>
-        Create project
-      </span></button>
+      <div class="flex flex-row items-center justify-end flex-1">
+        <div class="pb-2 flex flex-row sort-dp-container">
+          <mock-el-select size="default" value="" placeholder="Sort by" clearable="true">
+            <mock-el-option label="Popularity" value="ORDER_BY_POPULARITY"></mock-el-option>
+            <mock-el-option label="Last updated" value="ORDER_BY_DATE"></mock-el-option>
+            <mock-el-option label="Upload date" value="ORDER_BY_UP_DATE"></mock-el-option>
+            <mock-el-option label="Project name" value="ORDER_BY_NAME"></mock-el-option>
+            <mock-el-option label="Manager name" value="ORDER_BY_MANAGER_NAME"></mock-el-option>
+            <mock-el-option label="Number of datasets" value="ORDER_BY_DATASETS_COUNT"></mock-el-option>
+            <mock-el-option label="Number of members" value="ORDER_BY_MEMBERS_COUNT"></mock-el-option>
+          </mock-el-select>
+          <div class="el-input-group__append sort-dp-btn">
+            <mock-el-tooltip content="Sorting order" placement="right"><button type="button" class="el-button el-button--default cursor-not-allowed">
+                <!----><i class="el-icon-sort"></i>
+                <!----></button></mock-el-tooltip>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="clearfix"></div>
+    <div style="" mock-v-loading="true" class="clearfix"></div>
     <div style="min-height: 100px;" mock-v-loading="false">
       <div class="project-item border border-solid border-gray-200 leading-5 relative rounded w-full p-5 box-border transition-shadow ease-in-out duration-200"><a href="/project/proj-one" class="underlay"></a>
         <div class="item-body">
@@ -198,6 +216,11 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
     </div>
   </mock-el-dialog>
   <div class="page-content">
+    <div class="flex flex-row items-center justify-end flex-1 w-full py-4"><button type="button" class="el-button el-button--primary el-button--small">
+        <!---->
+        <!----><span>
+        Create project
+      </span></button></div>
     <div class="header-row">
       <div class="filter-panel">
         <!---->
@@ -213,13 +236,26 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
           <!---->
         </div>
       </div>
-      <div style="flex-grow: 1;"></div> <button type="button" class="el-button el-button--default">
-        <!---->
-        <!----><span>
-        Create project
-      </span></button>
+      <div class="flex flex-row items-center justify-end flex-1">
+        <div class="pb-2 flex flex-row sort-dp-container">
+          <mock-el-select size="default" value="" placeholder="Sort by" clearable="true">
+            <mock-el-option label="Popularity" value="ORDER_BY_POPULARITY"></mock-el-option>
+            <mock-el-option label="Last updated" value="ORDER_BY_DATE"></mock-el-option>
+            <mock-el-option label="Upload date" value="ORDER_BY_UP_DATE"></mock-el-option>
+            <mock-el-option label="Project name" value="ORDER_BY_NAME"></mock-el-option>
+            <mock-el-option label="Manager name" value="ORDER_BY_MANAGER_NAME"></mock-el-option>
+            <mock-el-option label="Number of datasets" value="ORDER_BY_DATASETS_COUNT"></mock-el-option>
+            <mock-el-option label="Number of members" value="ORDER_BY_MEMBERS_COUNT"></mock-el-option>
+          </mock-el-select>
+          <div class="el-input-group__append sort-dp-btn">
+            <mock-el-tooltip content="Sorting order" placement="right"><button type="button" class="el-button el-button--default cursor-not-allowed">
+                <!----><i class="el-icon-sort"></i>
+                <!----></button></mock-el-tooltip>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="clearfix"></div>
+    <div style="" mock-v-loading="true" class="clearfix"></div>
     <div style="min-height: 100px;" mock-v-loading="false">
       <div class="project-item border border-solid border-gray-200 leading-5 relative rounded w-full p-5 box-border transition-shadow ease-in-out duration-200"><a href="/project/proj-one" class="underlay"></a>
         <div class="item-body">
@@ -343,6 +379,11 @@ exports[`ProjectsListPage should match snapshot 1`] = `
     </div>
   </mock-el-dialog>
   <div class="page-content">
+    <div class="flex flex-row items-center justify-end flex-1 w-full py-4"><button type="button" class="el-button el-button--primary el-button--small">
+        <!---->
+        <!----><span>
+        Create project
+      </span></button></div>
     <div class="header-row">
       <div class="filter-panel">
         <!---->
@@ -358,13 +399,26 @@ exports[`ProjectsListPage should match snapshot 1`] = `
           <!---->
         </div>
       </div>
-      <div style="flex-grow: 1;"></div> <button type="button" class="el-button el-button--default">
-        <!---->
-        <!----><span>
-        Create project
-      </span></button>
+      <div class="flex flex-row items-center justify-end flex-1">
+        <div class="pb-2 flex flex-row sort-dp-container">
+          <mock-el-select size="default" value="" placeholder="Sort by" clearable="true">
+            <mock-el-option label="Popularity" value="ORDER_BY_POPULARITY"></mock-el-option>
+            <mock-el-option label="Last updated" value="ORDER_BY_DATE"></mock-el-option>
+            <mock-el-option label="Upload date" value="ORDER_BY_UP_DATE"></mock-el-option>
+            <mock-el-option label="Project name" value="ORDER_BY_NAME"></mock-el-option>
+            <mock-el-option label="Manager name" value="ORDER_BY_MANAGER_NAME"></mock-el-option>
+            <mock-el-option label="Number of datasets" value="ORDER_BY_DATASETS_COUNT"></mock-el-option>
+            <mock-el-option label="Number of members" value="ORDER_BY_MEMBERS_COUNT"></mock-el-option>
+          </mock-el-select>
+          <div class="el-input-group__append sort-dp-btn">
+            <mock-el-tooltip content="Sorting order" placement="right"><button type="button" class="el-button el-button--default cursor-not-allowed">
+                <!----><i class="el-icon-sort"></i>
+                <!----></button></mock-el-tooltip>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="clearfix"></div>
+    <div style="" mock-v-loading="true" class="clearfix"></div>
     <div style="min-height: 100px;" mock-v-loading="false">
       <div class="project-item border border-solid border-gray-200 leading-5 relative rounded w-full p-5 box-border transition-shadow ease-in-out duration-200"><a href="/project/proj-one" class="underlay"></a>
         <div class="item-body">


### PR DESCRIPTION
### Description

In order to improve user experience, an option to sort the project list like the one existing in dataset list page must be added.
#831 

#### Changes

##### Front end

###### Project list page
- [x] Added "SortDropDown" component
- [x] Changed filter/create button disposition on page
- [x] Changed Create button to highlight/differentiate it from "SortDropDown" component
- [x] Sort projects by:   ORDER_BY_DATE, ORDER_BY_POPULARITY, ORDER_BY_NAME, ORDER_BY_UP_DATE,  ORDER_BY_MANAGER_NAME, ORDER_BY_DATASETS_COUNT and ORDER_BY_MEMBERS_COUNT.
 
##### Graphql

######  Projects
- [x] Added orderBy parameter to allProjects query
- [x] Added sortingOrder parameter to allProjects query

 #### Tests
 
 ##### Graphql
 
- [x] Unit Test
 
 ###### Browsers and resolutions
- [x] Chrome
- [x]  Safari
- [x] sm, md, lg, xl, lg

![image](https://user-images.githubusercontent.com/35172605/117299304-c32b2980-ae4e-11eb-9d8a-b8665beec990.png)




