### PR TITLE
SMInstance.submit_dataset changes

### DIFF
--- a/metaspace/python-client/docs/source/content/examples/submit-dataset.ipynb
+++ b/metaspace/python-client/docs/source/content/examples/submit-dataset.ipynb
@@ -152,20 +152,52 @@
    },
    "outputs": [],
    "source": [
-    "# Available databases:\n",
-    "# Please notice that if you choose more than 3 databases the processing may take a while\n",
-    "\n",
-    "# BraChemDB-2018-01\n",
-    "# ChEBI-2018-01\n",
-    "# HMDB-v2.5\n",
-    "# HMDB-v4\n",
-    "# HMDB-v4-cotton\n",
-    "# LipidMaps-2017-12-12\n",
-    "# PAMDB-v1.0\n",
-    "# SwissLipids-2018-02-02\n",
-    "\n",
-    "databases = ['HMDB-v4', 'ChEBI-2018-01']"
+    "# Get list of available databases:\n",
+    "print(sm.databases())"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Public databases:\n",
+    "```\n",
+    "[<18:BraChemDB:2018-01>,\n",
+    " <19:ChEBI:2018-01>,\n",
+    " <22:HMDB:v4>,\n",
+    " <23:HMDB-endogenous:v4>,\n",
+    " <24:LipidMaps:2017-12-12>,\n",
+    " <25:PAMDB:v1.0>,\n",
+    " <26:SwissLipids:2018-02-02>,\n",
+    " <27:HMDB-cotton:v4>,\n",
+    " <33:ECMDB:2018-12>,\n",
+    " <38:CoreMetabolome:v3>]\n",
+    "```"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Databases may be specified either as an integer ID, or in ('name', 'version') form\n",
+    "# Please notice that if you choose more than 3 databases the processing may take a while\n",
+    "databases = [\n",
+    "    22,  # ID 22 corresponds to HMDB v4\n",
+    "    ('ChEBI', '2018-01'), # ('name', 'version') style is also accepted\n",
+    "]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
@@ -220,7 +252,7 @@
    "source": [
     "sm.submit_dataset(\n",
     "    imzml_fn, ibd_fn, dataset_name,\n",
-    "    json.dumps(metadata), is_public, databases\n",
+    "    metadata, is_public, databases\n",
     ")"
    ]
   },
@@ -229,7 +261,7 @@
    "metadata": {},
    "source": [
     "- In case of successful submission, you should see the Dataset ID like `2021-01-01_10h11m12s`.\n",
-    "Go to [metaspace](https://metaspace2020.eu) to check your annotations!\n",
+    "Go to [METASPACE](https://metaspace2020.eu) to check your annotations!\n",
     "\n",
     "- If you get `KeyError: 'errors'` make sure that you provided API token and try it again\n",
     "\n",

--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.8.7'
+__version__ = '1.8.8'
 
 from metaspace.sm_annotation_utils import (
     SMInstance,

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -250,13 +250,15 @@ def _dataset_upload(imzml_fn, ibd_fn, companion_url):
 
 def _str_to_tiptap_markup(text):
     """Convert a plain text string into a TipTap-compatible markup structure"""
-    return json.dumps({
-        'type': 'doc',
-        'content': [
-            {'type': 'paragraph', 'content': [{'type': 'text', 'text': paragraph}]}
-            for paragraph in text.split('\n\n')
-        ]
-    })
+    return json.dumps(
+        {
+            'type': 'doc',
+            'content': [
+                {'type': 'paragraph', 'content': [{'type': 'text', 'text': paragraph}]}
+                for paragraph in text.split('\n\n')
+            ],
+        }
+    )
 
 
 class GraphQLClient(object):
@@ -1538,24 +1540,26 @@ class SMInstance(object):
             assert imzml_fn and ibd_fn, 'imzml_fn and ibd_fn must be supplied'
             input_path = _dataset_upload(imzml_fn, ibd_fn, self._config['dataset_upload_url'])
 
-        graphql_response = self._gqclient.create_dataset({
-            'name': name,
-            'inputPath': input_path,
-            'description': description_json,
-            'metadataJson': json.dumps(metadata),
-            'databaseIds': database_ids,
-            'adducts': adducts,
-            'neutralLosses': neutral_losses,
-            'chemMods': chem_mods,
-            'ppm': ppm,
-            'numPeaks': num_isotopic_peaks,
-            'decoySampleSize': decoy_sample_size,
-            'analysisVersion': analysis_version,
-            'submitterId': current_user_id,
-            'groupId': primary_group_id,
-            'projectIds': project_ids,
-            'isPublic': is_public,
-        })
+        graphql_response = self._gqclient.create_dataset(
+            {
+                'name': name,
+                'inputPath': input_path,
+                'description': description_json,
+                'metadataJson': json.dumps(metadata),
+                'databaseIds': database_ids,
+                'adducts': adducts,
+                'neutralLosses': neutral_losses,
+                'chemMods': chem_mods,
+                'ppm': ppm,
+                'numPeaks': num_isotopic_peaks,
+                'decoySampleSize': decoy_sample_size,
+                'analysisVersion': analysis_version,
+                'submitterId': current_user_id,
+                'groupId': primary_group_id,
+                'projectIds': project_ids,
+                'isPublic': is_public,
+            }
+        )
         return json.loads(graphql_response)['datasetId']
 
     def update_dataset_dbs(self, dataset_id, molDBs=None, adducts=None):

--- a/metaspace/python-client/metaspace/tests/test_sm_instance.py
+++ b/metaspace/python-client/metaspace/tests/test_sm_instance.py
@@ -111,7 +111,7 @@ def test_submit_dataset_clone(sm: SMInstance, my_ds_id, metadata):
         decoy_sample_size=10,
         analysis_version=2,
         input_path=sm.dataset(id=my_ds_id)._info['inputPath'],
-        description='Test description\nNew line\n\nNew paragraph [{"\\escape characters'
+        description='Test description\nNew line\n\nNew paragraph [{"\\escape characters',
     )
 
     new_ds = sm.dataset(id=new_ds_id)
@@ -128,7 +128,6 @@ def test_submit_dataset_clone(sm: SMInstance, my_ds_id, metadata):
     assert new_ds.config['isotope_generation']['chem_mods'] == ['+CO2']
     assert new_ds.config['fdr']['decoy_sample_size'] == 10
     assert new_ds.config['image_generation']['ppm'] == 2
-
 
 
 def test_update_dataset_without_reprocessing(sm: SMInstance, my_ds_id):

--- a/metaspace/python-client/metaspace/tests/test_sm_instance.py
+++ b/metaspace/python-client/metaspace/tests/test_sm_instance.py
@@ -1,10 +1,13 @@
 import time
 from copy import deepcopy
+from pathlib import Path
 
 import pytest
 
 from metaspace import SMInstance
-from metaspace.tests.utils import sm, my_ds_id
+from metaspace.tests.utils import sm, my_ds_id, metadata
+
+TEST_DATA_PATH = str((Path(__file__).parent / '../../../engine/tests/data').resolve())
 
 
 def test_add_dataset_external_link(sm, my_ds_id):
@@ -69,6 +72,63 @@ def test_datasets_by_all_fields(sm: SMInstance):
         organism='Human',
         organismPart='Cells',
     )
+
+
+def test_submit_dataset(sm: SMInstance, metadata):
+    time.sleep(1)  # Ensure no more than 1 DS per second is submitted to prevent errors
+
+    new_ds_id = sm.submit_dataset(
+        f'{TEST_DATA_PATH}/untreated/Untreated_3_434.imzML',
+        f'{TEST_DATA_PATH}/untreated/Untreated_3_434.ibd',
+        'Test dataset',
+        metadata,
+        False,
+    )
+
+    new_ds = sm.dataset(id=new_ds_id)
+    assert new_ds.name == 'Test dataset'
+    assert new_ds.polarity == 'Positive'
+    assert set(new_ds.adducts) == {'+H', '+Na', '+K'}  # Ensure defaults were added
+
+
+def test_submit_dataset_clone(sm: SMInstance, my_ds_id, metadata):
+    time.sleep(1)  # Ensure no more than 1 DS per second is submitted to prevent errors
+
+    project_id = sm.projects.get_all_projects()[0]['id']
+    new_ds_id = sm.submit_dataset(
+        None,
+        None,
+        'Test clone dataset',
+        metadata,
+        False,
+        [22, ('ChEBI', '2018-01')],
+        project_ids=[project_id],
+        adducts=['[M]+'],
+        neutral_losses=['-H2O'],
+        chem_mods=['+CO2'],
+        ppm=2,
+        num_isotopic_peaks=2,
+        decoy_sample_size=10,
+        analysis_version=2,
+        input_path=sm.dataset(id=my_ds_id)._info['inputPath'],
+        description='Test description\nNew line\n\nNew paragraph [{"\\escape characters'
+    )
+
+    new_ds = sm.dataset(id=new_ds_id)
+    assert new_ds.name == 'Test clone dataset'
+    assert new_ds.polarity == 'Positive'
+    assert new_ds.adducts == ['[M]+']
+
+    dbs = [dd['name'] for dd in new_ds.database_details]
+    assert 'HMDB' in dbs
+    assert 'ChEBI' in dbs
+    assert new_ds.config['analysis_version'] == 2
+    assert new_ds.config['isotope_generation']['n_peaks'] == 2
+    assert new_ds.config['isotope_generation']['neutral_losses'] == ['-H2O']
+    assert new_ds.config['isotope_generation']['chem_mods'] == ['+CO2']
+    assert new_ds.config['fdr']['decoy_sample_size'] == 10
+    assert new_ds.config['image_generation']['ppm'] == 2
+
 
 
 def test_update_dataset_without_reprocessing(sm: SMInstance, my_ds_id):

--- a/metaspace/python-client/metaspace/tests/utils.py
+++ b/metaspace/python-client/metaspace/tests/utils.py
@@ -29,3 +29,36 @@ def advanced_ds_id(sm):
     )
     assert annotations, 'TEST SETUP: Process a dataset with a -H2O neutral loss and -H+C chem mod'
     return annotations[0]['dataset']['id']
+
+
+@pytest.fixture()
+def metadata():
+    return {
+        'Data_Type': 'Imaging MS',
+        'Sample_Information': {
+            'Organism': 'Species',
+            'Organism_Part': 'Organ or organism part',
+            'Condition': 'E.g. wildtype, diseased',
+            'Sample_Growth_Conditions': 'E.g. intervention, treatment'
+        },
+        'Sample_Preparation': {
+            'Sample_Stabilisation': 'Preservation method',
+            'Tissue_Modification': 'E.g. chemical modification',
+            'MALDI_Matrix': '2,5-dihydroxybenzoic acid (DHB)',
+            'MALDI_Matrix_Application': 'ImagePrep',
+            'Solvent': 'none'
+        },
+        'MS_Analysis': {
+            'Polarity': 'Positive',
+            'Ionisation_Source': 'E.g. MALDI, DESI',
+            'Analyzer': 'E.g. FTICR, Orbitrap',
+            'Detector_Resolving_Power': {
+                'mz': 400,
+                'Resolving_Power': 130000
+            },
+            'Pixel_Size': {
+                'Xaxis': 20,
+                'Yaxis': 40
+            }
+        }
+    }

--- a/metaspace/python-client/metaspace/tests/utils.py
+++ b/metaspace/python-client/metaspace/tests/utils.py
@@ -39,26 +39,20 @@ def metadata():
             'Organism': 'Species',
             'Organism_Part': 'Organ or organism part',
             'Condition': 'E.g. wildtype, diseased',
-            'Sample_Growth_Conditions': 'E.g. intervention, treatment'
+            'Sample_Growth_Conditions': 'E.g. intervention, treatment',
         },
         'Sample_Preparation': {
             'Sample_Stabilisation': 'Preservation method',
             'Tissue_Modification': 'E.g. chemical modification',
             'MALDI_Matrix': '2,5-dihydroxybenzoic acid (DHB)',
             'MALDI_Matrix_Application': 'ImagePrep',
-            'Solvent': 'none'
+            'Solvent': 'none',
         },
         'MS_Analysis': {
             'Polarity': 'Positive',
             'Ionisation_Source': 'E.g. MALDI, DESI',
             'Analyzer': 'E.g. FTICR, Orbitrap',
-            'Detector_Resolving_Power': {
-                'mz': 400,
-                'Resolving_Power': 130000
-            },
-            'Pixel_Size': {
-                'Xaxis': 20,
-                'Yaxis': 40
-            }
-        }
+            'Detector_Resolving_Power': {'mz': 400, 'Resolving_Power': 130000},
+            'Pixel_Size': {'Xaxis': 20, 'Yaxis': 40},
+        },
     }


### PR DESCRIPTION
* Added most available graphql parameters to `SMInstance.submit_dataset`
    * I renamed several parameters to names that are used elsewhere in python-client (`mol_dbs` -> `databases`, `dataset_name` -> `name`). 
    * I moved a lot of logic out of `GraphQLClient.submit_dataset` because there were too many variables to pass through, and I generally don't think any "business logic" should be in `GraphQLClient`
    * I changed the docstring to use `:param:`s for consistency with the rest of the file, and because they're easier to work with with Sphinx docs
    * I made `metadata` accept either a JSON string or dict, as previously discussed
    * I made most optional parameters keyword-only arguments, because having so many positional arguments can be a huge pain in the future for keeping backwards compatibility when adding/removing arguments
* Fixed the instructions for specifying which database to use in the example notebook. I also sorted `SMInstance.databases` by ID to make this tidier
* Added support for uploading databases/datasets to Minio