### PR TITLE
Bug/project manage datasets

### DIFF
--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -298,11 +298,6 @@ type Query {
               filter: DatasetFilter = {}, simpleQuery: String,
               offset: Int = 0, limit: Int = 10): [Dataset!]
 
-  allProjectDatasets(orderBy: DatasetOrderBy = ORDER_BY_DATE,
-              sortingOrder: SortingOrder = DESCENDING,
-              filter: DatasetFilter = {}, simpleQuery: String
-  ): [Dataset!]
-
   countDatasets(filter: DatasetFilter = {}, simpleQuery: String): Int!
 
   countDatasetsPerGroup(query: DatasetCountPerGroupInput!): DatasetCountPerGroup!

--- a/metaspace/graphql/src/modules/dataset/controller/Query.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Query.ts
@@ -43,15 +43,6 @@ const QueryResolvers: FieldResolversFor<Query, void> = {
     return await esSearchResults(filteredArgs, 'dataset', ctx.user)
   },
 
-  async allProjectDatasets(source, args, ctx): Promise<DatasetSource[]> {
-    const { args: filteredArgs } = await applyQueryFilters(ctx, {
-      ...args,
-      datasetFilter: args.filter,
-      filter: {},
-    })
-    return await esSearchResults(filteredArgs, 'dataset', ctx.user)
-  },
-
   async countDatasets(source, args, ctx): Promise<number> {
     const { args: filteredArgs } = await applyQueryFilters(ctx, {
       ...args,

--- a/metaspace/graphql/src/modules/project/controller/Mutation.ts
+++ b/metaspace/graphql/src/modules/project/controller/Mutation.ts
@@ -217,7 +217,7 @@ const MutationResolvers: FieldResolversFor<Mutation, void> = {
     removedDatasetIds,
   }, ctx: Context): Promise<boolean> {
     const userProjectRole = (await ctx.user.getProjectRoles())[projectId]
-    if (userProjectRole == null) {
+    if (userProjectRole == null && !ctx.isAdmin) {
       throw new UserError('Not a member of project')
     }
 
@@ -237,7 +237,7 @@ const MutationResolvers: FieldResolversFor<Mutation, void> = {
           projectId, userProjectRole, true)
       }))
 
-      const approved = [UPRO.MEMBER, UPRO.MANAGER].includes(userProjectRole)
+      const approved = ([UPRO.MEMBER, UPRO.MANAGER].includes(userProjectRole) || ctx.isAdmin)
       await updateProjectDatasets(ctx, projectId, (datasetIds || []), (removedDatasetIds || []),
         approved, false)
     }

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -169,15 +169,6 @@ export const datasetListItemsQuery =
     }
   }`
 
-export const projectDatasetListItemsQuery =
-  gql`query GetProjectDatasets($dFilter: DatasetFilter, $query: String) {
-    allProjectDatasets(filter: $dFilter, simpleQuery: $query) {
-      id
-      name
-      uploadDT
-    }
-  }`
-
 export type OpticalImageType = 'SCALED' | 'CLIPPED_TO_ION_IMAGE';
 
 export interface OpticalImage {

--- a/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.spec.ts
+++ b/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.spec.ts
@@ -35,17 +35,6 @@ describe('ProjectDatasetsDialog', () => {
   const graphqlWithData = () => {
     initMockGraphqlClient({
       Query: () => ({
-        allProjectDatasets: () => {
-          return [{
-            id: '2021-03-31_11h02m28s',
-            name: 'New 3 (1)',
-            uploadDT: '2021-03-31T14:02:28.722Z',
-          }, {
-            id: '2021-03-30_18h25m18s',
-            name: 'Untreated_3_434_super_lite_19_31 (1)',
-            uploadDT: '2021-03-30T21:25:18.473Z',
-          }]
-        },
         allDatasets: () => {
           return [{
             id: '2021-03-31_11h02m28s',
@@ -71,16 +60,6 @@ describe('ProjectDatasetsDialog', () => {
     })
   }
 
-  const graphqlProjectDsWithNoData = () => {
-    initMockGraphqlClient({
-      Query: () => ({
-        allProjectDatasets: () => {
-          return []
-        },
-      }),
-    })
-  }
-
   it('it should match snapshot', async() => {
     graphqlWithData()
     const wrapper = mount(testHarness, { store, router, apolloProvider, propsData })
@@ -91,7 +70,6 @@ describe('ProjectDatasetsDialog', () => {
 
   it('it should match no dataset snapshot', async() => {
     graphqlWithNoData()
-    graphqlProjectDsWithNoData()
     const wrapper = mount(testHarness, { store, router, apolloProvider, propsData })
     await Vue.nextTick()
 
@@ -100,7 +78,6 @@ describe('ProjectDatasetsDialog', () => {
 
   it('it should have disabled update button when no data available', async() => {
     graphqlWithNoData()
-    graphqlProjectDsWithNoData()
     const wrapper = mount(testHarness, { store, router, apolloProvider, propsData })
     await Vue.nextTick()
 
@@ -168,7 +145,6 @@ describe('ProjectDatasetsDialog', () => {
 
   it('it should check one dataset and hit update', async() => {
     graphqlWithData()
-    graphqlProjectDsWithNoData()
 
     const wrapper = mount(testHarness, {
       store,
@@ -189,23 +165,23 @@ describe('ProjectDatasetsDialog', () => {
     expect(wrapper.find('.el-button--primary').props('disabled')).toBe(false)
   })
 
-  it('it should uncheck one dataset and hit update', async() => {
-    graphqlWithData()
-
-    const wrapper = mount(testHarness, {
-      store,
-      router,
-      apolloProvider,
-      propsData,
-    })
-    await Vue.nextTick()
-
-    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(true)
-    expect(wrapper.findAll('.el-checkbox').at(0).classes('is-checked')).toBe(true)
-    wrapper.findAll('.el-checkbox').at(0).trigger('click')
-    await Vue.nextTick()
-
-    expect(wrapper.findAll('.el-checkbox').at(0).classes('is-checked')).toBe(false)
-    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(false)
-  })
+  // it('it should uncheck one dataset and hit update', async() => {
+  //   graphqlWithData()
+  //
+  //   const wrapper = mount(testHarness, {
+  //     store,
+  //     router,
+  //     apolloProvider,
+  //     propsData,
+  //   })
+  //   await Vue.nextTick()
+  //
+  //   expect(wrapper.find('.el-button--primary').props('disabled')).toBe(true)
+  //   expect(wrapper.findAll('.el-checkbox').at(0).classes('is-checked')).toBe(true)
+  //   wrapper.findAll('.el-checkbox').at(0).trigger('click')
+  //   await Vue.nextTick()
+  //
+  //   expect(wrapper.findAll('.el-checkbox').at(0).classes('is-checked')).toBe(false)
+  //   expect(wrapper.find('.el-button--primary').props('disabled')).toBe(false)
+  // })
 })

--- a/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.spec.ts
+++ b/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.spec.ts
@@ -49,6 +49,27 @@ describe('ProjectDatasetsDialog', () => {
       }),
     })
   }
+  const graphqlWithExtraUserData = () => {
+    initMockGraphqlClient({
+      Query: () => ({
+        allDatasets: (src: any, { filter: { project } } : any) => {
+          if (project) {
+            return []
+          }
+
+          return [{
+            id: '2021-03-31_11h02m28s',
+            name: 'New 3 (1)',
+            uploadDT: '2021-03-31T14:02:28.722Z',
+          }, {
+            id: '2021-03-30_18h25m18s',
+            name: 'Untreated_3_434_super_lite_19_31 (1)',
+            uploadDT: '2021-03-30T21:25:18.473Z',
+          }]
+        },
+      }),
+    })
+  }
 
   const graphqlWithNoData = () => {
     initMockGraphqlClient({
@@ -144,7 +165,7 @@ describe('ProjectDatasetsDialog', () => {
   })
 
   it('it should check one dataset and hit update', async() => {
-    graphqlWithData()
+    graphqlWithExtraUserData()
 
     const wrapper = mount(testHarness, {
       store,
@@ -165,23 +186,23 @@ describe('ProjectDatasetsDialog', () => {
     expect(wrapper.find('.el-button--primary').props('disabled')).toBe(false)
   })
 
-  // it('it should uncheck one dataset and hit update', async() => {
-  //   graphqlWithData()
-  //
-  //   const wrapper = mount(testHarness, {
-  //     store,
-  //     router,
-  //     apolloProvider,
-  //     propsData,
-  //   })
-  //   await Vue.nextTick()
-  //
-  //   expect(wrapper.find('.el-button--primary').props('disabled')).toBe(true)
-  //   expect(wrapper.findAll('.el-checkbox').at(0).classes('is-checked')).toBe(true)
-  //   wrapper.findAll('.el-checkbox').at(0).trigger('click')
-  //   await Vue.nextTick()
-  //
-  //   expect(wrapper.findAll('.el-checkbox').at(0).classes('is-checked')).toBe(false)
-  //   expect(wrapper.find('.el-button--primary').props('disabled')).toBe(false)
-  // })
+  it('it should uncheck one dataset and hit update', async() => {
+    graphqlWithData()
+
+    const wrapper = mount(testHarness, {
+      store,
+      router,
+      apolloProvider,
+      propsData,
+    })
+    await Vue.nextTick()
+
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(true)
+    expect(wrapper.findAll('.el-checkbox').at(0).classes('is-checked')).toBe(true)
+    wrapper.findAll('.el-checkbox').at(0).trigger('click')
+    await Vue.nextTick()
+
+    expect(wrapper.findAll('.el-checkbox').at(0).classes('is-checked')).toBe(false)
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(false)
+  })
 })

--- a/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.tsx
+++ b/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.tsx
@@ -3,7 +3,7 @@ import { importDatasetsIntoProjectMutation, ProjectsListProject } from '../../ap
 import { Dialog, Checkbox, Button } from '../../lib/element-ui'
 import { uniqBy, isEmpty } from 'lodash'
 import './ProjectDatasetsDialog.scss'
-import { DatasetListItem, datasetListItemsQuery, projectDatasetListItemsQuery } from '../../api/dataset'
+import { DatasetListItem, datasetListItemsQuery } from '../../api/dataset'
 import { useQuery } from '@vue/apollo-composable'
 import ElapsedTime from '../../components/ElapsedTime'
 import reportError from '../../lib/reportError'
@@ -79,15 +79,15 @@ export const ProjectDatasetsDialog = defineComponent<ProjectDatasetsDialogProps>
     const {
       result: projectDatasetsResult,
       loading: loadingProjectDatasets,
-    } = useQuery<{allProjectDatasets: DatasetListItem[]}>(projectDatasetListItemsQuery,
+    } = useQuery<{allDatasets: DatasetListItem[]}>(datasetListItemsQuery,
       () => ({ dFilter: { project: props.project?.id } }))
     const projectDatasets = computed(() => {
       if (isEmpty(state.selectedDatasets)) {
-        state.selectedDatasets = getProjectDatasets(projectDatasetsResult.value?.allProjectDatasets)
+        state.selectedDatasets = getProjectDatasets(projectDatasetsResult.value?.allDatasets)
       }
 
       return projectDatasetsResult.value != null
-        ? projectDatasetsResult.value.allProjectDatasets as DatasetListItem[] : null
+        ? projectDatasetsResult.value.allDatasets as DatasetListItem[] : null
     })
 
     const handleClose = () => {

--- a/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.tsx
+++ b/metaspace/webapp/src/modules/Project/ProjectDatasetsDialog.tsx
@@ -79,6 +79,7 @@ export const ProjectDatasetsDialog = defineComponent<ProjectDatasetsDialogProps>
     const {
       result: projectDatasetsResult,
       loading: loadingProjectDatasets,
+      refetch: projectDatasetsRefetch,
     } = useQuery<{allDatasets: DatasetListItem[]}>(datasetListItemsQuery,
       () => ({ dFilter: { project: props.project?.id } }))
     const projectDatasets = computed(() => {
@@ -144,6 +145,7 @@ export const ProjectDatasetsDialog = defineComponent<ProjectDatasetsDialogProps>
           })
         }
         await props.refreshData()
+        await projectDatasetsRefetch()
         emit('update')
       } catch (err) {
         reportError(err)

--- a/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
+++ b/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
@@ -331,9 +331,9 @@ export default class ViewProjectPage extends Vue {
     get currentUserId(): string | null { return this.currentUser && this.currentUser.id }
     get roleInProject(): ProjectRole | null { return this.project && this.project.currentUserRole }
     get showManageDataset(): boolean {
-      const canEditRole = (this.project?.currentUserRole === ProjectRoleOptions.MANAGER
-        || this.project?.currentUserRole === ProjectRoleOptions.MEMBER)
-      return !!(this.currentUser?.id
+      const canEditRole = this.currentUser && (this.project?.currentUserRole === ProjectRoleOptions.MANAGER
+        || this.project?.currentUserRole === ProjectRoleOptions.MEMBER || this.currentUser.role === 'admin')
+      return !!(this.currentUser && this.currentUser.id
         && canEditRole && this.$route?.query?.tab === 'datasets')
     }
 
@@ -427,7 +427,8 @@ export default class ViewProjectPage extends Vue {
     }
 
     get isManager() {
-      return this.roleInProject === ProjectRoleOptions.MANAGER
+      return this.currentUser
+        && (this.roleInProject === ProjectRoleOptions.MANAGER || this.currentUser.role === 'admin')
     }
 
     get countHiddenMembers() {

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectDatasetsDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectDatasetsDialog.spec.ts.snap
@@ -8,10 +8,8 @@ exports[`ProjectDatasetsDialog it should match no dataset snapshot 1`] = `
       <div class="el-dialog__body">
         <div class="mt-6">
           <h4 class="m-0">Would you like to include/remove previously submitted datasets?</h4>
-          <div class="dataset-checkbox-list leading-6">
-            <div class="mb-2"><span class="select-link">Select none</span><span> | </span><span class="select-link">Select all</span></div><label class="el-checkbox flex h-6 items-center m-0 mx-2"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="allDatasets.0.name"></span><span class="el-checkbox__label"><span class="truncate">allDatasets.0.name</span><span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="allDatasets.0.uploadDT"></mock-elapsed-time></span>
-              <!----></span></label><label class="el-checkbox flex h-6 items-center m-0 mx-2"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value="allDatasets.1.name"></span><span class="el-checkbox__label"><span class="truncate">allDatasets.1.name</span><span class="text-gray-700 text-xs tracking-wide pl-1"><mock-elapsed-time date="allDatasets.1.uploadDT"></mock-elapsed-time></span>
-              <!----></span></label>
+          <div class="flex items-center justify-center leading-6">
+            <div>No datasets available</div>
           </div>
           <div class="button-bar"><button type="button" class="el-button el-button--default">
               <!---->


### PR DESCRIPTION
### Description

In order to show all the projects datasets, the project "Manage datasets" dialog query should get all the project datasets and not only the paginated ones.
#848 #807

#### Changes

##### Front end

###### ProjectDatasetsDialog
- [x] Stopped using allProjectDatasets query and started using only allDatasets as suggested on the last PR review
- [x] Showing all project datasets without pagination limit
- [x] Refetching project datasets when updated


###### ViewProjectPage
- [x] Enabled admin user with manager powers
- [x] Hid "Manage datasets" button from users that are not logged
- [x] Started showing  "Manage datasets" to admin users


##### Graphql

######  Dataset
- [x] Stopped using allProjectDatasets query and started using only allDatasets as suggested on the last PR review
- [x] Enabled datasets adding/removing for users with admin profile
 
 #### Tests
 
 ##### Front end
 
- [x] Unit Test
- [ ] e2e Test
 
 ###### Browsers and resolutions
- [x] Chrome
- [x]  Safari
- [x] sm, md, lg, xl, lg


