### PR TITLE
Feat/group projects filter persist

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
@@ -110,6 +110,7 @@ import updateApolloCache, { removeDatasetFromAllDatasetsQuery } from '../../../l
 import { merge, orderBy, pick } from 'lodash-es'
 import { formatDatabaseLabel } from '../../MolecularDatabases//formatting'
 import { datasetOwnerOptions } from '../../../lib/filterTypes'
+import { getLocalStorage } from '../../../lib/localStorage'
 
 const extractGroupedStatusCounts = (data) => {
   const counts = {
@@ -169,14 +170,23 @@ export default Vue.extend({
       return true
     },
     setDatasetOwnerOptions() {
+      if (!this.currentUser) {
+        return null
+      }
+
+      // due to some misbehaviour from setting initial value from getLocalstorage with null values
+      // on filterSpecs, the filter is being initialized here if user is logged
+      const localDsOwner = this.$store.getters.filter.datasetOwner
+        ? this.$store.getters.filter.datasetOwner : (getLocalStorage('datasetOwner') || null)
+      this.$store.commit('updateFilter', { ...this.$store.getters.filter, datasetOwner: localDsOwner })
+
       if (this.currentUser && Array.isArray(this.currentUser.groups)) {
         const groups = this.currentUser.groups
           .map((userGroup) => { return { isGroup: true, ...userGroup.group } })
         return datasetOwnerOptions.concat(groups)
-      } else if (this.currentUser) {
-        return datasetOwnerOptions
       }
-      return null
+
+      return datasetOwnerOptions
     },
     queryVariables() {
       return {

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DatasetTable should be able to export a CSV 1`] = `
-"# URL: http://localhost/
+"# URL: http://localhost/?ds_owner
 \\"datasetId\\",\\"datasetName\\",\\"group\\",\\"submitter\\",\\"PI\\",\\"organism\\",\\"organismPart\\",\\"condition\\",\\"growthConditions\\",\\"ionisationSource\\",\\"maldiMatrix\\",\\"analyzer\\",\\"resPower400\\",\\"polarity\\",\\"uploadDateTime\\",\\"FDR@10%\\",\\"database\\",\\"opticalImage\\"
 \\"FINISHED1\\",\\"datasets.0.name\\",\\"datasets.0.group.shortName\\",\\"datasets.0.submitter.name\\",\\"datasets.0.group.adminNames, datasets.0.group.adminNames\\",\\"datasets.0.organism\\",\\"datasets.0.organismPart\\",\\"datasets.0.condition\\",\\"datasets.0.growthConditions\\",\\"datasets.0.ionisationSource\\",\\"datasets.0.maldiMatrix\\",\\"datasets.0.analyzer.type\\",\\"13\\",\\"positive\\",\\"datasets.0.uploadDateTime\\",\\"20\\",\\"HMDB - v2.5\\",\\"http://localhostdatasets.0.rawOpticalImageUrl\\"
 \\"FINISHED2\\",\\"datasets.1.name\\",\\"\\",\\"datasets.1.submitter.name\\",\\"\\",\\"datasets.1.organism\\",\\"datasets.1.organismPart\\",\\"datasets.1.condition\\",\\"datasets.1.growthConditions\\",\\"datasets.1.ionisationSource\\",\\"datasets.1.maldiMatrix\\",\\"datasets.1.analyzer.type\\",\\"13\\",\\"positive\\",\\"datasets.1.uploadDateTime\\",\\"20\\",\\"HMDB - v2.5\\",\\"http://localhostdatasets.1.rawOpticalImageUrl\\"
@@ -77,14 +77,32 @@ exports[`DatasetTable should match snapshot 1`] = `
       />
       <mock-el-option
         label="Select data type"
-        value="datasetOwner"
-      />
-      <mock-el-option
-        label="Select data type"
         value="metadataType"
       />
     </mock-el-select>
      
+    <mock-el-select
+      class="filter-select"
+      data-test-key="datasetOwner"
+      filter-key="datasetOwner"
+    >
+      <mock-el-option
+        label="All datasets"
+      />
+      <mock-el-option
+        label="My datasets"
+        value="my-datasets"
+      />
+      <mock-el-option
+        label="currentUser.groups.0.group.label"
+        value="currentUser.groups.0.group.value"
+      />
+      <mock-el-option
+        label="currentUser.groups.1.group.label"
+        value="currentUser.groups.1.group.value"
+      />
+       
+    </mock-el-select>
   </div>
    
   <div>

--- a/metaspace/webapp/src/modules/Filters/FilterPanel.vue
+++ b/metaspace/webapp/src/modules/Filters/FilterPanel.vue
@@ -31,6 +31,7 @@
 <script>
 import { FILTER_COMPONENT_PROPS, FILTER_SPECIFICATIONS } from './filterSpecs'
 import { isFunction, pick, get, uniq } from 'lodash-es'
+import { setLocalStorage } from '../../lib/localStorage'
 
 const orderedFilterKeys = [
   'database',
@@ -208,6 +209,18 @@ const FilterPanel = {
               extraUpdatesAux.datasetOwner = null
             } else if (filterKey === 'datasetOwner' && submitter !== undefined && val === 'my-datasets') {
               extraUpdatesAux.submitter = undefined
+            }
+
+            // update datasetOwner settings
+            if (filterKey === 'datasetOwner' || ('datasetOwner' in extraUpdatesAux)) {
+              const dsValue = ('datasetOwner' in extraUpdatesAux)
+                ? extraUpdatesAux.datasetOwner : val
+              setLocalStorage(filterKey, dsValue)
+            }
+
+            // update simpleFilter settings
+            if (filterKey === 'simpleFilter') {
+              setLocalStorage(filterKey, val)
             }
 
             this.$store.commit('updateFilter',

--- a/metaspace/webapp/src/modules/Project/ProjectsListPage.vue
+++ b/metaspace/webapp/src/modules/Project/ProjectsListPage.vue
@@ -106,6 +106,8 @@ import { SortDropdown } from '../../components/SortDropdown/SortDropdown'
             query: this.query,
             offset: (this.page - 1) * this.pageSize,
             limit: this.pageSize,
+            orderBy: this.orderBy,
+            sortingOrder: this.sortingOrder,
           }
         },
       },

--- a/metaspace/webapp/src/modules/Project/ProjectsListPage.vue
+++ b/metaspace/webapp/src/modules/Project/ProjectsListPage.vue
@@ -78,6 +78,7 @@ import { FilterPanel } from '../Filters'
 import QuickFilterBox from '../Filters/filter-components/SimpleFilterBox.vue'
 import ProjectsListItem from './ProjectsListItem.vue'
 import CreateProjectDialog from './CreateProjectDialog.vue'
+import { getLocalStorage } from '../../lib/localStorage'
 import { SortDropdown } from '../../components/SortDropdown/SortDropdown'
 
   @Component<ProjectsListPage>({
@@ -218,6 +219,15 @@ export default class ProjectsListPage extends Vue {
       if (this.currentUser == null) {
         return null
       } else {
+        // due to some misbehaviour from setting initial value from getLocalstorage with null values
+        // on filterSpecs, the filter is being initialized here if user is logged
+        const localSimpleFilter = this.$store.getters.filter.simpleFilter
+          ? this.$store.getters.filter.simpleFilter : (getLocalStorage('simpleFilter') || null)
+        this.$store.commit('updateFilter', {
+          ...this.$store.getters.filter,
+          simpleFilter: localSimpleFilter,
+        })
+
         return [
           { value: null, label: 'All projects' },
           { value: 'my-projects', label: 'My projects' },


### PR DESCRIPTION
### Description

In order to improve user experience and allow the user filter settings regarding "My projects" and "My datasets" sould be persisted even without passing a query param.
#830 #829 

#### Changes

##### Front end

###### Dataset Table page
- [x] Setting initial value of "My datasets" filter with local storage stored value if query param not set and user logged

###### Project List page
- [x] Setting initial value of "My projects" filter with local storage stored value if query param not set and user logged

###### Filter Panel
- [x] Saving "datasetOwner" filter value on local storage
- [x] Saving "simpleFilter" filter value on local storage

 
 #### Tests
 
 ##### Front end
 
- [x] Unit Test
- [ ] e2e Test
 
 ###### Browsers and resolutions
- [x] Chrome
- [x]  Safari
- [x] sm, md, lg, xl, lg





