### PR TITLE
Add NGlycDB

### DIFF
--- a/ansible/aws/templates/all/vars.yml.template
+++ b/ansible/aws/templates/all/vars.yml.template
@@ -120,6 +120,8 @@ mol_db_image_archives:
 #    path: https://s3-eu-west-1.amazonaws.com/sm-mol-db/mol-images/mol-images-ecmdb.tar.xz
 #  - name: CoreMetabolome
 #    path: https://sm-mol-db.s3-eu-west-1.amazonaws.com/mol-images/mol-images-core-metabolome.tar.xz
+#  - name: NGlycDB
+#    path: https://sm-mol-db.s3-eu-west-1.amazonaws.com/mol-images/mol-images-nglyc.tar.xz
 mol_db_imports:
   - url: "https://s3-eu-west-1.amazonaws.com/sm-mol-db/db_files_2021/hmdb/hmdb_4.tsv"
     name: "HMDB"
@@ -152,6 +154,9 @@ mol_db_imports:
 #  - url: "https://s3-eu-west-1.amazonaws.com/sm-mol-db/db_files_2021/core_metabolome/core_metabolome_v3.csv"
 #    name: "CoreMetabolome"
 #    version: "v3"
+#  - url: "https://sm-mol-db.s3-eu-west-1.amazonaws.com/db_files_2021/nglyc/nglyc_v1.tsv"
+#    name: "NGlycDB"
+#    version: "v1"
 
 nodejs_version: 14.5
 

--- a/ansible/aws/templates/all/vars.yml.template
+++ b/ansible/aws/templates/all/vars.yml.template
@@ -127,7 +127,7 @@ mol_db_imports:
     name: "HMDB"
     version: "v4"
 # uncomment below for other databases
-#  - url: "https://s3-eu-west-1.amazonaws.com/sm-mol-db/db_files_2021/brachemdb/BraChemDB_2018-03_empty_inchi.tsv"
+#  - url: "https://s3-eu-west-1.amazonaws.com/sm-mol-db/db_files_2021/brachem/BraChemDB_2018-03_empty_inchi.tsv"
 #    name: "BraChemDB"
 #    version: "2018-01"
 #  - url: "https://s3-eu-west-1.amazonaws.com/sm-mol-db/db_files_2021/chebi/chebi_2018-01.tsv"

--- a/metaspace/webapp/src/modules/App/DatabaseHelp.vue
+++ b/metaspace/webapp/src/modules/App/DatabaseHelp.vue
@@ -172,6 +172,24 @@
           </a>
         </p>
       </li>
+      <li>
+        <b>NGlycDB:</b>
+        Database containing naturally occurring N-linked glycans. This DB is based on glycans reported in the
+        GlyConnect platform and is filtered to include only N-linked glycans.
+        <p class="m-0 text-sm">
+          <span class="text-gray-700 font-medium">
+            Citation TBC
+          </span>
+          <a
+            href="https://s3-eu-west-1.amazonaws.com/sm-mol-db/db_files_2021/nglyc/nglyc_v1.tsv"
+            class="ml-3"
+            target="_blank"
+            rel="noopener"
+          >
+            Download N-linked glycan list
+          </a>
+        </p>
+      </li>
     </ul>
   </div>
 </template>


### PR DESCRIPTION
Adding a new, slightly specific, database of molecules. For this database, there is no way to generate a structure as we did earlier. Information on the structure of molecules is available on the website.

Steps required to add:

1. Converting the source xlsx into a tsv file of the structure we need.
2. Downloading the structure of molecules and saving them to svg files.
3. Archiving the directory with svg files into tar.xz archive.
```
tar cf - NGlycDB/ | xz -z - > mol-images-nglyc.tar.xz
```
4. Loading tar.xz archive and tsv file on S3 and setting "Read Object" for "Everyone"  in Permission tab.
5. Adding information (name, version, link) about the database to vars.yml files for all environments.
6. Run ansible playbook to copy images inside EC2 instance.
```
ansible-playbook -i env/staging provision/web.yml -t sm-web --start-at-task="Create directory for molecular structure images"
```
7. Copying the tsv file inside the EC2 instance and starting the import of the database.
```
python scripts/import_molecular_db.py NGlycDB v1 /tmp/nglyc_v1.tsv
```
8. Set some fields in DB:
```
UPDATE public.molecular_db SET targeted=false WHERE id=ID;
UPDATE public.molecular_db SET molecule_link_template='https://glyconnect.expasy.org/browser/structures/' WHERE id=ID;
```
9. Adding a database description for the /help page.
10. Run ansible playbook to apply changes.