### PR TITLE
Changed default db logic from backend to frontend

### DIFF
--- a/metaspace/engine/sm/rest/dataset_manager.py
+++ b/metaspace/engine/sm/rest/dataset_manager.py
@@ -68,8 +68,6 @@ class SMapiDatasetManager:
         if 'id' not in doc:
             doc['id'] = now.strftime('%Y-%m-%d_%Hh%Mm%Ss')
 
-        if 'moldb_ids' in doc:
-            doc['moldb_ids'] = self._add_default_moldbs(doc['moldb_ids'])
         ds_config_kwargs = dict((k, v) for k, v in doc.items() if k in FLAT_DS_CONFIG_KEYS)
 
         try:

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -1462,7 +1462,7 @@ class SMInstance(object):
         name: str,
         metadata: Union[str, dict],
         is_public: bool,
-        databases: List[Union[int, str, Tuple[str, str]]] = None,
+        databases: List[Union[int, str, Tuple[str, str]]] = [DEFAULT_DATABASE],
         *,
         project_ids: Optional[List[str]] = None,
         adducts: Optional[List[str]] = None,

--- a/metaspace/webapp/src/lib/constants.ts
+++ b/metaspace/webapp/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const MAX_MOL_DBS = 3
+export const MAX_MOL_DBS = 4
 export const MAX_MOL_DBS_EXT = 5
 export const MAX_NEUTRAL_LOSSES = 3
 export const MAX_CHEM_MODS = 3

--- a/metaspace/webapp/src/lib/constants.ts
+++ b/metaspace/webapp/src/lib/constants.ts
@@ -1,5 +1,5 @@
 export const MAX_MOL_DBS = 4
-export const MAX_MOL_DBS_EXT = 5
+export const MAX_MOL_DBS_EXT = 6
 export const MAX_NEUTRAL_LOSSES = 3
 export const MAX_CHEM_MODS = 3
 export const DEFAULT_SCALE_TYPE = 'linear'

--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -146,7 +146,7 @@ export default {
       schema: null,
       loadingPromise: null,
       localErrors: {},
-      defaultDb: {},
+      defaultDb: null,
       molDBsByGroup: [],
       possibleAdducts: {},
       metaspaceOptions: cloneDeep(defaultMetaspaceOptions),

--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -41,6 +41,7 @@
           v-model="metaspaceOptions"
           :error="errors['metaspaceOptions']"
           :databases-by-group="molDBsByGroup"
+          :default-db="defaultDb"
           :adduct-options="adductOptions"
           :is-new-dataset="isNew"
         />
@@ -86,7 +87,7 @@ import {
   get, set, cloneDeep, defaults,
   isEmpty, isEqual, isPlainObject,
   mapValues, forEach, without, omit,
-  sortBy,
+  uniq,
 } from 'lodash-es'
 import {
   newDatasetQuery,
@@ -145,6 +146,7 @@ export default {
       schema: null,
       loadingPromise: null,
       localErrors: {},
+      defaultDb: {},
       molDBsByGroup: [],
       possibleAdducts: {},
       metaspaceOptions: cloneDeep(defaultMetaspaceOptions),
@@ -323,6 +325,7 @@ export default {
         Positive: adducts.filter(a => a.charge > 0),
         Negative: adducts.filter(a => a.charge < 0),
       }
+      this.defaultDb = molecularDatabases.find((db) => db.default) || {}
       this.molDBsByGroup = getDatabasesByGroup(molecularDatabases)
       this.schema = deriveFullSchema(metadataSchemas[mdType])
 
@@ -332,19 +335,24 @@ export default {
         delete this.schema.properties.Additional_Information
       }
 
+      const selectedDbs = dataset.databases || []
+
+      // enable default db normal edit if dataset already registered and does not have it
+      this.defaultDb = !this.isNew && !selectedDbs.map((db) => db.id).includes(this.defaultDb.id) ? {}
+        : this.defaultDb
+
       if (this.isNew) {
         // If this is a prepopulated form from a previous submission and metabolite databases have changed since that submission,
         // clear the databases so that the user has to re-pick. Otherwise populate it with the default databases.
         // This is because it's expensive to change database later. We want a smart default for new users,
         // but if the user has previously selected a value that is now invalid, they should be made aware so that they
         // can choose an appropriate substitute.
-        const selectedDbs = dataset.databases || []
-        if (selectedDbs.length === 0) {
-          metaspaceOptions.databaseIds = molecularDatabases.filter(d => d.default).map(_ => _.id)
-        } else {
+        metaspaceOptions.databaseIds = uniq(selectedDbs.map((db) => db.id)
+          .concat(molecularDatabases.filter(d => d.default).map(_ => _.id)))
+        if (selectedDbs.length > 0) {
           for (const db of selectedDbs) {
             if (molecularDatabases.find(_ => _.id === db.id) === undefined) {
-              metaspaceOptions.databaseIds = []
+              metaspaceOptions.databaseIds = molecularDatabases.filter(d => d.default).map(_ => _.id)
               break
             }
           }

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -846,7 +846,7 @@ exports[`MetadataEditor should match snapshot 1`] = `
                       </mock-el-popover>
                       </span></label>
                     <div class="el-form-item__content">
-                      <mock-el-select value="1" required="true" multiple="" multiple-limit="3">
+                      <mock-el-select value="1" required="true" multiple="" multiple-limit="4">
                         <ul class="el-select-group__wrap">
                           <li class="el-select-group__title">METASPACE</li>
                           <li>

--- a/metaspace/webapp/src/modules/MetadataEditor/formStructure.ts
+++ b/metaspace/webapp/src/modules/MetadataEditor/formStructure.ts
@@ -49,6 +49,7 @@ export interface FormSchema extends JsonSchemaProperty {
 export interface MetaspaceOptions {
   isPublic: boolean;
   databases: number[];
+  databaseIds: number[];
   adducts: string[];
   groupId: string | null;
   projectIds: string[];

--- a/metaspace/webapp/src/modules/MetadataEditor/inputs/FormField.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/inputs/FormField.vue
@@ -88,6 +88,7 @@
       :required="required"
       multiple
       v-bind="$attrs"
+      @remove-tag="onRemoveTag"
       @input="onInput"
     >
       <slot name="options">
@@ -220,6 +221,10 @@ export default class FormField extends Vue {
 
     onInput(val: any) {
       this.$emit('input', val)
+    }
+
+    onRemoveTag(val: any) {
+      this.$emit('remove-tag', val)
     }
 
     fetchSuggestionsAndTestWidth(queryString: string, callback: FetchSuggestionsCallback) {

--- a/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
@@ -26,6 +26,7 @@
                   :error="error && error.databaseIds"
                   :multiple-limit="maxMolDBs"
                   required
+                  @remove-tag="onDbRemoval"
                   @input="val => onInput('databaseIds', val)"
                 >
                   <el-option-group
@@ -264,7 +265,7 @@ import config, { limits } from '../../../lib/config'
 import { formatDatabaseLabel, MolDBsByGroup } from '../../MolecularDatabases/formatting'
 import { sortBy } from 'lodash-es'
 import PopupAnchor from '../../../modules/NewFeaturePopup/PopupAnchor.vue'
-
+import { MolecularDB } from '../../../api/moldb'
 import './FormSection.scss'
 
 interface Option {
@@ -301,6 +302,9 @@ export default class MetaspaceOptionsSection extends Vue {
     @Prop({ type: Array, required: true })
     databasesByGroup!: MolDBsByGroup[];
 
+    @Prop({ type: Object, required: true })
+    defaultDb!: MolecularDB;
+
     @Prop({ type: Array, required: true })
     adductOptions!: {value: string, label: string}[];
 
@@ -336,6 +340,16 @@ export default class MetaspaceOptionsSection extends Vue {
 
     onInput<TKey extends keyof MetaspaceOptions>(field: TKey, val: MetaspaceOptions[TKey]) {
       this.$emit('input', { ...this.value, [field]: val })
+    }
+
+    onDbRemoval<TKey extends keyof MetaspaceOptions>(val: any) {
+      if (val === this.defaultDb.id) {
+        this.$message({
+          message: `${(this.defaultDb.group?.shortName || 'METASPACE')}
+        ${formatDatabaseLabel(this.defaultDb)} is the default database and It can not be removed.`,
+        })
+        this.onInput('databaseIds', this.value.databaseIds)
+      }
     }
 
     updateNeutralLossOptions(query: string) {

--- a/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
@@ -303,7 +303,7 @@ export default class MetaspaceOptionsSection extends Vue {
     databasesByGroup!: MolDBsByGroup[];
 
     @Prop({ type: Object, required: true })
-    defaultDb!: MolecularDB;
+    defaultDb!: MolecularDB | null;
 
     @Prop({ type: Array, required: true })
     adductOptions!: {value: string, label: string}[];
@@ -343,7 +343,7 @@ export default class MetaspaceOptionsSection extends Vue {
     }
 
     onDbRemoval<TKey extends keyof MetaspaceOptions>(val: any) {
-      if (val === this.defaultDb.id) {
+      if (this.defaultDb && val === this.defaultDb.id) {
         this.$message({
           message: `${(this.defaultDb.group?.shortName || 'METASPACE')}
         ${formatDatabaseLabel(this.defaultDb)} is the default database and It can not be removed.`,


### PR DESCRIPTION
### Description

"We've had several internal projects where HMDB has been unwanted, but the current logic makes it impossible to exclude databases with the default flag. They just get re-added in the sm-api Python code. Ideally we'd make it so that the defaults were applied for all web-submitted datasets, but were easy to bypass for API-submitted datasets. The cleanest way to do this is to make it impossible to de-select HMDB when submitting a database through webapp, but have no code in graphql/sm-api to enforce this".
#858

#### Changes

##### Front end

###### MetadataEditor
- [x] Add default database to database list if new dataset
- [x] The default database can not be removed from the database list if new dataset
- [x] The default database can not be removed from the database list if updating a dataset which was already annotated with the default db
- [x] The default database can be removed/added from the database list if updating a dataset which was already annotated without the default db
- [x] Increased database limit to 4


##### Python client

###### dataset_manager
- [x] Removed the logic that adds the default DBs. 

###### sm_annotation_utils
- [x] Changed the default value for the submit_dataset databases parameter to [DEFAULT_DATABASE]

#### Tests
 
##### Front end
 
- [x] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [x]  Safari
- [x] sm, md, lg, xl, lg

![image](https://user-images.githubusercontent.com/35172605/119876617-74792880-befe-11eb-98c0-fe0a979a3de2.png)

