### PR TITLE
[DsTable] checking localstorage datasetowner filter options only when mounted

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
@@ -214,14 +214,13 @@ export default Vue.extend({
     },
   },
   mounted() {
-    if (!this.$store.getters.currentUser) {
-      return null
+    if (this.$store.getters.currentUser) {
+      // due to some misbehaviour from setting initial value from getLocalstorage with null values
+      // on filterSpecs, the filter is being initialized here if user is logged
+      const localDsOwner = this.$store.getters.filter.datasetOwner
+        ? this.$store.getters.filter.datasetOwner : (getLocalStorage('datasetOwner') || null)
+      this.$store.commit('updateFilter', { ...this.$store.getters.filter, datasetOwner: localDsOwner })
     }
-    // due to some misbehaviour from setting initial value from getLocalstorage with null values
-    // on filterSpecs, the filter is being initialized here if user is logged
-    const localDsOwner = this.$store.getters.filter.datasetOwner
-      ? this.$store.getters.filter.datasetOwner : (getLocalStorage('datasetOwner') || null)
-    this.$store.commit('updateFilter', { ...this.$store.getters.filter, datasetOwner: localDsOwner })
   },
 
   apollo: {

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
@@ -147,7 +147,6 @@ export default Vue.extend({
       sortingOrder: 'DESCENDING',
     }
   },
-
   computed: {
     currentPage: {
       get() {
@@ -173,12 +172,6 @@ export default Vue.extend({
       if (!this.currentUser) {
         return null
       }
-
-      // due to some misbehaviour from setting initial value from getLocalstorage with null values
-      // on filterSpecs, the filter is being initialized here if user is logged
-      const localDsOwner = this.$store.getters.filter.datasetOwner
-        ? this.$store.getters.filter.datasetOwner : (getLocalStorage('datasetOwner') || null)
-      this.$store.commit('updateFilter', { ...this.$store.getters.filter, datasetOwner: localDsOwner })
 
       if (this.currentUser && Array.isArray(this.currentUser.groups)) {
         const groups = this.currentUser.groups
@@ -219,6 +212,16 @@ export default Vue.extend({
     canSeeFailed() {
       return this.currentUser != null && this.currentUser.role === 'admin'
     },
+  },
+  mounted() {
+    if (!this.$store.getters.currentUser) {
+      return null
+    }
+    // due to some misbehaviour from setting initial value from getLocalstorage with null values
+    // on filterSpecs, the filter is being initialized here if user is logged
+    const localDsOwner = this.$store.getters.filter.datasetOwner
+      ? this.$store.getters.filter.datasetOwner : (getLocalStorage('datasetOwner') || null)
+    this.$store.commit('updateFilter', { ...this.$store.getters.filter, datasetOwner: localDsOwner })
   },
 
   apollo: {
@@ -300,7 +303,6 @@ export default Vue.extend({
       },
     },
   },
-
   methods: {
     formatSubmitter: (row, col) =>
       row.submitter.name,

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -77,32 +77,14 @@ exports[`DatasetTable should match snapshot 1`] = `
       />
       <mock-el-option
         label="Select data type"
+        value="datasetOwner"
+      />
+      <mock-el-option
+        label="Select data type"
         value="metadataType"
       />
     </mock-el-select>
      
-    <mock-el-select
-      class="filter-select"
-      data-test-key="datasetOwner"
-      filter-key="datasetOwner"
-    >
-      <mock-el-option
-        label="All datasets"
-      />
-      <mock-el-option
-        label="My datasets"
-        value="my-datasets"
-      />
-      <mock-el-option
-        label="currentUser.groups.0.group.label"
-        value="currentUser.groups.0.group.value"
-      />
-      <mock-el-option
-        label="currentUser.groups.1.group.label"
-        value="currentUser.groups.1.group.value"
-      />
-       
-    </mock-el-select>
   </div>
    
   <div>

--- a/metaspace/webapp/src/store/getters.js
+++ b/metaspace/webapp/src/store/getters.js
@@ -14,6 +14,10 @@ export default {
     return decodeParams(state.route, state.filterLists);
   },
 
+  currentUser(state) {
+    return state.currentUser;
+  },
+
   settings(state) {
     return decodeSettings(state.route);
   },


### PR DESCRIPTION
Sergii reported an error regarding the dataset filters. As the  set datasetOwnerOptions is being called every time the filter is updated, and with the change where the datasetOwner filter is setting the default value from localStorage, when some filter is added this function is also being called. As the function updates the filter, and the store filter update is being done after the serDatasetOwner is called, the new filter is not added.

In order to solve this bug, the default option from localStorage is only updating the filter when the dataset table page is mounted,

#875 