### PR TITLE
Ds comparison performance improvement

### DIFF
--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/RelatedMolecules.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/RelatedMolecules.vue
@@ -114,7 +114,6 @@ export default {
     annotations: { type: Array, required: false },
     databaseId: { type: Number, required: true },
     hideFdr: { type: Boolean, default: false },
-    skipQueries: { type: Boolean, default: false },
   },
   data() {
     return {
@@ -126,7 +125,7 @@ export default {
       query: relatedMoleculesQuery,
       loadingKey: 'loading',
       skip() {
-        return this.skipQueries || !config.features.isomers
+        return !config.features.isomers
       },
       variables() {
         return {
@@ -144,7 +143,7 @@ export default {
       query: relatedMoleculesQuery,
       loadingKey: 'loading',
       skip() {
-        return this.skipQueries || !config.features.isobars
+        return !config.features.isobars
       },
       variables() {
         return {
@@ -161,7 +160,11 @@ export default {
   },
   computed: {
     sortedAnnotations() {
-      let annotations = this.annotations ? this.annotations : [
+      let annotations = this.annotations ? [
+        ...this.annotations,
+        ...(this.isomerAnnotations || []).map(ann => ({ ...ann, isIsomer: true })),
+        ...(this.isobarAnnotations || []).map(ann => ({ ...ann, isIsobar: true })),
+      ] : [
         this.annotation,
         ...(this.isomerAnnotations || []).map(ann => ({ ...ann, isIsomer: true })),
         ...(this.isobarAnnotations || []).map(ann => ({ ...ann, isIsobar: true })),

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/RelatedMolecules.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/RelatedMolecules.vue
@@ -111,8 +111,10 @@ export default {
   },
   props: {
     annotation: { type: Object, required: true },
+    annotations: { type: Array, required: false },
     databaseId: { type: Number, required: true },
     hideFdr: { type: Boolean, default: false },
+    skipQueries: { type: Boolean, default: false },
   },
   data() {
     return {
@@ -124,7 +126,7 @@ export default {
       query: relatedMoleculesQuery,
       loadingKey: 'loading',
       skip() {
-        return !config.features.isomers
+        return this.skipQueries || !config.features.isomers
       },
       variables() {
         return {
@@ -142,7 +144,7 @@ export default {
       query: relatedMoleculesQuery,
       loadingKey: 'loading',
       skip() {
-        return !config.features.isobars
+        return this.skipQueries || !config.features.isobars
       },
       variables() {
         return {
@@ -159,7 +161,7 @@ export default {
   },
   computed: {
     sortedAnnotations() {
-      let annotations = [
+      let annotations = this.annotations ? this.annotations : [
         this.annotation,
         ...(this.isomerAnnotations || []).map(ann => ({ ...ann, isIsomer: true })),
         ...(this.isobarAnnotations || []).map(ann => ({ ...ann, isIsobar: true })),
@@ -181,7 +183,8 @@ export default {
     renderMolFormulaHtml,
     linkToAnnotation(other) {
       const filters = {
-        datasetIds: [this.annotation.dataset.id],
+        datasetIds: this.annotations ? this.annotations.map((annotation) => annotation.dataset.id)
+          : [this.annotation.dataset.id],
         compoundName: other.sumFormula,
         chemMod: other.chemMod,
         neutralLoss: other.neutralLoss,

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
@@ -357,7 +357,7 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
                 <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-11" dy="0.32em">100</text>
               </g>
             </g><text class="intensity-axis-label" transform="translate(-30, 120) rotate(-90)">Relative intensity</text><text style="text-anchor: middle;" transform="translate(60, 270) ">m/z</text>
-            <g class="sample-graph refSample">
+            <g class="sample-graph soloSample">
               <g>
                 <circle cx="9.999999999999526" cy="0" r="4"></circle>
                 <circle cx="110.00000000000047" cy="96" r="4"></circle>
@@ -371,26 +371,7 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
                 <rect width="0.06060000000047694" height="144" x="109.96970000000023" y="96"></rect>
               </g>
             </g>
-            <g class="sample-graph compSample">
-              <g>
-                <circle cx="9.999999999999526" cy="0" r="4"></circle>
-                <circle cx="110.00000000000047" cy="96" r="4"></circle>
-              </g>
-              <g>
-                <line x1="9.999999999999526" x2="9.999999999999526" y1="0" y2="240"></line>
-                <line x1="110.00000000000047" x2="110.00000000000047" y1="96" y2="240"></line>
-              </g>
-              <g>
-                <rect width="0.0599999999991514" height="240" x="9.969999999999951" y="0"></rect>
-                <rect width="0.06060000000047694" height="144" x="109.96970000000023" y="96"></rect>
-              </g>
-            </g>
-            <g class="theor-graph refTheor">
-              <g>
-                <path d="M0,240L9.999999999999526,237.6L19.99999999999905,240L100.00000000000095,240L110.00000000000047,238.8L120,240"></path>
-              </g>
-            </g>
-            <g class="theor-graph compTheor">
+            <g class="theor-graph soloTheor">
               <g>
                 <path d="M0,240L9.999999999999526,237.6L19.99999999999905,240L100.00000000000095,240L110.00000000000047,238.8L120,240"></path>
               </g>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
@@ -357,7 +357,7 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
                 <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-11" dy="0.32em">100</text>
               </g>
             </g><text class="intensity-axis-label" transform="translate(-30, 120) rotate(-90)">Relative intensity</text><text style="text-anchor: middle;" transform="translate(60, 270) ">m/z</text>
-            <g class="sample-graph soloSample">
+            <g class="sample-graph refSample">
               <g>
                 <circle cx="9.999999999999526" cy="0" r="4"></circle>
                 <circle cx="110.00000000000047" cy="96" r="4"></circle>
@@ -371,7 +371,26 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
                 <rect width="0.06060000000047694" height="144" x="109.96970000000023" y="96"></rect>
               </g>
             </g>
-            <g class="theor-graph soloTheor">
+            <g class="sample-graph compSample">
+              <g>
+                <circle cx="9.999999999999526" cy="0" r="4"></circle>
+                <circle cx="110.00000000000047" cy="96" r="4"></circle>
+              </g>
+              <g>
+                <line x1="9.999999999999526" x2="9.999999999999526" y1="0" y2="240"></line>
+                <line x1="110.00000000000047" x2="110.00000000000047" y1="96" y2="240"></line>
+              </g>
+              <g>
+                <rect width="0.0599999999991514" height="240" x="9.969999999999951" y="0"></rect>
+                <rect width="0.06060000000047694" height="144" x="109.96970000000023" y="96"></rect>
+              </g>
+            </g>
+            <g class="theor-graph refTheor">
+              <g>
+                <path d="M0,240L9.999999999999526,237.6L19.99999999999905,240L100.00000000000095,240L110.00000000000047,238.8L120,240"></path>
+              </g>
+            </g>
+            <g class="theor-graph compTheor">
               <g>
                 <path d="M0,240L9.999999999999526,237.6L19.99999999999905,240L100.00000000000095,240L110.00000000000047,238.8L120,240"></path>
               </g>

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonAnnotationTable.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonAnnotationTable.tsx
@@ -197,7 +197,11 @@ export const DatasetComparisonAnnotationTable = defineComponent<DatasetCompariso
       // guarantee old selection was removed
       if (state.currentRowIndex !== currentIndex && state.currentRowIndex !== -1) {
         setTimeout(() => {
-          if (document.querySelectorAll('.el-table__row').length > state.currentRowIndex) {
+          if (
+            document.querySelectorAll('.el-table__row')
+            && document.querySelectorAll('.el-table__row').length > state.currentRowIndex
+            && document.querySelectorAll('.el-table__row')[state.currentRowIndex]
+          ) {
             document.querySelectorAll('.el-table__row')[state.currentRowIndex]
               .classList.remove('current-row')
           }
@@ -208,7 +212,11 @@ export const DatasetComparisonAnnotationTable = defineComponent<DatasetCompariso
       if (currentIndex !== -1) {
         // gives time to clear and render the new selection
         setTimeout(() => {
-          if (document.querySelectorAll('.el-table__row').length > currentIndex) {
+          if (
+            document.querySelectorAll('.el-table__row')
+            && document.querySelectorAll('.el-table__row').length > currentIndex
+            && document.querySelectorAll('.el-table__row')[currentIndex]
+          ) {
             document.querySelectorAll('.el-table__row')[currentIndex].classList.add('current-row')
           }
         }, 100)

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonAnnotationTable.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonAnnotationTable.tsx
@@ -16,6 +16,7 @@ interface DatasetComparisonAnnotationTableProps {
 interface DatasetComparisonAnnotationTableState {
   processedAnnotations: any
   selectedRow: any
+  currentRowIndex: number
   pageSize: number
   offset: number
   keyListenerAdded: boolean
@@ -62,6 +63,7 @@ export const DatasetComparisonAnnotationTable = defineComponent<DatasetCompariso
     const pageSizes = [15, 20, 25, 30]
     const state = reactive<DatasetComparisonAnnotationTableState>({
       selectedRow: props.annotations[0],
+      currentRowIndex: -1,
       pageSize: 15,
       offset: 0,
       processedAnnotations: computed(() => props.annotations.slice()),
@@ -191,6 +193,18 @@ export const DatasetComparisonAnnotationTable = defineComponent<DatasetCompariso
     const setCurrentRow = () => {
       clearCurrentRow()
       const currentIndex = getCurrentRowIndex()
+
+      // guarantee old selection was removed
+      if (state.currentRowIndex !== currentIndex && state.currentRowIndex !== -1) {
+        setTimeout(() => {
+          if (document.querySelectorAll('.el-table__row').length > state.currentRowIndex) {
+            document.querySelectorAll('.el-table__row')[state.currentRowIndex]
+              .classList.remove('current-row')
+          }
+          state.currentRowIndex = currentIndex
+        }, 100)
+      }
+
       if (currentIndex !== -1) {
         // gives time to clear and render the new selection
         setTimeout(() => {
@@ -215,6 +229,11 @@ export const DatasetComparisonAnnotationTable = defineComponent<DatasetCompariso
         state.selectedRow = row
         const currentIndex = findIndex(props.annotations,
           (annotation) => { return row.id === annotation.id })
+
+        if (state.currentRowIndex === -1) {
+          state.currentRowIndex = currentIndex
+        }
+
         if (currentIndex !== -1) {
           $store.commit('setRow', currentIndex)
           emit('rowChange', currentIndex)

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
@@ -210,9 +210,16 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
         }
       })
 
-      Promise.all(settingPromises).then((values) => {
-        state.firstLoaded = true
-      })
+      Promise.all(settingPromises)
+        .then((values) => {
+          // pass
+        })
+        .catch((e) => {
+          // pass
+        })
+        .finally(() => {
+          state.firstLoaded = true
+        })
     }
 
     watchEffect(async() => {

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
@@ -108,7 +108,7 @@ export default defineComponent<DatasetComparisonPageProps>({
       }
     }
 
-    const queryOptions = reactive({ enabled: false })
+    const queryOptions = reactive({ enabled: false, fetchPolicy: 'no-cache' as const })
     const queryVars = computed(() => ({
       ...queryVariables(),
       dFilter: { ...queryVariables().dFilter, ids: Object.values(state.grid || {}).join('|') },
@@ -184,7 +184,6 @@ export default defineComponent<DatasetComparisonPageProps>({
       // @ts-ignore TS2604
       const relatedMolecules = () => <RelatedMolecules
         query="isomers"
-        skipQueries
         annotation={state.annotations[state.selectedAnnotation].annotations[0]}
         annotations={state.annotations[state.selectedAnnotation].annotations}
         databaseId={$store.getters.filter.database || 1}

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
@@ -92,10 +92,6 @@ export default defineComponent<DatasetComparisonPageProps>({
 
     const gridSettings = computed(() => settingsResult.value != null
       ? settingsResult.value.imageViewerSnapshot : null)
-    const compoundsAnnotations = computed(() =>
-      state.annotations
-        ? uniqBy((state.annotations[state.selectedAnnotation]?.annotations || []), 'id') : [],
-    )
 
     const queryVariables = () => {
       const filter = $store.getters.gqlAnnotationFilter


### PR DESCRIPTION
### Description

In order to improve the user experience when using the new dataset comparison feature, the performance of this feature should be improved.

#863 

#### Changes

##### Webapp

###### RelatedMolecules
- [x] Added skip apollo queries props
- [x] Added option to load annotations props as is

###### DatasetComparisonAnnotationTable
- [x] Fixed selected row highlight on change

###### DatasetComparisonPage
- [x] Render collapse item only if open

#### Tests
 
##### Front end
 
- [x] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [x]  Safari
- [x] sm, md, lg, xl, lg

* The main performance problem was basically the loading and rendering of the isomers and isobars on row change
