### PR TITLE
Release chem mods & hidden adducts

### DIFF
--- a/ansible/aws/templates/all/vars.yml.template
+++ b/ansible/aws/templates/all/vars.yml.template
@@ -220,7 +220,7 @@ sm_webapp_features:
   all_adducts: false
   neutral_losses: false
   neutral_losses_new_ds: true
-  chem_mods: false
+  chem_mods: true
   advanced_ds_config: false
   isomers: true
   isobars: true

--- a/metaspace/graphql/config/default.js
+++ b/metaspace/graphql/config/default.js
@@ -15,12 +15,12 @@ module.exports = {
     { adduct: '+H', name: '[M + H]⁺', charge: 1, hidden: false, default: true },
     { adduct: '+Na', name: '[M + Na]⁺', charge: 1, hidden: false, default: true },
     { adduct: '+K', name: '[M + K]⁺', charge: 1, hidden: false, default: true },
-    { adduct: '[M]+', name: '[M]⁺', charge: 1, hidden: true, default: false },
-    { adduct: '+NH4', name: '[M + NH₄]⁺', charge: 1, hidden: true, default: false },
+    { adduct: '[M]+', name: '[M]⁺', charge: 1, hidden: false, default: false },
+    { adduct: '+NH4', name: '[M + NH₄]⁺', charge: 1, hidden: false, default: false },
     // Negative mode
     { adduct: '-H', name: '[M - H]⁻', charge: -1, hidden: false, default: true },
     { adduct: '+Cl', name: '[M + Cl]⁻', charge: -1, hidden: false, default: true },
-    { adduct: '[M]-', name: '[M]⁻', charge: -1, hidden: true, default: false },
+    { adduct: '[M]-', name: '[M]⁻', charge: -1, hidden: false, default: false },
   ],
 
   /* Settings for image storage.

--- a/metaspace/webapp/src/components/MolecularFormula.tsx
+++ b/metaspace/webapp/src/components/MolecularFormula.tsx
@@ -1,6 +1,6 @@
 import { defineComponent, computed } from '@vue/composition-api'
 
-import { superscript } from '../lib/util'
+import { reorderAdducts, superscript } from '../lib/util'
 
 const MolecularFormula = defineComponent({
   props: {
@@ -24,7 +24,7 @@ const MolecularFormula = defineComponent({
 
     const parts = computed<string[]>(() => {
       const { formula } = formulaAndCharge.value
-      const fmtFormula = formula.replace(/-/g, ' - ').replace(/\+/g, ' + ')
+      const fmtFormula = reorderAdducts(formula).replace(/([+-])/g, ' $1 ')
       return fmtFormula.split(/(\d+)/g)
     })
 

--- a/metaspace/webapp/src/lib/config.ts
+++ b/metaspace/webapp/src/lib/config.ts
@@ -65,7 +65,7 @@ const defaultConfig: ClientConfig = {
     all_adducts: false,
     neutral_losses: false,
     neutral_losses_new_ds: true,
-    chem_mods: false,
+    chem_mods: true,
     advanced_ds_config: false,
     isomers: true,
     isobars: true,

--- a/metaspace/webapp/src/lib/normalizeFormulaModifier.spec.ts
+++ b/metaspace/webapp/src/lib/normalizeFormulaModifier.spec.ts
@@ -3,8 +3,11 @@ import { normalizeFormulaModifier } from './normalizeFormulaModifier'
 describe('normalizeFormulaModifier', () => {
   const validCases = [
     '-NaCHO',
-    '+CHEsSe',
+    '+CHIPS',
     '-O+C5H12N3O',
+    // All allowed elements from the regex:
+    '+AcAgAlArAsAtAuBBaBeBiBrCCaCdCeClCoCrCsCuDyErEuFFeFrGaGdGeHHeHfHgHoIInIrKKrLaLiLuMgMnMo'
+    + 'NNaNbNdNeNiOOsPPaPbPdPmPoPrPtRbReRhRuSSbScSeSiSmSnSrTaTbTcTeTiTlTmUVWXeYYbZnZr',
   ]
   it.each(validCases)('should validate valid formula modifiers', (input) => {
     expect(normalizeFormulaModifier(input, '+')).toEqual(input)
@@ -13,8 +16,8 @@ describe('normalizeFormulaModifier', () => {
   const casesWithoutSigns = [
     ['NaCHO', '-', '-NaCHO'],
     ['NaCHO', '+', '+NaCHO'],
-    ['NaCHO+CHEsSe', '-', '-NaCHO+CHEsSe'],
-    ['NaCHO-CHEsSe', '+', '+NaCHO-CHEsSe'],
+    ['NaCHOS+CoLa', '-', '-NaCHOS+CoLa'],
+    ['NaCHO-CHIPS', '+', '+NaCHO-CHIPS'],
   ] as const
   it.each(casesWithoutSigns)('should prepend a sign when necessary', (input, defaultSign, expected) => {
     expect(normalizeFormulaModifier(input, defaultSign)).toEqual(expected)
@@ -25,6 +28,10 @@ describe('normalizeFormulaModifier', () => {
     '',
     '(CH)2', // Parentheses not supported
     'Ad', // Invalid element
+    'D', // Invalid element (Shorthand for Deuterium, but isotopes aren't supported)
+    'Ee', // Invalid element (pyMSpec uses it for Electron - not supported)
+    // Elements not supported by pyMSpec
+    'Np', 'Pu', 'Am', 'Cm', 'Bk', 'Cf', 'Es', 'Fm', 'Md', 'No', 'Lr', 'Rf', 'Db', 'Sg',
   ]
   it.each(invalidCases)('should reject invalid formulas', (input) => {
     expect(normalizeFormulaModifier(input, '-')).toBe(null)

--- a/metaspace/webapp/src/lib/normalizeFormulaModifier.spec.ts
+++ b/metaspace/webapp/src/lib/normalizeFormulaModifier.spec.ts
@@ -1,0 +1,41 @@
+import { normalizeFormulaModifier } from './normalizeFormulaModifier'
+
+describe('normalizeFormulaModifier', () => {
+  const validCases = [
+    '-NaCHO',
+    '+CHEsSe',
+    '-O+C5H12N3O',
+  ]
+  it.each(validCases)('should validate valid formula modifiers', (input) => {
+    expect(normalizeFormulaModifier(input, '+')).toEqual(input)
+  })
+
+  const casesWithoutSigns = [
+    ['NaCHO', '-', '-NaCHO'],
+    ['NaCHO', '+', '+NaCHO'],
+    ['NaCHO+CHEsSe', '-', '-NaCHO+CHEsSe'],
+    ['NaCHO-CHEsSe', '+', '+NaCHO-CHEsSe'],
+  ] as const
+  it.each(casesWithoutSigns)('should prepend a sign when necessary', (input, defaultSign, expected) => {
+    expect(normalizeFormulaModifier(input, defaultSign)).toEqual(expected)
+  })
+
+  const invalidCases = [
+    'H2o', // 'o' should be capital
+    '',
+    '(CH)2', // Parentheses not supported
+    'Ad', // Invalid element
+  ]
+  it.each(invalidCases)('should reject invalid formulas', (input) => {
+    expect(normalizeFormulaModifier(input, '-')).toBe(null)
+  })
+
+  const lowerCaseCases = [
+    ['h2o', '+H2O'],
+    ['co2', '+CO2'],
+    ['nacl', null],
+  ] as const
+  it.each(lowerCaseCases)('should capitalize trivial formulas', (input, expected) => {
+    expect(normalizeFormulaModifier(input, '+')).toBe(expected)
+  })
+})

--- a/metaspace/webapp/src/lib/normalizeFormulaModifier.ts
+++ b/metaspace/webapp/src/lib/normalizeFormulaModifier.ts
@@ -1,0 +1,22 @@
+const validElement = new RegExp(
+  '/A[cglmrstu]|B[aeikr]?|C[adelorsu]?|D[by]|E[rsu]|F[er]?|G[ade]|H[efgo]?|I[nr]?|Kr?|L[airu]|M[dgno]|'
+  + 'N[abdeip]?|Os?|P[abdmrt]?|R[behu]|S[bceimnr]?|T[abceilm]|U|V|W|Xe|Yb?|Z[nr]',
+)
+
+const validFormulaModifier = new RegExp(`([+-]((${validElement.source})[0-9]{0,3})+)+`)
+
+export const normalizeFormulaModifier = (formula: string, defaultSign: '+' | '-') => {
+  if (!formula) return null
+  // It won't work for all situations, but for lazy users convert "h2o" to "H2O"
+  if (formula === formula.toLowerCase()) {
+    formula = formula.toUpperCase()
+  }
+  // Tidy & regularize formula as much as possible
+  if (!formula.startsWith('-') && !formula.startsWith('+')) {
+    formula = defaultSign + formula
+  }
+  formula = formula.replace(/\s/g, '')
+  // If it's not valid after tidying, reject it
+  const match = validFormulaModifier.exec(formula)
+  return match != null && match[0] === formula ? formula : null
+}

--- a/metaspace/webapp/src/lib/normalizeFormulaModifier.ts
+++ b/metaspace/webapp/src/lib/normalizeFormulaModifier.ts
@@ -1,6 +1,10 @@
 const validElement = new RegExp(
-  '/A[cglmrstu]|B[aeikr]?|C[adelorsu]?|D[by]|E[rsu]|F[er]?|G[ade]|H[efgo]?|I[nr]?|Kr?|L[airu]|M[dgno]|'
-  + 'N[abdeip]?|Os?|P[abdmrt]?|R[behu]|S[bceimnr]?|T[abceilm]|U|V|W|Xe|Yb?|Z[nr]',
+  // NOTE: this regex should only contain elements that are accepted by METASPACE.
+  // This means only elements that are supported in BOTH of these libraries:
+  // pyMSpec: https://github.com/alexandrovteam/pyMSpec/blob/master/pyMSpec/pyisocalc/periodic_table.py
+  // cpyMSpec (which uses ims-cpp): https://github.com/alexandrovteam/ims-cpp/blob/d8ba14b36c1a0303a6c9799c3c25ddb8eda3dea9/ms/periodic_table.cpp
+  'A[cglrstu]|B[aeir]?|C[adelorsu]?|Dy|E[ru]|F[er]?|G[ade]|H[efgo]?|I[nr]?|Kr?|L[aiu]|M[gno]|'
+  + 'N[abdei]?|Os?|P[abdmort]?|R[behu]|S[bceimnr]?|T[abceilm]|U|V|W|Xe|Yb?|Z[nr]',
 )
 
 const validFormulaModifier = new RegExp(`([+-]((${validElement.source})[0-9]{0,3})+)+`)

--- a/metaspace/webapp/src/modules/Annotations/__snapshots__/AnnotationTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/__snapshots__/AnnotationTable.spec.ts.snap
@@ -117,7 +117,7 @@ exports[`AnnotationTable should match snapshot 1`] = `
                         </div>
                       </div>
                     </div>
-                    <div slot-key="reference"><span>[C<sub class="leading-none">19</sub>H<sub class="leading-none">18</sub>N<sub class="leading-none">2</sub>O<sub class="leading-none">7</sub>S<sub class="leading-none">2</sub> - H]⁺</span>
+                    <div slot-key="reference"><span>[C<sub class="leading-none">19</sub>H<sub class="leading-none">18</sub>N<sub class="leading-none">2</sub>O<sub class="leading-none">7</sub>S<sub class="leading-none">2</sub> - H]⁺</span>
                       <!---->
                     </div>
                   </mock-el-popover> <svg data-icon="filter" class="cell-filter-button"></svg>
@@ -294,7 +294,7 @@ exports[`AnnotationTable should match snapshot when loading snapshot 1`] = `
                         </div>
                       </div>
                     </div>
-                    <div slot-key="reference"><span>[C<sub class="leading-none">19</sub>H<sub class="leading-none">18</sub>N<sub class="leading-none">2</sub>O<sub class="leading-none">7</sub>S<sub class="leading-none">2</sub> - H]⁺</span>
+                    <div slot-key="reference"><span>[C<sub class="leading-none">19</sub>H<sub class="leading-none">18</sub>N<sub class="leading-none">2</sub>O<sub class="leading-none">7</sub>S<sub class="leading-none">2</sub> - H]⁺</span>
                       <!---->
                     </div>
                   </mock-el-popover> <svg data-icon="filter" class="cell-filter-button"></svg>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/__snapshots__/RelatedMolecules.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/__snapshots__/RelatedMolecules.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`RelatedMolecules should match snapshot 1`] = `
         <div class="ion-heading">
           <div class="ion-link">
             <div>
-              <!----> <span class="ion-formula">[C<sub>10</sub>H<sub>11</sub>NO + Na]⁺</span></div>
+              <!----> <span class="ion-formula">[C<sub>10</sub>H<sub>11</sub>NO + Na]⁺</span></div>
             <div class="fdr-badge fdr-badge-10">
               10% FDR
             </div>
@@ -44,7 +44,7 @@ exports[`RelatedMolecules should match snapshot 1`] = `
     <div class="el-divider el-divider--horizontal">
       <div class="el-divider__text is-center">
         <div class="ion-heading"><a href="/?ds=2019-02-12_15h55m06s&amp;mol=allAnnotations.0.sumFormula&amp;chem_mod=allAnnotations.0.chemMod&amp;nl=allAnnotations.0.neutralLoss&amp;add=allAnnotations.0.adduct&amp;fdr=0.2" class="ion-link">
-            <div><span>Isomer:</span> <span class="ion-formula">[C<sub>10</sub>H<sub>13</sub>NO<sub>2</sub> - H<sub>2</sub>O + Na]⁺</span></div>
+            <div><span>Isomer:</span> <span class="ion-formula">[C<sub>10</sub>H<sub>13</sub>NO<sub>2</sub> + Na - H<sub>2</sub>O]⁺</span></div>
             <div class="fdr-badge fdr-badge-20">
               20% FDR
             </div>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
@@ -179,7 +179,7 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
   <div class="compare-container">
     Compare selected annotation to:
     <mock-el-select placeholder="None" clearable="" class="compare-select" value="C8H9S2">
-      <mock-el-option value="C8H9S2" label="[M+0.0000]: [C8H10S2 - H]⁻">[M+0.0000]: [C<sub>8</sub>H<sub>10</sub>S<sub>2</sub> - H]⁻</mock-el-option>
+      <mock-el-option value="C8H9S2" label="[M+0.0000]: [C8H10S2 - H]⁻">[M+0.0000]: [C<sub>8</sub>H<sub>10</sub>S<sub>2</sub> - H]⁻</mock-el-option>
     </mock-el-select>
   </div>
   <div class="ref-annotation-header">
@@ -200,7 +200,7 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
           <!---->
         </div>
       </div>
-      <div slot-key="reference"><span class="annotation-ion">[C<sub>19</sub>H<sub>18</sub>N<sub>2</sub>O<sub>7</sub>S<sub>2</sub> - H]⁺</span></div>
+      <div slot-key="reference"><span class="annotation-ion">[C<sub>19</sub>H<sub>18</sub>N<sub>2</sub>O<sub>7</sub>S<sub>2</sub> - H]⁺</span></div>
     </mock-el-popover> <span style="padding-left: 5px;">(Selected annotation)</span>
   </div>
   <div class="ref-annotation-container">
@@ -253,7 +253,7 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
       Candidate molecule
     </p> <ul class="p-0 list-none leading-7"><li>
         C.I. Food Red 6
-      </li> <!----></ul> <!----> <!----></div> </div><div slot-key="reference"><span class="annotation-ion">[C<sub>8</sub>H<sub>10</sub>S<sub>2</sub> - H]⁻</span></div>
+      </li> <!----></ul> <!----> <!----></div> </div><div slot-key="reference"><span class="annotation-ion">[C<sub>8</sub>H<sub>10</sub>S<sub>2</sub> - H]⁻</span></div>
   </mock-el-popover>
   <!----></span>
 </div>
@@ -393,7 +393,7 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
                 </g>
               </g>
             </g>
-          </svg> <span class="legend-item-name">[C<sub>19</sub>H<sub>18</sub>N<sub>2</sub>O<sub>7</sub>S<sub>2</sub> - H]⁺<br> Theoretical</span></div>
+          </svg> <span class="legend-item-name">[C<sub>19</sub>H<sub>18</sub>N<sub>2</sub>O<sub>7</sub>S<sub>2</sub> - H]⁺<br> Theoretical</span></div>
         <div class="legend-item"><svg width="64" height="32">
             <g>
               <g class="sample-graph refSample">
@@ -408,7 +408,7 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
                 </g>
               </g>
             </g>
-          </svg> <span class="legend-item-name">[C<sub>19</sub>H<sub>18</sub>N<sub>2</sub>O<sub>7</sub>S<sub>2</sub> - H]⁺<br> Sample</span></div>
+          </svg> <span class="legend-item-name">[C<sub>19</sub>H<sub>18</sub>N<sub>2</sub>O<sub>7</sub>S<sub>2</sub> - H]⁺<br> Sample</span></div>
         <div class="legend-item"><svg width="64" height="32">
             <g>
               <g class="theor-graph compTheor">
@@ -417,7 +417,7 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
                 </g>
               </g>
             </g>
-          </svg> <span class="legend-item-name">[C<sub>8</sub>H<sub>10</sub>S<sub>2</sub> - H]⁻<br> Theoretical</span></div>
+          </svg> <span class="legend-item-name">[C<sub>8</sub>H<sub>10</sub>S<sub>2</sub> - H]⁻<br> Theoretical</span></div>
         <div class="legend-item"><svg width="64" height="32">
             <g>
               <g class="sample-graph compSample">
@@ -432,7 +432,7 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
                 </g>
               </g>
             </g>
-          </svg> <span class="legend-item-name">[C<sub>8</sub>H<sub>10</sub>S<sub>2</sub> - H]⁻<br> Sample</span></div>
+          </svg> <span class="legend-item-name">[C<sub>8</sub>H<sub>10</sub>S<sub>2</sub> - H]⁻<br> Sample</span></div>
       </div>
     </div>
   </div>

--- a/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonAnnotationTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonAnnotationTable.spec.ts.snap
@@ -62,7 +62,7 @@ exports[`DatasetComparisonAnnotationTable it should match snapshot 1`] = `
                         <!---->
                       </div>
                     </div>
-                    <div slot-key="reference"><span>[C<sub class="leading-none">23</sub>H<sub class="leading-none">45</sub>NO<sub class="leading-none">4</sub> + H]⁺</span>
+                    <div slot-key="reference"><span>[C<sub class="leading-none">23</sub>H<sub class="leading-none">45</sub>NO<sub class="leading-none">4</sub> + H]⁺</span>
                       <!---->
                     </div>
                   </mock-el-popover> <svg data-icon="filter" class="cell-filter-button"></svg>
@@ -95,7 +95,7 @@ exports[`DatasetComparisonAnnotationTable it should match snapshot 1`] = `
                         <!---->
                       </div>
                     </div>
-                    <div slot-key="reference"><span>[C<sub class="leading-none">10</sub>H<sub class="leading-none">11</sub>NO + Na]⁺</span>
+                    <div slot-key="reference"><span>[C<sub class="leading-none">10</sub>H<sub class="leading-none">11</sub>NO + Na]⁺</span>
                       <!---->
                     </div>
                   </mock-el-popover> <svg data-icon="filter" class="cell-filter-button"></svg>

--- a/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonDialog.spec.ts.snap
@@ -12,19 +12,19 @@ exports[`DatasetComparisonDialog it should match snapshot 1`] = `
             <p class="sm-workflow-header">Select the datasets</p>
             <form>
               <div class="el-select w-full ">
-                <div class="el-select__tags" style="max-width: 168px; width: 100%;">
+                <div class="el-select__tags" style="max-width: -32px; width: 100%;">
                   <!---->
-                  <transition-group-stub><span class="el-tag el-tag--info el-tag--small el-tag--light"><span class="el-select__tags-text">Mock (1)</span><i class="el-tag__close el-icon-close"></i></span><span class="el-tag el-tag--info el-tag--small el-tag--light"><span class="el-select__tags-text">Mock (2)</span><i class="el-tag__close el-icon-close"></i></span><span class="el-tag el-tag--info el-tag--small el-tag--light"><span class="el-select__tags-text">Mock (3)</span><i class="el-tag__close el-icon-close"></i></span></transition-group-stub><input type="text" autocomplete="off" class="el-select__input" style="flex-grow: 1; width: 0.11904761904761904%; max-width: 158px;">
+                  <transition-group-stub><span class="el-tag el-tag--info el-tag--small el-tag--light"><span class="el-select__tags-text">Mock (1)</span><i class="el-tag__close el-icon-close"></i></span><span class="el-tag el-tag--info el-tag--small el-tag--light"><span class="el-select__tags-text">Mock (2)</span><i class="el-tag__close el-icon-close"></i></span><span class="el-tag el-tag--info el-tag--small el-tag--light"><span class="el-select__tags-text">Mock (3)</span><i class="el-tag__close el-icon-close"></i></span></transition-group-stub><input type="text" autocomplete="off" class="el-select__input" style="flex-grow: 1; width: -0.625%; max-width: -42px;">
                 </div>
                 <div class="el-input el-input--suffix">
-                  <!----><input tabindex="-1" type="text" readonly="readonly" autocomplete="off" placeholder="" class="el-input__inner" style="height: 300px;">
+                  <!----><input tabindex="-1" type="text" readonly="readonly" autocomplete="off" placeholder="" class="el-input__inner" style="height: 40px;">
                   <!----><span class="el-input__suffix"><span class="el-input__suffix-inner"><i class="el-select__caret el-input__icon el-icon-"></i><!----><!----><!----><!----><!----></span>
                   <!----></span>
                   <!---->
                   <!---->
                 </div>
                 <transition-stub name="el-zoom-in-top">
-                  <div class="el-select-dropdown el-popper is-multiple" style="display: none; min-width: 200px;">
+                  <div class="el-select-dropdown el-popper is-multiple" style="display: none;">
                     <div class="el-scrollbar" style="">
                       <div class="el-select-dropdown__wrap el-scrollbar__wrap el-scrollbar__wrap--hidden-default">
                         <ul class="el-scrollbar__view el-select-dropdown__list">

--- a/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonDialog.spec.ts.snap
@@ -12,19 +12,19 @@ exports[`DatasetComparisonDialog it should match snapshot 1`] = `
             <p class="sm-workflow-header">Select the datasets</p>
             <form>
               <div class="el-select w-full ">
-                <div class="el-select__tags" style="max-width: -32px; width: 100%;">
+                <div class="el-select__tags" style="max-width: 168px; width: 100%;">
                   <!---->
-                  <transition-group-stub><span class="el-tag el-tag--info el-tag--small el-tag--light"><span class="el-select__tags-text">Mock (1)</span><i class="el-tag__close el-icon-close"></i></span><span class="el-tag el-tag--info el-tag--small el-tag--light"><span class="el-select__tags-text">Mock (2)</span><i class="el-tag__close el-icon-close"></i></span><span class="el-tag el-tag--info el-tag--small el-tag--light"><span class="el-select__tags-text">Mock (3)</span><i class="el-tag__close el-icon-close"></i></span></transition-group-stub><input type="text" autocomplete="off" class="el-select__input" style="flex-grow: 1; width: -0.625%; max-width: -42px;">
+                  <transition-group-stub><span class="el-tag el-tag--info el-tag--small el-tag--light"><span class="el-select__tags-text">Mock (1)</span><i class="el-tag__close el-icon-close"></i></span><span class="el-tag el-tag--info el-tag--small el-tag--light"><span class="el-select__tags-text">Mock (2)</span><i class="el-tag__close el-icon-close"></i></span><span class="el-tag el-tag--info el-tag--small el-tag--light"><span class="el-select__tags-text">Mock (3)</span><i class="el-tag__close el-icon-close"></i></span></transition-group-stub><input type="text" autocomplete="off" class="el-select__input" style="flex-grow: 1; width: 0.11904761904761904%; max-width: 158px;">
                 </div>
                 <div class="el-input el-input--suffix">
-                  <!----><input tabindex="-1" type="text" readonly="readonly" autocomplete="off" placeholder="" class="el-input__inner" style="height: 40px;">
+                  <!----><input tabindex="-1" type="text" readonly="readonly" autocomplete="off" placeholder="" class="el-input__inner" style="height: 300px;">
                   <!----><span class="el-input__suffix"><span class="el-input__suffix-inner"><i class="el-select__caret el-input__icon el-icon-"></i><!----><!----><!----><!----><!----></span>
                   <!----></span>
                   <!---->
                   <!---->
                 </div>
                 <transition-stub name="el-zoom-in-top">
-                  <div class="el-select-dropdown el-popper is-multiple" style="display: none;">
+                  <div class="el-select-dropdown el-popper is-multiple" style="display: none; min-width: 200px;">
                     <div class="el-scrollbar" style="">
                       <div class="el-select-dropdown__wrap el-scrollbar__wrap el-scrollbar__wrap--hidden-default">
                         <ul class="el-scrollbar__view el-select-dropdown__list">

--- a/metaspace/webapp/src/modules/Filters/__snapshots__/FilterPanel.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Filters/__snapshots__/FilterPanel.spec.ts.snap
@@ -249,7 +249,11 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container pl-3">
       <div slot-key="default">
         <div>
-          <!---->
+          <mock-el-select remote-method="function () { [native code] }" placeholder="Select chemical modification" filterable="" clearable="" remote="">
+            <mock-el-option label="No chemical modification" value="none"></mock-el-option>
+            <mock-el-option label="chemMods.0.name" value="chemMods.0.chemMod"></mock-el-option>
+            <mock-el-option label="chemMods.1.name" value="chemMods.1.chemMod"></mock-el-option>
+          </mock-el-select>
           <!---->
           <mock-el-select value="+K" placeholder="Select ionising adduct" filterable="" clearable="" remote="">
             <mock-el-option label="[M + H]⁺" value="+H"></mock-el-option>

--- a/metaspace/webapp/src/modules/Filters/__snapshots__/FilterPanel.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Filters/__snapshots__/FilterPanel.spec.ts.snap
@@ -249,12 +249,6 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
     <mock-el-popover trigger="click" placement="bottom" width="300" class="tf-value-container pl-3">
       <div slot-key="default">
         <div>
-          <mock-el-select remote-method="function () { [native code] }" placeholder="Select chemical modification" filterable="" clearable="" remote="">
-            <mock-el-option label="No chemical modification" value="none"></mock-el-option>
-            <mock-el-option label="chemMods.0.name" value="chemMods.0.chemMod"></mock-el-option>
-            <mock-el-option label="chemMods.1.name" value="chemMods.1.chemMod"></mock-el-option>
-          </mock-el-select>
-          <!---->
           <mock-el-select value="+K" placeholder="Select ionising adduct" filterable="" clearable="" remote="">
             <mock-el-option label="[M + H]⁺" value="+H"></mock-el-option>
             <mock-el-option label="[M + Na]⁺" value="+Na"></mock-el-option>
@@ -262,6 +256,12 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
             <mock-el-option label="[M - H]⁻" value="-H"></mock-el-option>
             <mock-el-option label="[M + Cl]⁻" value="+Cl"></mock-el-option>
           </mock-el-select>
+          <mock-el-select remote-method="function () { [native code] }" placeholder="Select chemical modification" filterable="" clearable="" remote="">
+            <mock-el-option label="No chemical modification" value="none"></mock-el-option>
+            <mock-el-option label="chemMods.0.name" value="chemMods.0.chemMod"></mock-el-option>
+            <mock-el-option label="chemMods.1.name" value="chemMods.1.chemMod"></mock-el-option>
+          </mock-el-select>
+          <!---->
         </div>
       </div>
       <div slot-key="reference">

--- a/metaspace/webapp/src/modules/Filters/filter-components/AdductFilter.vue
+++ b/metaspace/webapp/src/modules/Filters/filter-components/AdductFilter.vue
@@ -6,6 +6,21 @@
   >
     <div slot="edit">
       <el-select
+        :value="filterValues.adduct"
+        placeholder="Select ionising adduct"
+        filterable
+        clearable
+        remote
+        @change="val => onChange('adduct', val)"
+      >
+        <el-option
+          v-for="item in adductOptions"
+          :key="item.adduct"
+          :label="item.name"
+          :value="item.adduct"
+        />
+      </el-select>
+      <el-select
         v-if="showChemMods"
         :value="filterValues.chemMod"
         :remote-method="updateChemModQuery"
@@ -41,21 +56,6 @@
           :key="item.neutralLoss"
           :label="item.name"
           :value="item.neutralLoss"
-        />
-      </el-select>
-      <el-select
-        :value="filterValues.adduct"
-        placeholder="Select ionising adduct"
-        filterable
-        clearable
-        remote
-        @change="val => onChange('adduct', val)"
-      >
-        <el-option
-          v-for="item in adductOptions"
-          :key="item.adduct"
-          :label="item.name"
-          :value="item.adduct"
         />
       </el-select>
     </div>
@@ -148,20 +148,20 @@ export default class AdductFilter extends Vue {
 
     formatValue() {
       const { chemMod, neutralLoss, adduct } = this.filterValues
-      let innerPart = 'M'
+      let suffix = ''
       if (chemMod && chemMod !== 'none') {
-        innerPart += chemMod
+        suffix += chemMod
       }
       if (neutralLoss && neutralLoss !== 'none') {
-        innerPart += neutralLoss
+        suffix += neutralLoss
       }
-      innerPart = innerPart.replace(/([+-])/g, ' $1 ')
+      suffix = suffix.replace(/([+-])/g, ' $1 ')
 
       if (adduct) {
         const adductInfo = this.filterLists.adducts.find((a:any) => a.adduct === adduct)
-        return (adductInfo && adductInfo.name || adduct).replace('M', innerPart)
+        return (adductInfo && adductInfo.name || adduct).replace(']', suffix + ']')
       } else if ((chemMod && chemMod !== 'none') || (neutralLoss && neutralLoss !== 'none')) {
-        return `[${innerPart} + ?]`
+        return `[M + ?${suffix}]`
       } else if (chemMod === 'none' && neutralLoss === 'none') {
         return 'Only ionising adducts'
       } else if (chemMod === 'none') {

--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -181,7 +181,6 @@ export default {
       return this.possibleAdducts[polarity].map(({ adduct, name, ...ad }) => ({
         ...ad,
         value: adduct,
-        // Without the feature flag, keep old-style names e.g. +H instead of [M+H]⁺
         label: name,
       }))
     },

--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -182,7 +182,7 @@ export default {
         ...ad,
         value: adduct,
         // Without the feature flag, keep old-style names e.g. +H instead of [M+H]⁺
-        label: config.features.all_adducts ? name : adduct,
+        label: name,
       }))
     },
   },

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -965,7 +965,7 @@ exports[`MetadataEditor should match snapshot 1`] = `
                       </mock-el-popover>
                       </span></label>
                     <div class="el-form-item__content">
-                      <mock-el-select multiple="" multiple-limit="3" popper-class="el-select-popper__free-entry" no-data-text="Enter a formula" filterable="" allow-create="" default-first-option=""></mock-el-select>
+                      <mock-el-select popper-class="el-select-popper__with-create" no-data-text="Invalid value" multiple="" filterable="" default-first-option="" remote="" remote-method="function () { [native code] }" multiple-limit="3"></mock-el-select>
                       <transition-stub name="el-zoom-in-top">
                         <!---->
                       </transition-stub>

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -872,12 +872,36 @@ exports[`MetadataEditor should match snapshot 1`] = `
                 </div>
                 <div class="el-col el-col-8" style="padding-left: 4px; padding-right: 4px;">
                   <div class="el-form-item md-form-field el-form-item--medium"><label class="el-form-item__label"><span class="field-label"><span>Adducts</span><span style="color: red;">*</span>
-                      <!----></span></label>
+                      <mock-el-popover trigger="hover" placement="right">
+                        <div slot-key="default">
+                          <div class="adducts-help">
+                            <p>
+                              Each selected adduct is applied to every molecule in the selected database.
+                              Only adducts that commonly form with the chosen ionization source or MALDI matrix should be selected,
+                              as searching for improbable adducts is likely to generate spurious annotations.
+                            </p>
+                            <p>
+                              We recommend selecting <span class="example-input">[M+H]⁺</span>, <span class="example-input">[M+Na]⁺</span>,
+                              <span class="example-input">[M+K]⁺</span> in positive mode,
+                              and <span class="example-input">[M-H]⁻</span>,&nbsp;<span class="example-input">[M+Cl]⁻</span> in negative mode.
+                            </p>
+                            <p>
+                              For ESI-based sources <span class="example-input">[M+NH₄]⁺</span> should also be selected in positive mode.
+                            </p>
+                            <p><span class="example-input">[M]⁺</span> and <span class="example-input">[M]⁻</span> should generally only be
+                              selected when annotating custom databases that have had adducts merged into their molecular formulas, or
+                              in cases when a derivatization agent causes molecules to become permanently charged.
+                            </p>
+                          </div>
+                        </div>
+                        <div slot-key="reference"><i class="el-icon-question metadata-help-icon"></i></div>
+                      </mock-el-popover>
+                      </span></label>
                     <div class="el-form-item__content">
                       <mock-el-select value="+H,+Na,+K" required="true" multiple="">
-                        <mock-el-option value="+H" label="+H"></mock-el-option>
-                        <mock-el-option value="+Na" label="+Na"></mock-el-option>
-                        <mock-el-option value="+K" label="+K"></mock-el-option>
+                        <mock-el-option value="+H" label="[M + H]⁺"></mock-el-option>
+                        <mock-el-option value="+Na" label="[M + Na]⁺"></mock-el-option>
+                        <mock-el-option value="+K" label="[M + K]⁺"></mock-el-option>
                       </mock-el-select>
                       <transition-stub name="el-zoom-in-top">
                         <!---->
@@ -903,7 +927,53 @@ exports[`MetadataEditor should match snapshot 1`] = `
                   </div>
                 </div>
               </div>
-              <!---->
+              <div class="el-row" style="margin-left: -4px; margin-right: -4px;">
+                <!---->
+                <div class="el-col el-col-8" style="padding-left: 4px; padding-right: 4px;">
+                  <div class="el-form-item md-form-field el-form-item--medium"><label class="el-form-item__label"><span class="field-label"><span>Chemical modifications</span>
+                      <!---->
+                      <mock-el-popover trigger="hover" placement="right">
+                        <div slot-key="default">
+                          <div style="max-width: 500px;">
+                            <p>
+                              This setting is intended for use in samples that have been treated with a derivatization agent.
+                              Chemical modifications add and remove elements from every formula in the selected database.
+                              Unmodified formulas will also be annotated, and each modification will have an independent FDR ranking.
+                            </p>
+                            <p>
+                              Extra scrutiny must be given to the results annotated with chemical modifications,
+                              as modified formulas are often isomeric to other unmodified molecules in the database.
+                            </p>
+                            <p>
+                              Modifications should be entered as a series of formulas being removed
+                              with <span class="example-input">-</span> and added with <span class="example-input">+</span>.
+                              For example, derivatization with Girard's Reagent T would be
+                              entered as <span class="example-input">-O+C5H12N3O</span>.
+                            </p>
+                            <p>
+                              In cases where a derivatization agent adds a permanent charge, such as with the
+                              quaternary ammonium moiety in the above example, additional steps are needed to ensure that
+                              METASPACE searches for the correct mass. Either
+                              the <span class="example-input">[M]⁺</span> or <span class="example-input">[M]⁻</span> adduct
+                              should be selected, or the number of hydrogens in the chemical modification formula should be adjusted
+                              so that the correct mass is calculated after
+                              the <span class="example-input">[M+H]⁺</span> or <span class="example-input">[M-H]⁻</span> adduct is applied.
+                            </p>
+                          </div>
+                        </div>
+                        <div slot-key="reference"><i class="el-icon-question metadata-help-icon"></i></div>
+                      </mock-el-popover>
+                      </span></label>
+                    <div class="el-form-item__content">
+                      <mock-el-select multiple="" multiple-limit="3" popper-class="el-select-popper__free-entry" no-data-text="Enter a formula" filterable="" allow-create="" default-first-option=""></mock-el-select>
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
+                    </div>
+                  </div>
+                </div>
+                <!---->
+              </div>
               <!---->
             </div>
           </div>

--- a/metaspace/webapp/src/modules/MetadataEditor/formStructure.ts
+++ b/metaspace/webapp/src/modules/MetadataEditor/formStructure.ts
@@ -47,16 +47,22 @@ export interface FormSchema extends JsonSchemaProperty {
 }
 
 export interface MetaspaceOptions {
+  name: string;
   isPublic: boolean;
-  databases: number[];
   databaseIds: number[];
   adducts: string[];
+  neutralLosses: string[];
+  chemMods: string[];
   groupId: string | null;
   projectIds: string[];
   principalInvestigator: {
     name: string;
     email: string;
   } | null;
+  analysisVersion: number;
+  ppm: number;
+  numPeaks: number;
+  decoySampleSize: number;
 }
 
 const FIELD_WIDTH: Record<string, number> = {

--- a/metaspace/webapp/src/modules/MetadataEditor/inputs/AdductsHelp.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/inputs/AdductsHelp.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="adducts-help">
+    <p>
+      Each selected adduct is applied to every molecule in the selected database.
+      Only adducts that commonly form with the chosen ionization source or MALDI matrix should be selected,
+      as searching for improbable adducts is likely to generate spurious annotations.
+    </p>
+    <p>
+      We recommend selecting <span class="example-input">[M+H]⁺</span>, <span class="example-input">[M+Na]⁺</span>,
+      <span class="example-input">[M+K]⁺</span> in positive mode,
+      and <span class="example-input">[M-H]⁻</span>,&nbsp;<span class="example-input">[M+Cl]⁻</span> in negative mode.
+    </p>
+    <p>
+      For ESI-based sources <span class="example-input">[M+NH₄]⁺</span> should also be selected in positive mode.
+    </p>
+    <p>
+      <span class="example-input">[M]⁺</span> and <span class="example-input">[M]⁻</span> should generally only be
+      selected when annotating custom databases that have had adducts merged into their molecular formulas, or
+      in cases when a derivatization agent causes molecules to become permanently charged.
+    </p>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AdductsHelp',
+}
+</script>
+
+<style scoped>
+  .adducts-help {
+    max-width: 400px;
+  }
+  .example-input {
+    background: #EEEEEE;
+    padding: 2px 0;
+    white-space: nowrap;
+  }
+</style>

--- a/metaspace/webapp/src/modules/MetadataEditor/inputs/ChemModsHelp.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/inputs/ChemModsHelp.vue
@@ -1,0 +1,42 @@
+<template>
+  <div style="max-width: 500px;">
+    <p>
+      This setting is intended for use in samples that have been treated with a derivatization agent.
+      Chemical modifications add and remove elements from every formula in the selected database.
+      Unmodified formulas will also be annotated, and each modification will have an independent FDR ranking.
+    </p>
+    <p>
+      Extra scrutiny must be given to the results annotated with chemical modifications,
+      as modified formulas are often isomeric to other unmodified molecules in the database.
+    </p>
+    <p>
+      Modifications should be entered as a series of formulas being removed
+      with <span class="example-input">-</span> and added with <span class="example-input">+</span>.
+      For example, derivatization with Girard's Reagent T would be
+      entered as <span class="example-input">-O+C5H12N3O</span>.
+    </p>
+    <p>
+      In cases where a derivatization agent adds a permanent charge, such as with the
+      quaternary ammonium moiety in the above example, additional steps are needed to ensure that
+      METASPACE searches for the correct mass. Either
+      the <span class="example-input">[M]⁺</span> or <span class="example-input">[M]⁻</span> adduct
+      should be selected, or the number of hydrogens in the chemical modification formula should be adjusted
+      so that the correct mass is calculated after
+      the <span class="example-input">[M+H]⁺</span> or <span class="example-input">[M-H]⁻</span> adduct is applied.
+    </p>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ChemModsHelp',
+}
+</script>
+
+<style scoped>
+.example-input {
+  background: #EEEEEE;
+  padding: 2px 8px;
+  white-space: nowrap;
+}
+</style>

--- a/metaspace/webapp/src/modules/MetadataEditor/inputs/FormField.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/inputs/FormField.vue
@@ -101,6 +101,32 @@
       </slot>
     </el-select>
 
+    <el-select
+      v-else-if="type === 'selectMultiWithCreate'"
+      popper-class="el-select-popper__with-create"
+      no-data-text="Invalid value"
+      :value="value"
+      :required="required"
+      multiple
+      filterable
+      default-first-option
+      remote
+      :remote-method="onCreateItemInput"
+      :loading="false"
+      v-bind="$attrs"
+      @remove-tag="onRemoveTag"
+      @input="onInput"
+    >
+      <slot name="options">
+        <el-option
+          v-for="opt in createItemPreviewOptions"
+          :key="createOptionsAreStrings ? opt : opt.value"
+          :value="createOptionsAreStrings ? opt : opt.value"
+          :label="createOptionsAreStrings ? opt : opt.label"
+        />
+      </slot>
+    </el-select>
+
     <table-input
       v-else-if="type === 'table'"
       :value="value"
@@ -158,7 +184,7 @@ import PixelSizeInput from './PixelSizeInput.vue'
 import { Component, Prop } from 'vue-property-decorator'
 import { FetchSuggestions, FetchSuggestionsCallback } from 'element-ui/types/autocomplete'
 import CustomNumberInput from './CustomNumberInput.vue'
-import { throttle } from 'lodash-es'
+import { throttle, uniq } from 'lodash-es'
 
   @Component({
     inheritAttrs: false,
@@ -201,7 +227,11 @@ export default class FormField extends Vue {
     @Prop(Function)
     fetchSuggestions!: FetchSuggestions;
 
+    @Prop(Function)
+    normalizeInput: (value: string) => string | null;
+
     wideAutocomplete = false;
+    createItemPreviewOptions = []
 
     created() {
       // WORKAROUND: Currently there's a delay that causes the autocomplete box to stutter when opening on focus.
@@ -215,16 +245,42 @@ export default class FormField extends Vue {
       return this.options && this.options.length > 0 && typeof this.options[0] === 'string'
     }
 
+    get createOptionsAreStrings() {
+      return this.createItemPreviewOptions.length > 0 && typeof this.createItemPreviewOptions[0] === 'string'
+    }
+
     onSelect(val: any) {
       this.$emit('select', val)
     }
 
     onInput(val: any) {
-      this.$emit('input', val)
+      if (this.type === 'selectMultiWithCreate' && this.normalizeInput) {
+        const valArray = val as string[]
+        const normalizedVals = valArray.flatMap(newVal => {
+          if (valArray.includes(newVal)) {
+            // Don't change existing values
+            return [newVal]
+          }
+          const normalizedVal = this.normalizeInput(newVal)
+          return normalizedVal != null ? [normalizedVal] : []
+        })
+
+        this.$emit('input', uniq(normalizedVals))
+      } else {
+        this.$emit('input', val)
+      }
     }
 
     onRemoveTag(val: any) {
       this.$emit('remove-tag', val)
+    }
+
+    onCreateItemInput(val: any) {
+      // WORKAROUND: This uses ElSelect's remote search interface to show the validated, normalized form of the
+      // user's input. If the input is null after normalization, the options list is empty and
+      // ElSelect shows the no-data-text instead.
+      const normalizedVal = this.normalizeInput != null ? this.normalizeInput(val) : val
+      this.createItemPreviewOptions = normalizedVal != null ? [normalizedVal] : []
     }
 
     fetchSuggestionsAndTestWidth(queryString: string, callback: FetchSuggestionsCallback) {
@@ -290,5 +346,14 @@ export default class FormField extends Vue {
 
   .el-input__inner {
     width: 100%;
+  }
+
+  .el-select-popper__with-create .el-select-dropdown__list::after {
+    @apply pt-2 px-5 text-center;
+    display: list-item;
+    content: 'Press enter to confirm';
+    // Style to match the no-data-text
+    font-size: 14px;
+    color: #999;
   }
 </style>

--- a/metaspace/webapp/src/modules/MetadataEditor/inputs/FormField.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/inputs/FormField.vue
@@ -228,10 +228,10 @@ export default class FormField extends Vue {
     fetchSuggestions!: FetchSuggestions;
 
     @Prop(Function)
-    normalizeInput: (value: string) => string | null;
+    normalizeInput?: (value: string) => string | null;
 
     wideAutocomplete = false;
-    createItemPreviewOptions = []
+    createItemPreviewOptions: string[] = []
 
     created() {
       // WORKAROUND: Currently there's a delay that causes the autocomplete box to stutter when opening on focus.
@@ -254,11 +254,11 @@ export default class FormField extends Vue {
     }
 
     onInput(val: any) {
-      if (this.type === 'selectMultiWithCreate' && this.normalizeInput) {
+      if (this.type === 'selectMultiWithCreate') {
         const valArray = val as string[]
         const normalizedVals = valArray.flatMap(newVal => {
-          if (valArray.includes(newVal)) {
-            // Don't change existing values
+          if (valArray.includes(newVal) || !this.normalizeInput) {
+            // Don't change existing values, don't normalize if no normalization function
             return [newVal]
           }
           const normalizedVal = this.normalizeInput(newVal)

--- a/metaspace/webapp/src/modules/MetadataEditor/inputs/NeutralLossesHelp.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/inputs/NeutralLossesHelp.vue
@@ -1,0 +1,33 @@
+<template>
+  <div style="max-width: 500px;">
+    <p>
+      Search for ions with a specific neutral loss by entering the formula of the loss here,
+      e.g. <span class="example-input">-H2O</span> to search for ions with H2O loss.
+    </p>
+    <p v-if="!features.neutral_losses_new_ds">
+      This functionality is only intended for diagnosis when specific expected molecules
+      were not found in a regular search. It may not be available until after the initial annotation has run.
+    </p>
+  </div>
+</template>
+
+<script>
+import config from '../../../lib/config'
+
+export default {
+  name: 'NeutralLossesHelp',
+  data() {
+    return {
+      features: config.features,
+    }
+  },
+}
+</script>
+
+<style scoped>
+  .example-input {
+    background: #EEEEEE;
+    padding: 2px 0;
+    white-space: nowrap;
+  }
+</style>

--- a/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
@@ -196,7 +196,10 @@ interface Option {
   label: string
 }
 
-const validElement = /A[cglmrstu]|B[aeikr]?|C[adelorsu]?|D[by]|E[rsu]|F[er]?|G[ade]|H[efgo]?|I[nr]?|Kr?|L[airu]|M[dgno]|N[abdeip]?|Os?|P[abdmrt]?|R[behu]|S[bceimnr]?|T[abceilm]|U|V|W|Xe|Yb?|Z[nr]/
+const validElement = new RegExp(
+  '/A[cglmrstu]|B[aeikr]?|C[adelorsu]?|D[by]|E[rsu]|F[er]?|G[ade]|H[efgo]?|I[nr]?|Kr?|L[airu]|M[dgno]|'
+  + 'N[abdeip]?|Os?|P[abdmrt]?|R[behu]|S[bceimnr]?|T[abceilm]|U|V|W|Xe|Yb?|Z[nr]',
+)
 const validFormulaModifier = new RegExp(`([+-]((${validElement.source})[0-9]{0,3})+)+`)
 const normalizeFormulaModifier = (formula: string, defaultSign: '+'|'-') => {
   if (!formula) return null
@@ -280,8 +283,8 @@ export default class MetaspaceOptionsSection extends Vue {
       }
     }
 
-    onNeutralLossesInput(neutralLosses: string) {
-      const parsedVals = []
+    onNeutralLossesInput(neutralLosses: string[]) {
+      const parsedVals: string[] = []
       neutralLosses.forEach(neutralLoss => {
         const parsedVal = normalizeFormulaModifier(neutralLoss, '-')
         if (parsedVal) {
@@ -300,7 +303,7 @@ export default class MetaspaceOptionsSection extends Vue {
     }
 
     onChemModsInput(chemMods: string[]) {
-      const parsedVals = []
+      const parsedVals: string[] = []
       chemMods.forEach(chemMod => {
         const parsedVal = normalizeFormulaModifier(chemMod, '+')
         if (parsedVal) {


### PR DESCRIPTION
Resolves #860 

As discussed in standup, I increased the scope a bit as I found that most chem mods require [M]+/[M]- adducts.

This adds some new UI:

#### Upload page
* Changed the way that inputs to the "Chemical modifications" and (hidden) "Neutral losses" fields work. Previously they'd lose input if you tabbed away. I've added the text "Press enter to confirm" to make it clearer.
* Refactored the logic so that the formula parsing is a bit better and it's mostly contained within `FormField.vue` instead of duplicated
* Changed the adducts selection box to always show the longer "[M + H]+" form instead of the old "+H" form. This is needed so that "[M]+" looks consistent.
![image](https://user-images.githubusercontent.com/26366936/123092054-5aae0100-d42a-11eb-8415-376e47410905.png)

Also, help text was added/updated:
![image](https://user-images.githubusercontent.com/26366936/123092115-6d283a80-d42a-11eb-98a3-23b22c10fef2.png)
![image](https://user-images.githubusercontent.com/26366936/123092159-7a452980-d42a-11eb-96c3-dc361f904837.png)


#### Annotations page

* This code already existed but is now active due to the feature flag change: the Adducts filter expands to show two dropdowns.
![image](https://user-images.githubusercontent.com/26366936/123099522-8df48e00-d432-11eb-8fe2-8c7520ffbbe2.png)
![image](https://user-images.githubusercontent.com/26366936/123099572-9947b980-d432-11eb-9ee3-d9aaa57dd18c.png)
![image](https://user-images.githubusercontent.com/26366936/123099624-a6fd3f00-d432-11eb-8ae9-c2fa8a4af077.png)


TBH the chem mods filter is a bit crap and will eventually fill up with garbage. Ideally we'd limit it to only show values for the selected datasets like the Databases filter, but that's a job for another task.

#### Molecular formulas
* I reordered molecular formulas to put Chem Mods / Neutral Losses AFTER the ionizing adduct. This was done to match the format I've seen in literature, and I double-checked it with Måns to confirm that it is the preferred order.
* I also changed the weird "[PSP]" space characters around "+" and "-" characters into regular spaces, as I've been frustrated a few times when copying molecular formulas and having weird invisible characters in them. There was a tiny reduction in the size of the spaces:

Before:
![image](https://user-images.githubusercontent.com/26366936/123102271-2b50c180-d435-11eb-84db-f0c29c859e4b.png)

After:
![image](https://user-images.githubusercontent.com/26366936/123102474-60f5aa80-d435-11eb-8b92-58cc95d76e89.png)
