### PR TITLE
Add Submitter/Group/PI data to python client

### DIFF
--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.8.8'
+__version__ = '1.8.9'
 
 from metaspace.sm_annotation_utils import (
     SMInstance,

--- a/metaspace/python-client/metaspace/tests/test_sm_instance.py
+++ b/metaspace/python-client/metaspace/tests/test_sm_instance.py
@@ -74,6 +74,7 @@ def test_datasets_by_all_fields(sm: SMInstance):
     )
 
 
+@pytest.mark.skip('This test triggers processing and should only be run manually')
 def test_submit_dataset(sm: SMInstance, metadata):
     time.sleep(1)  # Ensure no more than 1 DS per second is submitted to prevent errors
 
@@ -91,6 +92,7 @@ def test_submit_dataset(sm: SMInstance, metadata):
     assert set(new_ds.adducts) == {'+H', '+Na', '+K'}  # Ensure defaults were added
 
 
+@pytest.mark.skip('This test triggers processing and should only be run manually')
 def test_submit_dataset_clone(sm: SMInstance, my_ds_id, metadata):
     time.sleep(1)  # Ensure no more than 1 DS per second is submitted to prevent errors
 

--- a/metaspace/python-client/metaspace/types.py
+++ b/metaspace/python-client/metaspace/types.py
@@ -127,6 +127,8 @@ class DSConfig(TypedDict):
 
 
 class DatabaseDetails(TypedDict):
+    """DEPRECATED - this has been replaced by metaspace.sm_annotation_utils.MolecularDB"""
+
     id: int
     name: str
     version: str
@@ -154,3 +156,20 @@ class DatasetDownload(TypedDict):
     license: DatasetDownloadLicense
     contributors: List[DatasetDownloadContributor]
     files: List[DatasetDownloadFile]
+
+
+class DatasetUser(TypedDict):
+    id: str
+    name: str
+
+
+class DatasetGroup(TypedDict):
+    id: str
+    name: str
+    shortName: str
+
+
+class DatasetProject(TypedDict):
+    id: str
+    name: str
+    publicationStatus: str


### PR DESCRIPTION
* Add `submitter`, `group`, `projects`, and `principal_investigator` fields to `SMDataset` (resolves #333 )
* Change `SMDataset.database_details` `TypedDict`s to `MolecularDB` instances (with compatibility shim) (resolves #729 )
* Documentation & test tweaks

I haven't published this to PyPI yet. I'll wait until it's approved, as nobody is waiting for these changes.