### PR TITLE
Fix several sentry errors

### DIFF
--- a/metaspace/graphql/package.json
+++ b/metaspace/graphql/package.json
@@ -47,7 +47,7 @@
     "@types/passport-jwt": "^3.0.3",
     "@types/passport-local": "^1.0.33",
     "@types/sprintf-js": "^1.1.1",
-    "@types/uuid": "^3.4.3",
+    "@types/uuid": "^8.3.0",
     "@uppy/companion": "^1.13.2",
     "ajv": "4.10.0",
     "amqplib": "^0.5.1",
@@ -92,10 +92,11 @@
     "reflect-metadata": "^0.1.10",
     "sprintf-js": "^1.0.3",
     "subscriptions-transport-ws": "^0.9.16",
+    "superstruct": "^0.15.2",
     "ts-node": "^8.3.0",
     "typeorm": "0.2.25",
     "typescript": "^3.9.2",
-    "uuid": "^3.3.2",
+    "uuid": "^8.3.2",
     "winston": "^2.4.5"
   },
   "devDependencies": {

--- a/metaspace/graphql/src/modules/webServer/databaseUploadMiddleware.ts
+++ b/metaspace/graphql/src/modules/webServer/databaseUploadMiddleware.ts
@@ -1,7 +1,7 @@
 import * as http from 'http'
 import * as express from 'express'
 import * as companion from '@uppy/companion'
-import * as genUuid from 'uuid'
+import * as uuid from 'uuid'
 import config from '../../utils/config'
 import * as bodyParser from 'body-parser'
 
@@ -11,7 +11,7 @@ export default function(httpServer: http.Server) {
   const options = getCompanionOptions(
     '/database_upload',
     (req: express.Request, filename: string) => {
-      return `${config.upload.moldb_prefix}/${genUuid()}/${encodeURIComponent(filename)}`
+      return `${config.upload.moldb_prefix}/${uuid.v4()}/${encodeURIComponent(filename)}`
     },
   )
 

--- a/metaspace/graphql/src/modules/webServer/datasetUploadMiddleware.ts
+++ b/metaspace/graphql/src/modules/webServer/datasetUploadMiddleware.ts
@@ -24,7 +24,7 @@ function signUuid(uuid: string) {
  * @param next
  */
 function generateUuidForUpload(req: Request, res: Response) {
-  const uuid = genUuid()
+  const uuid = genUuid.v4()
   const uuidSignature = signUuid(uuid)
   res.json({ uuid, uuidSignature })
 }

--- a/metaspace/graphql/src/modules/webServer/uploadMiddleware.ts
+++ b/metaspace/graphql/src/modules/webServer/uploadMiddleware.ts
@@ -1,7 +1,7 @@
 import * as http from 'http'
 import * as express from 'express'
 import * as companion from '@uppy/companion'
-import * as genUuid from 'uuid'
+import * as uuid from 'uuid'
 import * as bodyParser from 'body-parser'
 
 import getCompanionOptions from './getCompanionOptions'
@@ -10,7 +10,7 @@ export default function(path: string, s3_prefix: string, httpServer?: http.Serve
   const options = getCompanionOptions(
     path,
     (req: express.Request, filename: string) => {
-      return `${s3_prefix}/${genUuid()}/${encodeURIComponent(filename)}`
+      return `${s3_prefix}/${uuid.v4()}/${encodeURIComponent(filename)}`
     },
   )
 

--- a/metaspace/graphql/yarn.lock
+++ b/metaspace/graphql/yarn.lock
@@ -1142,12 +1142,10 @@
   dependencies:
     "@types/superagent" "*"
 
-"@types/uuid@^3.4.3":
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.3.tgz#121ace265f5569ce40f4f6d0ff78a338c732a754"
-  integrity sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==
-  dependencies:
-    "@types/node" "*"
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
 
 "@types/ws@^7.0.0":
   version "7.2.5"
@@ -7969,6 +7967,11 @@ superagent@^3.8.3:
     qs "^6.5.1"
     readable-stream "^2.3.5"
 
+superstruct@^0.15.2:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-0.15.2.tgz#ab7fb84c455a9d7da84c11cfd82c85a4fee9dfff"
+  integrity sha512-OsJI8lv6/PsInwCf4ultejmsJYseYshKhkcbDendqNwj3MeGXENajl3ujMGMU4FDDSSeJTOwFn9T6pnfsS9DYA==
+
 supertest@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/supertest/-/supertest-4.0.2.tgz#c2234dbdd6dc79b6f15b99c8d6577b90e4ce3f36"
@@ -8544,10 +8547,10 @@ uuid@^7.0.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
-uuid@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d"
-  integrity sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==
+uuid@^8.0.0, uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.2.0"

--- a/metaspace/webapp/src/lib/ionImageRendering.ts
+++ b/metaspace/webapp/src/lib/ionImageRendering.ts
@@ -214,7 +214,11 @@ const quantizeScaleBar = (minIntensity: number, maxIntensity: number,
 export const loadPngFromUrl = async(url: string) => {
   const response = await fetch(url, { credentials: 'omit' })
   if (response.status !== 200) {
-    throw new Error(`Invalid response fetching image: ${response.status} ${response.statusText}`)
+    throw Object.assign(
+      new Error(`Invalid response fetching image: ${response.status} ${response.statusText}`),
+      // Don't report 403s/404s to Sentry - they're virtually always caused by deleted datasets
+      { isHandled: response.status === 403 || response.status === 404 },
+    )
   }
   const buffer = await response.arrayBuffer()
   return decode(buffer)

--- a/metaspace/webapp/src/lib/reportError.ts
+++ b/metaspace/webapp/src/lib/reportError.ts
@@ -11,7 +11,7 @@ export function setErrorNotifier(_$notify: ElNotification) {
 
 function isHandled(err: any) {
   try {
-    return err && err.graphQLErrors && every(err.graphQLErrors, e => e && e.isHandled)
+    return !!((err?.graphQLErrors && every(err.graphQLErrors, e => e && e.isHandled)) || err?.isHandled)
   } catch {
     return false
   }

--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
@@ -369,7 +369,7 @@ export default Vue.extend({
         colocalizationCoeffFilter,
         orderBy: this.orderBy,
         sortingOrder: this.sortingOrder,
-        offset: (this.currentPage - 1) * this.recordsPerPage,
+        offset: Math.max(0, (this.currentPage - 1) * this.recordsPerPage),
         limit: this.recordsPerPage,
         countIsomerCompounds: config.features.isomers,
       }

--- a/metaspace/webapp/src/modules/ImageViewer/ImageViewer.spec.ts
+++ b/metaspace/webapp/src/modules/ImageViewer/ImageViewer.spec.ts
@@ -53,7 +53,7 @@ describe('ImageViewer', () => {
 
   const mockAnnotationData = {
     ion: 'H2O',
-    isotopeImages: [{}],
+    isotopeImages: [{ url: 'fake://url' }],
     possibleCompounds: [
       { name: 'water' },
     ],

--- a/metaspace/webapp/src/modules/ImageViewer/useIonImages.ts
+++ b/metaspace/webapp/src/modules/ImageViewer/useIonImages.ts
@@ -45,7 +45,7 @@ function createComputedImageData(props: Props, layer: IonImageLayer) {
   if (rawImageCache[layer.id].value === null) {
     const annotation = annotationCache[layer.id]
     const [isotopeImage] = annotation.isotopeImages
-    if (isotopeImage) {
+    if (isotopeImage && isotopeImage.url) {
       loadPngFromUrl(isotopeImage.url)
         .then(img => {
           rawImageCache[layer.id].value = img

--- a/metaspace/webapp/src/modules/ImageViewer/useRestoredState.ts
+++ b/metaspace/webapp/src/modules/ImageViewer/useRestoredState.ts
@@ -5,42 +5,27 @@ import reportError from '../../lib/reportError'
 import { restoreImageViewerState } from './state'
 import { restoreIonImageState } from './ionImageState'
 import store from '../../store'
-import safeJsonParse from '../../lib/safeJsonParse'
+import { annotationDetailItemFragment } from '../../api/annotation'
 
 export default async($apollo: any, id: string, datasetId: string) => {
   try {
     const result: any = await $apollo.query({
-      query: gql`query fetchImageViewerSnapshot($id: String!, $datasetId: String!) {
+      query: gql`query fetchImageViewerSnapshot(
+        $id: String!,
+        $datasetId: String!,
+        $colocalizationCoeffFilter: ColocalizationCoeffFilter,
+        $countIsomerCompounds: Boolean,
+        $type: OpticalImageType
+      ) {
         imageViewerSnapshot(id: $id, datasetId: $datasetId) {
           version
           snapshot
           annotations {
-            id
-            ion
-            mz
-            dataset {
-              id
-              submitter { id name email }
-              principalInvestigator { name email }
-              group { id name shortName }
-              groupApproved
-              projects { id name }
-              name
-              polarity
-              metadataJson
-              isPublic
-            }
-            isotopeImages {
-              minIntensity,
-              maxIntensity,
-              url
-            }
-            possibleCompounds {
-              name
-            }
+            ...AnnotationDetailItem
           }
         }
-      }`,
+      }
+      ${annotationDetailItemFragment}`,
       variables: {
         id,
         datasetId,


### PR DESCRIPTION
One commit per Sentry error

#### `The input is not a PNG file!`
This happened when the first isotopic image is missing (possible with `targeted` custom DBs) - the `isotopeImage` structure was non-null for some reason, but the URL was null. Added an extra null check

#### `Invalid response fetching image: 403 Forbidden`
This happens when trying to view an image for a dataset that has been deleted/reprocessed. I just suppressed this error report as it's annoying.

#### Add parameter validation to authentication routes
The actual error(s) were like "Cannot read property 'toLowerCase' of undefined". I think bots were trying our REST-style authentication API without passing the correct query/body parameters. I added validation to all of these routes so that they get caught earlier, and disabled reporting that type of error to Sentry.

#### `undefined is not an object (evaluating 'e.information[0]')`
A bunch of fields were missing when the selected annotation was loaded from restored state. This only caused errors when the Molecules section was opened. I changed it to use the same GQL Fragment as the other annotation query so that these don't go out of sync again

####  `Cannot read property 'length' of undefined` / `[from] parameter cannot be negative`
Sometimes people seem to end up with `page=0` or `page=null` on the annotations page, even though `page=1` is the first. I'm unsure how it happens, but they quickly get redirected to a valid page number so it doesn't really matter. However, a request is still sent for `offset: -25`, which causes this hidden error.

The fix just stops requests with negative offsets from being sent.
