### PR TITLE
Retry on failure on image storage bucket creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,7 +308,9 @@ jobs:
           name: Run linter
           # Limit number of CPUs to prevent silent OOMs in background processes
           # https://github.com/PyCQA/pylint/issues/3899
-          command: pylint -j1 sm scripts
+          command: |
+            pylint --version
+            pylint -j1 sm scripts
       - run:
          name: Run code formatter
          command: black --check .

--- a/metaspace/engine/sm/engine/image_storage.py
+++ b/metaspace/engine/sm/engine/image_storage.py
@@ -11,6 +11,8 @@ from botocore.exceptions import ClientError
 from scipy.ndimage import zoom
 import PIL.Image
 
+from sm.engine.config import SMConfig
+from sm.engine.storage import get_s3_resource, create_bucket, get_s3_client
 from sm.engine.utils.retry_on_exception import retry_on_exception
 
 try:
@@ -20,8 +22,6 @@ except ImportError:
     S3ServiceResource = object
     S3Client = object
 
-from sm.engine.config import SMConfig
-from sm.engine.storage import get_s3_resource, create_bucket, get_s3_client
 
 logger = logging.getLogger('engine')
 

--- a/metaspace/engine/sm/engine/image_storage.py
+++ b/metaspace/engine/sm/engine/image_storage.py
@@ -7,8 +7,11 @@ from enum import Enum
 from typing import List, Tuple, Callable, Dict
 
 import numpy as np
+from botocore.exceptions import ClientError
 from scipy.ndimage import zoom
 import PIL.Image
+
+from sm.engine.utils.retry_on_exception import retry_on_exception
 
 try:
     from mypy_boto3_s3.service_resource import S3ServiceResource
@@ -179,6 +182,7 @@ get_image_url: Callable[[ImageType, str, str], str]
 get_ion_images_for_analysis = None
 
 
+@retry_on_exception(ClientError)
 def _configure_bucket(sm_config: Dict):
     bucket_name = sm_config['image_storage']['bucket']
     logger.info(f'Configuring image storage bucket: {bucket_name}')

--- a/metaspace/engine/sm/engine/util.py
+++ b/metaspace/engine/sm/engine/util.py
@@ -45,7 +45,7 @@ def populate_aws_env_vars(aws_config):
 
 
 def on_startup(config_path: str) -> Dict:
-    from sm.engine import image_storage  # pylint: disable=import-outside-toplevel
+    from sm.engine import image_storage  # pylint: disable=import-outside-toplevel,cyclic-import
 
     SMConfig.set_path(config_path)
     sm_config = SMConfig.get_conf()

--- a/metaspace/engine/sm/engine/util.py
+++ b/metaspace/engine/sm/engine/util.py
@@ -5,9 +5,14 @@ from pathlib import Path
 from typing import Dict
 
 from sm.engine.config import init_loggers, SMConfig
-from sm.engine import image_storage
 
 logger = logging.getLogger('engine')
+
+
+####################################################################################################
+############################### DON'T ADD NEW FUNCTIONS TO THIS FILE ###############################
+#### It's a frequent source of unwanted & circular imports. Create a new file in utils/ instead. ###
+####################################################################################################
 
 
 def split_s3_path(path):
@@ -40,6 +45,8 @@ def populate_aws_env_vars(aws_config):
 
 
 def on_startup(config_path: str) -> Dict:
+    from sm.engine import image_storage  # pylint: disable=import-outside-toplevel
+
     SMConfig.set_path(config_path)
     sm_config = SMConfig.get_conf()
 


### PR DESCRIPTION
Fixes #813 

The `@retry_on_exception(ClientError)` is the main part of this change. The rest is all fixing pylint issues (I added a version check to CI because I couldn't reproduce something locally. It turns out that `-j1` (i.e. parallel jobs = 1) affects the behavior), and preventing circular imports.

I added a comment to `util.py` just so it's clear not to add to it. I keep having circular import and unintended import (for Lithops pickled functions) problems with this file... 