### PR TITLE
Optimize webapp CI & fix graphql coverage reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,10 @@ jobs:
           command: |
             cp ci/clientConfig.json src/
       - run:
+          name: Generate metadata schema
+          command: |
+            yarn run deref-schema
+      - run:
           name: Lint code
           when: always
           command: yarn run lint --max-warnings 0 --no-fix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,23 +145,22 @@ jobs:
           command: |
             cp ci/clientConfig.json src/
       - run:
-          name: Compile
-          command: |
-            yarn run build-ci
+          name: Lint code
+          when: always
+          command: yarn run lint --max-warnings 0 --no-fix
       - run:
           name: Run tests
           command: |
             cp ~/workspace/graphql-schema.json ./tests/utils/graphql-schema.json
-            yarn run test-ci
+            yarn run test-ci --coverage --maxWorkers=2
       - run:
           name: Upload coverage
           command: |
-            yarn run test-ci --coverage --maxWorkers=1
             npx codecov -p ../.. -F webapp
       - run:
-          name: Lint code
-          when: always
-          command: yarn run lint --max-warnings 0 --no-fix
+          name: Test compilation
+          command: |
+            yarn run build-ci
 
   test-webapp-e2e:
     docker:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,16 +11,16 @@ coverage:
   status:
     project:
       engine:
-        range: 70...100
+        target: 70%
         threshold: 0.2
-        flags: engine
+        flags: ["engine"]
       webapp:
-        range: 50...100
+        target: 51%
         threshold: 0.5
-        flags: webapp
+        flags: ["webapp"]
       graphql:
-        range: 55...100
+        target: 62%
         threshold: 0.5
-        flags: graphql
+        flags: ["graphql"]
     patch: no
     changes: no

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -19,7 +19,7 @@ coverage:
         threshold: 0.5
         flags: ["webapp"]
       graphql:
-        target: 62%
+        target: 60%
         threshold: 0.5
         flags: ["graphql"]
     patch: no

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,7 +11,7 @@ coverage:
   status:
     project:
       engine:
-        target: 70%
+        target: 69%
         threshold: 0.2
         flags: ["engine"]
       webapp:

--- a/metaspace/webapp/package.json
+++ b/metaspace/webapp/package.json
@@ -17,13 +17,13 @@
   "scripts": {
     "dev": "cross-env NODE_ENV=development vue-cli-service serve",
     "test": "yarn run generate-local-graphql-schema && cross-env NODE_ENV=test jest",
-    "test-ci": "cross-env NODE_ENV=test jest --ci --maxWorkers 1",
+    "test-ci": "cross-env NODE_ENV=test jest --ci",
     "coverage": "cross-env NODE_ENV=test jest --coverage",
     "deref-schema": "node ./deref_schema.js src/lib/metadataSchemas",
     "generate-local-graphql-schema": "cd ../graphql && yarn run gen-graphql-schema",
     "fetch-prod-graphql-schema": "apollo schema:download tests/utils/graphql-schema.json --endpoint https://metaspace2020.eu/graphql",
     "build": "yarn run deref-schema && cross-env NODE_ENV=production vue-cli-service build --modern",
-    "build-ci": "yarn run deref-schema && cross-env NODE_ENV=production vue-cli-service build --no-progress --hide-modules",
+    "build-ci": "cross-env NODE_ENV=production vue-cli-service build --no-progress --hide-modules",
     "lint": "vue-cli-service lint",
     "analyze-size": "rm -rf dist ; NODE_ENV=production WEBPACK_STATS=true vue-cli-service build ; npx webpack-bundle-analyzer dist/stats.json dist/ -p 9900 -O"
   },


### PR DESCRIPTION
Several improvements to the CI, as I noticed some problems while waiting for it to get through its massive backlog this morning:
* Run webapp tests only once. Previously it would run tests without coverage, then run them again with coverage
* Reorder webapp CI tasks so that failures are likely to happen sooner. It used to be build, test, lint. Now it's lint, test, build.
* Raise parallelism from `1` to `2` during coverage testing. Previously we had to lower it to `1` to avoid OOMs, but hopefully with the recent TypeScript framework updates this will be fixed. I'll have to monitor this for regressions. **FYI: OOMs usually get reported in CircleCI as failures due to not logging anything for 10 minutes** - this is because the jest worker process gets killed and the CLI process stays alive waiting for the results.
* Fix the `.codecov.yml` file so that graphql shows up in the GitHub CI status checks - it had been failing syntax checks, so CodeCov was using a cached version from years ago.
    * Also updated the minimum coverage requirements to be slightly lower than the current coverage - previously this wasn't enforced due to the `.codecov.yml` file syntax issues, but going forward it will be checked