### PR TITLE
Topic/group approval message

### DIFF
--- a/metaspace/webapp/src/modules/GroupProfile/RequestedAccessDialog.scss
+++ b/metaspace/webapp/src/modules/GroupProfile/RequestedAccessDialog.scss
@@ -1,0 +1,15 @@
+.requested-access-dialog {
+  .el-dialog {
+    @apply max-w-lg;
+
+    .el-form-item {
+      margin-bottom: 10px;
+    }
+    .el-form-item__label {
+      line-height: 1.2em;
+    }
+  }
+
+
+}
+

--- a/metaspace/webapp/src/modules/GroupProfile/RequestedAccessDialog.spec.ts
+++ b/metaspace/webapp/src/modules/GroupProfile/RequestedAccessDialog.spec.ts
@@ -1,0 +1,82 @@
+import { mount } from '@vue/test-utils'
+import router from '../../router'
+import store from '../../store/index'
+import Vue from 'vue'
+import Vuex from 'vuex'
+import { sync } from 'vuex-router-sync'
+import { RequestedAccessDialog } from './RequestedAccessDialog'
+
+Vue.use(Vuex)
+sync(store, router)
+
+describe('RequestedAccessDialog', () => {
+  const propsData = {
+    group: {
+      id: '7871c940-8198-11eb-8245-9b435184cf72',
+      name: 'TEST_GROUP',
+      shortName: 'TG',
+      urlSlug: 'tgroup',
+      currentUserRole: 'PENDING',
+      members: [
+        {
+          role: 'GROUP_ADMIN',
+          numDatasets: 2,
+          user: {
+            id: '039801c8-919e-11eb-908e-3b2b8e672707',
+            name: 'John Doe',
+            email: 'jdoe@mail.com',
+          },
+        },
+        {
+          role: 'GROUP_ADMIN',
+          numDatasets: 2,
+          user: {
+            id: '039801c8-919e-11eb-908e-3b2b8e672701',
+            name: 'John Doe 2',
+            email: 'jdoe2@mail.com',
+          },
+        },
+        {
+          role: 'GROUP_ADMIN',
+          numDatasets: 2,
+          user: {
+            id: '039801c8-919e-11eb-908e-3b2b8e672702',
+            name: 'John Doe 3',
+            email: 'jdoe3@mail.com',
+          },
+        },
+      ],
+    },
+    visible: true,
+  }
+
+  const testHarness = Vue.extend({
+    components: {
+      RequestedAccessDialog,
+    },
+    render(h) {
+      return h(RequestedAccessDialog, { props: this.$attrs })
+    },
+  })
+
+  it('it should match snapshot', async() => {
+    const wrapper = mount(testHarness, { store, router })
+    await Vue.nextTick()
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('it should match dataset processing snapshot', async() => {
+    const wrapper = mount(testHarness, {
+      store,
+      router,
+      propsData: {
+        ...propsData,
+        dsSubmission: true,
+      },
+    })
+    await Vue.nextTick()
+
+    expect(wrapper).toMatchSnapshot()
+  })
+})

--- a/metaspace/webapp/src/modules/GroupProfile/RequestedAccessDialog.tsx
+++ b/metaspace/webapp/src/modules/GroupProfile/RequestedAccessDialog.tsx
@@ -1,5 +1,5 @@
 import { defineComponent } from '@vue/composition-api'
-import { Dialog, Button } from '../../lib/element-ui'
+import { Dialog } from '../../lib/element-ui'
 import './RequestedAccessDialog.scss'
 
 interface RequestedAccessDialogProps {

--- a/metaspace/webapp/src/modules/GroupProfile/RequestedAccessDialog.tsx
+++ b/metaspace/webapp/src/modules/GroupProfile/RequestedAccessDialog.tsx
@@ -1,0 +1,64 @@
+import { defineComponent } from '@vue/composition-api'
+import { Dialog, Button } from '../../lib/element-ui'
+import './RequestedAccessDialog.scss'
+
+interface RequestedAccessDialogProps {
+  visible: boolean
+  dsSubmission: boolean
+  group: any
+}
+
+export const RequestedAccessDialog = defineComponent<RequestedAccessDialogProps>({
+  name: 'RequestedAccessDialog',
+  props: {
+    visible: { type: Boolean, default: true },
+    dsSubmission: { type: Boolean, default: false },
+    group: { type: Object },
+  },
+  setup(props, ctx) {
+    const { emit, root } = ctx
+
+    const handleClose = () => {
+      emit('close')
+    }
+
+    return () => {
+      const {
+        visible,
+        group,
+        dsSubmission,
+      } = props
+      const groupAdmins = group
+        ? group.members.filter((member: any) => member.role === 'GROUP_ADMIN') : []
+
+      return (
+        <Dialog
+          class='requested-access-dialog'
+          visible={visible}
+          append-to-body
+          title={`${group?.name} Access Request`}
+          lockScroll={false}
+          onClose={handleClose}>
+          {
+            dsSubmission ? 'Your dataset was sent to processing. ' : 'Your request was sent. '
+          }
+          Please contact
+          {
+            groupAdmins.map((member: any,
+              memberIdx: number) => {
+              return <span key={member.user.id} class='ml-1'>
+                {member.user.email ? <a href={`mailto:${member.user.email}`}>{member.user.name}</a>
+                  : member.user.name}
+                {memberIdx < groupAdmins.length - 2 ? ',' : ''}
+                {memberIdx === groupAdmins.length - 2 ? ' or' : ''}
+                {memberIdx === groupAdmins.length - 1 ? ' ' : ''}
+              </span>
+            },
+            )
+          }
+          to approve your request within metaspace, so you can visualize the group datasets!
+        </Dialog>
+      )
+    }
+  },
+})

--- a/metaspace/webapp/src/modules/GroupProfile/RequestedAccessDialog.tsx
+++ b/metaspace/webapp/src/modules/GroupProfile/RequestedAccessDialog.tsx
@@ -56,7 +56,7 @@ export const RequestedAccessDialog = defineComponent<RequestedAccessDialogProps>
             },
             )
           }
-          to approve your request within metaspace, so you can visualize the group datasets!
+          to approve your request within METASPACE, so you can visualize the group datasets!
         </Dialog>
       )
     }

--- a/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.vue
+++ b/metaspace/webapp/src/modules/GroupProfile/ViewGroupPage.vue
@@ -14,6 +14,11 @@
         @accept="handleAcceptTransferDatasets"
         @close="handleCloseTransferDatasetsDialog"
       />
+      <requested-access-dialog
+        :visible="showRequestedDialog"
+        :group="group"
+        @close="handleCloseRequestedAccessDialog"
+      />
       <div class="header-row">
         <div class="header-names">
           <h1>{{ group.name }}</h1>
@@ -189,11 +194,11 @@ import { optionalSuffixInParens, plural } from '../../lib/vueFilters'
 import { removeDatasetFromAllDatasetsQuery } from '../../lib/updateApolloCache'
 import GroupDescription from './GroupDescription.vue'
 import MolecularDatabases from '../MolecularDatabases'
-import { MolecularDB } from '../../api/moldb'
 import config from '../../lib/config'
 import PopupAnchor from '../NewFeaturePopup/PopupAnchor.vue'
+import { RequestedAccessDialog } from './RequestedAccessDialog'
 
-  interface ViewGroupProfileData {
+interface ViewGroupProfileData {
     allDatasets: DatasetDetailItem[];
     countDatasets: number;
   }
@@ -208,6 +213,7 @@ import PopupAnchor from '../NewFeaturePopup/PopupAnchor.vue'
       GroupDescription,
       MolecularDatabases,
       PopupAnchor,
+      RequestedAccessDialog,
     },
     filters: {
       optionalSuffixInParens,
@@ -284,6 +290,7 @@ export default class ViewGroupPage extends Vue {
     groupLoading = 0;
     loaded = false;
     showTransferDatasetsDialog: boolean = false;
+    showRequestedDialog: boolean = false;
     showUploadDatabaseDialog: boolean = false;
     currentUser: CurrentUserRoleResult | null = null;
     group: ViewGroupResult | null = null;
@@ -291,6 +298,7 @@ export default class ViewGroupPage extends Vue {
 
     get currentUserId(): string | null { return this.currentUser && this.currentUser.id }
     get roleInGroup(): UserGroupRole | null { return this.group && this.group.currentUserRole }
+
     get groupDatasets(): DatasetDetailItem[] {
       return (this.data && this.data.allDatasets || []).filter(ds => ds.status !== 'FAILED')
     }
@@ -426,11 +434,16 @@ export default class ViewGroupPage extends Vue {
         reportError(err)
       } finally {
         this.showTransferDatasetsDialog = false
+        this.showRequestedDialog = true
       }
     }
 
     handleCloseTransferDatasetsDialog() {
       this.showTransferDatasetsDialog = false
+    }
+
+    handleCloseRequestedAccessDialog() {
+      this.showRequestedDialog = false
     }
 
     handleFilterUpdate(newFilter: any) {

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/RequestedAccessDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/RequestedAccessDialog.spec.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RequestedAccessDialog it should match dataset processing snapshot 1`] = `
+<transition-stub name="dialog-fade" class="requested-access-dialog" group="[object Object]" visible="true" dssubmission="true" style="z-index: 2003;">
+  <div class="el-dialog__wrapper">
+    <div role="dialog" aria-modal="true" aria-label="TEST_GROUP Access Request" class="el-dialog" style="margin-top: 15vh;">
+      <div class="el-dialog__header"><span class="el-dialog__title">TEST_GROUP Access Request</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+      <div class="el-dialog__body">Your dataset was sent to processing. Please contact<span class="ml-1"><a href="mailto:jdoe@mail.com">John Doe</a>,</span><span class="ml-1"><a href="mailto:jdoe2@mail.com">John Doe 2</a> or</span><span class="ml-1"><a href="mailto:jdoe3@mail.com">John Doe 3</a> </span>to approve your request within metaspace, so you can visualize the group datasets!</div>
+      <!---->
+    </div>
+  </div>
+</transition-stub>
+`;
+
+exports[`RequestedAccessDialog it should match snapshot 1`] = `
+<transition-stub name="dialog-fade" class="requested-access-dialog" style="z-index: 2001;">
+  <div class="el-dialog__wrapper">
+    <div role="dialog" aria-modal="true" aria-label="undefined Access Request" class="el-dialog" style="margin-top: 15vh;">
+      <div class="el-dialog__header"><span class="el-dialog__title">undefined Access Request</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+      <div class="el-dialog__body">Your request was sent. Please contactto approve your request within metaspace, so you can visualize the group datasets!</div>
+      <!---->
+    </div>
+  </div>
+</transition-stub>
+`;

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/RequestedAccessDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/RequestedAccessDialog.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`RequestedAccessDialog it should match dataset processing snapshot 1`] =
   <div class="el-dialog__wrapper">
     <div role="dialog" aria-modal="true" aria-label="TEST_GROUP Access Request" class="el-dialog" style="margin-top: 15vh;">
       <div class="el-dialog__header"><span class="el-dialog__title">TEST_GROUP Access Request</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
-      <div class="el-dialog__body">Your dataset was sent to processing. Please contact<span class="ml-1"><a href="mailto:jdoe@mail.com">John Doe</a>,</span><span class="ml-1"><a href="mailto:jdoe2@mail.com">John Doe 2</a> or</span><span class="ml-1"><a href="mailto:jdoe3@mail.com">John Doe 3</a> </span>to approve your request within metaspace, so you can visualize the group datasets!</div>
+      <div class="el-dialog__body">Your dataset was sent to processing. Please contact<span class="ml-1"><a href="mailto:jdoe@mail.com">John Doe</a>,</span><span class="ml-1"><a href="mailto:jdoe2@mail.com">John Doe 2</a> or</span><span class="ml-1"><a href="mailto:jdoe3@mail.com">John Doe 3</a> </span>to approve your request within METASPACE, so you can visualize the group datasets!</div>
       <!---->
     </div>
   </div>
@@ -17,7 +17,7 @@ exports[`RequestedAccessDialog it should match snapshot 1`] = `
   <div class="el-dialog__wrapper">
     <div role="dialog" aria-modal="true" aria-label="undefined Access Request" class="el-dialog" style="margin-top: 15vh;">
       <div class="el-dialog__header"><span class="el-dialog__title">undefined Access Request</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
-      <div class="el-dialog__body">Your request was sent. Please contactto approve your request within metaspace, so you can visualize the group datasets!</div>
+      <div class="el-dialog__body">Your request was sent. Please contactto approve your request within METASPACE, so you can visualize the group datasets!</div>
       <!---->
     </div>
   </div>

--- a/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/GroupProfile/__snapshots__/ViewGroupPage.spec.ts.snap
@@ -4,6 +4,15 @@ exports[`ViewGroupPage datasets tab should match snapshot (non-member) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
     <!---->
+    <transition-stub name="dialog-fade" class="requested-access-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="group name Access Request" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">group name Access Request</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1>group name</h1>
@@ -61,6 +70,15 @@ exports[`ViewGroupPage members tab should match snapshot (invited) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
     <!---->
+    <transition-stub name="dialog-fade" class="requested-access-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="group name Access Request" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">group name Access Request</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1>group name</h1>
@@ -133,6 +151,15 @@ exports[`ViewGroupPage members tab should match snapshot (manager, including tab
 <div class="page" mock-v-loading="false">
   <div class="page-content">
     <!---->
+    <transition-stub name="dialog-fade" class="requested-access-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="group name Access Request" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">group name Access Request</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1>group name</h1>
@@ -385,6 +412,15 @@ exports[`ViewGroupPage members tab should match snapshot (member) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
     <!---->
+    <transition-stub name="dialog-fade" class="requested-access-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="group name Access Request" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">group name Access Request</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1>group name</h1>
@@ -435,6 +471,15 @@ exports[`ViewGroupPage members tab should match snapshot (non-member) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
     <!---->
+    <transition-stub name="dialog-fade" class="requested-access-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="group name Access Request" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">group name Access Request</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1>group name</h1>
@@ -487,6 +532,15 @@ exports[`ViewGroupPage settings tab should match snapshot 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
     <!---->
+    <transition-stub name="dialog-fade" class="requested-access-dialog">
+      <div class="el-dialog__wrapper" style="display: none;">
+        <div role="dialog" aria-modal="true" aria-label="group name Access Request" class="el-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">group name Access Request</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+          <!---->
+          <!---->
+        </div>
+      </div>
+    </transition-stub>
     <div class="header-row">
       <div class="header-names">
         <h1>group name</h1>


### PR DESCRIPTION
### Description

In order to notify the user so he can better accompany its group status, two messages should be displayed:
1 - On group joining: "Your request was sent. Please contact to approve your request within the metaspace "
2 - On ds submission to a group which you were not approved yet: "Your dataset was sent to processing. Please contact to approve your request within the metaspace , so you can visualize the group datasets."

#902 

#### Changes

##### Webapp

###### RequestedAccessDialog
- [x] Created component to show group request status
- [x] Added message to be shown when requested to join group
- [x] Added message to be shown when dataset sent for processing, but user still pending approval 

###### ViewGroupPage
- [x] It shows RequestedAccessDialog when requested to join group

###### UploadPagex
- [x] It shows RequestedAccessDialog when dataset is upload to group in which user still have pending access

#### Tests
 
##### Front end
 
- [x] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [x] Safari
- [x] sm, md, lg, xl, lg