### PR TITLE
Parallelize sm-engine tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,10 @@ jobs:
             psql -h localhost -U sm -d sm_test -c "CREATE SCHEMA graphql;"
             yarn run gen-binding
             yarn run deref-schema
-            NODE_ENV=test yarn run test-ci --verbose --detectOpenHandles --forceExit
+            NODE_ENV=test yarn run test-ci --verbose --detectOpenHandles --forceExit --coverage
       - run:
           name: Upload coverage
-          command: |
-            yarn run test-ci --coverage
-            npx codecov -p ../.. -F graphql
+          command: npx codecov -p ../.. -F graphql
       - run:
           name: Lint code
           when: always

--- a/metaspace/engine/README.md
+++ b/metaspace/engine/README.md
@@ -31,6 +31,19 @@ There are two modules of pytest tests:
 It's recommended to use the `-vv -n auto` command line options when calling pytest to get sufficient debug information
 and utilize all available CPU cores.
 
+Additionally, there is a "Scientific test" that processes an entire dataset and compares the result against reference
+results. It can be run on both the Lithops and Spark (default) pipelines:
+
+* `python tests/sci_test/spheroid.py -r --mock-image-storage --lithops --config=conf/scitest_config.json`
+* `python tests/sci_test/spheroid.py -r --mock-image-storage --config=conf/scitest_config.json`
+
+NOTE: the Spark pipeline intermittently fails due to a bug in segment generation. This is a known issue that won't be
+fixed due to deprecation of the Spark pipeline. It manifests as a single item appearing in the "DIFFERENCES IN METRICS"
+output. The underlying bug is that when reconstructing ion images, if the last image for an annotation spans multiple 
+dataset segments, only the peaks from the first segment will be used. This causes that annotation's score to drop.
+As segmentation is based on a random sampling of spectra, the segment boundaries change every run, so it only happens
+in some runs.
+
 ## Troubleshooting/testing sm-engine CI
 
 Install [CircleCI CLI tool](https://circleci.com/docs/2.0/local-jobs/) and run `circleci build` from the project root.

--- a/metaspace/engine/README.md
+++ b/metaspace/engine/README.md
@@ -24,6 +24,15 @@ Please visit the help page of our web application running on AWS:
 
 ## Running sm-engine tests
 
+There are two modules of pytest tests:
+* `sm.engine.tests` - unit tests that don't involve the DB, etc.
+* `tests` - integration tests
+
+It's recommended to use the `-vv -n auto` command line options when calling pytest to get sufficient debug information
+and utilize all available CPU cores.
+
+## Troubleshooting/testing sm-engine CI
+
 Install [CircleCI CLI tool](https://circleci.com/docs/2.0/local-jobs/) and run `circleci build` from the project root.
 
 ## Acknowledgements and license

--- a/metaspace/engine/requirements-dev.txt
+++ b/metaspace/engine/requirements-dev.txt
@@ -5,3 +5,5 @@ pylint==2.7.0  # to prevent new pylint rules failing CI job
 black==20.8b1  # to prevent new black rules failing CI job
 boto3-stubs[s3]
 mypy_boto3_builder
+pytest-xdist
+fasteners

--- a/metaspace/engine/sm/engine/queue.py
+++ b/metaspace/engine/sm/engine/queue.py
@@ -387,7 +387,7 @@ class QueueConsumer(Thread):
         self._config = config
         self._heartbeat = 3 * 60 * 60  # 3h
         self._qdesc = qdesc
-        self._qname = self._qdesc['name']
+        self._qname = config.get('prefix', '') + self._qdesc['name']
         self._connection = None
         self._channel = None
         self._poll_interval = poll_interval
@@ -493,7 +493,7 @@ class QueuePublisher:
     def __init__(self, config, qdesc, logger=None):
         creds = pika.PlainCredentials(config['user'], config['password'])
         self.qdesc = qdesc
-        self.qname = qdesc['name']
+        self.qname = config.get('prefix', '') + qdesc['name']
         self.conn_params = pika.ConnectionParameters(
             host=config['host'], credentials=creds, heartbeat=0
         )

--- a/metaspace/engine/tests/conftest.py
+++ b/metaspace/engine/tests/conftest.py
@@ -29,7 +29,7 @@ TEST_CONFIG_PATH = 'conf/test_config.json'
 def sm_config():
     SMConfig.set_path(Path(proj_root()) / TEST_CONFIG_PATH)
     SMConfig.get_conf(update=True)  # Force reload in case previous tests modified it
-    worker_id = os.environ.get('PYTEST_XDIST_WORKER', '0')
+    worker_id = os.environ.get('PYTEST_XDIST_WORKER', 'gw0')
 
     test_id = f'sm_test_{worker_id}'
     # Update the internal cached copy of the config, so independent calls to SMConfig.get_conf()

--- a/metaspace/engine/tests/test_es_export.py
+++ b/metaspace/engine/tests/test_es_export.py
@@ -554,6 +554,7 @@ def test_rename_index_works(sm_config, test_db):
     yang_index = f'{alias}-yang'
     es_man = ESIndexManager(es_config)
     # Clean up previous test runs if needed
+    es_man.delete_index(alias)
     es_man.delete_index(yin_index)
     es_man.delete_index(yang_index)
 
@@ -572,6 +573,7 @@ def test_rename_index_works(sm_config, test_db):
         assert es_man.exists_index(yang_index)
         assert es_man.exists_index(yin_index)
     finally:
+        es_man.delete_index(alias)
         es_man.delete_index(yin_index)
         es_man.delete_index(yang_index)
 

--- a/metaspace/engine/tests/test_es_export.py
+++ b/metaspace/engine/tests/test_es_export.py
@@ -550,21 +550,30 @@ def test_update_ds_works_for_all_fields(sm_config, test_db, es, sm_index, es_dsl
 def test_rename_index_works(sm_config, test_db):
     es_config = sm_config['elasticsearch']
     alias = es_config['index']
+    yin_index = f'{alias}-yin'
+    yang_index = f'{alias}-yang'
     es_man = ESIndexManager(es_config)
+    # Clean up previous test runs if needed
+    es_man.delete_index(yin_index)
+    es_man.delete_index(yang_index)
 
-    es_man.create_index('{}-yin'.format(alias))
-    es_man.remap_alias('{}-yin'.format(alias), alias=alias)
+    try:
+        es_man.create_index(yin_index)
+        es_man.remap_alias(yin_index, alias=alias)
 
-    assert es_man.exists_index(alias)
-    assert es_man.exists_index('{}-yin'.format(alias))
-    assert not es_man.exists_index('{}-yang'.format(alias))
+        assert es_man.exists_index(alias)
+        assert es_man.exists_index(yin_index)
+        assert not es_man.exists_index(yang_index)
 
-    es_man.create_index('{}-yang'.format(alias))
-    es_man.remap_alias('{}-yang'.format(alias), alias=alias)
+        es_man.create_index(yang_index)
+        es_man.remap_alias(yang_index, alias=alias)
 
-    assert es_man.exists_index(alias)
-    assert es_man.exists_index('{}-yang'.format(alias))
-    assert es_man.exists_index('{}-yin'.format(alias))
+        assert es_man.exists_index(alias)
+        assert es_man.exists_index(yang_index)
+        assert es_man.exists_index(yin_index)
+    finally:
+        es_man.delete_index(yin_index)
+        es_man.delete_index(yang_index)
 
 
 def test_internal_index_name_return_valid_values(sm_config):

--- a/metaspace/engine/tests/test_queue.py
+++ b/metaspace/engine/tests/test_queue.py
@@ -41,8 +41,9 @@ def run_queue_consumer_thread(config, callback, output_q, wait=0.1):
 
 
 def queue_is_empty(config):
+    prefix = config.get('prefix', '')
     resp = requests.get(
-        url='http://localhost:15672/api/queues/%2F/{}'.format(QDESC['name']),
+        url=f'http://localhost:15672/api/queues/%2F/{prefix}{QDESC["name"]}',
         auth=(config['user'], config['password']),
         timeout=1,
     )

--- a/metaspace/engine/tests/test_sm_daemons.py
+++ b/metaspace/engine/tests/test_sm_daemons.py
@@ -75,9 +75,7 @@ def queue_pub(local_sm_config):
     from sm.engine import queue
 
     qname = 'annotate'
-
-    queue.SM_ANNOTATE['name'] = queue.SM_ANNOTATE['name'] + '_test'
-    queue.SM_UPDATE['name'] = queue.SM_UPDATE['name'] + '_test'
+    # Queue names are given a per-test-worker prefix in the sm_config fixture
     if qname == 'annotate':
         qdesc = queue.SM_ANNOTATE
     elif qname == 'update':


### PR DESCRIPTION
I've been used pytest-xdist to parallelize test execution, though some tests had race conditions that I just ignored locally. This PR fixes those race conditions and formally adds pytest-xdist to the intended development process.

Several changes were needed (or were just desirable):
* Remove the randomized DB names, instead just using the test worker ID (`gw0`, `gw1`, etc.). This ensures that large numbers of test databases don't get created when there are issues with cleanup. It's not an issue currently, but in the past there were cases of un-GC'd `DB()` instances blocking the test cleanup
* Add the test worker ID to the ElasticSearch index name to allow parallel tests
* Add the test worker ID as a prefix to RabbitMQ queues
* Add a file-based mutex around test usage of `SparkContext`, as it'd be too complex to support running multiple instances in parallel (requires assigning a several unique port numbers per instance)
* Changing the way that the `sm_config` fixture works, so that the `SMAnnotateDaemon`'s direct call to `SMConf.get_config()` gets the modified test environment, instead of the original config.
* Change `test_queues.py` so that it doesn't need 10 seconds of sleeping. The old `queue_is_empty` function seemed to require an inconsistent amount of time before the `'messages'` field would appear in the metadata, otherwise it would fail the test with a `KeyError`. No idea why RabbitMQ's HTTP interface changes schema this way, but switching to use `queue.empty()` just worked without needing any sleeping.
* Change es_export tests to force an ES refresh instead of waiting 1-2 seconds and hoping that the refresh had automatically finished. I added this because I found the [`test_index_ds_works` test recently became flaky](https://app.circleci.com/pipelines/github/metaspace2020/metaspace/1749/workflows/66e1586f-9776-4b7a-9384-21a14a67a407/jobs/16889)


On my PC this PR reduces the tests from 122s to 62s, running with 4 cores

I didn't enable parallel tests for CI, as I expect getting this to work well with coverage, and testing CircleCI's memory limits, would take too much time.

Also, as it was a tiny, related change, I changed sm-graphql's CI test to only run the tests once. Previously it ran without coverage, then re-ran with coverage, wasting about 4 minutes.