### PR TITLE
Tidy engine config files & make sci-test easier to run

### DIFF
--- a/metaspace/engine/conf/config.docker.json
+++ b/metaspace/engine/conf/config.docker.json
@@ -6,19 +6,6 @@
     "debug": false,
     "server": "cherrypy"
   },
-  "defaults": {
-    "adducts": {
-      "+": [
-        "+H",
-        "+Na",
-        "+K"
-      ],
-      "-": [
-        "-H",
-        "+Cl"
-      ]
-    }
-  },
   "db": {
     "host": "postgres",
     "database": "sm",
@@ -131,37 +118,6 @@
     "channel": "",
     "webhook_url": ""
   },
-  "ms_file_handlers": [
-    {
-      "type": "ims",
-      "extensions": [
-        "imzml",
-        "ibd"
-      ],
-      "parser_factory": {
-        "name": "ImzMLParser",
-        "path": "pyimzml.ImzMLParser"
-      },
-      "acq_geometry_factory": {
-        "name": "ImsGeometryFactory",
-        "path": "sm.engine.ims_geometry_factory"
-      }
-    },
-    {
-      "type": "lcms",
-      "extensions": [
-        "mzml"
-      ],
-      "parser_factory": {
-        "name": "MzMLParser",
-        "path": "sm.engine.mzml_parser"
-      },
-      "acq_geometry_factory": {
-        "name": "LcmsGeometryFactory",
-        "path": "sm.engine.lcms_geometry_factory"
-      }
-    }
-  ],
   "isotope_storage": {
     "path": "/opt/data/metaspace/isotope_storage"
   },
@@ -234,5 +190,8 @@
     "endpoint_url": "http://storage:9000",
     "access_key_id": "minioadmin",
     "secret_access_key": "minioadmin"
+  },
+  "image_storage": {
+    "bucket": "sm-image-storage-dev"
   }
 }

--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -6,9 +6,6 @@
     "server": "cherrypy"
   },
   "redis": {{ sm_redis | to_json }},
-  "defaults": {
-    "adducts": {{ sm_default_adducts | to_json }}
-  },
   "db": {
     "host": "{{ sm_postgres_host }}",
     "database": "sm",
@@ -118,24 +115,6 @@ The Prefix is necessary and should not have a leading or trailing slash
     "channel": "{{ slack_channel }}",
     "webhook_url": "{{ slack_webhook_url }}"
   },
-  "ms_file_handlers": [
-    {
-      "type": "ims",
-      "extensions": ["imzml", "ibd"],
-      "parser_factory": {
-        "name": "ImzMLParser",
-        "path": "pyimzml.ImzMLParser"
-      }
-    },
-    {
-      "type": "lcms",
-      "extensions": ["mzml"],
-      "parser_factory": {
-        "name": "MzMLParser",
-        "path": "sm.engine.mzml_parser"
-      }
-    }
-  ],
   "isotope_storage": {
     "path": "{{ sm_isotope_storage_path }}"
   },

--- a/metaspace/engine/conf/scitest_config.json
+++ b/metaspace/engine/conf/scitest_config.json
@@ -5,12 +5,6 @@
     "debug": false,
     "server": "cherrypy"
   },
-  "defaults": {
-    "adducts": {
-      "+": ["+H", "+Na", "+K"],
-      "-": ["-H", "+Cl"]
-    }
-  },
   "db": {
     "host": "localhost",
     "database": "sm_test",
@@ -66,38 +60,10 @@
       "pipeline_cache": ["metaspace-sci-test", "pipeline_cache"]
     }
   },
-  "aws": {
-    "aws_access_key_id": "",
-    "aws_secret_access_key": "",
-    "aws_default_region": "eu-west-1"
-  },
   "slack": {
     "channel": "",
     "webhook_url": ""
   },
-  "ms_file_handlers": [{
-      "type": "ims",
-      "extensions": ["imzml", "ibd"],
-      "parser_factory": {
-        "name": "ImzMLParser",
-        "path": "pyimzml.ImzMLParser"
-      },
-      "acq_geometry_factory": {
-        "name": "ImsGeometryFactory",
-        "path": "sm.engine.ims_geometry_factory"
-      }
-    }, {
-      "type": "lcms",
-      "extensions": ["mzml"],
-      "parser_factory": {
-        "name": "MzMLParser",
-        "path": "sm.engine.mzml_parser"
-      },
-      "acq_geometry_factory": {
-        "name": "LcmsGeometryFactory",
-        "path": "sm.engine.lcms_geometry_factory"
-      }
-  }],
   "isotope_storage": {
     "path": "/tmp/isotope_storage"
   },
@@ -109,53 +75,63 @@
       }
     },
     "handlers": {
-        "console_debug": {
-            "class": "logging.StreamHandler",
-            "formatter": "sm",
-            "level": "DEBUG"
-        },
-        "context_logger": {
-            "class": "sm.engine.utils.log_capture.ContextLogHandler",
-            "formatter": "sm",
-            "level": "INFO"
-        }
+      "console_debug": {
+        "class": "logging.StreamHandler",
+        "formatter": "sm",
+        "level": "DEBUG"
+      },
+      "context_logger": {
+        "class": "sm.engine.utils.log_capture.ContextLogHandler",
+        "formatter": "sm",
+        "level": "INFO"
+      }
     },
     "root": {
-      "handlers": ["console_debug", "context_logger"],
-      "level": "WARNING"
+      "handlers": [
+        "console_debug",
+        "context_logger"
+      ],
+      "level": "INFO"
     },
     "loggers": {
-        "engine": {
-            "level": "DEBUG"
-        },
-        "engine.db": {
-            "level": "INFO"
-        },
-        "engine.lithops-wrapper": {
-            "level": "DEBUG"
-        },
-        "api": {
-            "level": "INFO"
-        },
-        "annotate-daemon": {
-            "level": "INFO"
-        },
-        "update-daemon": {
-            "level": "INFO"
-        },
-        "lithops-daemon": {
-            "level": "INFO"
-        },
-        "lithops": {
-            "level": "INFO"
-        }
+      "engine": {
+        "level": "DEBUG"
+      },
+      "engine.db": {
+        "level": "INFO"
+      },
+      "engine.lithops-wrapper": {
+        "level": "INFO"
+      },
+      "api": {
+        "level": "INFO"
+      },
+      "annotate-daemon": {
+        "level": "INFO"
+      },
+      "lithops-daemon": {
+        "level": "INFO"
+      },
+      "update-daemon": {
+        "level": "INFO"
+      },
+      "lithops": {
+        "level": "INFO"
+      }
     }
   },
   "ds_config_defaults": {
     "adducts": {
       "+": ["+H", "+Na", "+K"],
       "-": ["-H", "+Cl" ]
-    },
-    "moldb_names": ["HMDB-v2.5"]
+    }
+  },
+  "storage": {
+    "endpoint_url": "http://storage:9000",
+    "access_key_id": "minioadmin",
+    "secret_access_key": "minioadmin"
+  },
+  "image_storage": {
+    "bucket": "sm-image-storage-sci-test"
   }
 }

--- a/metaspace/engine/conf/test_config.json
+++ b/metaspace/engine/conf/test_config.json
@@ -1,17 +1,4 @@
 {
-  "defaults": {
-    "adducts": {
-      "+": [
-        "+H",
-        "+Na",
-        "+K"
-      ],
-      "-": [
-        "-H",
-        "+Cl"
-      ]
-    }
-  },
   "db": {
     "host": "localhost",
     "database": "sm_test",
@@ -80,29 +67,6 @@
     }
   },
   "slack": {},
-  "ms_file_handlers": [
-    {
-      "type": "ims",
-      "extensions": [
-        "imzml",
-        "ibd"
-      ],
-      "parser_factory": {
-        "name": "ImzMLParser",
-        "path": "pyimzml.ImzMLParser"
-      }
-    },
-    {
-      "type": "lcms",
-      "extensions": [
-        "mzml"
-      ],
-      "parser_factory": {
-        "name": "MzMLParser",
-        "path": "sm.engine.mzml_parser"
-      }
-    }
-  ],
   "isotope_storage": {
     "path": "/tmp/isotope_storage"
   },

--- a/metaspace/engine/sm/engine/config.py
+++ b/metaspace/engine/sm/engine/config.py
@@ -89,8 +89,15 @@ class SMConfig:
         : dict
             SM configuration for handling specific type of MS data
         """
-        conf = cls.get_conf()
+        handlers = [
+            {
+                "type": "ims",
+                "extensions": ["imzml", "ibd"],
+            },
+            {
+                "type": "lcms",
+                "extensions": ["mzml"],
+            },
+        ]
         ms_file_extension = Path(ms_file_path).suffix[1:].lower()  # skip the leading "."
-        return next(
-            (h for h in conf['ms_file_handlers'] if ms_file_extension in h['extensions']), None
-        )
+        return next((h for h in handlers if ms_file_extension in h['extensions']), None)

--- a/metaspace/engine/sm/engine/tests/db_sql_schema.py
+++ b/metaspace/engine/sm/engine/tests/db_sql_schema.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 SCHEMA_PATH = (Path(__file__) / '../../../../scripts/db_schema.sql').resolve()
-print(SCHEMA_PATH)
 
 PATCH = """
 ALTER TABLE "graphql"."user" ALTER COLUMN credentials_id DROP NOT NULL;

--- a/metaspace/engine/tests/sci_test/spheroid.py
+++ b/metaspace/engine/tests/sci_test/spheroid.py
@@ -160,7 +160,7 @@ class SciTester:
             lithops_executor.RUNTIME_DOCKER_IMAGE = 'python'
 
             executor = Executor(self.sm_config['lithops'], perf)
-            ServerAnnotationJob(executor, None, ds, perf, self.sm_config).run(debug_validate=True)
+            ServerAnnotationJob(executor, ds, perf, self.sm_config).run(debug_validate=True)
         else:
             AnnotationJob(ds, perf).run()
 

--- a/metaspace/engine/tests/sci_test/spheroid.py
+++ b/metaspace/engine/tests/sci_test/spheroid.py
@@ -4,17 +4,22 @@ import os
 import sys
 from pathlib import Path
 from pprint import pprint
+from tempfile import TemporaryDirectory
+from urllib.request import urlretrieve
 
 import numpy as np
+import psycopg2
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
-from sm.engine import image_storage
+from sm.engine import image_storage, molecular_db
 from sm.engine.annotation_lithops.annotation_job import ServerAnnotationJob
 from sm.engine.annotation_lithops.executor import Executor
 import sm.engine.annotation_lithops.executor as lithops_executor
 from sm.engine.annotation_spark.annotation_job import AnnotationJob
 from sm.engine.db import DB
+from sm.engine.tests.db_sql_schema import DB_SQL_SCHEMA
 from sm.engine.util import GlobalInit
-from sm.engine.config import proj_root
+from sm.engine.config import proj_root, SMConfig
 from sm.engine.utils.create_ds_from_files import create_ds_from_files
 from sm.engine.utils.perf_profile import NullProfiler
 
@@ -187,6 +192,44 @@ def save(sm_config, *args):
         SciTester(sm_config).save_sci_test_report()
 
 
+def ensure_db_exists(sm_config):
+    db_config = sm_config['db']
+    try:
+        with psycopg2.connect(**db_config):
+            pass
+    except psycopg2.OperationalError as ex:
+        if 'does not exist' in str(ex):
+            db_name = db_config['database']
+            db_owner = db_config['user']
+
+            print(f'Creating database {db_name}')
+            # Connect to postgres database so that the configured DB can be created
+            with psycopg2.connect(**{**db_config, 'database': 'postgres'}) as conn:
+                conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+                with conn.cursor() as curs:
+                    curs.execute(f'CREATE DATABASE {db_name} OWNER {db_owner}')
+
+
+def ensure_db_populated():
+    db = DB()
+    # Install DB schema if needed
+    query = "SELECT COUNT(*) FROM pg_tables WHERE schemaname = 'public' AND tablename = 'dataset'"
+    tables_exist = db.select_one(query)[0] >= 1
+    if not tables_exist:
+        print('Installing DB schema')
+        db.alter(DB_SQL_SCHEMA)
+
+    # Import HMDB if needed
+    query = "SELECT COUNT(*) FROM molecular_db WHERE name = 'HMDB' AND version = 'v4'"
+    hmdb_exists = db.select_one(query)[0] >= 1
+    if not hmdb_exists:
+        print('Importing HMDB')
+        with TemporaryDirectory() as tmp:
+            hmdb_url = 'https://sm-engine.s3-eu-west-1.amazonaws.com/tests/hmdb_4.tsv'
+            urlretrieve(hmdb_url, f'{tmp}/hmdb-v4.tsv')
+            molecular_db.create('HMDB', 'v4', f'{tmp}/hmdb-v4.tsv')
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Scientific tests runner')
     parser.add_argument(
@@ -207,7 +250,12 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
 
+    # Need to ensure test DB exists before GlobalInit is called
+    SMConfig.set_path(args.sm_config_path)
+    ensure_db_exists(SMConfig.get_conf())
+
     with GlobalInit(config_path=args.sm_config_path) as sm_config:
+        ensure_db_populated()
         if args.run:
             run(
                 sm_config=sm_config,


### PR DESCRIPTION
Fix the configs & synchronize them:
* Removed `"defaults"` section as it was unused
* Removed unused `"parser_factory"` and `"acq_geometry_factory"` sections from `"ms_file_handlers"` and then moved the remaining parts to be inline in code. This "config" was never actually meaningfully configurable.
* Added missing `"image_storage"` section
* Update differing parts of the test and sci-test config to match the docker config, when the differences didn't matter

Sci-test currently requires some undocumented manual environment setup to run on a development machine, so I updated it to not need that anymore:
* Create database if it doesn't already exist
* Import the DB schema if it doesn't already exist
* Import HMDB-v4 if it doesn't already exist
