### PR TITLE
[Edit page] description update bug 

### DIFF
--- a/metaspace/graphql/src/modules/dataset/controller/Mutation.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Mutation.ts
@@ -140,13 +140,16 @@ const saveDataset = async(entityManager: EntityManager, args: SaveDatasetArgs, r
     : principalInvestigator === null
       ? { piName: null, piEmail: null }
       : { piName: principalInvestigator.name, piEmail: principalInvestigator.email }
-  const dsDescriptionUpdate = description === undefined ? null : description
   const dsUpdate = {
     id: datasetId,
     userId: submitterId,
-    description: dsDescriptionUpdate,
+    description,
     ...groupUpdate,
     ...piUpdate,
+  }
+
+  if (description === undefined) {
+    delete dsUpdate.description
   }
 
   if (requireInsert) {
@@ -326,7 +329,7 @@ const MutationResolvers: FieldResolversFor<Mutation, void> = {
       }
     }
 
-    let description
+    let description : string | null | undefined = update.description === null ? null : undefined
     if (update.description) {
       if (!skipValidation || !ctx.isAdmin) {
         description = update.description


### PR DESCRIPTION
### Description

Bug report for dataset descriptions: I (as an admin) edited another user's dataset on prod to add it to a project and the dataset's description got deleted when I saved it.

In order to keep the dataset description when updated, the description should not be saved if not updated.

#907 


Solution: not sending description when it comes as undefined. It is still updating if the description is null (user deleted the description by hand)

#### Changes

##### Graphql

###### Dataset controller
- [x] Not sending description on update object if undefined
