### PR TITLE
TIC Backend

### DIFF
--- a/metaspace/engine/conf/config.docker.json
+++ b/metaspace/engine/conf/config.docker.json
@@ -108,6 +108,14 @@
       "access_key": "",
       "secret_key": ""
     },
+    "aws": {
+      "access_key_id": "minioadmin",
+      "secret_access_key": "minioadmin"
+    },
+    "aws_s3": {
+      "__comment__": "Lithops overrides this to be HTTPS (https://github.com/lithops-cloud/lithops/issues/708). A workaround is needed to access MinIO through Lithops Storage - see update_diagnostics.py for an example",
+      "endpoint": "http://storage:9000"
+    },
     "sm_storage": {
       "imzml": [
         "DATA_BUCKET",

--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -97,10 +97,17 @@
       "access_key": "{{ sm_lithops_cos_access_key }}",
       "secret_key": "{{ sm_lithops_cos_secret_key }}"
     },
+    "aws": {
+      "access_key_id": "{{ aws_access_key_id }}",
+      "secret_access_key": "{{ aws_secret_access_key }}"
+    },
+    "aws_s3": {
+      "endpoint": "https://s3.{{ aws_region }}.amazonaws.com"
+    },
     "sm_storage": {
 {#
 Each entry in this block is an array of [Bucket name, Prefix]
-e.g. "imzml": ["my-bucket","files/go/here"] means ImzML files will be stored under cos://my-bucket/store/things/in/here/
+e.g. "imzml": ["my-bucket","files/go/here"] means ImzML files will be stored under cos://my-bucket/files/go/here/
 The Prefix is necessary and should not have a leading or trailing slash
 #}
       "imzml": ["{{ sm_lithops_cos_bucket_imzml }}", "imzml"],

--- a/metaspace/engine/scripts/db_schema.sql
+++ b/metaspace/engine/scripts/db_schema.sql
@@ -192,6 +192,29 @@ CREATE TABLE "public"."job" (
   CONSTRAINT "PK_456bc75d32d741774ab85e6606a" PRIMARY KEY ("id")
 );
 
+CREATE TABLE "public"."dataset_diagnostic" (
+  "id" uuid NOT NULL DEFAULT uuid_generate_v1mc(), 
+  "type" text NOT NULL, 
+  "ds_id" text NOT NULL, 
+  "job_id" integer, 
+  "updated_dt" TIMESTAMP NOT NULL DEFAULT (now() at time zone 'utc'), 
+  "data" json, 
+  "error" text, 
+  "images" json NOT NULL, 
+  CONSTRAINT "PK_2ddb635004b2e08782649e0c638" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "IDX_8064cf8bd1bc774a3d53db893f" ON "public"."dataset_diagnostic" (
+  "ds_id", 
+  "type"
+) WHERE job_id IS NULL;
+
+CREATE UNIQUE INDEX "IDX_2e8c4885755304fd125f7c4815" ON "public"."dataset_diagnostic" (
+  "ds_id", 
+  "type", 
+  "job_id"
+) ;
+
 CREATE TABLE "public"."annotation" (
   "id" SERIAL NOT NULL, 
   "job_id" integer NOT NULL, 
@@ -259,29 +282,6 @@ CREATE TABLE "graphql"."dataset_project" (
   CONSTRAINT "PK_9511b6cda2f4d4299812106cdd4" PRIMARY KEY ("dataset_id", 
   "project_id")
 );
-
-CREATE TABLE "graphql"."dataset_diagnostic" (
-  "id" uuid NOT NULL DEFAULT uuid_generate_v1mc(), 
-  "type" text NOT NULL, 
-  "ds_id" text NOT NULL, 
-  "job_id" integer, 
-  "updated_dt" TIMESTAMP NOT NULL DEFAULT (now() at time zone 'utc'), 
-  "data" json, 
-  "error" text, 
-  "images" text array NOT NULL, 
-  CONSTRAINT "PK_604d02805f10893127e79ef1250" PRIMARY KEY ("id")
-);
-
-CREATE UNIQUE INDEX "IDX_810c0fd2cbcfcb4395f7f120ef" ON "graphql"."dataset_diagnostic" (
-  "ds_id", 
-  "type"
-) WHERE jobId IS NULL;
-
-CREATE UNIQUE INDEX "IDX_f3da139561a67f5656bcf6f786" ON "graphql"."dataset_diagnostic" (
-  "ds_id", 
-  "type", 
-  "job_id"
-) WHERE jobId IS NOT NULL;
 
 CREATE TABLE "graphql"."user" (
   "id" uuid NOT NULL DEFAULT uuid_generate_v1mc(), 
@@ -352,6 +352,14 @@ ALTER TABLE "public"."job" ADD CONSTRAINT "FK_07f17ed55cabe0ef556bc0e0c93" FOREI
   "moldb_id") REFERENCES "public"."molecular_db"("id"
 ) ON DELETE CASCADE ON UPDATE NO ACTION;
 
+ALTER TABLE "public"."dataset_diagnostic" ADD CONSTRAINT "FK_e13bfa279306d04d020139312d1" FOREIGN KEY (
+  "ds_id") REFERENCES "public"."dataset"("id"
+) ON DELETE CASCADE ON UPDATE NO ACTION;
+
+ALTER TABLE "public"."dataset_diagnostic" ADD CONSTRAINT "FK_0216974d86c145e2a08ea291c5d" FOREIGN KEY (
+  "job_id") REFERENCES "public"."job"("id"
+) ON DELETE CASCADE ON UPDATE NO ACTION;
+
 ALTER TABLE "public"."annotation" ADD CONSTRAINT "FK_bfed30991918671d59fc1f5d5e4" FOREIGN KEY (
   "job_id") REFERENCES "public"."job"("id"
 ) ON DELETE CASCADE ON UPDATE NO ACTION;
@@ -383,14 +391,6 @@ ALTER TABLE "graphql"."dataset_project" ADD CONSTRAINT "FK_8bb698a02c945dc2a67a2
 ALTER TABLE "graphql"."dataset_project" ADD CONSTRAINT "FK_e192464449c2ac136fd4f00b439" FOREIGN KEY (
   "project_id") REFERENCES "graphql"."project"("id"
 ) ON DELETE NO ACTION ON UPDATE NO ACTION;
-
-ALTER TABLE "graphql"."dataset_diagnostic" ADD CONSTRAINT "FK_c43b99d980f560e82f711562c73" FOREIGN KEY (
-  "ds_id") REFERENCES "public"."dataset"("id"
-) ON DELETE CASCADE ON UPDATE NO ACTION;
-
-ALTER TABLE "graphql"."dataset_diagnostic" ADD CONSTRAINT "FK_1b73cd1c238b2e78080031618e6" FOREIGN KEY (
-  "job_id") REFERENCES "public"."job"("id"
-) ON DELETE CASCADE ON UPDATE NO ACTION;
 
 ALTER TABLE "graphql"."user" ADD CONSTRAINT "FK_1b5eb1327a74d679537bdc1fa5b" FOREIGN KEY (
   "credentials_id") REFERENCES "graphql"."credentials"("id"

--- a/metaspace/engine/scripts/update_diagnostics.py
+++ b/metaspace/engine/scripts/update_diagnostics.py
@@ -1,0 +1,184 @@
+import argparse
+import logging
+import warnings
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+from lithops import Storage
+from lithops.storage.utils import CloudObject
+
+from sm.engine.annotation.diagnostics import (
+    DiagnosticType,
+    extract_dataset_diagnostics,
+    add_diagnostics,
+    del_diagnostics,
+)
+from sm.engine.annotation.imzml_reader import LithopsImzMLReader, FSImzMLReader
+from sm.engine.db import DB
+from sm.engine.storage import get_s3_client
+from sm.engine.util import GlobalInit, split_cos_path, split_s3_path
+
+logger = logging.getLogger('engine')
+
+
+def run_diagnostics(sm_config, ds_id, sql_where, missing, failed, succeeded, del_first, jobs):
+    def parse_input_path_for_lithops(input_path):
+        if input_path.startswith('s3://') or input_path.startswith('s3a://'):
+            backend = 'aws_s3'
+            bucket, prefix = split_s3_path(input_path)
+        else:
+            backend = 'ibm_cos'
+            bucket, prefix = split_cos_path(input_path)
+
+        storage = Storage(sm_config['lithops'], backend)
+        if backend == 'aws_s3' and sm_config['lithops']['aws_s3']['endpoint'].startswith('http://'):
+            # WORKAROUND for local Minio access
+            # Lithops forces the url to HTTPS, so overwrite the S3 client with a fixed client
+            storage.storage_handler.s3_client = get_s3_client()
+
+        keys_in_path = storage.list_keys(bucket, prefix)
+        imzml_keys = [key for key in keys_in_path if key.lower().endswith('.imzml')]
+        ibd_keys = [key for key in keys_in_path if key.lower().endswith('.ibd')]
+
+        debug_info = f'Path {input_path} had keys: {keys_in_path}'
+        assert len(imzml_keys) == 1, f'Couldn\'t determine imzML file. {debug_info}'
+        assert len(ibd_keys) == 1, f'Couldn\'t determine ibd file. {debug_info}'
+
+        imzml_cobject = CloudObject(storage.backend, bucket, imzml_keys[0])
+        ibd_cobject = CloudObject(storage.backend, bucket, ibd_keys[0])
+        return storage, imzml_cobject, ibd_cobject
+
+    def process_dataset(ds_id):
+        logger.info(f'Processing {ds_id}')
+        try:
+            if del_first:
+                del_diagnostics(ds_id)
+
+            ds = DB().select_one_with_fields('SELECT * FROM dataset WHERE id = %s', (ds_id,))
+            input_path = ds['input_path']
+
+            if input_path.startswith('/'):
+                imzml_reader = FSImzMLReader(input_path)
+                if not imzml_reader.is_mz_from_metadata or not imzml_reader.is_tic_from_metadata:
+                    logger.info(f'{ds_id} missing metadata, reading spectra...')
+                    for _ in imzml_reader.iter_spectra(np.arange(imzml_reader.n_spectra)):
+                        # Read all spectra so that mz/tic data is populated
+                        pass
+            else:
+                storage, imzml_cobject, ibd_cobject = parse_input_path_for_lithops(input_path)
+                imzml_reader = LithopsImzMLReader(
+                    storage,
+                    imzml_cobject=imzml_cobject,
+                    ibd_cobject=ibd_cobject,
+                )
+
+                if not imzml_reader.is_mz_from_metadata or not imzml_reader.is_tic_from_metadata:
+                    logger.info(f'{ds_id} missing metadata, reading spectra...')
+                    chunk_size = 1000
+                    for chunk_start in range(0, imzml_reader.n_spectra, chunk_size):
+                        chunk_end = min(imzml_reader.n_spectra, chunk_start + chunk_size)
+                        chunk = np.arange(chunk_start, chunk_end)
+                        for _ in imzml_reader.iter_spectra(storage, chunk):
+                            # Read all spectra so that mz/tic data is populated
+                            pass
+
+            diagnostics = extract_dataset_diagnostics(ds_id, imzml_reader)
+            add_diagnostics(diagnostics)
+            return ds_id, True
+        except:
+            logger.error(f'Failed to process {ds_id}', exc_info=True)
+            return ds_id, False
+
+    db = DB()
+
+    if ds_id:
+        specified_ds_ids = ds_id.split(',')
+    elif sql_where:
+        specified_ds_ids = db.select_onecol(f"SELECT id FROM dataset WHERE {sql_where}")
+    else:
+        specified_ds_ids = None
+
+    if not missing:
+        # Default to processing all datasets missing diagnostics
+        missing = specified_ds_ids is None and not failed and not succeeded
+
+    ds_type_counts = db.select(
+        'SELECT d.id, COUNT(DISTINCT dd.type), COUNT(dd.error) '
+        'FROM dataset d LEFT JOIN dataset_diagnostic dd on d.id = dd.ds_id '
+        'WHERE d.status = \'FINISHED\' '
+        'GROUP BY d.id'
+    )
+    if missing or failed or succeeded:
+        # Get ds_ids based on status (or filter specified ds_ids on status)
+        status_ds_ids = set()
+        for ds_id, n_diagnostics, n_errors in ds_type_counts:
+            if missing and (n_diagnostics or 0) < len(DiagnosticType):
+                status_ds_ids.add(ds_id)
+            elif failed and n_errors > 0:
+                status_ds_ids.add(ds_id)
+            elif succeeded and n_diagnostics == len(DiagnosticType) and n_errors == 0:
+                status_ds_ids.add(ds_id)
+
+        if specified_ds_ids is not None:
+            # Keep order, if directly specified
+            ds_ids = [ds_id for ds_id in specified_ds_ids if ds_id in status_ds_ids]
+        else:
+            # Order by ID descending, so that newer DSs are updated first
+            ds_ids = sorted(status_ds_ids, reverse=True)
+    else:
+        ds_ids = specified_ds_ids
+
+    assert ds_ids, 'No datasets found'
+
+    failed_ds_ids = []
+    with ThreadPoolExecutor(jobs) as executor:
+        for i, (ds_id, success) in enumerate(executor.map(process_dataset, ds_ids)):
+            logger.info(f'Completed {ds_id} ({i}/{len(ds_ids)})')
+            if not success:
+                failed_ds_ids.append(ds_id)
+
+    if failed_ds_ids:
+        logger.error(f'Failed datasets ({len(failed_ds_ids)}): {failed_ds_ids}')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Reindex or update dataset results')
+    parser.add_argument('--config', default='conf/config.json', help='SM config path')
+    parser.add_argument('--ds-id', help='DS id (or comma-separated list of ids)')
+    parser.add_argument('--sql-where', help='SQL WHERE clause for datasets table')
+    parser.add_argument(
+        '--missing',
+        action='store_true',
+        help='(Default if ds-id/failed/succeeded not specified) '
+        'Process datasets that are missing diagnostics',
+    )
+    parser.add_argument(
+        '--failed',
+        action='store_true',
+        help='Process datasets that have errors in their diagnostics',
+    )
+    parser.add_argument(
+        '--succeeded', action='store_true', help='Process datasets even if they have diagnostics'
+    )
+    parser.add_argument(
+        '--del-first', action='store_true', help='Delete existing diagnostics before regenerating'
+    )
+    parser.add_argument('--jobs', '-j', type=int, default=1, help='Number of parallel jobs to run')
+    parser.add_argument('--verbose', '-v', action='store_true')
+    args = parser.parse_args()
+
+    with GlobalInit(config_path=args.config) as sm_config:
+        if not args.verbose:
+            logging.getLogger('lithops.storage.backends').setLevel(logging.WARNING)
+            warnings.filterwarnings('ignore', module='pyimzml')
+
+        run_diagnostics(
+            sm_config=sm_config,
+            ds_id=args.ds_id,
+            sql_where=args.sql_where,
+            missing=args.missing,
+            failed=args.failed,
+            succeeded=args.succeeded,
+            del_first=args.del_first,
+            jobs=args.jobs,
+        )

--- a/metaspace/engine/scripts/update_diagnostics.py
+++ b/metaspace/engine/scripts/update_diagnostics.py
@@ -33,6 +33,7 @@ def parse_input_path_for_lithops(sm_config, input_path):
     if backend == 'aws_s3' and sm_config['lithops']['aws_s3']['endpoint'].startswith('http://'):
         # WORKAROUND for local Minio access
         # Lithops forces the url to HTTPS, so overwrite the S3 client with a fixed client
+        # https://github.com/lithops-cloud/lithops/issues/708
         storage.storage_handler.s3_client = get_s3_client()
 
     keys_in_path = storage.list_keys(bucket, prefix)

--- a/metaspace/engine/sm/engine/annotation/diagnostics.py
+++ b/metaspace/engine/sm/engine/annotation/diagnostics.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from enum import Enum
 from io import BytesIO
 from traceback import format_exc
-from typing import Literal, Optional, Any, Union, List, TypedDict
+from typing import Optional, Any, Union, List, TypedDict
 
 import numpy as np
 
@@ -32,6 +32,7 @@ class DiagnosticImage(TypedDict, total=False):
     key: Optional[str]
     index: Optional[int]
     image_id: str  # required
+    url: str  # required
     format: DiagnosticImageFormat  # required
 
 
@@ -51,7 +52,7 @@ def add_diagnostics(diagnostics: List[DatasetDiagnostic]):
         assert 'ds_id' in diagnostic
         assert 'type' in diagnostic
         images = diagnostic.get('images', [])
-        assert all('image_id' in image for image in images)
+        assert all(image['image_id'] in image['url'] for image in images)
         assert all('format' in image for image in images)
         image_keys = set((image.get('key'), image.get('index')) for image in images)
         assert len(image_keys) == len(images), 'diagnostic image keys should be unique'
@@ -152,6 +153,7 @@ def save_diagnostic_image(ds_id: str, arr: np.ndarray, key=None, index=None) -> 
     if index is not None:
         image['index'] = index
     image['image_id'] = save_npy_image(ds_id, arr)
+    image['url'] = image_storage.get_image_url(image_storage.DIAG, ds_id, image['image_id'])
     image['format'] = DiagnosticImageFormat.NPY
     return image
 

--- a/metaspace/engine/sm/engine/annotation/diagnostics.py
+++ b/metaspace/engine/sm/engine/annotation/diagnostics.py
@@ -1,0 +1,93 @@
+from datetime import datetime
+from typing import Literal, Optional, Any, Union, List
+
+from sm.engine import image_storage
+from sm.engine.db import DB
+
+DiagnosticImageFormat = Literal['PNG', 'NPY']
+# Should match the enum in metaspace/graphql/src/modules/dataset/model.ts
+DiagnosticType = Literal['TIC', 'IMZML_METADATA']
+
+
+class DiagnosticTypes:
+    TIC: DiagnosticType = 'TIC'
+    IMZML_METADATA: DiagnosticType = 'IMZML_METADATA'
+
+
+class DiagnosticImage:
+    key: Optional[str]
+    index: Optional[int]
+    image_id: str
+    format: DiagnosticImageFormat
+
+
+class DatasetDiagnostic:
+    ds_id: str
+    job_id: Optional[int]
+    type: str
+    data: Any
+    error: Union[str, None]
+    images: List[DiagnosticImage]
+
+
+def save_diagnostics(diagnostics: List[DatasetDiagnostic]):
+    db = DB()
+    # Find all diagnostics that should be replaced by the new diagnostics
+    existing = db.select(
+        """
+        WITH new_diagnostic AS (
+            SELECT UNNEST(%s::text[]) as ds_id, UNNEST(%s::text[]) as job_id, 
+            UNNEST(%s::text[]) as type
+        )
+        SELECT ds_id, id, images 
+        FROM new_diagnostic nd
+        JOIN dataset_diagnostic dd ON nd.ds_id = dd.ds_id
+            AND (nd.job_id = dd.job_id OR (nd.job_id IS NULL AND dd.job_id is NULL))
+            AND nd.type = dd.type
+        """,
+        list(zip(*((d.ds_id, d.job_id, d.type) for d in diagnostics))),
+    )
+
+    if existing:
+        # Delete existing images
+        for row in existing:
+            for img in row['images'] or []:
+                image_storage.delete_image(image_storage.DIAG, row.ds_id, img.image_id)
+        # Delete existing DB rows
+        db.alter(
+            'DELETE FROM dataset_diagnostic WHERE id = ANY(%s)', [row['id'] for row in existing]
+        )
+
+    db.insert(
+        'INSERT INTO dataset_diagnostic (ds_id, job_id, type, updated_dt, data, error, images) '
+        'VALUES (%s, %s, %s, %s, %s, %s, %s, %s)',
+        [
+            (d.ds_id, d.job_id, d.type, datetime.now(), d.data, d.error, d.images)
+            for d in diagnostics
+        ],
+    )
+
+
+def delete_diagnostics(ds_id: str, job_ids: Optional[List[int]] = None):
+    db = DB()
+    if job_ids is None:
+        existing = db.select(
+            'SELECT id, images FROM dataset_diagnostic dd WHERE dd.ds_id = %s',
+            [ds_id],
+        )
+    else:
+        existing = db.select(
+            'SELECT id, images FROM dataset_diagnostic dd '
+            'WHERE dd.ds_id = %s AND dd.job_id = ANY(%s)',
+            [ds_id, job_ids],
+        )
+
+    if existing:
+        # Delete existing images
+        for row in existing:
+            for img in row['images'] or []:
+                image_storage.delete_image(image_storage.DIAG, ds_id, img.image_id)
+        # Delete existing DB rows
+        db.alter(
+            'DELETE FROM dataset_diagnostic WHERE id = ANY(%s)', [row['id'] for row in existing]
+        )

--- a/metaspace/engine/sm/engine/annotation/diagnostics.py
+++ b/metaspace/engine/sm/engine/annotation/diagnostics.py
@@ -1,12 +1,22 @@
+import json
+import logging
+from collections import defaultdict
 from datetime import datetime
-from typing import Literal, Optional, Any, Union, List
+from io import BytesIO
+from traceback import format_exc
+from typing import Literal, Optional, Any, Union, List, TypedDict
+
+import numpy as np
 
 from sm.engine import image_storage
+from sm.engine.annotation.imzml_reader import ImzMLReader
 from sm.engine.db import DB
 
-DiagnosticImageFormat = Literal['PNG', 'NPY']
+logger = logging.getLogger('engine')
+
 # Should match the enum in metaspace/graphql/src/modules/dataset/model.ts
 DiagnosticType = Literal['TIC', 'IMZML_METADATA']
+DiagnosticImageFormat = Literal['PNG', 'NPY']
 
 
 class DiagnosticTypes:
@@ -14,45 +24,65 @@ class DiagnosticTypes:
     IMZML_METADATA: DiagnosticType = 'IMZML_METADATA'
 
 
-class DiagnosticImage:
+class DiagnosticImageFormats:
+    PNG: DiagnosticImageFormat = 'PNG'
+    NPY: DiagnosticImageFormat = 'NPY'
+
+
+class DiagnosticImage(TypedDict, total=False):
     key: Optional[str]
     index: Optional[int]
-    image_id: str
-    format: DiagnosticImageFormat
+    image_id: str  # required
+    format: DiagnosticImageFormat  # required
 
 
-class DatasetDiagnostic:
-    ds_id: str
+class DatasetDiagnostic(TypedDict, total=False):
+    ds_id: str  # required
     job_id: Optional[int]
-    type: str
+    type: str  # required
     data: Any
     error: Union[str, None]
     images: List[DiagnosticImage]
 
 
-def save_diagnostics(diagnostics: List[DatasetDiagnostic]):
+def add_diagnostics(diagnostics: List[DatasetDiagnostic]):
+    """Upserts dataset diagnostics, overwriting existing values with the same ds_id, job_id, type"""
+    # Validate input
+    for diagnostic in diagnostics:
+        assert 'ds_id' in diagnostic
+        assert 'type' in diagnostic
+        images = diagnostic.get('images', [])
+        assert all('image_id' in image for image in images)
+        assert all('format' in image for image in images)
+        image_keys = set((image.get('key'), image.get('index')) for image in images)
+        assert len(image_keys) == len(images), 'diagnostic image keys should be unique'
+
     db = DB()
     # Find all diagnostics that should be replaced by the new diagnostics
     existing = db.select(
         """
         WITH new_diagnostic AS (
-            SELECT UNNEST(%s::text[]) as ds_id, UNNEST(%s::text[]) as job_id, 
+            SELECT UNNEST(%s::text[]) as ds_id, UNNEST(%s::int[]) as job_id,
             UNNEST(%s::text[]) as type
         )
-        SELECT ds_id, id, images 
+        SELECT dd.ds_id, dd.id, dd.images
         FROM new_diagnostic nd
         JOIN dataset_diagnostic dd ON nd.ds_id = dd.ds_id
             AND (nd.job_id = dd.job_id OR (nd.job_id IS NULL AND dd.job_id is NULL))
             AND nd.type = dd.type
         """,
-        list(zip(*((d.ds_id, d.job_id, d.type) for d in diagnostics))),
+        list(map(list, zip(*((d['ds_id'], d.get('job_id'), d['type']) for d in diagnostics)))),
     )
 
     if existing:
         # Delete existing images
+        image_ids_by_ds = defaultdict(list)
         for row in existing:
             for img in row['images'] or []:
-                image_storage.delete_image(image_storage.DIAG, row.ds_id, img.image_id)
+                image_ids_by_ds[row['ds_id']].append(img['image_id'])
+        for ds_id, image_ids in image_ids_by_ds.values():
+            image_storage.delete_images(image_storage.DIAG, ds_id, image_ids)
+
         # Delete existing DB rows
         db.alter(
             'DELETE FROM dataset_diagnostic WHERE id = ANY(%s)', [row['id'] for row in existing]
@@ -60,15 +90,23 @@ def save_diagnostics(diagnostics: List[DatasetDiagnostic]):
 
     db.insert(
         'INSERT INTO dataset_diagnostic (ds_id, job_id, type, updated_dt, data, error, images) '
-        'VALUES (%s, %s, %s, %s, %s, %s, %s, %s)',
+        'VALUES (%s, %s, %s, %s, %s, %s, %s)',
         [
-            (d.ds_id, d.job_id, d.type, datetime.now(), d.data, d.error, d.images)
+            (
+                d['ds_id'],
+                d.get('job_id'),
+                d['type'],
+                datetime.now(),
+                json.dumps(d['data']) if d.get('data') is not None else None,
+                d.get('error'),
+                json.dumps(d.get('images', [])),
+            )
             for d in diagnostics
         ],
     )
 
 
-def delete_diagnostics(ds_id: str, job_ids: Optional[List[int]] = None):
+def del_diagnostics(ds_id: str, job_ids: Optional[List[int]] = None):
     db = DB()
     if job_ids is None:
         existing = db.select(
@@ -84,10 +122,79 @@ def delete_diagnostics(ds_id: str, job_ids: Optional[List[int]] = None):
 
     if existing:
         # Delete existing images
-        for row in existing:
-            for img in row['images'] or []:
-                image_storage.delete_image(image_storage.DIAG, ds_id, img.image_id)
+        image_ids = [img['image_id'] for row in existing for img in row['images'] or []]
+        image_storage.delete_images(image_storage.DIAG, ds_id, image_ids)
+
         # Delete existing DB rows
         db.alter(
             'DELETE FROM dataset_diagnostic WHERE id = ANY(%s)', [row['id'] for row in existing]
         )
+
+
+def get_dataset_diagnostics(ds_id: str):
+    return DB().select_with_fields(
+        'SELECT ds_id, job_id, type, data, error, images FROM dataset_diagnostic WHERE ds_id = %s',
+        (ds_id,),
+    )
+
+
+def save_npy_image(ds_id: str, arr: np.ndarray):
+    buf = BytesIO()
+    np.save(buf, arr, allow_pickle=False)
+    buf.seek(0)
+
+    return image_storage.post_image(image_storage.DIAG, ds_id, buf)
+
+
+def load_npy_image(ds_id: str, image_id: str):
+    buf = image_storage.get_image(image_storage.DIAG, ds_id, image_id)
+    return np.load(BytesIO(buf), allow_pickle=False)
+
+
+def extract_dataset_diagnostics(ds_id: str, imzml_reader: ImzMLReader):
+    mask_image_id = save_npy_image(ds_id, imzml_reader.mask)
+    diagnostics: List[DatasetDiagnostic] = [
+        {
+            'ds_id': ds_id,
+            'type': DiagnosticTypes.IMZML_METADATA,
+            'data': {
+                'n_spectra': imzml_reader.n_spectra,
+                'min_coords': imzml_reader.raw_coord_bounds[0].tolist(),
+                'max_coords': imzml_reader.raw_coord_bounds[1].tolist(),
+                'min_mz': imzml_reader.min_mz,
+                'max_mz': imzml_reader.max_mz,
+                'metadata': imzml_reader.metadata_summary,
+            },
+            'images': [
+                {'key': 'mask', 'image_id': mask_image_id, 'format': DiagnosticImageFormats.NPY}
+            ],
+        }
+    ]
+    try:
+        tic_image = imzml_reader.tic_image()
+        tic_vals = tic_image[~np.isnan(tic_image)]
+        tic_image_id = save_npy_image(ds_id, tic_image)
+
+        diagnostics.append(
+            {
+                'ds_id': ds_id,
+                'type': DiagnosticTypes.TIC,
+                'data': {
+                    'min_tic': np.min(tic_vals).item() if len(tic_vals) else 0,
+                    'max_tic': np.max(tic_vals).item() if len(tic_vals) else 0,
+                    'sum_tic': np.sum(tic_vals).item() if len(tic_vals) else 0,
+                    'is_from_metadata': imzml_reader.is_tic_from_metadata,
+                },
+                'images': [{'image_id': tic_image_id, 'format': DiagnosticImageFormats.NPY}],
+            }
+        )
+    except Exception:
+        logger.exception('Exception generating TIC diagnostic', exc_info=True)
+        diagnostics.append(
+            {
+                'ds_id': ds_id,
+                'type': DiagnosticTypes.TIC,
+                'error': format_exc(),
+            }
+        )
+    return diagnostics

--- a/metaspace/engine/sm/engine/annotation/imzml_parser.py
+++ b/metaspace/engine/sm/engine/annotation/imzml_parser.py
@@ -1,22 +1,162 @@
+from __future__ import annotations
+from pathlib import Path
+from threading import Lock
 from traceback import format_exc
+from typing import TYPE_CHECKING, Sequence
 
+import numpy as np
 from pyimzml.ImzMLParser import ImzMLParser
+from scipy.sparse import coo_matrix
+
 from sm.engine.errors import ImzMLError
 
 from sm.engine.util import find_file_by_ext
 
+if TYPE_CHECKING:
+    from lithops import Storage
+    from lithops.storage.utils import CloudObject
+
+TIC_ACCESSION = 'MS:1000285'
+METADATA_FIELDS = [TIC_ACCESSION]
+
 
 class ImzMLParserWrapper:
-    def __init__(self, path):
+    """This class bundles the ability to somehow access ImzML data (implemented in subclasses)
+    with some commonly-used pre-computed data such as the mask image and the mapping between
+    spectrum index and pixel index.  Additionally, it provides a central place to efficiently
+    intercept and gather additional data while the file is being read, to minimize I/O for things
+    like
+
+    The main purpose of this class is to consolidate functionality that's shared between
+    the Lithops and Spark implementations and migration scripts.
+    """
+
+    def __init__(self, imzml_parser: ImzMLParser):
+        coordinates = np.array(imzml_parser.coordinates)[:, :2]
+        coordinates -= np.min(coordinates, axis=0)
+        self.n_spectra = coordinates.shape[0]
+        self.ys, self.xs = coordinates[:, 1], coordinates[:, 0]
+        self.w, self.h = np.max(coordinates, axis=0) + 1
+        # pixel_indexes - spectrum index to pixel index mapping. Pixel indexes (referred to as sp_i
+        # in many places) are simply `Y * width + X`, allowing easy reshaping into a 2D image
+        # without needing to compensate for missing spectra.
+        # NOTE: ImzML reports coordinates in X,Y order, but all other code uses Y,X order as it
+        # is a more commonly accepted way to do image processing.
+        self.pixel_indexes = self.ys * self.w + self.xs
+
+        # Add 2D mask
+        sample_area_mask = np.zeros(self.h * self.w, dtype=bool)
+        sample_area_mask[self.pixel_indexes] = True
+        self.mask = sample_area_mask.reshape(self.h, self.w)
+
+        self.metadata_summary = imzml_parser.metadata.pretty()
+
+        self.min_mz = np.inf
+        self.max_mz = -np.inf
+
+        self.mz_precision = imzml_parser.mzPrecision
+
+        tic_metadata = imzml_parser.spectrum_metadata_fields[TIC_ACCESSION]
+        self._sp_tic_from_metadata = all(tic_metadata)
+        if self._sp_tic_from_metadata:
+            self._sp_tic = np.array(tic_metadata, dtype='f')
+        else:
+            self._sp_tic = np.full(self.n_spectra, np.nan, dtype='f')
+
+    def spectrum_vals_to_image(self, values):
+        return coo_matrix((values, (self.ys, self.xs)), shape=(self.h, self.w)).toarray()
+
+    def tic_image(self):
+        return self.spectrum_vals_to_image(self._sp_tic)
+
+    def _process_spectrum(self, idx, mzs, ints):
+        # Remove zero-intensity peaks, as some export processes generate them in large numbers,
+        # but they add no value at all.
+        nonzero_ints_mask = ints > 0
+        if not np.all(nonzero_ints_mask):
+            mzs, ints = mzs[nonzero_ints_mask], ints[nonzero_ints_mask]
+
+        # Populate TIC
+        if not self._sp_tic_from_metadata:
+            self._sp_tic[idx] = np.nan_to_num(self._sp_tic[idx]) + np.sum(ints)
+
+        # Populate min/max m/zs
+        if len(mzs):
+            self.min_mz = min(self.min_mz, np.min(mzs))
+            self.max_mz = min(self.max_mz, np.max(mzs))
+
+        return idx, mzs, ints
+
+
+class FSImzMLParserWrapper(ImzMLParserWrapper):
+    def __init__(self, path: Path):
         self.filename = find_file_by_ext(path, 'imzml')
         try:
-            self._imzml_parser = ImzMLParser(self.filename, parse_lib='ElementTree')
+            self._imzml_parser = ImzMLParser(
+                self.filename,
+                parse_lib='ElementTree',
+                include_spectra_metadata=METADATA_FIELDS,
+            )
         except Exception as e:
             raise ImzMLError(format_exc()) from e
-        self.coordinates = [coord[:2] for coord in self._imzml_parser.coordinates]
-        self.mz_precision = self._imzml_parser.mzPrecision
 
-    def get_spectrum(self, idx):
-        mzs, ints = self._imzml_parser.getspectrum(idx)
-        nonzero_ints_mask = ints > 0
-        return mzs[nonzero_ints_mask], ints[nonzero_ints_mask]
+        super().__init__(self._imzml_parser)
+
+    def iter_spectra(self, sp_idxs: Sequence[int]):
+        for sp_idx in sp_idxs:
+            mzs, ints = self._imzml_parser.getspectrum(sp_idx)
+            sp_idx, mzs, ints = self._process_spectrum(sp_idx, mzs, ints)
+            yield sp_idx, mzs, ints
+
+
+class LithopsImzMLParserWrapper(ImzMLParserWrapper):
+    def __init__(self, storage: Storage, imzml_cobject: CloudObject, ibd_cobject: CloudObject):
+        imzml_parser = ImzMLParser(
+            storage.get_cloudobject(imzml_cobject, stream=True),
+            ibd_file=None,
+            parse_lib='ElementTree',
+            include_spectra_metadata=METADATA_FIELDS,
+        )
+
+        self._ibd_cobject = ibd_cobject
+        self.imzml_reader = imzml_parser.portable_spectrum_reader()
+        self._process_spectrum_lock = Lock()
+
+        super().__init__(imzml_parser)
+
+    def iter_spectra(self, storage: Storage, sp_inds: Sequence[int]):
+        from sm.engine.annotation_lithops.io import get_ranges_from_cobject
+
+        mz_starts = np.array(self.imzml_reader.mzOffsets)[sp_inds]
+        mz_ends = (
+            mz_starts
+            + np.array(self.imzml_reader.mzLengths)[sp_inds] * np.dtype(self.mz_precision).itemsize
+        )
+        mz_ranges = np.stack([mz_starts, mz_ends], axis=1)
+        int_starts = np.array(self.imzml_reader.intensityOffsets)[sp_inds]
+        int_ends = (
+            int_starts
+            + np.array(self.imzml_reader.intensityLengths)[sp_inds]
+            * np.dtype(self.imzml_reader.intensityPrecision).itemsize
+        )
+        int_ranges = np.stack([int_starts, int_ends], axis=1)
+        ranges_to_read = np.vstack([mz_ranges, int_ranges])
+        data_ranges = get_ranges_from_cobject(storage, self._ibd_cobject, ranges_to_read)
+        mz_data = data_ranges[: len(sp_inds)]
+        int_data = data_ranges[len(sp_inds) :]
+        del data_ranges
+
+        for i, sp_idx in enumerate(sp_inds):
+            # Copy the arrays, as np.frombuffer only makes a view over the existing buffer,
+            # and this should avoid holding references to the source data as they may be slices
+            # of larger arrays that should be GC'd.
+            mzs = np.frombuffer(mz_data[i], dtype=self.imzml_reader.mzPrecision).copy()
+            ints = np.frombuffer(int_data[i], dtype=self.imzml_reader.intensityPrecision).copy()
+            mz_data[i] = None  # type: ignore # Avoid holding memory longer than necessary
+            int_data[i] = None  # type: ignore
+
+            # _process_spectrum isn't thread-safe, so only access it in a mutex
+            with self._process_spectrum_lock:
+                sp_idx, mzs, ints = self._process_spectrum(sp_idx, mzs, ints)
+
+            yield sp_idx, mzs, ints

--- a/metaspace/engine/sm/engine/annotation/imzml_reader.py
+++ b/metaspace/engine/sm/engine/annotation/imzml_reader.py
@@ -20,7 +20,7 @@ TIC_ACCESSION = 'MS:1000285'
 METADATA_FIELDS = [TIC_ACCESSION]
 
 
-class ImzMLParserWrapper:
+class ImzMLReader:
     """This class bundles the ability to somehow access ImzML data (implemented in subclasses)
     with some commonly-used pre-computed data such as the mask image and the mapping between
     spectrum index and pixel index.  Additionally, it provides a central place to efficiently
@@ -88,7 +88,7 @@ class ImzMLParserWrapper:
         return idx, mzs, ints
 
 
-class FSImzMLParserWrapper(ImzMLParserWrapper):
+class FSImzMLReader(ImzMLReader):
     def __init__(self, path: Path):
         self.filename = find_file_by_ext(path, 'imzml')
         try:
@@ -109,7 +109,7 @@ class FSImzMLParserWrapper(ImzMLParserWrapper):
             yield sp_idx, mzs, ints
 
 
-class LithopsImzMLParserWrapper(ImzMLParserWrapper):
+class LithopsImzMLReader(ImzMLReader):
     def __init__(self, storage: Storage, imzml_cobject: CloudObject, ibd_cobject: CloudObject):
         imzml_parser = ImzMLParser(
             storage.get_cloudobject(imzml_cobject, stream=True),

--- a/metaspace/engine/sm/engine/annotation/png_generator.py
+++ b/metaspace/engine/sm/engine/annotation/png_generator.py
@@ -299,7 +299,7 @@ class PngGenerator:
             image = rgba
         return image
 
-    def generate_png(self, array: np.array) -> bytes:
+    def generate_png(self, array: np.ndarray) -> bytes:
         img = self._to_image(array)
         fp = BytesIO()
         png_writer = png.Writer(

--- a/metaspace/engine/sm/engine/annotation_lithops/annotate.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/annotate.py
@@ -6,7 +6,6 @@ from typing import List, Dict, Tuple, Optional
 import numpy as np
 import pandas as pd
 from lithops.storage import Storage
-from pyimzml.ImzMLParser import PortableSpectrumReader
 from scipy.sparse import coo_matrix
 
 from sm.engine.annotation.formula_validator import (
@@ -15,9 +14,9 @@ from sm.engine.annotation.formula_validator import (
     MetricsDict,
     METRICS,
 )
+from sm.engine.annotation.imzml_parser import LithopsImzMLParserWrapper
 from sm.engine.annotation_lithops.executor import Executor
 from sm.engine.annotation_lithops.io import save_cobj, load_cobj, CObj, load_cobjs
-from sm.engine.annotation_lithops.utils import ds_dims, get_pixel_indices
 from sm.engine.ds_config import DSConfig
 from sm.engine.annotation.isocalc_wrapper import IsocalcWrapper
 from sm.engine.utils.perf_profile import Profiler
@@ -195,14 +194,6 @@ def read_ds_segments(
     return sp_df
 
 
-def make_sample_area_mask(coordinates):
-    pixel_indices = get_pixel_indices(coordinates)
-    nrows, ncols = ds_dims(coordinates)
-    sample_area_mask = np.zeros(ncols * nrows, dtype=bool)
-    sample_area_mask[pixel_indices] = True
-    return sample_area_mask.reshape(nrows, ncols)
-
-
 def choose_ds_segments(ds_segments_bounds, centr_df, isocalc_wrapper):
     centr_segm_min_mz, centr_segm_max_mz = centr_df.mz.agg([np.min, np.max])
     centr_segm_min_mz, _ = isocalc_wrapper.mass_accuracy_bounds(centr_segm_min_mz)
@@ -224,18 +215,19 @@ def process_centr_segments(
     ds_segments_bounds,
     ds_segm_lens: np.ndarray,
     db_segms_cobjs: List[CObj[pd.DataFrame]],
-    imzml_reader: PortableSpectrumReader,
+    imzml_wrapper: LithopsImzMLParserWrapper,
     ds_config: DSConfig,
     ds_segm_size_mb: float,
     is_intensive_dataset: bool,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     # pylint: disable=too-many-locals
-    ds_segm_dtype = imzml_reader.mzPrecision
-    sample_area_mask = make_sample_area_mask(imzml_reader.coordinates)
-    nrows, ncols = ds_dims(imzml_reader.coordinates)
+    # Copy needed fields out of imzml_wrapper so that the other unneeded fields aren't pulled into
+    # the pickled `process_centr_segment` function
+    ds_segm_dtype = imzml_wrapper.mz_precision
+    nrows, ncols = imzml_wrapper.h, imzml_wrapper.w
     isocalc_wrapper = IsocalcWrapper(ds_config)
     image_gen_config = ds_config['image_generation']
-    compute_metrics = make_compute_image_metrics(sample_area_mask, nrows, ncols, image_gen_config)
+    compute_metrics = make_compute_image_metrics(imzml_wrapper.mask, nrows, ncols, image_gen_config)
     min_px = image_gen_config['min_px']
     # TODO: Get available memory from Lithops somehow so it updates if memory is increased on retry
     pw_mem_mb = 2048 if is_intensive_dataset else 1024

--- a/metaspace/engine/sm/engine/annotation_lithops/annotate.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/annotate.py
@@ -14,7 +14,7 @@ from sm.engine.annotation.formula_validator import (
     MetricsDict,
     METRICS,
 )
-from sm.engine.annotation.imzml_parser import LithopsImzMLParserWrapper
+from sm.engine.annotation.imzml_reader import LithopsImzMLReader
 from sm.engine.annotation_lithops.executor import Executor
 from sm.engine.annotation_lithops.io import save_cobj, load_cobj, CObj, load_cobjs
 from sm.engine.ds_config import DSConfig
@@ -215,19 +215,19 @@ def process_centr_segments(
     ds_segments_bounds,
     ds_segm_lens: np.ndarray,
     db_segms_cobjs: List[CObj[pd.DataFrame]],
-    imzml_wrapper: LithopsImzMLParserWrapper,
+    imzml_reader: LithopsImzMLReader,
     ds_config: DSConfig,
     ds_segm_size_mb: float,
     is_intensive_dataset: bool,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     # pylint: disable=too-many-locals
-    # Copy needed fields out of imzml_wrapper so that the other unneeded fields aren't pulled into
+    # Copy needed fields out of imzml_reader so that the other unneeded fields aren't pulled into
     # the pickled `process_centr_segment` function
-    ds_segm_dtype = imzml_wrapper.mz_precision
-    nrows, ncols = imzml_wrapper.h, imzml_wrapper.w
+    ds_segm_dtype = imzml_reader.mz_precision
+    nrows, ncols = imzml_reader.h, imzml_reader.w
     isocalc_wrapper = IsocalcWrapper(ds_config)
     image_gen_config = ds_config['image_generation']
-    compute_metrics = make_compute_image_metrics(imzml_wrapper.mask, nrows, ncols, image_gen_config)
+    compute_metrics = make_compute_image_metrics(imzml_reader.mask, nrows, ncols, image_gen_config)
     min_px = image_gen_config['min_px']
     # TODO: Get available memory from Lithops somehow so it updates if memory is increased on retry
     pw_mem_mb = 2048 if is_intensive_dataset else 1024

--- a/metaspace/engine/sm/engine/annotation_lithops/annotation_job.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/annotation_job.py
@@ -175,6 +175,8 @@ class LocalAnnotationJob:
         ds_config: DSConfig,
         sm_config: Optional[Dict] = None,
         use_cache=True,
+        out_dir: Optional[str] = None,
+        executor: Optional[Executor] = None,
     ):
         sm_config = sm_config or SMConfig.get_conf()
         self.storage = Storage(config=sm_config['lithops'])
@@ -187,6 +189,7 @@ class LocalAnnotationJob:
         else:
             self.moldb_defs = _upload_moldbs_from_files(moldb_files, self.storage, sm_storage)
         self.ds_config = ds_config
+        self.out_dir = Path(out_dir) if out_dir else Path('./result_pngs')
 
         if use_cache:
             cache_key: Optional[str] = jsonhash(
@@ -196,14 +199,20 @@ class LocalAnnotationJob:
             cache_key = None
 
         self.pipe = Pipeline(
-            self.imzml_cobj, self.ibd_cobj, self.moldb_defs, self.ds_config, cache_key=cache_key
+            self.imzml_cobj,
+            self.ibd_cobj,
+            self.moldb_defs,
+            self.ds_config,
+            executor=executor,
+            cache_key=cache_key,
+            use_db_mutex=False,
         )
 
     def run(self, save=True, **kwargs):
         results_dfs, png_cobjs = self.pipe(**kwargs)
         if save:
             for moldb_id, results_df in results_dfs.items():
-                results_df.to_csv(f'./results_{moldb_id}.csv')
+                results_df.to_csv(self.out_dir / f'results_{moldb_id}.csv')
             all_results = pd.concat(list(results_dfs.values()))
             all_results = all_results[~all_results.index.duplicated()]
             image_names = (
@@ -212,13 +221,14 @@ class LocalAnnotationJob:
                 + all_results.neutral_loss.fillna('')
                 + all_results.adduct
             )
-            out_dir = Path('./result_pngs')
-            out_dir.mkdir(exist_ok=True)
+
+            self.out_dir.mkdir(exist_ok=True)
             for imageset in iter_cobjs_with_prefetch(self.storage, png_cobjs):
                 for formula_i, imgs in imageset:
                     for i, img in enumerate(imgs, 1):
                         if img:
-                            (out_dir / f'{image_names[formula_i]}_{i}.png').open('wb').write(img)
+                            out_file = self.out_dir / f'{image_names[formula_i]}_{i}.png'
+                            out_file.open('wb').write(img)
 
 
 class ServerAnnotationJob:

--- a/metaspace/engine/sm/engine/annotation_lithops/annotation_job.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/annotation_job.py
@@ -11,6 +11,7 @@ from ibm_boto3.s3.transfer import TransferConfig, MB
 from lithops.storage import Storage
 from lithops.storage.utils import StorageNoSuchKeyError, CloudObject
 
+from sm.engine.annotation.diagnostics import extract_dataset_diagnostics, add_diagnostics
 from sm.engine.annotation.formula_validator import METRICS
 from sm.engine.annotation.job import del_jobs, insert_running_job, update_finished_job, JobStatus
 from sm.engine.annotation_lithops.executor import Executor
@@ -313,6 +314,10 @@ class ServerAnnotationJob:
                 pd.concat(list(self.results_dfs.values())),
                 iter_cobjs_with_prefetch(self.storage, self.png_cobjs),
             )
+
+            # Save non-job-related diagnostics
+            diagnostics = extract_dataset_diagnostics(self.ds.id, self.pipe.imzml_reader)
+            add_diagnostics(diagnostics)
 
             for moldb_id, job_id in moldb_to_job_map.items():
                 results_df = self.results_dfs[moldb_id]

--- a/metaspace/engine/sm/engine/annotation_lithops/executor.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/executor.py
@@ -88,7 +88,7 @@ def _save_subtask_perf(
         exec_times = [f.stats.get('worker_func_exec_time', -1) for f in futures]
     else:
         # debug_run_locally=True doesn't make futures
-        exec_times = [-1] * len(subtask_perfs)
+        exec_times = [sum(perf.entries.values()) for perf in subtask_perfs]
     inner_times = subtask_data.pop('inner time', [-1])
     mem_befores = subtask_data.pop('mem before', [-1])
     mem_afters = subtask_data.pop('mem after', [-1])

--- a/metaspace/engine/sm/engine/annotation_lithops/executor.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/executor.py
@@ -87,12 +87,13 @@ def _save_subtask_perf(
     if futures:
         exec_times = [f.stats.get('worker_func_exec_time', -1) for f in futures]
     else:
-        exec_times = [-1]
+        # debug_run_locally=True doesn't make futures
+        exec_times = [-1] * len(subtask_perfs)
     inner_times = subtask_data.pop('inner time', [-1])
     mem_befores = subtask_data.pop('mem before', [-1])
     mem_afters = subtask_data.pop('mem after', [-1])
     perf_data = {
-        'num_actions': len(futures) if futures else -1,
+        'num_actions': len(exec_times),
         'attempts': attempt,
         'runtime_memory': runtime_memory,
         'max_memory': np.max(mem_afters).item(),

--- a/metaspace/engine/sm/engine/annotation_lithops/io.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/io.py
@@ -49,7 +49,7 @@ def serialize(obj):
 def deserialize(data):
     try:
         return pa.deserialize(data)
-    except pa.lib.ArrowInvalid:
+    except (pa.lib.ArrowInvalid, OSError):
         return pickle.loads(data)
 
 

--- a/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
@@ -178,7 +178,8 @@ def validate_ds_segments(fexec, imzml_reader, ds_segments_bounds, ds_segms_cobjs
         2,
     ), (ds_segments_bounds.shape, (n_segms, 2))
 
-    results = fexec.map(get_segm_stats, ds_segms_cobjs)
+    args = [(cobj,) for cobj in ds_segms_cobjs]
+    results = fexec.map(get_segm_stats, args)
 
     segms_df = pd.DataFrame(results)
     segms_df['min_bound'] = np.concatenate([[0], ds_segments_bounds[1:, 0]])

--- a/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
@@ -9,7 +9,7 @@ import pandas as pd
 from lithops.storage import Storage
 from lithops.storage.utils import CloudObject
 
-from sm.engine.annotation.imzml_parser import LithopsImzMLParserWrapper
+from sm.engine.annotation.imzml_reader import LithopsImzMLReader
 from sm.engine.annotation_lithops.executor import Executor
 from sm.engine.annotation_lithops.io import CObj, load_cobj, save_cobj
 from sm.engine.utils.perf_profile import SubtaskProfiler
@@ -17,22 +17,22 @@ from sm.engine.utils.perf_profile import SubtaskProfiler
 logger = logging.getLogger('annotation-pipeline')
 
 
-def _load_spectra(storage, imzml_wrapper):
+def _load_spectra(storage, imzml_reader):
     # Pre-allocate lists of mz & int arrays
-    mz_arrays = [np.array([], dtype=imzml_wrapper.mz_precision)] * imzml_wrapper.n_spectra
-    int_arrays = [np.array([], dtype=np.float32)] * imzml_wrapper.n_spectra
-    sp_lens = np.empty(imzml_wrapper.n_spectra, np.int64)
+    mz_arrays = [np.array([], dtype=imzml_reader.mz_precision)] * imzml_reader.n_spectra
+    int_arrays = [np.array([], dtype=np.float32)] * imzml_reader.n_spectra
+    sp_lens = np.empty(imzml_reader.n_spectra, np.int64)
 
     def read_spectrum_chunk(start_end):
-        for sp_i, mzs, ints in imzml_wrapper.iter_spectra(storage, list(range(*start_end))):
+        for sp_i, mzs, ints in imzml_reader.iter_spectra(storage, list(range(*start_end))):
             mz_arrays[sp_i] = mzs
             int_arrays[sp_i] = ints.astype(np.float32)
             sp_lens[sp_i] = len(ints)
 
     # Break into approx. 100MB chunks to read in parallel
-    n_peaks = np.sum(imzml_wrapper.imzml_reader.mzLengths)
-    n_chunks = min(int(np.ceil(n_peaks / (10 * 2 ** 20))), imzml_wrapper.n_spectra)
-    chunk_bounds = np.linspace(0, imzml_wrapper.n_spectra, n_chunks + 1, dtype=np.int64)
+    n_peaks = np.sum(imzml_reader.imzml_reader.mzLengths)
+    n_chunks = min(int(np.ceil(n_peaks / (10 * 2 ** 20))), imzml_reader.n_spectra)
+    chunk_bounds = np.linspace(0, imzml_reader.n_spectra, n_chunks + 1, dtype=np.int64)
     spectrum_chunks = zip(chunk_bounds, chunk_bounds[1:])
 
     with ThreadPoolExecutor(4) as executor:
@@ -42,7 +42,7 @@ def _load_spectra(storage, imzml_wrapper):
     return np.concatenate(mz_arrays), np.concatenate(int_arrays), sp_lens
 
 
-def _sort_spectra(imzml_wrapper, mzs, ints, sp_lens):
+def _sort_spectra(imzml_reader, mzs, ints, sp_lens):
     # Specify mergesort explicitly because numpy often chooses heapsort which is super slow
     by_mz = np.argsort(mzs, kind='mergesort')
 
@@ -55,16 +55,16 @@ def _sort_spectra(imzml_wrapper, mzs, ints, sp_lens):
     # sp_idxs in a compacted form with sp_lens until the last minute.
     sp_idxs = np.empty(len(ints), np.uint32)
     sp_lens = np.insert(np.cumsum(sp_lens), 0, 0)
-    for sp_idx, start, end in zip(imzml_wrapper.pixel_indexes, sp_lens[:-1], sp_lens[1:]):
+    for sp_idx, start, end in zip(imzml_reader.pixel_indexes, sp_lens[:-1], sp_lens[1:]):
         sp_idxs[start:end] = sp_idx
     sp_idxs = sp_idxs[by_mz]
     return mzs, ints, sp_idxs
 
 
-def _upload_segments(storage, ds_segm_size_mb, imzml_wrapper, mzs, ints, sp_idxs):
+def _upload_segments(storage, ds_segm_size_mb, imzml_reader, mzs, ints, sp_idxs):
     # Split into segments no larger than ds_segm_size_mb
     total_n_mz = len(sp_idxs)
-    row_size = (4 if imzml_wrapper.mz_precision == 'f' else 8) + 4 + 4
+    row_size = (4 if imzml_reader.mz_precision == 'f' else 8) + 4 + 4
     segm_n = int(np.ceil(total_n_mz * row_size / (ds_segm_size_mb * 2 ** 20)))
     segm_bounds = np.linspace(0, total_n_mz, segm_n + 1, dtype=np.int64)
     segm_ranges = list(zip(segm_bounds[:-1], segm_bounds[1:]))
@@ -91,36 +91,36 @@ def _load_ds(
     *,
     storage: Storage,
     perf: SubtaskProfiler,
-) -> Tuple[LithopsImzMLParserWrapper, np.ndarray, List[CObj[pd.DataFrame]], np.ndarray,]:
+) -> Tuple[LithopsImzMLReader, np.ndarray, List[CObj[pd.DataFrame]], np.ndarray,]:
     logger.info('Loading .imzML file...')
-    imzml_wrapper = LithopsImzMLParserWrapper(storage, imzml_cobject, ibd_cobject)
+    imzml_reader = LithopsImzMLReader(storage, imzml_cobject, ibd_cobject)
     perf.record_entry(
         'loaded imzml',
-        n_peaks=np.sum(imzml_wrapper.imzml_reader.intensityLengths),
-        mz_dtype=imzml_wrapper.imzml_reader.mzPrecision,
-        int_dtype=imzml_wrapper.imzml_reader.intensityPrecision,
+        n_peaks=np.sum(imzml_reader.imzml_reader.intensityLengths),
+        mz_dtype=imzml_reader.imzml_reader.mzPrecision,
+        int_dtype=imzml_reader.imzml_reader.intensityPrecision,
     )
 
     logger.info('Reading spectra')
-    mzs, ints, sp_lens = _load_spectra(storage, imzml_wrapper)
+    mzs, ints, sp_lens = _load_spectra(storage, imzml_reader)
     perf.record_entry('read spectra', n_peaks=len(mzs))
 
     logger.info('Sorting spectra')
-    mzs, ints, sp_idxs = _sort_spectra(imzml_wrapper, mzs, ints, sp_lens)
+    mzs, ints, sp_idxs = _sort_spectra(imzml_reader, mzs, ints, sp_lens)
     perf.record_entry('sorted spectra')
 
     logger.info('Uploading segments')
     ds_segms_cobjs, ds_segments_bounds, ds_segm_lens = _upload_segments(
-        storage, ds_segm_size_mb, imzml_wrapper, mzs, ints, sp_idxs
+        storage, ds_segm_size_mb, imzml_reader, mzs, ints, sp_idxs
     )
     perf.record_entry('uploaded segments', n_segms=len(ds_segms_cobjs))
 
-    return imzml_wrapper, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens
+    return imzml_reader, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens
 
 
 def load_ds(
     executor: Executor, imzml_cobject: CloudObject, ibd_cobject: CloudObject, ds_segm_size_mb: int
-) -> Tuple[LithopsImzMLParserWrapper, np.ndarray, List[CObj[pd.DataFrame]], np.ndarray,]:
+) -> Tuple[LithopsImzMLReader, np.ndarray, List[CObj[pd.DataFrame]], np.ndarray,]:
     try:
         ibd_head = executor.storage.head_object(ibd_cobject.bucket, ibd_cobject.key)
         ibd_size_mb = int(ibd_head['content-length']) / 1024 // 1024
@@ -138,7 +138,7 @@ def load_ds(
         logger.debug(f'Found {ibd_size_mb}MB .ibd file. Using VM-based load_ds')
         runtime_memory = 32768
 
-    imzml_wrapper, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens = executor.call(
+    imzml_reader, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens = executor.call(
         _load_ds,
         (imzml_cobject, ibd_cobject, ds_segm_size_mb),
         runtime_memory=runtime_memory,
@@ -146,10 +146,10 @@ def load_ds(
 
     logger.info(f'Segmented dataset chunks into {len(ds_segms_cobjs)} segments')
 
-    return imzml_wrapper, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens
+    return imzml_reader, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens
 
 
-def validate_ds_segments(fexec, imzml_wrapper, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens):
+def validate_ds_segments(fexec, imzml_reader, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens):
     def get_segm_stats(cobj, storage):
         segm = load_cobj(storage, cobj)
         assert (
@@ -206,7 +206,7 @@ def validate_ds_segments(fexec, imzml_wrapper, ds_segments_bounds, ds_segms_cobj
             logger.warning(unsorted)
 
         total_len = segms_df.n_rows.sum()
-        expected_total_len = np.sum(imzml_wrapper.imzml_reader.mzLengths)
+        expected_total_len = np.sum(imzml_reader.imzml_reader.mzLengths)
         if total_len != expected_total_len:
             logger.warning(
                 f'segment_spectra output {total_len} peaks, '

--- a/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
@@ -8,85 +8,31 @@ import numpy as np
 import pandas as pd
 from lithops.storage import Storage
 from lithops.storage.utils import CloudObject
-from pyimzml.ImzMLParser import ImzMLParser, PortableSpectrumReader
 
+from sm.engine.annotation.imzml_parser import LithopsImzMLParserWrapper
 from sm.engine.annotation_lithops.executor import Executor
-from sm.engine.annotation_lithops.io import (
-    save_cobj,
-    CObj,
-    get_ranges_from_cobject,
-    load_cobj,
-)
-from sm.engine.annotation_lithops.utils import get_pixel_indices
+from sm.engine.annotation_lithops.io import CObj, load_cobj, save_cobj
 from sm.engine.utils.perf_profile import SubtaskProfiler
 
 logger = logging.getLogger('annotation-pipeline')
 
 
-def load_portable_spectrum_reader(storage: Storage, imzml_cobject: CloudObject):
-    stream = storage.get_cloudobject(imzml_cobject, stream=True)
-
-    imzml_parser = ImzMLParser(stream, parse_lib='ElementTree', ibd_file=None)
-    return imzml_parser.portable_spectrum_reader()
-
-
-def get_spectra(
-    storage: Storage,
-    imzml_reader: PortableSpectrumReader,
-    ibd_cobj: CloudObject,
-    sp_inds: List[int],
-):
-    mz_starts = np.array(imzml_reader.mzOffsets)[sp_inds]
-    mz_ends = (
-        mz_starts
-        + np.array(imzml_reader.mzLengths)[sp_inds] * np.dtype(imzml_reader.mzPrecision).itemsize
-    )
-    mz_ranges = np.stack([mz_starts, mz_ends], axis=1)
-    int_starts = np.array(imzml_reader.intensityOffsets)[sp_inds]
-    int_ends = (
-        int_starts
-        + np.array(imzml_reader.intensityLengths)[sp_inds]
-        * np.dtype(imzml_reader.intensityPrecision).itemsize
-    )
-    int_ranges = np.stack([int_starts, int_ends], axis=1)
-    ranges_to_read = np.vstack([mz_ranges, int_ranges])
-    data_ranges = get_ranges_from_cobject(storage, ibd_cobj, ranges_to_read)
-    mz_data = data_ranges[: len(sp_inds)]
-    int_data = data_ranges[len(sp_inds) :]
-    del data_ranges
-
-    for i, sp_idx in enumerate(sp_inds):
-        mzs = np.frombuffer(mz_data[i], dtype=imzml_reader.mzPrecision)
-        ints = np.frombuffer(int_data[i], dtype=imzml_reader.intensityPrecision)
-        if (ints == 0).any():
-            # One imzml exporter includes all m/z values for all spectra, even if intensities are
-            # zero. Zero-intensity peaks are useless, so exclude them.
-            mzs = mzs[ints != 0]
-            ints = ints[ints != 0]
-
-        mz_data[i] = None  # type: ignore # Avoid holding memory longer than necessary
-        int_data[i] = None  # type: ignore
-        yield sp_idx, mzs.copy(), ints.copy()
-
-
-def _load_spectra(storage, imzml_reader, ibd_cobject):
+def _load_spectra(storage, imzml_wrapper):
     # Pre-allocate lists of mz & int arrays
-    n_spectra = len(imzml_reader.coordinates)
-    mz_arrays = [np.array([], dtype=imzml_reader.mzPrecision)] * n_spectra
-    int_arrays = [np.array([], dtype=np.float32)] * n_spectra
-    sp_lens = np.empty(n_spectra, np.int64)
+    mz_arrays = [np.array([], dtype=imzml_wrapper.mz_precision)] * imzml_wrapper.n_spectra
+    int_arrays = [np.array([], dtype=np.float32)] * imzml_wrapper.n_spectra
+    sp_lens = np.empty(imzml_wrapper.n_spectra, np.int64)
 
     def read_spectrum_chunk(start_end):
-        spectra = get_spectra(storage, imzml_reader, ibd_cobject, list(range(*start_end)))
-        for sp_i, mzs, ints in spectra:
+        for sp_i, mzs, ints in imzml_wrapper.iter_spectra(storage, list(range(*start_end))):
             mz_arrays[sp_i] = mzs
             int_arrays[sp_i] = ints.astype(np.float32)
             sp_lens[sp_i] = len(ints)
 
     # Break into approx. 100MB chunks to read in parallel
-    n_peaks = np.sum(imzml_reader.mzLengths)
-    n_chunks = min(int(np.ceil(n_peaks / (10 * 2 ** 20))), n_spectra)
-    chunk_bounds = np.linspace(0, n_spectra, n_chunks + 1, dtype=np.int64)
+    n_peaks = np.sum(imzml_wrapper.imzml_reader.mzLengths)
+    n_chunks = min(int(np.ceil(n_peaks / (10 * 2 ** 20))), imzml_wrapper.n_spectra)
+    chunk_bounds = np.linspace(0, imzml_wrapper.n_spectra, n_chunks + 1, dtype=np.int64)
     spectrum_chunks = zip(chunk_bounds, chunk_bounds[1:])
 
     with ThreadPoolExecutor(4) as executor:
@@ -96,7 +42,7 @@ def _load_spectra(storage, imzml_reader, ibd_cobject):
     return np.concatenate(mz_arrays), np.concatenate(int_arrays), sp_lens
 
 
-def _sort_spectra(imzml_reader, mzs, ints, sp_lens):
+def _sort_spectra(imzml_wrapper, mzs, ints, sp_lens):
     # Specify mergesort explicitly because numpy often chooses heapsort which is super slow
     by_mz = np.argsort(mzs, kind='mergesort')
 
@@ -107,19 +53,18 @@ def _sort_spectra(imzml_reader, mzs, ints, sp_lens):
     ints[:] = ints[by_mz]
     # Build sp_idxs after sorting mzs. Sorting mzs uses the most memory, so it's best to keep
     # sp_idxs in a compacted form with sp_lens until the last minute.
-    sp_id_to_idx = get_pixel_indices(imzml_reader.coordinates)
     sp_idxs = np.empty(len(ints), np.uint32)
     sp_lens = np.insert(np.cumsum(sp_lens), 0, 0)
-    for sp_idx, start, end in zip(sp_id_to_idx, sp_lens[:-1], sp_lens[1:]):
+    for sp_idx, start, end in zip(imzml_wrapper.pixel_indexes, sp_lens[:-1], sp_lens[1:]):
         sp_idxs[start:end] = sp_idx
     sp_idxs = sp_idxs[by_mz]
     return mzs, ints, sp_idxs
 
 
-def _upload_segments(storage, ds_segm_size_mb, imzml_reader, mzs, ints, sp_idxs):
+def _upload_segments(storage, ds_segm_size_mb, imzml_wrapper, mzs, ints, sp_idxs):
     # Split into segments no larger than ds_segm_size_mb
     total_n_mz = len(sp_idxs)
-    row_size = (4 if imzml_reader.mzPrecision == 'f' else 8) + 4 + 4
+    row_size = (4 if imzml_wrapper.mz_precision == 'f' else 8) + 4 + 4
     segm_n = int(np.ceil(total_n_mz * row_size / (ds_segm_size_mb * 2 ** 20)))
     segm_bounds = np.linspace(0, total_n_mz, segm_n + 1, dtype=np.int64)
     segm_ranges = list(zip(segm_bounds[:-1], segm_bounds[1:]))
@@ -146,36 +91,36 @@ def _load_ds(
     *,
     storage: Storage,
     perf: SubtaskProfiler,
-) -> Tuple[PortableSpectrumReader, np.ndarray, List[CObj[pd.DataFrame]], np.ndarray,]:
+) -> Tuple[LithopsImzMLParserWrapper, np.ndarray, List[CObj[pd.DataFrame]], np.ndarray,]:
     logger.info('Loading .imzML file...')
-    imzml_reader = load_portable_spectrum_reader(storage, imzml_cobject)
+    imzml_wrapper = LithopsImzMLParserWrapper(storage, imzml_cobject, ibd_cobject)
     perf.record_entry(
         'loaded imzml',
-        n_peaks=np.sum(imzml_reader.intensityLengths),
-        mz_dtype=imzml_reader.mzPrecision,
-        int_dtype=imzml_reader.intensityPrecision,
+        n_peaks=np.sum(imzml_wrapper.imzml_reader.intensityLengths),
+        mz_dtype=imzml_wrapper.imzml_reader.mzPrecision,
+        int_dtype=imzml_wrapper.imzml_reader.intensityPrecision,
     )
 
     logger.info('Reading spectra')
-    mzs, ints, sp_lens = _load_spectra(storage, imzml_reader, ibd_cobject)
+    mzs, ints, sp_lens = _load_spectra(storage, imzml_wrapper)
     perf.record_entry('read spectra', n_peaks=len(mzs))
 
     logger.info('Sorting spectra')
-    mzs, ints, sp_idxs = _sort_spectra(imzml_reader, mzs, ints, sp_lens)
+    mzs, ints, sp_idxs = _sort_spectra(imzml_wrapper, mzs, ints, sp_lens)
     perf.record_entry('sorted spectra')
 
     logger.info('Uploading segments')
     ds_segms_cobjs, ds_segments_bounds, ds_segm_lens = _upload_segments(
-        storage, ds_segm_size_mb, imzml_reader, mzs, ints, sp_idxs
+        storage, ds_segm_size_mb, imzml_wrapper, mzs, ints, sp_idxs
     )
     perf.record_entry('uploaded segments', n_segms=len(ds_segms_cobjs))
 
-    return imzml_reader, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens
+    return imzml_wrapper, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens
 
 
 def load_ds(
     executor: Executor, imzml_cobject: CloudObject, ibd_cobject: CloudObject, ds_segm_size_mb: int
-):
+) -> Tuple[LithopsImzMLParserWrapper, np.ndarray, List[CObj[pd.DataFrame]], np.ndarray,]:
     try:
         ibd_head = executor.storage.head_object(ibd_cobject.bucket, ibd_cobject.key)
         ibd_size_mb = int(ibd_head['content-length']) / 1024 // 1024
@@ -193,7 +138,7 @@ def load_ds(
         logger.debug(f'Found {ibd_size_mb}MB .ibd file. Using VM-based load_ds')
         runtime_memory = 32768
 
-    imzml_reader, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens = executor.call(
+    imzml_wrapper, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens = executor.call(
         _load_ds,
         (imzml_cobject, ibd_cobject, ds_segm_size_mb),
         runtime_memory=runtime_memory,
@@ -201,10 +146,10 @@ def load_ds(
 
     logger.info(f'Segmented dataset chunks into {len(ds_segms_cobjs)} segments')
 
-    return imzml_reader, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens
+    return imzml_wrapper, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens
 
 
-def validate_ds_segments(fexec, imzml_reader, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens):
+def validate_ds_segments(fexec, imzml_wrapper, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens):
     def get_segm_stats(cobj, storage):
         segm = load_cobj(storage, cobj)
         assert (
@@ -261,7 +206,7 @@ def validate_ds_segments(fexec, imzml_reader, ds_segments_bounds, ds_segms_cobjs
             logger.warning(unsorted)
 
         total_len = segms_df.n_rows.sum()
-        expected_total_len = np.sum(imzml_reader.mzLengths)
+        expected_total_len = np.sum(imzml_wrapper.imzml_reader.mzLengths)
         if total_len != expected_total_len:
             logger.warning(
                 f'segment_spectra output {total_len} peaks, '

--- a/metaspace/engine/sm/engine/annotation_lithops/moldb_pipeline.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/moldb_pipeline.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-from contextlib import contextmanager
+from contextlib import contextmanager, ExitStack
 from typing import List, Dict
 
 import pandas as pd
@@ -113,10 +113,14 @@ def get_moldb_centroids(
     moldbs: List[InputMolDb],
     debug_validate=False,
     use_cache=True,
+    use_db_mutex=True,
 ):
     moldb_cache = CentroidsCacheEntry(executor, sm_storage, ds_config, moldbs)
 
-    with moldb_cache.lock():
+    with ExitStack() as stack:
+        if use_db_mutex:
+            stack.enter_context(moldb_cache.lock())
+
         if use_cache:
             cached_val = moldb_cache.load()
         else:

--- a/metaspace/engine/sm/engine/annotation_lithops/pipeline.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/pipeline.py
@@ -6,7 +6,6 @@ from typing import List, Tuple, Optional, Dict
 import numpy as np
 import pandas as pd
 from lithops.storage.utils import CloudObject
-from pyimzml.ImzMLParser import PortableSpectrumReader
 
 from sm.engine.annotation.imzml_reader import LithopsImzMLReader
 from sm.engine.annotation_lithops.annotate import process_centr_segments

--- a/metaspace/engine/sm/engine/annotation_lithops/pipeline.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/pipeline.py
@@ -56,6 +56,7 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
         lithops_config=None,
         cache_key=None,
         use_db_cache=True,
+        use_db_mutex=True,
     ):
         lithops_config = lithops_config or SMConfig.get_conf()['lithops']
         self.lithops_config = lithops_config
@@ -77,6 +78,7 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
             self.cacher = None
 
         self.use_db_cache = use_db_cache
+        self.use_db_mutex = use_db_mutex
         self.ds_segm_size_mb = 128
 
     def __call__(
@@ -107,6 +109,7 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
             moldbs=self.moldbs,
             debug_validate=debug_validate,
             use_cache=self.use_db_cache,
+            use_db_mutex=self.use_db_mutex,
         )
 
     @use_pipeline_cache

--- a/metaspace/engine/sm/engine/annotation_lithops/pipeline.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/pipeline.py
@@ -8,7 +8,7 @@ import pandas as pd
 from lithops.storage.utils import CloudObject
 from pyimzml.ImzMLParser import PortableSpectrumReader
 
-from sm.engine.annotation.imzml_parser import LithopsImzMLParserWrapper
+from sm.engine.annotation.imzml_reader import LithopsImzMLReader
 from sm.engine.annotation_lithops.annotate import process_centr_segments
 from sm.engine.annotation_lithops.build_moldb import InputMolDb, DbFDRData
 from sm.engine.annotation_lithops.cache import PipelineCacher, use_pipeline_cache
@@ -35,7 +35,7 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
     formula_cobjs: List[CObj[pd.DataFrame]]
     db_data_cobjs: List[CObj[DbFDRData]]
     peaks_cobjs: List[CObj[pd.DataFrame]]
-    imzml_wrapper: LithopsImzMLParserWrapper
+    imzml_reader: LithopsImzMLReader
     ds_segments_bounds: np.ndarray
     ds_segms_cobjs: List[CObj[pd.DataFrame]]
     ds_segm_lens: np.ndarray
@@ -122,7 +122,7 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
     @use_pipeline_cache
     def load_ds(self):
         (
-            self.imzml_wrapper,
+            self.imzml_reader,
             self.ds_segments_bounds,
             self.ds_segms_cobjs,
             self.ds_segm_lens,
@@ -133,7 +133,7 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
     def validate_load_ds(self):
         validate_ds_segments(
             self.executor,
-            self.imzml_wrapper,
+            self.imzml_reader,
             self.ds_segments_bounds,
             self.ds_segms_cobjs,
             self.ds_segm_lens,
@@ -168,7 +168,7 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
             self.ds_segments_bounds,
             self.ds_segm_lens,
             self.db_segms_cobjs,
-            self.imzml_wrapper,
+            self.imzml_reader,
             self.ds_config,
             self.ds_segm_size_mb,
             self.is_intensive_dataset,
@@ -187,7 +187,7 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
             self.moldbs,
             self.fdrs,
             self.images_df,
-            self.imzml_wrapper,
+            self.imzml_reader,
         )
 
     def clean(self, all_caches=False):

--- a/metaspace/engine/sm/engine/annotation_lithops/pipeline.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/pipeline.py
@@ -8,6 +8,7 @@ import pandas as pd
 from lithops.storage.utils import CloudObject
 from pyimzml.ImzMLParser import PortableSpectrumReader
 
+from sm.engine.annotation.imzml_parser import LithopsImzMLParserWrapper
 from sm.engine.annotation_lithops.annotate import process_centr_segments
 from sm.engine.annotation_lithops.build_moldb import InputMolDb, DbFDRData
 from sm.engine.annotation_lithops.cache import PipelineCacher, use_pipeline_cache
@@ -34,7 +35,7 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
     formula_cobjs: List[CObj[pd.DataFrame]]
     db_data_cobjs: List[CObj[DbFDRData]]
     peaks_cobjs: List[CObj[pd.DataFrame]]
-    imzml_reader: PortableSpectrumReader
+    imzml_wrapper: LithopsImzMLParserWrapper
     ds_segments_bounds: np.ndarray
     ds_segms_cobjs: List[CObj[pd.DataFrame]]
     ds_segm_lens: np.ndarray
@@ -121,7 +122,7 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
     @use_pipeline_cache
     def load_ds(self):
         (
-            self.imzml_reader,
+            self.imzml_wrapper,
             self.ds_segments_bounds,
             self.ds_segms_cobjs,
             self.ds_segm_lens,
@@ -132,7 +133,7 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
     def validate_load_ds(self):
         validate_ds_segments(
             self.executor,
-            self.imzml_reader,
+            self.imzml_wrapper,
             self.ds_segments_bounds,
             self.ds_segms_cobjs,
             self.ds_segm_lens,
@@ -167,7 +168,7 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
             self.ds_segments_bounds,
             self.ds_segm_lens,
             self.db_segms_cobjs,
-            self.imzml_reader,
+            self.imzml_wrapper,
             self.ds_config,
             self.ds_segm_size_mb,
             self.is_intensive_dataset,
@@ -186,7 +187,7 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
             self.moldbs,
             self.fdrs,
             self.images_df,
-            self.imzml_reader,
+            self.imzml_wrapper,
         )
 
     def clean(self, all_caches=False):

--- a/metaspace/engine/sm/engine/annotation_lithops/prepare_results.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/prepare_results.py
@@ -5,13 +5,11 @@ from typing import Dict, List
 import numpy as np
 import pandas as pd
 from lithops.storage import Storage
-from pyimzml.ImzMLParser import PortableSpectrumReader
 
-from sm.engine.annotation_lithops.annotate import make_sample_area_mask
+from sm.engine.annotation.imzml_parser import LithopsImzMLParserWrapper
 from sm.engine.annotation_lithops.build_moldb import InputMolDb
 from sm.engine.annotation_lithops.executor import Executor
 from sm.engine.annotation_lithops.io import save_cobj, iter_cobjs_with_prefetch
-from sm.engine.annotation_lithops.utils import ds_dims
 from sm.engine.annotation.png_generator import PngGenerator
 
 logger = logging.getLogger('annotation-pipeline')
@@ -56,7 +54,7 @@ def filter_results_and_make_pngs(
     moldbs: List[InputMolDb],
     fdrs: Dict[int, pd.DataFrame],
     images_df: pd.DataFrame,
-    imzml_reader: PortableSpectrumReader,
+    imzml_wrapper: LithopsImzMLParserWrapper,
 ):
     results_dfs = {}
     all_formula_is = set()
@@ -71,9 +69,8 @@ def filter_results_and_make_pngs(
         all_formula_is.update(results_dfs[moldb_id].index)
 
     image_tasks_df = images_df[images_df.index.isin(all_formula_is)].copy()
-    w, h = ds_dims(imzml_reader.coordinates)
-    jobs = _split_png_jobs(image_tasks_df, w, h)
-    png_generator = PngGenerator(make_sample_area_mask(imzml_reader.coordinates))
+    jobs = _split_png_jobs(image_tasks_df, imzml_wrapper.w, imzml_wrapper.h)
+    png_generator = PngGenerator(imzml_wrapper.mask)
 
     def save_png_chunk(df: pd.DataFrame, *, storage: Storage):
         pngs = []

--- a/metaspace/engine/sm/engine/annotation_lithops/prepare_results.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/prepare_results.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 from lithops.storage import Storage
 
-from sm.engine.annotation.imzml_parser import LithopsImzMLParserWrapper
+from sm.engine.annotation.imzml_reader import LithopsImzMLReader
 from sm.engine.annotation_lithops.build_moldb import InputMolDb
 from sm.engine.annotation_lithops.executor import Executor
 from sm.engine.annotation_lithops.io import save_cobj, iter_cobjs_with_prefetch
@@ -54,7 +54,7 @@ def filter_results_and_make_pngs(
     moldbs: List[InputMolDb],
     fdrs: Dict[int, pd.DataFrame],
     images_df: pd.DataFrame,
-    imzml_wrapper: LithopsImzMLParserWrapper,
+    imzml_reader: LithopsImzMLReader,
 ):
     results_dfs = {}
     all_formula_is = set()
@@ -69,8 +69,8 @@ def filter_results_and_make_pngs(
         all_formula_is.update(results_dfs[moldb_id].index)
 
     image_tasks_df = images_df[images_df.index.isin(all_formula_is)].copy()
-    jobs = _split_png_jobs(image_tasks_df, imzml_wrapper.w, imzml_wrapper.h)
-    png_generator = PngGenerator(imzml_wrapper.mask)
+    jobs = _split_png_jobs(image_tasks_df, imzml_reader.w, imzml_reader.h)
+    png_generator = PngGenerator(imzml_reader.mask)
 
     def save_png_chunk(df: pd.DataFrame, *, storage: Storage):
         pngs = []

--- a/metaspace/engine/sm/engine/annotation_lithops/run_fdr.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/run_fdr.py
@@ -43,7 +43,8 @@ def run_fdr(
         return db_data['id'], results_df
 
     logger.info('Estimating FDRs...')
-    results = executor.map(_run_fdr_for_db, db_data_cobjs, runtime_memory=1024)
+    args = [(db_data_cobj,) for db_data_cobj in db_data_cobjs]
+    results = executor.map(_run_fdr_for_db, args, runtime_memory=1024)
 
     for moldb_id, moldb_fdrs in results:
         logger.info(f'DB {moldb_id} number of annotations with FDR less than:')

--- a/metaspace/engine/sm/engine/annotation_lithops/segment_centroids.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/segment_centroids.py
@@ -21,6 +21,8 @@ from sm.engine.annotation_lithops.io import (
 )
 from sm.engine.annotation.isocalc_wrapper import IsocalcWrapper
 
+MIN_CENTR_SEGMS = 32
+
 logger = logging.getLogger('annotation-pipeline')
 MAX_MZ_VALUE = 10 ** 5
 
@@ -77,7 +79,7 @@ def define_centr_segments(
     data_per_centr_segm_mb = 50
     peaks_per_centr_segm = 10000
     centr_segm_n = int(
-        max(ds_size_mb // data_per_centr_segm_mb, centr_n // peaks_per_centr_segm, 32)
+        max(ds_size_mb // data_per_centr_segm_mb, centr_n // peaks_per_centr_segm, MIN_CENTR_SEGMS)
     )
 
     segm_bounds_q = [i * 1 / centr_segm_n for i in range(0, centr_segm_n)]

--- a/metaspace/engine/sm/engine/annotation_lithops/segment_centroids.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/segment_centroids.py
@@ -233,7 +233,7 @@ def validate_centroid_segments(fexec, db_segms_cobjs, ds_segms_bounds, isocalc_w
         if df:
             logger.warning(df)
 
-    def get_segm_stats(storage, segm_cobject):
+    def get_segm_stats(segm_cobject, *, storage):
         segm = load_cobj(storage, segm_cobject)
         mzs = np.sort(segm.mz.values)
         ds_segm_lo, ds_segm_hi = choose_ds_segments(ds_segms_bounds, segm, isocalc_wrapper)
@@ -263,7 +263,8 @@ def validate_centroid_segments(fexec, db_segms_cobjs, ds_segms_bounds, isocalc_w
 
     warnings = []
 
-    segm_formula_is, stats = fexec.map_unpack(get_segm_stats, db_segms_cobjs, runtime_memory=1024)
+    args = [(cobj,) for cobj in db_segms_cobjs]
+    segm_formula_is, stats = fexec.map_unpack(get_segm_stats, args, runtime_memory=1024)
     stats_df = pd.DataFrame(stats)
 
     with pd.option_context(

--- a/metaspace/engine/sm/engine/annotation_lithops/utils.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/utils.py
@@ -5,29 +5,7 @@ import logging
 from base64 import urlsafe_b64encode
 from hashlib import blake2b
 
-import numpy as np
-
 logger = logging.getLogger('annotation-pipeline')
-
-
-def ds_dims(coordinates):
-    min_x, min_y = np.amin(coordinates, axis=0)[:2]
-    max_x, max_y = np.amax(coordinates, axis=0)[:2]
-    nrows, ncols = max_y - min_y + 1, max_x - min_x + 1
-    return nrows, ncols
-
-
-def get_pixel_indices(coordinates):
-    """
-    Converts original spectrum indexes (which may be out of order, or sparse) to "sp_i" values,
-    which represent the pixel index of the output image, i.e. `y, x = divmod(sp_i, width)`.
-    """
-    _coord = np.array(coordinates, dtype=np.int64)[:, :2]
-    _coord -= np.amin(_coord, axis=0)
-
-    ncols = np.max(_coord[:, 0]) + 1
-    pixel_indices = _coord[:, 1] * ncols + _coord[:, 0]
-    return pixel_indices.astype(np.uint32)
 
 
 def jsonhash(obj) -> str:

--- a/metaspace/engine/sm/engine/annotation_spark/annotation_job.py
+++ b/metaspace/engine/sm/engine/annotation_spark/annotation_job.py
@@ -93,10 +93,6 @@ class AnnotationJob:
             )
             search_results_it = search_alg.search()
 
-            # Save non-job-related diagnostics
-            diagnostics = extract_dataset_diagnostics(self._ds.id, imzml_reader)
-            add_diagnostics(diagnostics)
-
             for job_id, (moldb_ion_metrics_df, moldb_ion_images_rdd) in zip(
                 job_ids, search_results_it
             ):
@@ -116,6 +112,10 @@ class AnnotationJob:
                     job_status = JobStatus.FINISHED
                 finally:
                     update_finished_job(job_id, job_status)
+
+            # Save non-job-related diagnostics
+            diagnostics = extract_dataset_diagnostics(self._ds.id, imzml_reader)
+            add_diagnostics(diagnostics)
 
     def _save_data_from_raw_ms_file(self, imzml_reader: FSImzMLReader):
         ms_file_path = imzml_reader.filename

--- a/metaspace/engine/sm/engine/annotation_spark/formula_imager.py
+++ b/metaspace/engine/sm/engine/annotation_spark/formula_imager.py
@@ -49,32 +49,6 @@ def gen_iso_images(ds_segm_it, centr_df, nrows, ncols, isocalc):
             yield centr_f_inds[i], centr_p_inds[i], centr_ints[i], m
 
 
-def get_ds_dims(coordinates):
-    min_x, min_y = np.amin(coordinates, axis=0)
-    max_x, max_y = np.amax(coordinates, axis=0)
-    nrows, ncols = max_y - min_y + 1, max_x - min_x + 1
-    return nrows, ncols
-
-
-def get_pixel_indices(coordinates):
-    _coord = np.array(coordinates)
-    _coord = np.around(_coord, 5)  # correct for numerical precision
-    _coord -= np.amin(_coord, axis=0)
-
-    _, ncols = get_ds_dims(coordinates)
-    pixel_indices = _coord[:, 1] * ncols + _coord[:, 0]
-    pixel_indices = pixel_indices.astype(np.int32)
-    return pixel_indices
-
-
-def make_sample_area_mask(coordinates):
-    pixel_indices = get_pixel_indices(coordinates)
-    nrows, ncols = get_ds_dims(coordinates)
-    sample_area_mask = np.zeros(ncols * nrows, dtype=bool)
-    sample_area_mask[pixel_indices] = True
-    return sample_area_mask.reshape(nrows, ncols)
-
-
 def choose_ds_segments(ds_segments, centr_df, ppm):
     centr_segm_min_mz, centr_segm_max_mz = centr_df.mz.agg([np.min, np.max])
     centr_segm_min_mz -= centr_segm_min_mz * ppm * 1e-6
@@ -120,13 +94,13 @@ def get_file_path(name):
 
 def create_process_segment(
     ds_segments: List,
-    coordinates: np.ndarray,
+    sample_area_mask: np.ndarray,
+    nrows: int,
+    ncols: int,
     ds_config: DSConfig,
     target_formula_inds: Set[int],
     targeted_database_formula_inds: Set[int],
 ):
-    sample_area_mask = make_sample_area_mask(coordinates)
-    nrows, ncols = get_ds_dims(coordinates)
     compute_metrics = make_compute_image_metrics(
         sample_area_mask, nrows, ncols, ds_config['image_generation']
     )

--- a/metaspace/engine/sm/engine/annotation_spark/msm_basic_search.py
+++ b/metaspace/engine/sm/engine/annotation_spark/msm_basic_search.py
@@ -11,7 +11,7 @@ from pyspark.storagelevel import StorageLevel
 
 from sm.engine import molecular_db
 from sm.engine.annotation.formula_centroids import CentroidsGenerator
-from sm.engine.annotation.imzml_parser import ImzMLParserWrapper
+from sm.engine.annotation.imzml_reader import ImzMLReader
 from sm.engine.annotation_spark.formula_imager import create_process_segment
 from sm.engine.annotation_spark.segmenter import (
     calculate_centroids_segments_n,
@@ -144,7 +144,7 @@ class MSMSearch:
     def __init__(
         self,
         spark_context: pyspark.SparkContext,
-        imzml_wrapper: ImzMLParserWrapper,
+        imzml_reader: ImzMLReader,
         moldbs: List[MolecularDB],
         ds_config: DSConfig,
         ds_data_path: Path,
@@ -152,7 +152,7 @@ class MSMSearch:
     ):
         self._spark_context = spark_context
         self._ds_config = ds_config
-        self._imzml_wrapper = imzml_wrapper
+        self._imzml_reader = imzml_reader
         self._moldbs = moldbs
         self._sm_config = SMConfig.get_conf()
         self._ds_data_path = ds_data_path
@@ -196,24 +196,24 @@ class MSMSearch:
 
     def define_segments_and_segment_ds(self, sample_ratio=0.05, ds_segm_size_mb=5):
         logger.info('Reading spectra sample')
-        spectra_n = self._imzml_wrapper.n_spectra
+        spectra_n = self._imzml_reader.n_spectra
         sample_size = int(spectra_n * sample_ratio)
         sample_size = np.clip(sample_size, min(spectra_n, 20), 1000)
-        spectra_sample = list(spectra_sample_gen(self._imzml_wrapper, sample_size))
+        spectra_sample = list(spectra_sample_gen(self._imzml_reader, sample_size))
         sample_mzs = np.concatenate([mzs for sp_id, mzs, ints in spectra_sample])
         sample_ints = np.concatenate([ints for sp_id, mzs, ints in spectra_sample])
         check_spectra_quality(sample_mzs, sample_ints)
 
         actual_sample_ratio = sample_size / spectra_n
         ds_segments = define_ds_segments(
-            sample_mzs, actual_sample_ratio, self._imzml_wrapper, ds_segm_size_mb=ds_segm_size_mb
+            sample_mzs, actual_sample_ratio, self._imzml_reader, ds_segm_size_mb=ds_segm_size_mb
         )
 
         ds_segments_path = self._ds_data_path / 'ds_segments'
         spectra_per_chunk_n = calculate_chunk_sp_n(
             sample_mzs.nbytes, sample_size, max_chunk_size_mb=500
         )
-        segment_ds(self._imzml_wrapper, spectra_per_chunk_n, ds_segments, ds_segments_path)
+        segment_ds(self._imzml_reader, spectra_per_chunk_n, ds_segments, ds_segments_path)
 
         logger.info('Putting dataset segments to workers')
         self.put_segments_to_workers(ds_segments_path)
@@ -280,7 +280,7 @@ class MSMSearch:
         centr_segm_n = self.clip_and_segment_centroids(
             centroids_df=formula_centroids.centroids_df(),
             ds_segments=ds_segments,
-            ds_dims=(self._imzml_wrapper.h, self._imzml_wrapper.w),
+            ds_dims=(self._imzml_reader.h, self._imzml_reader.w),
         )
         self._perf.record_entry('segmented centroids')
 
@@ -298,9 +298,9 @@ class MSMSearch:
 
         process_centr_segment = create_process_segment(
             ds_segments,
-            self._imzml_wrapper.mask,
-            self._imzml_wrapper.h,
-            self._imzml_wrapper.w,
+            self._imzml_reader.mask,
+            self._imzml_reader.h,
+            self._imzml_reader.w,
             self._ds_config,
             target_formula_inds,
             targeted_database_formula_inds,

--- a/metaspace/engine/sm/engine/annotation_spark/segmenter.py
+++ b/metaspace/engine/sm/engine/annotation_spark/segmenter.py
@@ -6,8 +6,8 @@ from shutil import rmtree
 import numpy as np
 import pandas as pd
 
+from sm.engine.annotation.imzml_parser import ImzMLParserWrapper, FSImzMLParserWrapper
 from sm.engine.errors import SMError
-from sm.engine.annotation_spark.formula_imager import get_pixel_indices
 
 MAX_MZ_VALUE = 10 ** 5
 MAX_INTENS_VALUE = 10 ** 12
@@ -42,19 +42,17 @@ def check_spectra_quality(mz_arr, int_arr):
         raise SMError(' '.join(err_msgs))
 
 
-def spectra_sample_gen(imzml_parser, sample_size):
-    sp_n = len(imzml_parser.coordinates)
-    sample_sp_inds = np.random.choice(np.arange(sp_n), sample_size, replace=False)
-    for sp_idx in sample_sp_inds:
-        mzs, ints = imzml_parser.get_spectrum(sp_idx)
+def spectra_sample_gen(imzml_wrapper, sample_size):
+    sample_sp_inds = np.random.choice(imzml_wrapper.n_spectra, sample_size, replace=False)
+    for sp_idx, mzs, ints in imzml_wrapper.iter_spectra(sample_sp_inds):
         yield sp_idx, mzs, ints
 
 
-def define_ds_segments(sample_mzs, sample_ratio, imzml_parser, ds_segm_size_mb=5):
+def define_ds_segments(sample_mzs, sample_ratio, imzml_wrapper, ds_segm_size_mb=5):
     logger.info('Defining dataset segment bounds')
     sp_arr_row_size_b = (
         np.dtype(SpIdxDType).itemsize
-        + np.dtype(imzml_parser.mz_precision).itemsize
+        + np.dtype(imzml_wrapper.mz_precision).itemsize
         + np.dtype(IntensityDType).itemsize
     )
     total_mz_n = sample_mzs.shape[0] / sample_ratio  # pylint: disable=unsubscriptable-object
@@ -94,12 +92,10 @@ def calculate_chunk_sp_n(sample_mzs_bytes, sample_sp_n, max_chunk_size_mb=500):
     return max(1, chunk_sp_n)
 
 
-def fetch_chunk_spectra_data(sp_ids, imzml_parser, sp_id_to_idx):
+def fetch_chunk_spectra_data(sp_ids, imzml_wrapper):
     sp_idxs_list, mzs_list, ints_list = [], [], []
-    for sp_id in sp_ids:
-        mzs_, ints_ = imzml_parser.get_spectrum(sp_id)
-        mzs_, ints_ = map(np.array, [mzs_, ints_])
-        sp_idx = sp_id_to_idx[sp_id]
+    for sp_id, mzs_, ints_ in imzml_wrapper.iter_spectra(sp_ids):
+        sp_idx = imzml_wrapper.pixel_indexes[sp_id]
         sp_idxs_list.append(np.ones_like(mzs_) * sp_idx)
         mzs_list.append(mzs_)
         ints_list.append(ints_)
@@ -109,7 +105,7 @@ def fetch_chunk_spectra_data(sp_ids, imzml_parser, sp_id_to_idx):
     sp_chunk_df = pd.DataFrame(
         {
             'sp_idx': np.concatenate(sp_idxs_list)[by_mz].astype(SpIdxDType),
-            'mz': mzs[by_mz].astype(imzml_parser.mz_precision),
+            'mz': mzs[by_mz].astype(imzml_wrapper.mz_precision),
             'int': np.concatenate(ints_list)[by_mz].astype(IntensityDType),
         }
     )
@@ -131,18 +127,19 @@ def extend_ds_segment_bounds(ds_segments):
     return mz_segments
 
 
-def segment_ds(imzml_parser, spectra_per_chunk_n, ds_segments, ds_segments_path):
+def segment_ds(
+    imzml_wrapper: FSImzMLParserWrapper, spectra_per_chunk_n, ds_segments, ds_segments_path
+):
     logger.info(f'Segmenting dataset into {len(ds_segments)} segments')
 
     rmtree(ds_segments_path, ignore_errors=True)
     ds_segments_path.mkdir(parents=True)
 
-    sp_id_to_idx = get_pixel_indices(imzml_parser.coordinates)
     mz_segments = extend_ds_segment_bounds(ds_segments)
-    sp_id_chunks = chunk_list(xs=range(len(imzml_parser.coordinates)), size=spectra_per_chunk_n)
+    sp_id_chunks = chunk_list(xs=range(imzml_wrapper.n_spectra), size=spectra_per_chunk_n)
     for chunk_i, sp_ids in enumerate(sp_id_chunks, 1):
         logger.debug(f'Segmenting spectra chunk {chunk_i}')
-        sp_chunk_df = fetch_chunk_spectra_data(sp_ids, imzml_parser, sp_id_to_idx)
+        sp_chunk_df = fetch_chunk_spectra_data(sp_ids, imzml_wrapper)
         segment_spectra_chunk(sp_chunk_df, mz_segments, ds_segments_path)
 
 

--- a/metaspace/engine/sm/engine/annotation_spark/segmenter.py
+++ b/metaspace/engine/sm/engine/annotation_spark/segmenter.py
@@ -6,7 +6,7 @@ from shutil import rmtree
 import numpy as np
 import pandas as pd
 
-from sm.engine.annotation.imzml_reader import ImzMLReader, FSImzMLReader
+from sm.engine.annotation.imzml_reader import FSImzMLReader
 from sm.engine.errors import SMError
 
 MAX_MZ_VALUE = 10 ** 5

--- a/metaspace/engine/sm/engine/daemons/annotate.py
+++ b/metaspace/engine/sm/engine/daemons/annotate.py
@@ -20,7 +20,6 @@ class SMAnnotateDaemon:
 
     def __init__(self, manager, annot_qdesc, upd_qdesc, poll_interval=1):
         self._sm_config = SMConfig.get_conf()
-        print('annot daemon', self._sm_config['rabbitmq'], annot_qdesc, upd_qdesc)
         self._stopped = False
         self._manager = manager
         self._annot_queue_consumer = QueueConsumer(

--- a/metaspace/engine/sm/engine/daemons/annotate.py
+++ b/metaspace/engine/sm/engine/daemons/annotate.py
@@ -20,6 +20,7 @@ class SMAnnotateDaemon:
 
     def __init__(self, manager, annot_qdesc, upd_qdesc, poll_interval=1):
         self._sm_config = SMConfig.get_conf()
+        print('annot daemon', self._sm_config['rabbitmq'], annot_qdesc, upd_qdesc)
         self._stopped = False
         self._manager = manager
         self._annot_queue_consumer = QueueConsumer(

--- a/metaspace/engine/sm/engine/daemons/dataset_manager.py
+++ b/metaspace/engine/sm/engine/daemons/dataset_manager.py
@@ -7,6 +7,7 @@ from botocore.exceptions import ClientError
 from requests.api import post
 
 from sm.engine import molecular_db
+from sm.engine.annotation.diagnostics import del_diagnostics
 from sm.engine.annotation.job import del_jobs
 from sm.engine.annotation_lithops.annotation_job import ServerAnnotationJob
 from sm.engine.annotation_lithops.executor import Executor
@@ -152,6 +153,7 @@ class DatasetManager:
         """Delete all dataset related data."""
 
         self.logger.info(f'Deleting dataset: {ds.id}')
+        del_diagnostics(ds.id)
         del_jobs(ds)
         del_optical_image(self._db, ds.id)
         delete_ion_thumbnail(self._db, ds)

--- a/metaspace/engine/sm/engine/image_storage.py
+++ b/metaspace/engine/sm/engine/image_storage.py
@@ -30,12 +30,14 @@ class ImageType(str, Enum):
     ISO = 'iso'
     OPTICAL = 'optical'
     THUMB = 'thumb'
+    DIAG = 'diag'
 
 
 class ImageStorage:
     ISO = ImageType.ISO
     OPTICAL = ImageType.OPTICAL
     THUMB = ImageType.THUMB
+    DIAG = ImageType.DIAG
 
     def __init__(self, sm_config: Dict = None):
         sm_config = sm_config or SMConfig.get_conf()
@@ -174,6 +176,7 @@ _instance: ImageStorage
 ISO = ImageType.ISO
 OPTICAL = ImageType.OPTICAL
 THUMB = ImageType.THUMB
+DIAG = ImageType.DIAG
 
 get_image: Callable[[ImageType, str, str], bytes]
 post_image: Callable[[ImageType, str, bytes], str]

--- a/metaspace/engine/sm/engine/tests/annotation/test_imzml_reader.py
+++ b/metaspace/engine/sm/engine/tests/annotation/test_imzml_reader.py
@@ -10,7 +10,7 @@ from tests.conftest import make_imzml_reader_mock, sm_config, executor
 
 
 MOCK_COORDINATES = [(x, y, 1) for y in range(1, 4, 2) for x in range(1, 4, 2)]
-MOCK_SPECTRA = [(np.arange(i), np.full(i, i)) for i in range(1, len(MOCK_COORDINATES) + 1)]
+MOCK_SPECTRA = [(np.arange(1, i + 1), np.full(i, i)) for i in range(1, len(MOCK_COORDINATES) + 1)]
 EXPECTED_TIC = np.array(
     [
         [1 * 1, np.nan, 2 * 2],
@@ -35,7 +35,6 @@ def make_lithops_imzml_reader(
 
         imzml_content = open(f'{tmpdir}/test.imzML', 'rb').read()
         ibd_content = open(f'{tmpdir}/test.ibd', 'rb').read()
-        print(imzml_content)
 
     imzml_cobj = storage.put_cloudobject(imzml_content)
     ibd_cobj = storage.put_cloudobject(ibd_content)
@@ -47,7 +46,7 @@ def test_imzml_reader_tic_image_from_spectra():
     # Ensure all spectra have been read before getting the TIC image
     for _ in imzml_reader.iter_spectra(np.arange(4)):
         pass
-    print(imzml_reader._sp_tic_from_metadata, imzml_reader._sp_tic)
+    print(imzml_reader.is_tic_from_metadata, imzml_reader._sp_tic)
 
     assert np.array_equal(imzml_reader.tic_image(), EXPECTED_TIC, equal_nan=True)
 
@@ -86,6 +85,11 @@ def test_imzml_reader_lithops(executor):
     assert np.array_equal(imzml_reader.xs, [0, 2, 0, 2])
     assert np.array_equal(imzml_reader.ys, [0, 0, 2, 2])
     assert np.array_equal(imzml_reader.pixel_indexes, [0, 2, 6, 8])
+
+    assert np.array_equal(imzml_reader.raw_coord_bounds[0], [1, 1, 1])
+    assert np.array_equal(imzml_reader.raw_coord_bounds[1], [3, 3, 1])
+    assert imzml_reader.min_mz == 1.0
+    assert imzml_reader.max_mz == 4.0
 
     assert np.array_equal(imzml_reader.tic_image(), EXPECTED_TIC, equal_nan=True)
 

--- a/metaspace/engine/sm/engine/tests/annotation/test_imzml_reader.py
+++ b/metaspace/engine/sm/engine/tests/annotation/test_imzml_reader.py
@@ -1,0 +1,93 @@
+import pickle
+from tempfile import TemporaryDirectory
+
+import numpy as np
+from lithops import Storage
+from pyimzml.ImzMLWriter import ImzMLWriter
+
+from sm.engine.annotation.imzml_reader import LithopsImzMLReader
+from tests.conftest import make_imzml_reader_mock, sm_config, executor
+
+
+MOCK_COORDINATES = [(x, y, 1) for y in range(1, 4, 2) for x in range(1, 4, 2)]
+MOCK_SPECTRA = [(np.arange(i), np.full(i, i)) for i in range(1, len(MOCK_COORDINATES) + 1)]
+EXPECTED_TIC = np.array(
+    [
+        [1 * 1, np.nan, 2 * 2],
+        [np.nan, np.nan, np.nan],
+        [3 * 3, np.nan, 4 * 4],
+    ]
+)
+TIC_ACCESSION = 'MS:1000285'
+
+
+def make_lithops_imzml_reader(
+    storage: Storage,
+    mz_precision='f',
+    polarity='positive',
+):
+    """Create an ImzML file, upload it into storage, and return an imzml_reader for it"""
+    mz_dtype = {'f': np.float32, 'd': np.float64}[mz_precision]
+    with TemporaryDirectory() as tmpdir:
+        with ImzMLWriter(f'{tmpdir}/test.imzML', polarity=polarity, mz_dtype=mz_dtype) as writer:
+            for coords, (mzs, ints) in zip(MOCK_COORDINATES, MOCK_SPECTRA):
+                writer.addSpectrum(mzs, ints, coords)
+
+        imzml_content = open(f'{tmpdir}/test.imzML', 'rb').read()
+        ibd_content = open(f'{tmpdir}/test.ibd', 'rb').read()
+        print(imzml_content)
+
+    imzml_cobj = storage.put_cloudobject(imzml_content)
+    ibd_cobj = storage.put_cloudobject(ibd_content)
+    return LithopsImzMLReader(storage, imzml_cobj, ibd_cobj)
+
+
+def test_imzml_reader_tic_image_from_spectra():
+    imzml_reader = make_imzml_reader_mock(coordinates=MOCK_COORDINATES, spectra=MOCK_SPECTRA)
+    # Ensure all spectra have been read before getting the TIC image
+    for _ in imzml_reader.iter_spectra(np.arange(4)):
+        pass
+    print(imzml_reader._sp_tic_from_metadata, imzml_reader._sp_tic)
+
+    assert np.array_equal(imzml_reader.tic_image(), EXPECTED_TIC, equal_nan=True)
+
+
+def test_imzml_reader_tic_image_from_metadata():
+    imzml_reader = make_imzml_reader_mock(
+        coordinates=MOCK_COORDINATES,
+        spectra=MOCK_SPECTRA,
+        spectrum_metadata_fields={TIC_ACCESSION: [0, 1, 2, 3]},
+    )
+
+    # metadata_tic intentionally matches the metadata but not the spectra
+    metadata_tic = np.array(
+        [
+            [0, np.nan, 1],
+            [np.nan, np.nan, np.nan],
+            [2, np.nan, 3],
+        ]
+    )
+    assert np.array_equal(imzml_reader.tic_image(), metadata_tic, equal_nan=True)
+
+
+def test_imzml_reader_lithops(executor):
+    imzml_reader = make_lithops_imzml_reader(
+        executor.storage, mz_precision='d', polarity='negative'
+    )
+
+    spectra = list(imzml_reader.iter_spectra(executor.storage, np.arange(imzml_reader.n_spectra)))
+
+    assert imzml_reader.mz_precision == 'd'
+    for sp_idx, (mzs, ints) in enumerate(MOCK_SPECTRA):
+        _sp_idx, _mzs, _ints = spectra[sp_idx]
+        assert np.array_equal(mzs, _mzs)
+        assert np.array_equal(ints, np.float32(_ints))
+
+    assert np.array_equal(imzml_reader.xs, [0, 2, 0, 2])
+    assert np.array_equal(imzml_reader.ys, [0, 0, 2, 2])
+    assert np.array_equal(imzml_reader.pixel_indexes, [0, 2, 6, 8])
+
+    assert np.array_equal(imzml_reader.tic_image(), EXPECTED_TIC, equal_nan=True)
+
+    # Ensure imzml_reader is pickleable, as Lithops will pickle it
+    p = pickle.dumps(imzml_reader)

--- a/metaspace/engine/sm/engine/tests/annotation/test_imzml_reader.py
+++ b/metaspace/engine/sm/engine/tests/annotation/test_imzml_reader.py
@@ -46,7 +46,6 @@ def test_imzml_reader_tic_image_from_spectra():
     # Ensure all spectra have been read before getting the TIC image
     for _ in imzml_reader.iter_spectra(np.arange(4)):
         pass
-    print(imzml_reader.is_tic_from_metadata, imzml_reader._sp_tic)
 
     assert np.array_equal(imzml_reader.tic_image(), EXPECTED_TIC, equal_nan=True)
 

--- a/metaspace/engine/sm/engine/tests/annotation_lithops/test_annotation_job.py
+++ b/metaspace/engine/sm/engine/tests/annotation_lithops/test_annotation_job.py
@@ -1,0 +1,209 @@
+from datetime import datetime
+from itertools import product
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+from lithops import Storage
+from pyimzml.ImzMLWriter import ImzMLWriter
+
+from sm.engine import molecular_db, image_storage
+from sm.engine.annotation import fdr
+from sm.engine.annotation.diagnostics import DiagnosticTypes, load_npy_image
+from sm.engine.annotation.isocalc_wrapper import IsocalcWrapper
+from sm.engine.annotation_lithops.annotation_job import ServerAnnotationJob
+from sm.engine.annotation_lithops.io import load_cobjs
+from sm.engine.dataset import Dataset, DatasetStatus
+from sm.engine.db import DB
+from sm.engine.utils.perf_profile import perf_profile
+from tests.conftest import (
+    global_setup,
+    empty_test_db,
+    test_db,
+    executor,
+    sm_config,
+    ds_config,
+    metadata,
+)
+from sm.engine.annotation_lithops.executor import Executor
+
+# Use monoisotopic decoys that won't have any overlap with the target peaks
+MOCK_DECOY_ADDUCTS = ['+Be', '+Al']
+MOCK_FORMULAS = [
+    # Methanol, ethanol, propanol, etc. as they have a decent, non-overlapping isotopic spread
+    f'C{i}H{2+2*i}O'
+    for i in range(1, 11)
+]
+# 4x4 image missing the lower-right quarter
+MOCK_COORDS = list(zip([2, 3, 4, 5, 2, 3, 4, 5, 2, 3, 2, 3], [2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 5, 5]))
+
+# NOCOMMIT
+pd.set_option('max_colwidth', 1000)
+pd.set_option('display.max_rows', 103)
+pd.set_option('display.max_columns', 20)
+pd.set_option('display.width', 1000)
+np.set_printoptions(suppress=True)
+
+
+def make_mock_spectrum(ds_config):
+    isocalc_wrapper = IsocalcWrapper(ds_config)
+    formulas = [
+        *MOCK_FORMULAS[:2],
+        # Insert decoys after the first 2 formulas, so that the calculated FDRs are predictable:
+        # first 10 formulas = 0/2 (quantized to 5% FDR)
+        # remaining 90 formulas = 3/10 (quantized to 50% FDR)
+        *(formula + decoy for formula, decoy in product(MOCK_FORMULAS[:3], fdr.DECOY_ADDUCTS)),
+        *MOCK_FORMULAS[2:],
+    ]
+    mzs = []
+    ints = []
+    for i, formula in enumerate(formulas):
+        formula_mzs, formula_ints = isocalc_wrapper.centroids(formula)
+        mzs.extend(formula_mzs)
+        # Reduce MSM based on the order in `formulas` by sabotaging spectral correlation
+        sabotage = (1 - i / len(formulas)) ** np.arange(len(formula_ints))
+        ints.extend(formula_ints * sabotage)
+
+    mzs = np.array(mzs)
+    ints = np.array(ints)
+    order = np.argsort(mzs)
+    return mzs[order], ints[order]
+    # return mzs, ints
+
+
+def make_test_imzml(storage: Storage, sm_config, ds_config):
+    """Create an ImzML file, upload it into storage, and return an imzml_reader for it"""
+    mzs, ints = make_mock_spectrum(ds_config)
+    with TemporaryDirectory() as tmpdir:
+        with ImzMLWriter(f'{tmpdir}/test.imzML', polarity='positive') as writer:
+            for x, y in MOCK_COORDS:
+                # Scale intensity differently per spectrum, as chaos and spatial metrics
+                # return 0 on completely uniform images
+                writer.addSpectrum(mzs, ints * x * y, (x, y, 1))
+
+        imzml_content = open(f'{tmpdir}/test.imzML', 'rb').read()
+        ibd_content = open(f'{tmpdir}/test.ibd', 'rb').read()
+
+    bucket, prefix = sm_config['lithops']['sm_storage']['imzml']
+    storage.put_cloudobject(imzml_content, bucket, f'{prefix}/test_ds/test.imzML')
+    storage.put_cloudobject(ibd_content, bucket, f'{prefix}/test_ds/test.ibd')
+    input_path = f'cos://{bucket}/{prefix}/test_ds'
+    return input_path
+
+
+def make_test_molecular_db():
+    with TemporaryDirectory() as tmpdir:
+        fname = f'{tmpdir}/db.tsv'
+        pd.DataFrame(
+            {
+                'id': [f'id_{i}' for i in range(len(MOCK_FORMULAS))],
+                'name': [f'name_{i}' for i in range(len(MOCK_FORMULAS))],
+                'formula': MOCK_FORMULAS,
+            }
+        ).to_csv(fname, sep='\t', index=False)
+        moldb = molecular_db.create(name='test db', version='v0.9a-final', file_path=fname)
+
+    # Make it untargeted so that FDR is emitted
+    DB().alter('UPDATE molecular_db SET targeted = false WHERE id = %s', params=(moldb.id,))
+
+    return moldb.id
+
+
+@patch('sm.engine.annotation.fdr.DECOY_ADDUCTS', MOCK_DECOY_ADDUCTS)
+@patch('sm.engine.annotation_lithops.segment_centroids.MIN_CENTR_SEGMS', 2)  # Reduce log spam
+def test_server_annotation_job(test_db, executor: Executor, sm_config, ds_config, metadata):
+    db = DB()
+    moldb_id = make_test_molecular_db()
+    ds_config['database_ids'] = [moldb_id]
+    ds_config['isotope_generation']['adducts'] = ['[M]+']  # test spectrum was made with no adduct
+    # ds_config['isotope_generation']['n_peaks'] = 2  # minimize overlap between decoys and targets
+    ds_config['image_generation']['ppm'] = 0.001  # minimize overlap between decoys and targets
+    ds_config['fdr']['decoy_sample_size'] = len(MOCK_DECOY_ADDUCTS)
+    input_path = make_test_imzml(executor.storage, sm_config, ds_config)
+
+    ds = Dataset(
+        id=datetime.now().strftime('%Y-%m-%d_%Hh%Mm%Ss'),
+        name='Test Lithops Dataset',
+        input_path=input_path,
+        upload_dt=datetime.now(),
+        metadata=metadata,
+        config=ds_config,
+        is_public=True,
+        status=DatasetStatus.QUEUED,
+    )
+    ds.save(db, None, allow_insert=True)
+
+    with perf_profile(db, 'test_lithops_annotate', ds.id) as perf:
+        executor._perf = perf
+        job = ServerAnnotationJob(executor=executor, ds=ds, perf=perf)
+        job.run()
+
+    def db_df(sql, args):
+        return pd.DataFrame(db.select_with_fields(sql, args))
+
+    jobs = db_df('SELECT * FROM job WHERE ds_id = %s', (ds.id,))
+    anns = db_df(
+        'SELECT * FROM annotation WHERE job_id = ANY(%s) ORDER BY msm DESC', (jobs.id.tolist(),)
+    )
+    diags = db_df('SELECT * FROM dataset_diagnostic WHERE ds_id = %s', (ds.id,))
+    profiles = db_df('SELECT * FROM perf_profile WHERE ds_id = %s', (ds.id,))
+    profile_entries = db_df(
+        'SELECT * FROM perf_profile_entry WHERE profile_id = ANY(%s)', (profiles.id.tolist(),)
+    )
+    # For debugging annotations / FDR-related issues
+    # db_data = load_cobjs(executor.storage, job.pipe.db_data_cobjs)[0]
+    # print(db_data)
+    # print(load_cobjs(executor.storage, job.pipe.ds_segms_cobjs))
+    # moldb = pd.concat(load_cobjs(executor.storage, job.pipe.db_segms_cobjs))
+    # formula_mzs = moldb.groupby('formula_i').mz.apply(list)
+    # all_metrics = (
+    #     job.pipe.formula_metrics_df.join(db_data['formula_map_df'].set_index('formula_i'))
+    #     .join(formula_mzs)
+    #     .sort_values('msm', ascending=False)
+    # )
+    # print(all_metrics)
+    # print(job.pipe.ds_segments_bounds)
+    # print(job.pipe.ds_segm_lens)
+    # print(job.pipe.fdrs)
+
+    # print(pd.DataFrame(anns))
+    # print(pd.DataFrame(diags))
+    # print(pd.DataFrame(profiles))
+    # print(pd.DataFrame(profile_entries))
+
+    # Validate jobs
+    assert len(jobs) == 1
+    assert jobs.moldb_id[0] == moldb_id
+
+    # Validate annotations
+    assert np.array_equal(anns.formula, MOCK_FORMULAS)  # Formulas should be MSM-descending
+    assert np.array_equal(anns.fdr, [0.05] * 2 + [0.5] * 8)
+
+    # Validate images were saved
+    image_ids = [imgs[0] for imgs in anns.iso_image_ids]
+    images = image_storage.get_ion_images_for_analysis(ds.id, image_ids)[0]
+    assert images.shape == (len(anns), 4 * 4)
+    # All non-masked pixels should have a value
+    assert np.count_nonzero(images) == len(anns) * len(MOCK_COORDS)
+
+    # Validate diagnostics
+    metadata_diag = diags[diags.type == DiagnosticTypes.IMZML_METADATA].iloc[0]
+    tic_diag = diags[diags.type == DiagnosticTypes.TIC].iloc[0]
+
+    assert metadata_diag.error is None
+    assert metadata_diag.data['n_spectra'] == len(MOCK_COORDS)
+    mask_image = load_npy_image(ds.id, metadata_diag.images[0]['image_id'])
+    assert np.count_nonzero(mask_image) == len(MOCK_COORDS)
+
+    assert tic_diag.error is None
+    assert tic_diag.data['min_tic'] > 0
+    tic_image = load_npy_image(ds.id, tic_diag.images[0]['image_id'])
+    assert tic_image.dtype == np.float32
+    assert tic_image.shape == (4, 4)
+    assert np.array_equal(np.isnan(tic_image), ~mask_image)  # Masked area should be NaNs
+    assert (tic_image[mask_image] > 0).all()  # Non-masked area should be non-zero
+
+    # Validate perf profile
+    assert len(profiles) == 1
+    assert len(profile_entries) > 10

--- a/metaspace/engine/sm/engine/tests/annotation_spark/test_segmenter.py
+++ b/metaspace/engine/sm/engine/tests/annotation_spark/test_segmenter.py
@@ -5,7 +5,7 @@ import pandas as pd
 from itertools import product
 from numpy.testing import assert_array_almost_equal
 
-from sm.engine.annotation.imzml_parser import FSImzMLParserWrapper
+from sm.engine.annotation.imzml_reader import FSImzMLReader
 from sm.engine.annotation_spark.segmenter import (
     segment_centroids,
     define_ds_segments,
@@ -13,7 +13,7 @@ from sm.engine.annotation_spark.segmenter import (
     calculate_chunk_sp_n,
     fetch_chunk_spectra_data,
 )
-from tests.conftest import make_imzml_wrapper_mock
+from tests.conftest import make_imzml_reader_mock
 
 
 def test_calculate_chunk_sp_n():
@@ -28,11 +28,11 @@ def test_calculate_chunk_sp_n():
 
 def test_fetch_chunk_spectra_data():
     mz_n = 10
-    imzml_wrapper = make_imzml_wrapper_mock(
+    imzml_reader = make_imzml_reader_mock(
         [(1, 1, 1), (2, 1, 1)], (np.linspace(0, 90, num=mz_n), np.ones(mz_n))
     )
 
-    sp_chunk_df = fetch_chunk_spectra_data(sp_ids=[0, 1], imzml_wrapper=imzml_wrapper)
+    sp_chunk_df = fetch_chunk_spectra_data(sp_ids=[0, 1], imzml_reader=imzml_reader)
 
     exp_mzs, exp_ints = [
         np.sort([mz for mz in np.linspace(0, 90, num=mz_n) for _ in range(2)]),
@@ -45,14 +45,14 @@ def test_fetch_chunk_spectra_data():
 
 
 def test_define_ds_segments():
-    imzml_wrapper = make_imzml_wrapper_mock()
-    imzml_wrapper.mz_precision = 'd'
+    imzml_reader = make_imzml_reader_mock()
+    imzml_reader.mz_precision = 'd'
 
     mz_max = 100
     sample_mzs = np.linspace(0, mz_max, 100)
     ds_segm_size_mb = 800 / (2 ** 20)  # 1600 b total data size / 2 segments, converted to MB
     ds_segments = define_ds_segments(
-        sample_mzs, sample_ratio=1, imzml_wrapper=imzml_wrapper, ds_segm_size_mb=ds_segm_size_mb
+        sample_mzs, sample_ratio=1, imzml_reader=imzml_reader, ds_segm_size_mb=ds_segm_size_mb
     )
 
     exp_ds_segm_n = 8
@@ -64,13 +64,13 @@ def test_define_ds_segments():
 
 @patch('sm.engine.annotation_spark.segmenter.pickle.dump')
 def test_segment_ds(dump_mock):
-    imzml_wrapper = make_imzml_wrapper_mock(
+    imzml_reader = make_imzml_reader_mock(
         list(product([0], range(10))), (np.linspace(0, 90, num=10), np.ones(10))
     )
     ds_segments = np.array([[0, 50], [50, 90.0]])
 
     chunk_sp_n = 1000
-    segment_ds(imzml_wrapper, chunk_sp_n, ds_segments, Path('/tmp/abc'))
+    segment_ds(imzml_reader, chunk_sp_n, ds_segments, Path('/tmp/abc'))
 
     for segm_i, ((sp_chunk_df, f), _) in enumerate(dump_mock.call_args_list):
         min_mz, max_mz = ds_segments[segm_i]

--- a/metaspace/engine/sm/engine/tests/annotation_spark/test_segmenter.py
+++ b/metaspace/engine/sm/engine/tests/annotation_spark/test_segmenter.py
@@ -45,8 +45,7 @@ def test_fetch_chunk_spectra_data():
 
 
 def test_define_ds_segments():
-    imzml_reader = make_imzml_reader_mock()
-    imzml_reader.mz_precision = 'd'
+    imzml_reader = make_imzml_reader_mock(mz_precision='d')
 
     mz_max = 100
     sample_mzs = np.linspace(0, mz_max, 100)

--- a/metaspace/engine/sm/engine/tests/annotation_spark/test_segmenter.py
+++ b/metaspace/engine/sm/engine/tests/annotation_spark/test_segmenter.py
@@ -5,6 +5,7 @@ import pandas as pd
 from itertools import product
 from numpy.testing import assert_array_almost_equal
 
+from sm.engine.annotation.imzml_parser import FSImzMLParserWrapper
 from sm.engine.annotation_spark.segmenter import (
     segment_centroids,
     define_ds_segments,
@@ -12,6 +13,7 @@ from sm.engine.annotation_spark.segmenter import (
     calculate_chunk_sp_n,
     fetch_chunk_spectra_data,
 )
+from tests.conftest import make_imzml_wrapper_mock
 
 
 def test_calculate_chunk_sp_n():
@@ -26,14 +28,11 @@ def test_calculate_chunk_sp_n():
 
 def test_fetch_chunk_spectra_data():
     mz_n = 10
-    imzml_parser_mock = Mock()
-    imzml_parser_mock.get_spectrum.return_value = (np.linspace(0, 90, num=mz_n), np.ones(mz_n))
-    imzml_parser_mock.mz_precision = 'f'
-    sp_id_to_idx = {0: 0, 1: 1}
-
-    sp_chunk_df = fetch_chunk_spectra_data(
-        sp_ids=[0, 1], imzml_parser=imzml_parser_mock, sp_id_to_idx=sp_id_to_idx
+    imzml_wrapper = make_imzml_wrapper_mock(
+        [(1, 1, 1), (2, 1, 1)], (np.linspace(0, 90, num=mz_n), np.ones(mz_n))
     )
+
+    sp_chunk_df = fetch_chunk_spectra_data(sp_ids=[0, 1], imzml_wrapper=imzml_wrapper)
 
     exp_mzs, exp_ints = [
         np.sort([mz for mz in np.linspace(0, 90, num=mz_n) for _ in range(2)]),
@@ -46,14 +45,14 @@ def test_fetch_chunk_spectra_data():
 
 
 def test_define_ds_segments():
-    imzml_parser_mock = Mock()
-    imzml_parser_mock.mz_precision = 'd'
+    imzml_wrapper = make_imzml_wrapper_mock()
+    imzml_wrapper.mz_precision = 'd'
 
     mz_max = 100
     sample_mzs = np.linspace(0, mz_max, 100)
     ds_segm_size_mb = 800 / (2 ** 20)  # 1600 b total data size / 2 segments, converted to MB
     ds_segments = define_ds_segments(
-        sample_mzs, sample_ratio=1, imzml_parser=imzml_parser_mock, ds_segm_size_mb=ds_segm_size_mb
+        sample_mzs, sample_ratio=1, imzml_wrapper=imzml_wrapper, ds_segm_size_mb=ds_segm_size_mb
     )
 
     exp_ds_segm_n = 8
@@ -65,14 +64,13 @@ def test_define_ds_segments():
 
 @patch('sm.engine.annotation_spark.segmenter.pickle.dump')
 def test_segment_ds(dump_mock):
-    imzml_parser_mock = Mock()
-    imzml_parser_mock.get_spectrum.return_value = (np.linspace(0, 90, num=10), np.ones(10))
-    imzml_parser_mock.mz_precision = 'f'
-    imzml_parser_mock.coordinates = list(product([0], range(10)))
+    imzml_wrapper = make_imzml_wrapper_mock(
+        list(product([0], range(10))), (np.linspace(0, 90, num=10), np.ones(10))
+    )
     ds_segments = np.array([[0, 50], [50, 90.0]])
 
     chunk_sp_n = 1000
-    segment_ds(imzml_parser_mock, chunk_sp_n, ds_segments, Path('/tmp/abc'))
+    segment_ds(imzml_wrapper, chunk_sp_n, ds_segments, Path('/tmp/abc'))
 
     for segm_i, ((sp_chunk_df, f), _) in enumerate(dump_mock.call_args_list):
         min_mz, max_mz = ds_segments[segm_i]

--- a/metaspace/engine/sm/engine/util.py
+++ b/metaspace/engine/sm/engine/util.py
@@ -32,7 +32,7 @@ def split_cos_path(path):
         tuple[string, string]
     Returns a pair of (bucket, key)
     """
-    return re.sub(r'^cos?://', '', path).split(sep='/', maxsplit=1)
+    return re.sub(r'^cos://', '', path).split(sep='/', maxsplit=1)
 
 
 def find_file_by_ext(path, ext):

--- a/metaspace/engine/tests/annotation_lithops/test_annotation_job.py
+++ b/metaspace/engine/tests/annotation_lithops/test_annotation_job.py
@@ -137,7 +137,7 @@ def test_server_annotation_job(test_db, executor: Executor, sm_config, ds_config
     with perf_profile(db, 'test_lithops_annotate', ds.id) as perf:
         executor._perf = perf
         job = ServerAnnotationJob(executor=executor, ds=ds, perf=perf)
-        job.run()
+        job.run(debug_validate=True)
 
     def db_df(sql, args):
         return pd.DataFrame(db.select_with_fields(sql, args))

--- a/metaspace/engine/tests/annotation_lithops/test_annotation_job.py
+++ b/metaspace/engine/tests/annotation_lithops/test_annotation_job.py
@@ -10,7 +10,7 @@ from pyimzml.ImzMLWriter import ImzMLWriter
 
 from sm.engine import molecular_db, image_storage
 from sm.engine.annotation import fdr
-from sm.engine.annotation.diagnostics import DiagnosticType, load_npy_image
+from sm.engine.annotation.diagnostics import DiagnosticType, load_npy_image, DiagnosticImageKey
 from sm.engine.annotation.isocalc_wrapper import IsocalcWrapper
 from sm.engine.annotation_lithops.annotation_job import ServerAnnotationJob
 from sm.engine.annotation_lithops.io import load_cobjs
@@ -193,11 +193,13 @@ def test_server_annotation_job(test_db, executor: Executor, sm_config, ds_config
 
     assert metadata_diag.error is None
     assert metadata_diag.data['n_spectra'] == len(MOCK_COORDS)
+    assert metadata_diag.images[0]['key'] == DiagnosticImageKey.MASK
     mask_image = load_npy_image(ds.id, metadata_diag.images[0]['image_id'])
     assert np.count_nonzero(mask_image) == len(MOCK_COORDS)
 
     assert tic_diag.error is None
     assert tic_diag.data['min_tic'] > 0
+    assert tic_diag.images[0]['key'] == DiagnosticImageKey.TIC
     tic_image = load_npy_image(ds.id, tic_diag.images[0]['image_id'])
     assert tic_image.dtype == np.float32
     assert tic_image.shape == (4, 4)

--- a/metaspace/engine/tests/annotation_lithops/test_annotation_job.py
+++ b/metaspace/engine/tests/annotation_lithops/test_annotation_job.py
@@ -222,7 +222,6 @@ def test_server_annotation_job(test_db, executor: Executor, sm_config, ds_config
 @patch('sm.engine.annotation.fdr.DECOY_ADDUCTS', MOCK_DECOY_ADDUCTS)
 @patch('sm.engine.annotation_lithops.segment_centroids.MIN_CENTR_SEGMS', 2)  # Reduce log spam
 def test_local_annotation_job(executor: Executor, sm_config, ds_config):
-    print('0')
     ds_config['database_ids'] = [1]
     ds_config['isotope_generation']['adducts'] = ['[M]+']  # test spectrum was made with no adduct
     ds_config['image_generation']['ppm'] = 0.001  # minimize overlap between decoys and targets
@@ -243,6 +242,6 @@ def test_local_annotation_job(executor: Executor, sm_config, ds_config):
 
                 output_files = list(Path(out_dir).glob('*.png'))
                 assert len(output_files) == len(MOCK_FORMULAS) * 4
-                print(list(Path(out_dir).glob('*.csv')))
+
                 results_csv = pd.read_csv(Path(out_dir) / 'results_db.csv')
                 assert len(results_csv) == len(MOCK_FORMULAS)

--- a/metaspace/engine/tests/annotation_lithops/test_annotation_job.py
+++ b/metaspace/engine/tests/annotation_lithops/test_annotation_job.py
@@ -38,13 +38,6 @@ MOCK_FORMULAS = [
 # 4x4 image missing the lower-right quarter
 MOCK_COORDS = list(zip([2, 3, 4, 5, 2, 3, 4, 5, 2, 3, 2, 3], [2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 5, 5]))
 
-# NOCOMMIT
-pd.set_option('max_colwidth', 1000)
-pd.set_option('display.max_rows', 103)
-pd.set_option('display.max_columns', 20)
-pd.set_option('display.width', 1000)
-np.set_printoptions(suppress=True)
-
 
 def make_mock_spectrum(ds_config):
     isocalc_wrapper = IsocalcWrapper(ds_config)
@@ -209,5 +202,3 @@ def test_server_annotation_job(test_db, executor: Executor, sm_config, ds_config
     # Validate perf profile
     assert len(profiles) == 1
     assert len(profile_entries) > 10
-
-    print(diags)

--- a/metaspace/engine/tests/annotation_lithops/test_annotation_job.py
+++ b/metaspace/engine/tests/annotation_lithops/test_annotation_job.py
@@ -10,7 +10,7 @@ from pyimzml.ImzMLWriter import ImzMLWriter
 
 from sm.engine import molecular_db, image_storage
 from sm.engine.annotation import fdr
-from sm.engine.annotation.diagnostics import DiagnosticTypes, load_npy_image
+from sm.engine.annotation.diagnostics import DiagnosticType, load_npy_image
 from sm.engine.annotation.isocalc_wrapper import IsocalcWrapper
 from sm.engine.annotation_lithops.annotation_job import ServerAnnotationJob
 from sm.engine.annotation_lithops.io import load_cobjs
@@ -188,8 +188,8 @@ def test_server_annotation_job(test_db, executor: Executor, sm_config, ds_config
     assert np.count_nonzero(images) == len(anns) * len(MOCK_COORDS)
 
     # Validate diagnostics
-    metadata_diag = diags[diags.type == DiagnosticTypes.IMZML_METADATA].iloc[0]
-    tic_diag = diags[diags.type == DiagnosticTypes.TIC].iloc[0]
+    metadata_diag = diags[diags.type == DiagnosticType.IMZML_METADATA].iloc[0]
+    tic_diag = diags[diags.type == DiagnosticType.TIC].iloc[0]
 
     assert metadata_diag.error is None
     assert metadata_diag.data['n_spectra'] == len(MOCK_COORDS)
@@ -207,3 +207,5 @@ def test_server_annotation_job(test_db, executor: Executor, sm_config, ds_config
     # Validate perf profile
     assert len(profiles) == 1
     assert len(profile_entries) > 10
+
+    print(diags)

--- a/metaspace/engine/tests/conftest.py
+++ b/metaspace/engine/tests/conftest.py
@@ -97,6 +97,7 @@ def _autocommit_execute(db_config, *sqls):
                 curs.execute(sql)
     except Exception as e:
         logging.getLogger('engine').error(e)
+        raise
     finally:
         if conn:
             conn.close()

--- a/metaspace/engine/tests/conftest.py
+++ b/metaspace/engine/tests/conftest.py
@@ -218,8 +218,8 @@ def executor(sm_config):
             executor.storage.delete_objects(bucket, keys)
 
 
-def make_imzml_wrapper_mock(coordinates=None, spectra=None):
-    from sm.engine.annotation.imzml_parser import FSImzMLParserWrapper
+def make_imzml_reader_mock(coordinates=None, spectra=None):
+    from sm.engine.annotation.imzml_reader import FSImzMLReader
 
     if coordinates is None:
         coordinates = list(product(range(1, 11), range(1, 11), [1]))
@@ -228,10 +228,10 @@ def make_imzml_wrapper_mock(coordinates=None, spectra=None):
     if isinstance(spectra, tuple):
         spectra = [spectra] * len(coordinates)
 
-    with patch('sm.engine.annotation.imzml_parser.find_file_by_ext') as find_file_mock:
-        with patch('sm.engine.annotation.imzml_parser.ImzMLParser') as imzml_parser_mock:
+    with patch('sm.engine.annotation.imzml_reader.find_file_by_ext') as find_file_mock:
+        with patch('sm.engine.annotation.imzml_reader.ImzMLParser') as imzml_parser_mock:
             find_file_mock.return_value = 'test_dataset.imzml'
             imzml_parser_mock().coordinates = coordinates
             imzml_parser_mock().getspectrum.side_effect = lambda i: spectra[i]
             imzml_parser_mock().mzPrecision = 'f'
-            return FSImzMLParserWrapper(Path('mock_input_path'))
+            return FSImzMLReader(Path('mock_input_path'))

--- a/metaspace/engine/tests/conftest.py
+++ b/metaspace/engine/tests/conftest.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
 import json
 import logging
+import os
 from copy import deepcopy
 from itertools import product
-from random import randint
 from pathlib import Path
 import uuid
-from unittest.mock import patch
+from unittest.mock import patch, DEFAULT
 
 import numpy as np
 import pytest
@@ -21,6 +22,7 @@ from sm.engine.tests.db_sql_schema import DB_SQL_SCHEMA
 from sm.engine.util import populate_aws_env_vars
 from sm.engine.config import proj_root, init_loggers, SMConfig
 from sm.engine.es_export import ESIndexManager
+from sm.engine.annotation.imzml_reader import FSImzMLReader
 from .utils import TEST_METADATA, TEST_DS_CONFIG, create_test_molecular_db
 
 TEST_CONFIG_PATH = 'conf/test_config.json'
@@ -29,14 +31,24 @@ TEST_CONFIG_PATH = 'conf/test_config.json'
 @pytest.fixture(scope='session')
 def sm_config():
     SMConfig.set_path(Path(proj_root()) / TEST_CONFIG_PATH)
-    sm_config = SMConfig.get_conf()
-    test_id = f'sm_test_{hex(randint(0, 0xFFFFFFFF))[2:]}'
-    sm_config['db']['database'] = test_id
-    for path in sm_config['lithops']['sm_storage'].values():
+    SMConfig.get_conf(update=True)  # Force reload in case previous tests modified it
+    worker_id = os.environ.get('PYTEST_XDIST_WORKER', 'gw0')
+
+    test_id = f'sm_test_{worker_id}'
+    # Update the internal cached copy of the config, so independent calls to SMConfig.get_conf()
+    # also get the updated config
+    SMConfig._config_dict['db']['database'] = test_id
+    SMConfig._config_dict['elasticsearch']['index'] = test_id
+    SMConfig._config_dict['rabbitmq']['prefix'] = f'test_{worker_id}__'
+
+    for path in SMConfig._config_dict['lithops']['sm_storage'].values():
         # prefix keys with test ID so they can be cleaned up later
         path[1] = f'{test_id}/{path[1]}'
 
-    return sm_config
+    # __LITHOPS_SESSION_ID determines the prefix to use for anonymous cloudobjects
+    os.environ['__LITHOPS_SESSION_ID'] = f'{test_id}/cloudobjects'
+
+    return SMConfig.get_conf()
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -218,9 +230,12 @@ def executor(sm_config):
             executor.storage.delete_objects(bucket, keys)
 
 
-def make_imzml_reader_mock(coordinates=None, spectra=None):
-    from sm.engine.annotation.imzml_reader import FSImzMLReader
-
+def make_imzml_reader_mock(
+    coordinates=None,
+    spectra=None,
+    mz_precision='f',
+    spectrum_metadata_fields=None,
+) -> FSImzMLReader:
     if coordinates is None:
         coordinates = list(product(range(1, 11), range(1, 11), [1]))
     if spectra is None:
@@ -230,8 +245,21 @@ def make_imzml_reader_mock(coordinates=None, spectra=None):
 
     with patch('sm.engine.annotation.imzml_reader.find_file_by_ext') as find_file_mock:
         with patch('sm.engine.annotation.imzml_reader.ImzMLParser') as imzml_parser_mock:
+
+            def add_spectra_metadata(*args, **kwargs):
+                include_spectra_metadata = kwargs.get('include_spectra_metadata', [])
+                assert include_spectra_metadata != 'full', 'not supported'
+                for accession in include_spectra_metadata:
+                    if accession not in imzml_parser_mock().spectrum_metadata_fields:
+                        imzml_parser_mock().spectrum_metadata_fields[accession] = [None] * len(
+                            coordinates
+                        )
+                return DEFAULT
+
             find_file_mock.return_value = 'test_dataset.imzml'
+            imzml_parser_mock.side_effect = add_spectra_metadata
             imzml_parser_mock().coordinates = coordinates
             imzml_parser_mock().getspectrum.side_effect = lambda i: spectra[i]
-            imzml_parser_mock().mzPrecision = 'f'
+            imzml_parser_mock().mzPrecision = mz_precision
+            imzml_parser_mock().spectrum_metadata_fields = spectrum_metadata_fields or {}
             return FSImzMLReader(Path('mock_input_path'))

--- a/metaspace/engine/tests/sci_test/spheroid.py
+++ b/metaspace/engine/tests/sci_test/spheroid.py
@@ -155,7 +155,7 @@ class SciTester:
             lithops_executor.RUNTIME_DOCKER_IMAGE = 'python'
 
             executor = Executor(self.sm_config['lithops'], perf)
-            ServerAnnotationJob(executor, None, ds, perf, self.sm_config).run(debug_validate=True)
+            ServerAnnotationJob(executor, ds, perf, self.sm_config).run(debug_validate=True)
         else:
             AnnotationJob(ds, perf).run()
 

--- a/metaspace/engine/tests/test_msm_basic_search_integr.py
+++ b/metaspace/engine/tests/test_msm_basic_search_integr.py
@@ -17,7 +17,7 @@ from sm.engine.annotation_spark.msm_basic_search import (
     compute_fdr_and_filter_results,
 )
 from sm.engine.utils.perf_profile import NullProfiler
-from tests.conftest import make_imzml_wrapper_mock
+from tests.conftest import make_imzml_reader_mock
 
 
 def make_fetch_formula_centroids_mock():
@@ -121,7 +121,7 @@ def test_search(formula_image_metrics_mock, spark_context, ds_config):
         print(ds_data_path)
         msm_search = MSMSearch(
             spark_context,
-            make_imzml_wrapper_mock(),
+            make_imzml_reader_mock(),
             [MolecularDB(0, 'tests_db', 'version')],
             ds_config,
             ds_data_path,
@@ -180,7 +180,7 @@ def test_ambiguous_modifiers(
         ]  # Formulae selected to create isobars with the above modifiers
         msm_search = MSMSearch(
             spark_context,
-            make_imzml_wrapper_mock(),
+            make_imzml_reader_mock(),
             [MolecularDB(0, 'test_db', 'version')],
             ds_config,
             ds_data_path,

--- a/metaspace/engine/tests/test_msm_basic_search_integr.py
+++ b/metaspace/engine/tests/test_msm_basic_search_integr.py
@@ -1,8 +1,7 @@
-from itertools import product
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import pytest
-from unittest.mock import patch, Mock, MagicMock
+from unittest.mock import patch, MagicMock
 
 import numpy as np
 import pandas as pd
@@ -18,14 +17,7 @@ from sm.engine.annotation_spark.msm_basic_search import (
     compute_fdr_and_filter_results,
 )
 from sm.engine.utils.perf_profile import NullProfiler
-
-
-def make_imzml_parser_mock(sp_n=100):
-    imzml_parser_mock = Mock()
-    imzml_parser_mock.coordinates = list(product([0], range(sp_n)))
-    imzml_parser_mock.get_spectrum.return_value = (np.linspace(0, 100, num=sp_n), np.ones(sp_n))
-    imzml_parser_mock.mz_precision = 'f'
-    return imzml_parser_mock
+from tests.conftest import make_imzml_wrapper_mock
 
 
 def make_fetch_formula_centroids_mock():
@@ -129,7 +121,7 @@ def test_search(formula_image_metrics_mock, spark_context, ds_config):
         print(ds_data_path)
         msm_search = MSMSearch(
             spark_context,
-            make_imzml_parser_mock(),
+            make_imzml_wrapper_mock(),
             [MolecularDB(0, 'tests_db', 'version')],
             ds_config,
             ds_data_path,
@@ -188,7 +180,7 @@ def test_ambiguous_modifiers(
         ]  # Formulae selected to create isobars with the above modifiers
         msm_search = MSMSearch(
             spark_context,
-            make_imzml_parser_mock(),
+            make_imzml_wrapper_mock(),
             [MolecularDB(0, 'test_db', 'version')],
             ds_config,
             ds_data_path,

--- a/metaspace/graphql/config/default.js
+++ b/metaspace/graphql/config/default.js
@@ -28,24 +28,9 @@ module.exports = {
   img_upload: {
     iso_img_fs_path: '/opt/data/metaspace/public/',
     categories: {
-      iso_image: {
-        type: 'image/png',
-        path: '/iso_images/',
-        storage_types: ['fs'],
-      },
-      optical_image: {
-        type: 'image/jpeg',
-        path: '/optical_images/',
-        storage_types: ['fs'],
-      },
       raw_optical_image: {
         type: 'image/jpeg',
         path: '/raw_optical_images/',
-        storage_types: ['fs'],
-      },
-      ion_thumbnail: {
-        type: 'image/png',
-        path: '/ion_thumbnails',
         storage_types: ['fs'],
       },
     },

--- a/metaspace/graphql/package.json
+++ b/metaspace/graphql/package.json
@@ -94,7 +94,7 @@
     "subscriptions-transport-ws": "^0.9.16",
     "superstruct": "^0.15.2",
     "ts-node": "^10.0.0",
-    "typeorm": "0.2.25",
+    "typeorm": "0.2.31",
     "typescript": "^3.9.2",
     "uuid": "^8.3.2",
     "winston": "^2.4.5"

--- a/metaspace/graphql/schemas/annotation.graphql
+++ b/metaspace/graphql/schemas/annotation.graphql
@@ -48,6 +48,8 @@ type AggregatedAnnotation {
 type CompoundInfoEntry {
   database: String!
   url: String
+  # NOTE: CompoundInfoEntry.databaseId is the molecule's ID from the database (e.g. HMDB0000001). It is not the
+  # METASPACE-assigned ID of the database. To get the ID of the database itself, see `Annotation.databaseId`.
   databaseId: String!
 }
 

--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -57,6 +57,9 @@ type Dataset {
   # the licence (if any) the authors allow the dataset to be used under,
   # time-limited download links to the dataset files
   downloadLinkJson: String
+
+  # Additional metadata and output data generated during processing
+  diagnostics: [DatasetDiagnostic!]!
 }
 
 type FdrCounts {
@@ -105,6 +108,28 @@ type DatasetProject {
   publicationStatus: String!
   isPublic: Boolean  # @deprecated(reason: "Field removed as it cannot be accessed both consistently and efficiently")
   urlSlug: String  # @deprecated(reason: "Field removed as it cannot be accessed both consistently and efficiently")
+}
+
+enum DiagnosticImageFormat {
+  PNG
+  NPY # N-Dimensional Array in NumPy's .npy serialization format
+}
+
+type DiagnosticImage {
+  key: String  # Optional identifier for type of image
+  index: Int   # Optional index, if there are multiple images with the same `key`
+  url: String!
+  format: DiagnosticImageFormat!
+}
+
+type DatasetDiagnostic {
+  id: String!
+  type: String!
+  jobId: Int
+  databaseId: Int
+  updatedDT: String!
+  data: String! # JSON-serialized. Structure depends on `type`
+  images: [DiagnosticImage!]!
 }
 
 enum DatasetOrderBy {

--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -116,7 +116,7 @@ enum DiagnosticImageFormat {
 }
 
 type DiagnosticImage {
-  key: String  # Optional identifier for type of image
+  key: String!
   index: Int   # Optional index, if there are multiple images with the same `key`
   url: String!
   format: DiagnosticImageFormat!
@@ -125,8 +125,8 @@ type DiagnosticImage {
 type DatasetDiagnostic {
   id: String!
   type: String!
-  jobId: Int
-  databaseId: Int
+  jobId: Int  # Only present for diagnostics associated with a database, currently unused
+  database: MolecularDB  # Only present for diagnostics associated with a database, currently unused
   updatedDT: String!
   data: String! # JSON-serialized. Structure depends on `type`
   images: [DiagnosticImage!]!

--- a/metaspace/graphql/src/migrations/1626189727821-DatasetDiagnostics.ts
+++ b/metaspace/graphql/src/migrations/1626189727821-DatasetDiagnostics.ts
@@ -1,0 +1,22 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class DatasetDiagnostics1626189727821 implements MigrationInterface {
+    name = 'DatasetDiagnostics1626189727821'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "public"."dataset_diagnostic" ("id" uuid NOT NULL DEFAULT uuid_generate_v1mc(), "type" text NOT NULL, "ds_id" text NOT NULL, "job_id" integer, "updated_dt" TIMESTAMP NOT NULL DEFAULT (now() at time zone 'utc'), "data" json, "error" text, "images" json NOT NULL, CONSTRAINT "PK_2ddb635004b2e08782649e0c638" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_8064cf8bd1bc774a3d53db893f" ON "public"."dataset_diagnostic" ("ds_id", "type") WHERE job_id IS NULL`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_2e8c4885755304fd125f7c4815" ON "public"."dataset_diagnostic" ("ds_id", "type", "job_id") `);
+        await queryRunner.query(`ALTER TABLE "public"."dataset_diagnostic" ADD CONSTRAINT "FK_e13bfa279306d04d020139312d1" FOREIGN KEY ("ds_id") REFERENCES "public"."dataset"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "public"."dataset_diagnostic" ADD CONSTRAINT "FK_0216974d86c145e2a08ea291c5d" FOREIGN KEY ("job_id") REFERENCES "public"."job"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "public"."dataset_diagnostic" DROP CONSTRAINT "FK_0216974d86c145e2a08ea291c5d"`);
+        await queryRunner.query(`ALTER TABLE "public"."dataset_diagnostic" DROP CONSTRAINT "FK_e13bfa279306d04d020139312d1"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_2e8c4885755304fd125f7c4815"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_8064cf8bd1bc774a3d53db893f"`);
+        await queryRunner.query(`DROP TABLE "public"."dataset_diagnostic"`);
+    }
+
+}

--- a/metaspace/graphql/src/migrations/1626348078740-DatasetDiagnostics.ts
+++ b/metaspace/graphql/src/migrations/1626348078740-DatasetDiagnostics.ts
@@ -1,7 +1,7 @@
 import {MigrationInterface, QueryRunner} from "typeorm";
 
-export class DatasetDiagnostics1626189727821 implements MigrationInterface {
-    name = 'DatasetDiagnostics1626189727821'
+export class DatasetDiagnostics1626348078740 implements MigrationInterface {
+    name = 'DatasetDiagnostics1626348078740'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`CREATE TABLE "public"."dataset_diagnostic" ("id" uuid NOT NULL DEFAULT uuid_generate_v1mc(), "type" text NOT NULL, "ds_id" text NOT NULL, "job_id" integer, "updated_dt" TIMESTAMP NOT NULL DEFAULT (now() at time zone 'utc'), "data" json, "error" text, "images" json NOT NULL, CONSTRAINT "PK_2ddb635004b2e08782649e0c638" PRIMARY KEY ("id"))`);

--- a/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
+++ b/metaspace/graphql/src/modules/annotation/controller/Annotation.ts
@@ -125,18 +125,12 @@ const Annotation: FieldResolversFor<Annotation, ESAnnotation | ESAnnotationWithC
   },
 
   isotopeImages(hit) {
-    const { iso_image_ids, iso_image_urls, centroid_mzs, total_iso_ints, min_iso_ints, max_iso_ints } = hit._source
+    const { iso_image_urls, centroid_mzs, total_iso_ints, min_iso_ints, max_iso_ints } = hit._source
     return centroid_mzs
       .map(function(mz, i) {
-        let url
-        if (iso_image_urls != null) {
-          url = iso_image_urls[i]
-        } else { // FIXME: remove after data migration
-          url = `/${hit._source.ds_ion_img_storage}${config.img_upload.categories.iso_image.path}${iso_image_ids[i]}`
-        }
         return {
           mz: parseFloat(mz as any),
-          url,
+          url: iso_image_urls && iso_image_urls[i] || null,
           totalIntensity: total_iso_ints[i],
           minIntensity: min_iso_ints[i],
           maxIntensity: max_iso_ints[i],

--- a/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
@@ -433,12 +433,12 @@ const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
             datasetId: In(datasetIds),
             error: IsNull(),
           },
-          relations: ['job'],
+          relations: ['job', 'job.molecularDB'],
         })
         const formattedResults = results.map(diag => ({
           ...diag,
           data: JSON.stringify(diag.data),
-          databaseId: diag.job?.moldbId ?? null,
+          database: diag.job?.molecularDB ?? null,
         }))
         const keyedResults = _.groupBy(formattedResults, 'datasetId')
         return datasetIds.map(id => keyedResults[id] || [])

--- a/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
@@ -3,7 +3,11 @@ import { dsField } from '../../../../datasetFilters'
 import { DatasetSource, FieldResolversFor } from '../../../bindingTypes'
 import { ProjectSourceRepository } from '../../project/ProjectSourceRepository'
 import { Dataset as DatasetModel } from '../model'
-import { DatasetDiagnostic as DatasetDiagnosticModel, EngineDataset, OpticalImage as OpticalImageModel } from '../../engine/model'
+import {
+  DatasetDiagnostic as DatasetDiagnosticModel,
+  EngineDataset,
+  OpticalImage as OpticalImageModel,
+} from '../../engine/model'
 import { Dataset, OpticalImage, OpticalImageType } from '../../../binding'
 import getScopeRoleForEsDataset from '../operation/getScopeRoleForEsDataset'
 import logger from '../../../utils/logger'

--- a/metaspace/graphql/src/modules/dataset/model.ts
+++ b/metaspace/graphql/src/modules/dataset/model.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, Index, JoinColumn, ManyToOne, OneToMany, OneToOne, PrimaryColumn } from 'typeorm'
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, OneToOne, PrimaryColumn } from 'typeorm'
 import { Group } from '../group/model'
 import { User } from '../user/model'
 import { Project } from '../project/model'

--- a/metaspace/graphql/src/modules/dataset/model.ts
+++ b/metaspace/graphql/src/modules/dataset/model.ts
@@ -1,8 +1,9 @@
-import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryColumn } from 'typeorm'
+import { Column, Entity, Index, JoinColumn, ManyToOne, OneToMany, OneToOne, PrimaryColumn } from 'typeorm'
 import { Group } from '../group/model'
 import { User } from '../user/model'
 import { Project } from '../project/model'
 import { ExternalLink } from '../project/ExternalLink'
+import { DatasetDiagnostic, EngineDataset } from '../engine/model'
 
 @Entity()
 export class Dataset {
@@ -36,11 +37,20 @@ export class Dataset {
   @Column({ type: 'text', nullable: true })
   piEmail: string | null;
 
+  // sm-engine and sm-graphql create & manage the public.dataset (EngineDataset) and graphql.dataset (Dataset) tables
+  // independently, so this relationship doesn't enforce an FK.
+  @OneToOne(() => EngineDataset, { createForeignKeyConstraints: false })
+  @JoinColumn({ name: 'id' })
+  engineDataset: EngineDataset;
+
   @OneToMany(() => DatasetProject, datasetProject => datasetProject.dataset)
   datasetProjects: DatasetProject[];
 
   @Column({ type: 'json', nullable: true })
   externalLinks: ExternalLink[] | null;
+
+  @OneToMany(() => DatasetDiagnostic, datasetDiagnostic => datasetDiagnostic.dataset)
+  datasetDiagnostics: DatasetDiagnostic[];
 }
 
 @Entity({ name: 'dataset_project' })

--- a/metaspace/graphql/src/modules/engine/model.ts
+++ b/metaspace/graphql/src/modules/engine/model.ts
@@ -137,7 +137,7 @@ export const DiagnosticTypeOptions: {[k in DiagnosticType]: k} = {
 
 export type DiagnosticImageFormat = 'PNG' | 'NPY'
 export interface DiagnosticImage {
-  key?: string;
+  key: string;
   index?: number;
   image_id: string;
   url: string;

--- a/metaspace/graphql/src/modules/engine/model.ts
+++ b/metaspace/graphql/src/modules/engine/model.ts
@@ -12,6 +12,8 @@ import {
 import { MomentValueTransformer } from '../../utils/MomentValueTransformer'
 import { Ion } from '../annotation/model'
 import { MolecularDB } from '../moldb/model'
+import { Dataset } from '../dataset/model'
+import { Moment } from 'moment'
 
 export type DatasetStatus = 'QUEUED' | 'ANNOTATING' | 'FINISHED' | 'FAILED';
 
@@ -53,6 +55,12 @@ export class EngineDataset {
   @Column({ type: 'text', nullable: true })
   ionThumbnailUrl: string | null;
 
+  // sm-engine and sm-graphql create & manage the public.dataset (EngineDataset) and graphql.dataset (Dataset) tables
+  // independently, so this relationship doesn't enforce an FK.
+  @ManyToOne(() => Dataset, { createForeignKeyConstraints: false })
+  @JoinColumn({ name: 'id' })
+  dataset: Dataset;
+
   @OneToMany(() => OpticalImage, opticalImage => opticalImage.dataset)
   opticalImages: OpticalImage[];
 
@@ -61,6 +69,9 @@ export class EngineDataset {
 
   @OneToMany(() => PerfProfile, pipelineStats => pipelineStats.dataset)
   pipelineStats: PerfProfile[];
+
+  @OneToMany(() => DatasetDiagnostic, datasetDiagnostic => datasetDiagnostic.engineDataset)
+  datasetDiagnostics: DatasetDiagnostic[];
 }
 
 @Entity({ schema: 'public' })
@@ -112,6 +123,79 @@ export class Job {
 
   @OneToMany(() => Annotation, annotation => annotation.job)
   annotations: Annotation[];
+
+  @OneToMany(() => DatasetDiagnostic, datasetDiagnostic => datasetDiagnostic.job)
+  datasetDiagnostics: DatasetDiagnostic[];
+}
+
+// Should match the literal in metaspace/engine/sm/engine/annotation/diagnostics.py
+export type DiagnosticType = 'TIC' | 'IMZML_METADATA'
+export const DiagnosticTypeOptions: {[k in DiagnosticType]: k} = {
+  TIC: 'TIC',
+  IMZML_METADATA: 'IMZML_METADATA',
+}
+
+export type DiagnosticImageFormat = 'PNG' | 'NPY'
+export interface DiagnosticImage {
+  key?: string;
+  index?: number;
+  image_id: string;
+  format: DiagnosticImageFormat;
+}
+
+@Entity({ schema: 'public' })
+// This is the main index for lookup performance. It enforces uniqueness when jobId is non-null, however because
+// NULL != NULL in postgres, this index doesn't enforce uniqueness of (datasetId, type) when jobId is NULL.
+// (i.e. counterintuitively, this index won't prevent inserting ('2001-01-01_00h00m00s', 'TIC', NULL) even if an
+// identical row already exists, because NULL != NULL, so NULL is always considered a unique value)
+// Therefore a second index is used for enforcing uniqueness when jobId is null.
+@Index(['datasetId', 'type', 'jobId'], { unique: true })
+@Index(['datasetId', 'type'], { unique: true, where: 'job_id IS NULL' })
+export class DatasetDiagnostic {
+  @PrimaryColumn({ type: 'uuid', default: () => 'uuid_generate_v1mc()' })
+  id: string;
+
+  @Column({ type: 'text', enum: Object.values(DiagnosticTypeOptions) })
+  type: DiagnosticType;
+
+  @Column({ name: 'ds_id', type: 'text' })
+  datasetId: string;
+
+  @Column({ type: 'text', nullable: true })
+  jobId: string | null;
+
+  @Column({
+    type: 'timestamp without time zone',
+    default: () => "(now() at time zone 'utc')",
+    transformer: new MomentValueTransformer(),
+  })
+  updatedDT: Moment;
+
+  @Column({ type: 'json', nullable: true })
+  data: any;
+
+  @Column({ type: 'text', nullable: true })
+  error: any;
+
+  // images are stored separately in an array with a defined structure so that it's easy for all images to be cleaned
+  // up when a dataset is deleted, without needing to understand any of the structure in `data`.
+  // All created Image IDs MUST be included in this column. Additionally, they MAY be referenced in `data`
+  // (preferably by `key` instead of `image_id`).
+  @Column({ type: 'json' })
+  images: DiagnosticImage[];
+
+  // This table is a child table of public.dataset, not graphql.dataset, so avoid making an FK
+  @ManyToOne(() => Dataset, { createForeignKeyConstraints: false })
+  @JoinColumn({ name: 'ds_id' })
+  dataset: Dataset;
+
+  @ManyToOne(() => EngineDataset, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'ds_id' })
+  engineDataset: EngineDataset;
+
+  @ManyToOne(() => Job, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'job_id' })
+  job: Job;
 }
 
 interface AnnotationStats {
@@ -234,6 +318,7 @@ export const ENGINE_ENTITIES = [
   EngineDataset,
   OpticalImage,
   Job,
+  DatasetDiagnostic,
   Annotation,
   PerfProfile,
   PerfProfileEntry,

--- a/metaspace/graphql/src/modules/engine/model.ts
+++ b/metaspace/graphql/src/modules/engine/model.ts
@@ -140,6 +140,7 @@ export interface DiagnosticImage {
   key?: string;
   index?: number;
   image_id: string;
+  url: string;
   format: DiagnosticImageFormat;
 }
 
@@ -161,8 +162,8 @@ export class DatasetDiagnostic {
   @Column({ name: 'ds_id', type: 'text' })
   datasetId: string;
 
-  @Column({ type: 'text', nullable: true })
-  jobId: string | null;
+  @Column({ type: 'int', nullable: true })
+  jobId: number | null;
 
   @Column({
     type: 'timestamp without time zone',

--- a/metaspace/graphql/yarn.lock
+++ b/metaspace/graphql/yarn.lock
@@ -683,6 +683,11 @@
   dependencies:
     type-detect "4.0.8"
 
+"@sqltools/formatter@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@sqltools/formatter/-/formatter-1.2.2.tgz#9390a8127c0dcba61ebd7fdcc748655e191bdd68"
+  integrity sha512-/5O7Fq6Vnv8L6ucmPjaWbVG1XkP4FO+w5glqfkIsq3Xw4oyNAdJddbnYodNDAfjVUvo/rrSCTom4kAND7T1o5Q==
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
@@ -1456,7 +1461,7 @@ ansi-styles@^2.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
   integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
-ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -1958,6 +1963,11 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
   integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -2132,13 +2142,13 @@ buffer@4.9.1:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.2.0.tgz#53cf98241100099e9eeae20ee6d51d21b16e541e"
-  integrity sha512-nUJyfChH7PMJy75eRDCCKtszSEFokUNXC1hNVSe+o+VdcgvDPLs20k3v8UXI8ruRYAJiYtyRea8mYyqPxoHWDw==
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
   dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 busboy@^0.2.11:
   version "0.2.14"
@@ -2228,7 +2238,7 @@ casual@^1.5.19:
     mersenne-twister "^1.0.1"
     moment "^2.15.2"
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.3.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2260,6 +2270,14 @@ chalk@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -2304,16 +2322,17 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-cli-highlight@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/cli-highlight/-/cli-highlight-2.1.1.tgz#2180223d51618b112f4509cf96e4a6c750b07e97"
-  integrity sha512-0y0VlNmdD99GXZHYnvrQcmHxP8Bi6T00qucGgBgGv4kJ0RyDthNnnFPupHV7PYv/OXSVk+azFbOeaW6+vGmx9A==
+cli-highlight@^2.1.10:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/cli-highlight/-/cli-highlight-2.1.11.tgz#49736fa452f0aaf4fae580e30acb26828d2dc1bf"
+  integrity sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==
   dependencies:
-    chalk "^2.3.0"
-    highlight.js "^9.6.0"
+    chalk "^4.0.0"
+    highlight.js "^10.7.1"
     mz "^2.4.0"
-    parse5 "^4.0.0"
-    yargs "^13.0.0"
+    parse5 "^5.1.1"
+    parse5-htmlparser2-tree-adapter "^6.0.0"
+    yargs "^16.0.0"
 
 cliui@^4.0.0:
   version "4.1.0"
@@ -2324,15 +2343,6 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
-cliui@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
-  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
-  dependencies:
-    string-width "^3.1.0"
-    strip-ansi "^5.2.0"
-    wrap-ansi "^5.1.0"
-
 cliui@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
@@ -2341,6 +2351,15 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone@^2.1.2:
   version "2.1.2"
@@ -2947,10 +2966,10 @@ dont-sniff-mimetype@1.1.0:
   resolved "https://registry.yarnpkg.com/dont-sniff-mimetype/-/dont-sniff-mimetype-1.1.0.tgz#c7d0427f8bcb095762751252af59d148b0a623b2"
   integrity sha512-ZjI4zqTaxveH2/tTlzS1wFp+7ncxNZaIEWYg3lzZRHkKf5zPT/MnEG6WL0BhHMJUabkh8GeU5NL5j+rEUCb7Ug==
 
-dotenv@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
-  integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
+dotenv@^8.2.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
+  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
 double-ended-queue@^2.1.0-0:
   version "2.1.0-0"
@@ -2992,11 +3011,6 @@ elasticsearch@^12.1.0:
     forever-agent "^0.6.0"
     lodash "^4.12.0"
     promise "^7.1.1"
-
-emoji-regex@^7.0.1:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
-  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -3074,6 +3088,11 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -3557,9 +3576,9 @@ feature-policy@0.3.0:
   integrity sha512-ZtijOTFN7TzCujt1fnNhfWPFPSHeZkesff9AXZj+UEjYBynWNUIYpC87Ve4wHzyexQsImicLu7WsC2LHq7/xrQ==
 
 figlet@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/figlet/-/figlet-1.2.0.tgz#6c46537378fab649146b5a6143dda019b430b410"
-  integrity sha1-bEZTc3j6tkkUa1phQ92gGbQwtBA=
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/figlet/-/figlet-1.5.0.tgz#2db4d00a584e5155a96080632db919213c3e003c"
+  integrity sha512-ZQJM4aifMpz6H19AW1VqvZ7l4pOE9p7i/3LyxgO2kp+PO/VcDYNqIHEMtkccqIhTXMKci4kjueJr/iCQEaT/Ww==
 
 file-entry-cache@^6.0.0:
   version "6.0.0"
@@ -3604,13 +3623,6 @@ find-up@^2.0.0, find-up@^2.1.0:
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
-
-find-up@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
-  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
-  dependencies:
-    locate-path "^3.0.0"
 
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
@@ -3791,7 +3803,7 @@ get-caller-file@^1.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -3852,6 +3864,18 @@ glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.6:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -4146,10 +4170,10 @@ hide-powered-by@1.1.0:
   resolved "https://registry.yarnpkg.com/hide-powered-by/-/hide-powered-by-1.1.0.tgz#be3ea9cab4bdb16f8744be873755ca663383fa7a"
   integrity sha512-Io1zA2yOA1YJslkr+AJlWSf2yWFkKjvkcL9Ni1XSUqnGLr/qRQe2UI3Cn/J9MsJht7yEVCe0SscY1HgVMujbgg==
 
-highlight.js@^9.6.0:
-  version "9.18.5"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.5.tgz#d18a359867f378c138d6819edfc2a8acd5f29825"
-  integrity sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==
+highlight.js@^10.7.1:
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
+  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
 homedir-polyfill@^1.0.1:
   version "1.0.3"
@@ -4254,6 +4278,11 @@ ieee754@1.1.13:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ieee754@^1.1.4:
   version "1.1.12"
@@ -5111,6 +5140,14 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.14.0:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
+  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 jsbn@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
@@ -5404,14 +5441,6 @@ locate-path@^2.0.0:
   integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
   dependencies:
     p-locate "^2.0.0"
-    path-exists "^3.0.0"
-
-locate-path@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
-  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
-  dependencies:
-    p-locate "^3.0.0"
     path-exists "^3.0.0"
 
 locate-path@^5.0.0:
@@ -5819,7 +5848,7 @@ mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3:
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@^1.0.3, mkdirp@^1.0.4:
+mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -6311,13 +6340,6 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.1.tgz#aa07a788cc3151c939b5131f63570f0dd2009537"
-  integrity sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==
-  dependencies:
-    p-try "^2.0.0"
-
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -6331,13 +6353,6 @@ p-locate@^2.0.0:
   integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
   dependencies:
     p-limit "^1.1.0"
-
-p-locate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
-  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
-  dependencies:
-    p-limit "^2.0.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -6404,15 +6419,27 @@ parse-passwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
   integrity sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=
 
+parse5-htmlparser2-tree-adapter@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
+  integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
+  dependencies:
+    parse5 "^6.0.1"
+
 parse5@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
   integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
 
-parse5@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
-  integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
+parse5@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
+  integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
+
+parse5@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
 parseurl@^1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -7652,15 +7679,6 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^3.0.0, string-width@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
-  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
-  dependencies:
-    emoji-regex "^7.0.1"
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^5.1.0"
-
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
@@ -7728,7 +7746,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -7925,9 +7943,9 @@ thenify-all@^1.0.0:
     thenify ">= 3.1.0 < 4"
 
 "thenify@>= 3.1.0 < 4":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
-  integrity sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
   dependencies:
     any-promise "^1.0.0"
 
@@ -8136,7 +8154,7 @@ tsconfig@^7.0.0:
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -8235,26 +8253,27 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typeorm@0.2.25:
-  version "0.2.25"
-  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.2.25.tgz#1a33513b375b78cc7740d2405202208b918d7dde"
-  integrity sha512-yzQ995fyDy5wolSLK9cmjUNcmQdixaeEm2TnXB5HN++uKbs9TiR6Y7eYAHpDlAE8s9J1uniDBgytecCZVFergQ==
+typeorm@0.2.31:
+  version "0.2.31"
+  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.2.31.tgz#82b8a1b233224f81c738f53b0380386ccf360917"
+  integrity sha512-dVvCEVHH48DG0QPXAKfo0l6ecQrl3A8ucGP4Yw4myz4YEDMProebTQo8as83uyES+nrwCbu3qdkL4ncC2+qcMA==
   dependencies:
+    "@sqltools/formatter" "1.2.2"
     app-root-path "^3.0.0"
-    buffer "^5.1.0"
-    chalk "^2.4.2"
-    cli-highlight "^2.0.0"
+    buffer "^5.5.0"
+    chalk "^4.1.0"
+    cli-highlight "^2.1.10"
     debug "^4.1.1"
-    dotenv "^6.2.0"
-    glob "^7.1.2"
-    js-yaml "^3.13.1"
-    mkdirp "^1.0.3"
+    dotenv "^8.2.0"
+    glob "^7.1.6"
+    js-yaml "^3.14.0"
+    mkdirp "^1.0.4"
     reflect-metadata "^0.1.13"
     sha.js "^2.4.11"
-    tslib "^1.9.0"
-    xml2js "^0.4.17"
+    tslib "^1.13.0"
+    xml2js "^0.4.23"
     yargonaut "^1.1.2"
-    yargs "^13.2.1"
+    yargs "^16.0.3"
 
 typescript@^3.9.2:
   version "3.9.2"
@@ -8547,19 +8566,19 @@ wrap-ansi@^2.0.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
 
-wrap-ansi@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
-  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
-  dependencies:
-    ansi-styles "^3.2.0"
-    string-width "^3.0.0"
-    strip-ansi "^5.0.0"
-
 wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -8609,13 +8628,26 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xml2js@0.4.19, xml2js@^0.4.17:
+xml2js@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
   integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
+
+xml2js@^0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlbuilder@~9.0.1:
   version "9.0.7"
@@ -8650,6 +8682,11 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -8671,9 +8708,9 @@ yallist@^4.0.0:
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargonaut@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/yargonaut/-/yargonaut-1.1.3.tgz#1cf6bbe511ecc865d6014203385628bcc39b0493"
-  integrity sha512-+FKokBOLV7DYnHjJpXniUnn1Zng2XBqX2k8d4E4eha19rvEbnctu1TsH98yixJmge7pDSQGS2Av/R30ya+ukrw==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/yargonaut/-/yargonaut-1.1.4.tgz#c64f56432c7465271221f53f5cc517890c3d6e0c"
+  integrity sha512-rHgFmbgXAAzl+1nngqOcwEljqHGG9uUZoPjsdZEs1w5JW9RXYzrSvH/u70C1JE5qFi0qjsdhnUX/dJRpWqitSA==
   dependencies:
     chalk "^1.1.1"
     figlet "^1.1.1"
@@ -8687,13 +8724,10 @@ yargs-parser@18.x, yargs-parser@^18.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^13.1.1:
-  version "13.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
-  integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-parser@^9.0.2:
   version "9.0.2"
@@ -8720,22 +8754,6 @@ yargs@^11.0.0:
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
 
-yargs@^13.0.0, yargs@^13.2.1:
-  version "13.3.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
-  integrity sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==
-  dependencies:
-    cliui "^5.0.0"
-    find-up "^3.0.0"
-    get-caller-file "^2.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^2.0.0"
-    set-blocking "^2.0.0"
-    string-width "^3.0.0"
-    which-module "^2.0.0"
-    y18n "^4.0.0"
-    yargs-parser "^13.1.1"
-
 yargs@^15.3.1:
   version "15.3.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
@@ -8752,6 +8770,19 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.1"
+
+yargs@^16.0.0, yargs@^16.0.3:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Resolves #885

Mostly went according to plan (as described in #885)

Notes:
* The big increase in sm-engine coverage (69% -> 83% :sunglasses: ) comes from `test_annotation_job`, which covers most of the Lithops pipeline. Previously this pipeline was only covered by sci-test, which isn't included in codecov. 
* I upgraded TypeORM in sm-graphql so that I could specify `createForeignKeyConstraints: false` on several relations, as our DB schema avoids the `public.dataset` and `graphql.dataset` tables. This is a risk - TypeORM releases aren't always stable. I specifically chose version 0.2.31 because the latest version has several unresolved issues around migrations.
* I refactored the way that ImzML files are loaded so that code could be shared between Lithops, Spark, and the `update_diagnostics` migration script. This conflicts with #785 . When work resumes on that PR, I suggest to scrap its ImzML parsing code changes and use the [new `ImzMLParser.polarity` field](https://github.com/alexandrovteam/pyimzML/pull/27) instead.
* I removed the temporary code in sm-graphql that handled non-S3 images during the #773 migration, as it's no longer needed because that migration has finished. I did this while trying to figure out how to convert image IDs to URLs in sm-graphql, but found that it wasn't needed in the end so I just kept the cleanups.