### PR TITLE
Update molecule link template in NPA database

### DIFF
--- a/metaspace/graphql/src/migrations/1627384009831-UpdateNPAUrl.ts
+++ b/metaspace/graphql/src/migrations/1627384009831-UpdateNPAUrl.ts
@@ -1,0 +1,29 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class UpdateNPAUrl1627384009831 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // The WHERE clause matches two rows on prod:
+        // id,name,version
+        // 36,NPA-2019-08,2019-09-30  // EMBL's copy
+        // 356,NPA-EMBL,2019-08       // Another group's private copy
+
+        await queryRunner.query(`
+            UPDATE public.molecular_db 
+            SET molecule_link_template = 'https://www.npatlas.org/explore/compounds/'
+            WHERE name LIKE 'NPA-%' 
+            AND version LIKE '2019%';
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Revert to the old template, which no longer works
+        await queryRunner.query(`
+            UPDATE public.molecular_db 
+            SET molecule_link_template = 'https://www.npatlas.org/joomla/index.php/explore/compounds#npaid='
+            WHERE name LIKE 'NPA-%' 
+            AND version LIKE '2019%';
+        `)
+    }
+
+}


### PR DESCRIPTION
I noticed that these links are now broken as they've changed link structure. This fixes it.

Normally I'd just manually update the database directly to save ~20 minutes of PR overhead, but these values were previously defined via migration, so I'm reluctantly following the existing convention.

Example broken link with current template: https://www.npatlas.org/explore/compounds#npaid=NPA001673
Example fixed link with new template: https://www.npatlas.org/explore/compounds/NPA001673