### PR TITLE
Trim spaces from ends of invited users' email addresses

### DIFF
--- a/metaspace/graphql/src/modules/group/controller.ts
+++ b/metaspace/graphql/src/modules/group/controller.ts
@@ -385,7 +385,7 @@ export const Resolvers = {
     async inviteUserToGroup(
       _: any, { groupId, email }: any, { user, getUserIdOrFail, entityManager }: Context
     ): Promise<UserGroupModel> {
-      email = email.trim() // Trim any spaces at the ends, because it's easy to do when copy+pasting email addresses
+      email = email.trim() // Trim spaces at the ends, because copy+pasting email addresses often adds unwanted spaces
       await assertCanEditGroup(entityManager, user, groupId)
       logger.info(`User '${user.id}' inviting ${email} to join '${groupId}' group...`)
 

--- a/metaspace/graphql/src/modules/group/controller.ts
+++ b/metaspace/graphql/src/modules/group/controller.ts
@@ -385,6 +385,7 @@ export const Resolvers = {
     async inviteUserToGroup(
       _: any, { groupId, email }: any, { user, getUserIdOrFail, entityManager }: Context
     ): Promise<UserGroupModel> {
+      email = email.trim() // Trim any spaces at the ends, because it's easy to do when copy+pasting email addresses
       await assertCanEditGroup(entityManager, user, groupId)
       logger.info(`User '${user.id}' inviting ${email} to join '${groupId}' group...`)
 

--- a/metaspace/graphql/src/modules/project/controller/Mutation.membership.spec.ts
+++ b/metaspace/graphql/src/modules/project/controller/Mutation.membership.spec.ts
@@ -140,6 +140,12 @@ describe('modules/project/controller (membership-related mutations)', () => {
         .toEqual(undefined)
     })
 
+    test('Manager invites existing user with spaces at ends of email address', async() => {
+      await doQuery(inviteUserToProjectQuery, { projectId, email: ` ${userContext.user.email} ` }, { context: managerContext })
+      expect(await testEntityManager.findOne(UserProjectModel, { projectId, userId }))
+        .toEqual(expect.objectContaining({ role: UPRO.INVITED }))
+    })
+
     test('User attempts to accept non-existent invitation', async() => {
       await expect(doQuery(acceptProjectInvitationQuery, { projectId })).rejects.toThrow('Unauthorized')
     })

--- a/metaspace/graphql/src/modules/project/controller/Mutation.ts
+++ b/metaspace/graphql/src/modules/project/controller/Mutation.ts
@@ -178,6 +178,7 @@ const MutationResolvers: FieldResolversFor<Mutation, void> = {
   },
 
   async inviteUserToProject(source, { projectId, email }, ctx: Context): Promise<UserProjectSource> {
+    email = email.trim() // Trim any spaces at the ends, because it's easy to do when copy+pasting email addresses
     let user = await findUserByEmail(ctx.entityManager, email)
       || await findUserByEmail(ctx.entityManager, email, 'not_verified_email')
     const currentUser = await ctx.entityManager.findOneOrFail(UserModel, ctx.getUserIdOrFail())

--- a/metaspace/graphql/src/modules/project/controller/Mutation.ts
+++ b/metaspace/graphql/src/modules/project/controller/Mutation.ts
@@ -178,7 +178,7 @@ const MutationResolvers: FieldResolversFor<Mutation, void> = {
   },
 
   async inviteUserToProject(source, { projectId, email }, ctx: Context): Promise<UserProjectSource> {
-    email = email.trim() // Trim any spaces at the ends, because it's easy to do when copy+pasting email addresses
+    email = email.trim() // Trim spaces at the ends, because copy+pasting email addresses often adds unwanted spaces
     let user = await findUserByEmail(ctx.entityManager, email)
       || await findUserByEmail(ctx.entityManager, email, 'not_verified_email')
     const currentUser = await ctx.entityManager.findOneOrFail(UserModel, ctx.getUserIdOrFail())


### PR DESCRIPTION
As reported in the #metaspace slack channel - when copy+pasting email addresses into the "Invite user to group/project" box, it's easy to accidentally have spaces added to the front or end of the `email` string. These code paths will create new accounts for the invited users if the email address wasn't found, so it's a problem if the `email` string has trailing spaces - a new account might be created for an existing user.

It was slightly easier to fix this on the back-end instead of the front-end. I haven't changed account creation / login because they already have validation.