### PR TITLE
Add more instructions directing users to check the Diagnostics panel

### DIFF
--- a/metaspace/webapp/src/lib/util.ts
+++ b/metaspace/webapp/src/lib/util.ts
@@ -34,6 +34,7 @@ export function renderMolFormula(ion: string): string {
 }
 
 export function renderMolFormulaHtml(ion: string): string {
+  // Deprecated - use src/components/MolecularFormula.tsx instead when possible
   return renderMolFormula(ion).replace(/(\d+)/g, '<sub>$1</sub>')
 }
 

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/AmbiguityAlert.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/AmbiguityAlert.vue
@@ -35,6 +35,11 @@
           <molecular-formula :ion="isobar.ion" />
         </li>
       </ul>
+      <p class="max-w-measure-1">
+        This <b>Molecules</b> panel lists candidate molecules from the isobaric
+        {{ isobars.length === 1 ? 'ion' : 'ions' }},
+        and the <b>Diagnostics</b> panel contains more information about the overlapping isotopic peaks.
+      </p>
     </div>
     <div
       slot="reference"

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/RelatedMolecules.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/RelatedMolecules.vue
@@ -16,10 +16,18 @@
           >
             <div>
               <span v-if="other.isIsomer">Isomer:</span>
-              <span v-else-if="other.isIsobar">Isobar {{ renderMassShift(annotation.mz, other.mz) }}: </span>
-              <span
+              <span v-else-if="other.isIsobar">
+                Isobar
+                <el-popover trigger="hover">
+                  <span slot="reference">{{ renderMassShift(annotation.mz, other.mz) }}</span>
+                  <p><molecular-formula :ion="annotation.ion" /> (Selected annotation): {{ annotation.mz.toFixed(4) }}</p>
+                  <p><molecular-formula :ion="other.ion" /> (Isobar): {{ other.mz.toFixed(4) }}</p>
+                  <p>Check the <b>Diagnostics</b> panel for more detail about the overlapping peaks.</p>
+                </el-popover>:
+              </span>
+              <molecular-formula
                 class="ion-formula"
-                v-html="renderMolFormulaHtml(other.ion)"
+                :ion="other.ion"
               />
             </div>
 
@@ -94,7 +102,7 @@
 
 <script>
 import { omit, sortBy, uniqBy } from 'lodash-es'
-import { renderMassShift, renderMolFormulaHtml } from '../../../lib/util'
+import { renderMassShift } from '../../../lib/util'
 import { relatedMoleculesQuery } from '../../../api/annotation'
 import { encodeParams, stripFilteringParams } from '../../Filters'
 import { ANNOTATION_SPECIFIC_FILTERS } from '../../Filters/filterSpecs'
@@ -102,12 +110,14 @@ import CompoundsList from './CompoundsList.vue'
 import FdrBadge from './FdrBadge.vue'
 import MsmBadge from './MsmBadge.vue'
 import config from '../../../lib/config'
+import MolecularFormula from '../../../components/MolecularFormula'
 
 export default {
   components: {
     CompoundsList,
     FdrBadge,
     MsmBadge,
+    MolecularFormula,
   },
   props: {
     annotation: { type: Object, required: true },
@@ -183,7 +193,6 @@ export default {
   },
   methods: {
     renderMassShift,
-    renderMolFormulaHtml,
     linkToAnnotation(other) {
       const filters = {
         datasetIds: this.annotations ? this.annotations.map((annotation) => annotation.dataset.id)

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/__snapshots__/RelatedMolecules.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/__snapshots__/RelatedMolecules.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`RelatedMolecules should match snapshot 1`] = `
         <div class="ion-heading">
           <div class="ion-link">
             <div>
-              <!----> <span class="ion-formula">[C<sub>10</sub>H<sub>11</sub>NO + Na]⁺</span></div>
+              <!----> <span class="ion-formula">[C<sub class="leading-none">10</sub>H<sub class="leading-none">11</sub>NO + Na]⁺</span></div>
             <div class="fdr-badge fdr-badge-10">
               10% FDR
             </div>
@@ -44,7 +44,7 @@ exports[`RelatedMolecules should match snapshot 1`] = `
     <div class="el-divider el-divider--horizontal">
       <div class="el-divider__text is-center">
         <div class="ion-heading"><a href="/?ds=2019-02-12_15h55m06s&amp;mol=allAnnotations.0.sumFormula&amp;chem_mod=allAnnotations.0.chemMod&amp;nl=allAnnotations.0.neutralLoss&amp;add=allAnnotations.0.adduct&amp;fdr=0.2" class="ion-link">
-            <div><span>Isomer:</span> <span class="ion-formula">[C<sub>10</sub>H<sub>13</sub>NO<sub>2</sub> + Na - H<sub>2</sub>O]⁺</span></div>
+            <div><span>Isomer:</span> <span class="ion-formula">[C<sub class="leading-none">10</sub>H<sub class="leading-none">13</sub>NO<sub class="leading-none">2</sub> + Na - H<sub class="leading-none">2</sub>O]⁺</span></div>
             <div class="fdr-badge fdr-badge-20">
               20% FDR
             </div>


### PR DESCRIPTION
Resolves #911 

Note that this change only applies to iso**bars**, not iso**mers**. Isobars are molecules that are close enough they could fall in the same detection window (different combination of atoms at a very similar mass). Isomers are completely identical (same atoms after the adduct was applied, same mass), so they don't have any additional information in the Diagnostics panel.

# Screenshots:
#### AmbiguityAlert.vue
![image](https://user-images.githubusercontent.com/26366936/127181512-0241f39d-1e14-46d6-b209-c6a3048c7cd6.png)

#### RelatedMolecules.vue
I added this popup because the "[M+1.0075]" text seems to have been the original source of confusion.

![image](https://user-images.githubusercontent.com/26366936/127181678-8b289e74-e2b9-4fcf-ae0d-c0d0d9a08f41.png)

