### PR TITLE
Correctly format DatabaseDiagnostics.updatedDT

### DIFF
--- a/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
@@ -443,6 +443,7 @@ const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
           ...diag,
           data: JSON.stringify(diag.data),
           database: diag.job?.molecularDB ?? null,
+          updatedDT: diag.updatedDT.toISOString(),
         }))
         const keyedResults = _.groupBy(formattedResults, 'datasetId')
         return datasetIds.map(id => keyedResults[id] || [])


### PR DESCRIPTION
Non-critical fix for diagnostics - making this date field a UTC ISO-8601 string to be consistent with the rest of the dates in the GraphQL API. No need to rush this to today's deployment, as nothing actually uses this field.

Old behavior:
![image](https://user-images.githubusercontent.com/26366936/129002424-040f2ced-963d-4c01-b4cb-e99b300823c9.png)

New behavior:
![image](https://user-images.githubusercontent.com/26366936/129002528-ec6ab925-d003-41d1-9e82-3018acc7106a.png)

These can be checked at https://staging.metaspace2020.eu/graphql with this query:
```
query {
  dataset(id:"2021-08-11_10h17m05s") {
    diagnostics {
      type
      updatedDT
      database { id name }
      images { key url format }
      data
    }
  }
}
```