### PR TITLE
Fix bugs found in diagnostics migration

### DIFF
--- a/metaspace/engine/sm/engine/annotation/diagnostics.py
+++ b/metaspace/engine/sm/engine/annotation/diagnostics.py
@@ -206,9 +206,9 @@ def extract_dataset_diagnostics(ds_id: str, imzml_reader: ImzMLReader):
                 'ds_id': ds_id,
                 'type': DiagnosticType.TIC,
                 'data': {
-                    'min_tic': np.min(tic_vals).item() if len(tic_vals) else 0,
-                    'max_tic': np.max(tic_vals).item() if len(tic_vals) else 0,
-                    'sum_tic': np.sum(tic_vals).item() if len(tic_vals) else 0,
+                    'min_tic': np.nan_to_num(np.min(tic_vals).item()) if len(tic_vals) else 0,
+                    'max_tic': np.nan_to_num(np.max(tic_vals).item()) if len(tic_vals) else 0,
+                    'sum_tic': np.nan_to_num(np.sum(tic_vals).item()) if len(tic_vals) else 0,
                     'is_from_metadata': imzml_reader.is_tic_from_metadata,
                 },
                 'images': [tic_image],

--- a/metaspace/engine/sm/engine/annotation_lithops/io.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/io.py
@@ -142,7 +142,9 @@ def get_ranges_from_cobject(
     to minimize the number of requests without wasting any bandwidth if there are large gaps
     between requested ranges."""
     max_jump = 2 ** 16  # Largest gap between ranges before a new request should be made
-    max_chunk_size = 256 * 2 ** 20  # Limit to 256MB because SSL fails if requests are >2GB
+    # Limit chunks to 256MB to avoid large memory allocations, and because SSL fails if requests
+    # are >2GB https://bugs.python.org/issue42853 (Fixed in Python 3.9.7, broken in 3.8.*)
+    max_chunk_size = 256 * 2 ** 20
 
     request_ranges: List[Tuple[int, int]] = []
     tasks = []

--- a/metaspace/engine/sm/engine/annotation_lithops/io.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/io.py
@@ -142,6 +142,7 @@ def get_ranges_from_cobject(
     to minimize the number of requests without wasting any bandwidth if there are large gaps
     between requested ranges."""
     max_jump = 2 ** 16  # Largest gap between ranges before a new request should be made
+    max_chunk_size = 256 * 2 ** 20  # Limit to 256MB because SSL fails if requests are >2GB
 
     request_ranges: List[Tuple[int, int]] = []
     tasks = []
@@ -151,7 +152,7 @@ def get_ranges_from_cobject(
         lo_idx, hi_idx = ranges[input_i]
         if range_start is None:
             range_start, range_end = lo_idx, hi_idx
-        elif lo_idx - range_end <= max_jump:
+        elif lo_idx - range_end <= max_jump and range_end - range_start <= max_chunk_size:
             range_end = max(range_end, hi_idx)
         else:
             request_ranges.append((range_start, range_end))


### PR DESCRIPTION
# Limit maximum chunk size of batched spectrum reads
```
Traceback (most recent call last):
  File "/opt/dev/metaspace/metaspace/engine/scripts/update_diagnostics.py", line 84, in process_dataset
    for _ in imzml_reader.iter_spectra(storage, chunk):
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation/imzml_reader.py", line 168, in iter_spectra
    data_ranges = get_ranges_from_cobject(storage, self._ibd_cobject, ranges_to_read)
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/io.py", line 174, in get_ranges_from_cobject
    request_results = list(executor.map(get_range, request_ranges))
...
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/io.py", line 172, in get_range
    return storage.get_object(cobj.bucket, cobj.key, extra_get_args=args)
  File "/opt/dev/miniconda3/envs/sm38/lib/python3.8/site-packages/lithops/storage/storage.py", line 88, in get_object
    return self.storage_handler.get_object(bucket, key, stream, extra_get_args)
...
  File "/opt/dev/miniconda3/envs/sm38/lib/python3.8/ssl.py", line 1099, in read
    return self._sslobj.read(len, buffer)
OverflowError: signed integer is greater than maximum
```

This is a [Python bug](https://bugs.python.org/issue42853) causing HTTPS requests larger than 2GB to always fail. It only appeared here because the migration script reads chunks of 1000 spectra, and some datasets have >2MB per spectrum. 

I added a workaround by changing `get_ranges_from_cobject` (used for loading partial sets of spectra from .ibd files in the Lithops pipeline) so that it would never try to read a chunk greater than 2GB (unless a intensity/mz array is >2GB, but if that edge-case ever happens we have bigger problems).

# Handle datasets with infinite TICs

```
Traceback (most recent call last):
  File "/opt/dev/metaspace/metaspace/engine/scripts/update_diagnostics.py", line 89, in process_dataset
    add_diagnostics(diagnostics)
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation/diagnostics.py", line 101, in add_diagnostics
    db.insert(
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/db.py", line 90, in wrapper
    return func(self, sql, *args, **kwargs)
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/db.py", line 176, in insert
    self._curs.executemany(sql, rows)
psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type json
LINE 1: ..., 'TIC', '2021-08-13T11:00:38.607805'::timestamp, '{"min_tic...
                                                             ^
DETAIL:  Token "Infinity" is invalid.
CONTEXT:  JSON data, line 1: {"min_tic": 1256.710205078125, "max_tic": Infinity...
```

JSON doesn't support Infinity or NaN values at all. I just wrapped these fields in `np.nan_to_num` to convert them to a large number (`1.7976931348623157e+308`). I also tested that these can still be read successfully from the graphql API.