### PR TITLE
Feat/ds comparison improvements

### DIFF
--- a/metaspace/webapp/src/components/IonImageViewer.tsx
+++ b/metaspace/webapp/src/components/IonImageViewer.tsx
@@ -412,6 +412,7 @@ const useImageSize = (props: Props) => {
 }
 
 export default defineComponent<Props>({
+  name: 'IonImageViewer',
   props: {
     ionImageLayers: Array,
     isLoading: { type: Boolean, default: false },

--- a/metaspace/webapp/src/lib/ionImageRendering.ts
+++ b/metaspace/webapp/src/lib/ionImageRendering.ts
@@ -211,7 +211,7 @@ const quantizeScaleBar = (minIntensity: number, maxIntensity: number,
   return quantizeIonImage(linearDistribution, minIntensity, maxIntensity, rankValues, scaleMode)
 }
 
-export const loadPngFromUrl = async(url: string) => {
+export const loadPngFromUrl = async(url: string): Promise<Image> => {
   const response = await fetch(url, { credentials: 'omit' })
   if (response.status !== 200) {
     throw Object.assign(

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
@@ -33,30 +33,10 @@ import LockSvg from '../../assets/inline/refactoring-ui/icon-lock.svg'
 import LocationPinSvg from '../../assets/inline/refactoring-ui/icon-location-pin.svg'
 import FilterIcon from '../../assets/inline/filter.svg'
 
-import { useIonImageSettings } from '../ImageViewer/ionImageState'
+import { ImageSettings, useIonImageSettings } from '../ImageViewer/ionImageState'
 import viewerState from '../ImageViewer/state'
 
 const { settings: ionImageSettings } = useIonImageSettings()
-
- type ImagePosition = {
-   zoom: number
-   xOffset: number
-   yOffset: number
- }
-
- type ImageSettings = {
-   annotImageOpacity: number
-   opacityMode: OpacityMode
-   imagePosition: ImagePosition
-   opticalSrc: string | null
-   opticalTransform: number[][] | null
-   pixelAspectRatio: number
-   opticalOpacity: number
-   // scaleType is deliberately not included here, because every time it changes some slow computation occurs,
-   // and the computed getters were being triggered by any part of the ImageSettings object changing, such as opacity,
-   // causing a lot of jank.
-   // scaleType?: ScaleType
- }
 
 const metadataDependentComponents: any = {}
 const componentsToRegister: any = {

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/IonImageSettings.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/IonImageSettings.vue
@@ -34,9 +34,25 @@
       </el-form-item>
       <el-form-item
         v-if="showIntensityTemplate"
-        label="Intensity lock"
         data-feature-anchor="global-intensity-lock"
       >
+        <el-popover
+          slot="label"
+          trigger="hover"
+          placement="right"
+        >
+          <div slot="reference">
+            Intensity lock
+            <new-feature-badge feature-key="template-intensity-lock">
+              <i class="el-icon-question metadata-help-icon ml-1" />
+            </new-feature-badge>
+          </div>
+          <div class="max-w-xs">
+            Select a dataset as template to lock
+            all the other dataset's according
+            to the template max and min intensities value.
+          </div>
+        </el-popover>
         <el-select
           :value="selectedTemplate"
           style="width: 300px;"
@@ -128,6 +144,7 @@ import ColorBar from './Colorbar.vue'
 import { Component, Prop } from 'vue-property-decorator'
 import { ScaleType } from '../../../../lib/ionImageRendering'
 import ScaleBar from '../../../../components/ScaleBar.vue'
+import NewFeatureBadge, { hideFeatureBadge } from '../../../../components/NewFeatureBadge'
 
  interface colorObjType {
    code: string,
@@ -137,7 +154,7 @@ import ScaleBar from '../../../../components/ScaleBar.vue'
 
  @Component({
    name: 'ion-image-setting',
-   components: { ColorBar, ScaleBar },
+   components: { ColorBar, ScaleBar, NewFeatureBadge },
  })
 export default class IonImageSettings extends Vue {
    @Prop({ type: String })
@@ -153,7 +170,7 @@ export default class IonImageSettings extends Vue {
    defaultLockTemplate: string | undefined;
 
    @Prop({ type: Array })
-   lockTemplateOptions: any[];
+   lockTemplateOptions: any[] | undefined;
 
    @Prop({ type: Boolean })
    showIntensityTemplate: boolean | undefined
@@ -214,6 +231,7 @@ export default class IonImageSettings extends Vue {
    onTemplateChange(dsId: string) {
      this.$store.commit('setLockTemplate', dsId)
      this.$emit('templateChange', dsId)
+     hideFeatureBadge('template-intensity-lock')
    }
 }
 </script>
@@ -232,4 +250,9 @@ export default class IonImageSettings extends Vue {
   #ion-image-settings > .el-form--label-top .el-form-item__label {
     padding: 0;
   }
+
+ .el-badge__content.is-fixed{
+   right: 0;
+   top: 10px;
+ }
 </style>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/IonImageSettings.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/IonImageSettings.vue
@@ -48,9 +48,7 @@
             </new-feature-badge>
           </div>
           <div class="max-w-xs">
-            Select a dataset as template to lock
-            all the other dataset's according
-            to the template max and min intensities value.
+            Apply intensities range of one dataset to all other datasets.
           </div>
         </el-popover>
         <el-select

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/IonImageSettings.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/IonImageSettings.vue
@@ -32,6 +32,28 @@
           />
         </el-select>
       </el-form-item>
+      <el-form-item
+        v-if="showIntensityTemplate"
+        label="Intensity lock"
+        data-feature-anchor="global-intensity-lock"
+      >
+        <el-select
+          :value="selectedTemplate"
+          style="width: 300px;"
+          clearable
+          placeholder="Choose the template dataset"
+          @input="onTemplateChange"
+          @clear="onTemplateChange"
+        >
+          <el-option
+            v-for="item in lockTemplateOptions"
+            :key="item.id"
+            :label="item.name"
+            :value="item.id"
+          >
+          </el-option>
+        </el-select>
+      </el-form-item>
       <el-form-item label="Colormap">
         <el-select
           :value="colormap"
@@ -127,6 +149,15 @@ export default class IonImageSettings extends Vue {
    @Prop({ type: String })
    defaultScaleBarColor: string | undefined;
 
+   @Prop({ type: String })
+   defaultLockTemplate: string | undefined;
+
+   @Prop({ type: Array })
+   lockTemplateOptions: any[];
+
+   @Prop({ type: Boolean })
+   showIntensityTemplate: boolean | undefined
+
    availableScales: string[] = ['Viridis', 'Cividis', 'Hot', 'YlGnBu', 'Portland', 'Greys', 'Inferno', 'Turbo'];
    paletteColors: colorObjType[] = [{
      code: '#000000',
@@ -152,6 +183,11 @@ export default class IonImageSettings extends Vue {
      return this.defaultScaleType ? this.defaultScaleType : this.$store.getters.settings.annotationView.scaleType
    }
 
+   get selectedTemplate() {
+     return this.defaultLockTemplate ? this.defaultLockTemplate
+       : this.$store.getters.settings.annotationView.lockTemplate
+   }
+
    scaleBarColors(color: string): string {
      let cssBaseRule = `width: 100px; height: 20px; margin: 2px auto; background-color:${color};`
      if (color === '#FFFFFF') {
@@ -173,6 +209,11 @@ export default class IonImageSettings extends Vue {
    onScaleBarColorChange(c: string) {
      this.pickedColor = c
      this.$emit('scaleBarColorChange', c === 'hidden' ? null : c)
+   }
+
+   onTemplateChange(dsId: string) {
+     this.$store.commit('setLockTemplate', dsId)
+     this.$emit('templateChange', dsId)
    }
 }
 </script>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImageHeader.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImageHeader.vue
@@ -17,9 +17,13 @@
         <ion-image-settings
           :default-colormap="colormap"
           :default-scale-type="scaleType"
+          :default-lock-template="lockedTemplate"
+          :show-intensity-template="showIntensityTemplate"
+          :lock-template-options="lockTemplateOptions"
           @colormapChange="onColormapChange"
           @scaleTypeChange="onScaleTypeChange"
           @scaleBarColorChange="onScaleBarColorChange"
+          @templateChange="onTemplateChange"
         />
         <button
           v-if="!hideOptions"
@@ -100,7 +104,13 @@ export default class MainImageHeader extends Vue {
     colormap: string | undefined;
 
     @Prop({ type: String })
+    lockedTemplate: string | undefined;
+
+    @Prop({ type: String })
     scaleType: string | undefined;
+
+    @Prop({ type: Array })
+    lockTemplateOptions: any[] | undefined;
 
     @Prop({ required: true, type: Function })
     resetViewport!: Function;
@@ -114,12 +124,19 @@ export default class MainImageHeader extends Vue {
     @Prop({ type: Boolean })
     hideOptions: boolean | undefined
 
+    @Prop({ type: Boolean })
+    showIntensityTemplate: boolean | undefined
+
     get multiImageFlag() {
       return config.features.multiple_ion_images
     }
 
     onScaleBarColorChange(color: string | null) {
       this.$emit('scaleBarColorChange', color)
+    }
+
+    onTemplateChange(dsId: string) {
+      this.$emit('templateChange', dsId)
     }
 
     onColormapChange(color: string | null) {

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonAnnotationTable.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonAnnotationTable.tsx
@@ -590,7 +590,7 @@ export const DatasetComparisonAnnotationTable = defineComponent<DatasetCompariso
             <TableColumn
               key="datasetCount"
               property="datasetCount"
-              label="# of datasets"
+              label="Datasets #"
               sortable="custom"
               minWidth="100"
             />

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.scss
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.scss
@@ -51,6 +51,12 @@
     background: #F1F5F8;
   }
 
+  .ds-name{
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
   .dataset-comparison-grid-item-header{
     @apply flex flex-row;
     background: #F1F5F8;

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.scss
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.scss
@@ -51,12 +51,6 @@
     background: #F1F5F8;
   }
 
-  .ds-name{
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-  }
-
   .dataset-comparison-grid-item-header{
     @apply flex flex-row;
     background: #F1F5F8;

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.spec.ts
@@ -6,7 +6,90 @@ import { sync } from 'vuex-router-sync'
 import store from '../../../store'
 import router from '../../../router'
 
-describe('DatasetComparisonAnnotationTable', () => {
+// Mock loadPngFromUrl to prevent network requests, but keep the rest of ionImageRendering as it's actually used
+jest.mock('../../../lib/ionImageRendering', () => Object.assign(
+  {},
+  jest.requireActual('../../../lib/ionImageRendering'),
+  { loadPngFromUrl: jest.fn() },
+))
+
+describe('DatasetComparisonGrid', () => {
+  const datasets = [
+    {
+      id: '2021-04-14_07h23m35s',
+      submitter: {
+        id: '039801c8-919e-11eb-908e-3b2b8e672707',
+        name: 'John Doe',
+        email: null,
+      },
+      principalInvestigator: {
+        name: 'Jhon Doe',
+        email: null,
+      },
+      group: null,
+      groupApproved: false,
+      projects: [
+        {
+          id: 'b738905e-9229-11eb-8e15-4fc9140611d2',
+          name: 'New Test',
+        },
+        {
+          id: '05c6519a-8049-11eb-927e-6bf28a9b25ae',
+          name: 'Test',
+        },
+        {
+          id: '717123c8-9d0b-11eb-a675-eb973178fad8',
+          name: 'Teste antigo',
+        },
+      ],
+      name: 'New test create',
+      polarity: 'POSITIVE',
+      metadataJson: '{"Data_Type":"Imaging MS","Sample_Information":'
+      + '{"Condition":"wild","Organism":"Fish","Organism_Part":"tail",'
+      + '"Sample_Growth_Conditions":""},"Sample_Preparation":'
+      + '{"MALDI_Matrix":"none","Tissue_Modification":"chemical",'
+      + '"Sample_Stabilisation":"water","MALDI_Matrix_Application":'
+      + '"none","Solvent":"none"},"MS_Analysis":{"Polarity":"Positive"'
+      + ',"Ionisation_Source":"MALDI","Analyzer":"Orbittrap",'
+      + '"Detector_Resolving_Power":{"Resolving_Power":140000,"mz":200},"'
+      + 'Pixel_Size":{"Xaxis":12,"Yaxis":12}},"Additional_Information":{"Supplementary":""}}',
+      isPublic: true,
+      opticalImages: [],
+    },
+    {
+      id: '2021-03-31_08h41m01s',
+      submitter: {
+        id: '19cd5e98-919e-11eb-a246-03c68134260b',
+        name: 'Zed Doe',
+        email: null,
+      },
+      principalInvestigator: {
+        name: 'ZEDX',
+        email: null,
+      },
+      group: null,
+      groupApproved: false,
+      projects: [
+        {
+          id: '05c6519a-8049-11eb-927e-6bf28a9b25ae',
+          name: 'Test',
+        },
+      ],
+      name: 'New 2',
+      polarity: 'POSITIVE',
+      metadataJson: '{"Data_Type":"Imaging MS","Sample_Information":'
+      + '{"Condition":"wild","Organism":"Fish","Organism_Part":"tail",'
+      + '"Sample_Growth_Conditions":""},"Sample_Preparation":'
+      + '{"MALDI_Matrix":"none","Tissue_Modification":"chemical",'
+      + '"Sample_Stabilisation":"water","MALDI_Matrix_Application":'
+      + '"none","Solvent":"none"},"MS_Analysis":{"Polarity":"Positive"'
+      + ',"Ionisation_Source":"MALDI","Analyzer":"Orbittrap",'
+      + '"Detector_Resolving_Power":{"Resolving_Power":140000,"mz":200},"'
+      + 'Pixel_Size":{"Xaxis":12,"Yaxis":12}},"Additional_Information":{"Supplementary":""}}',
+      isPublic: true,
+      opticalImages: [],
+    },
+  ]
   const propsData = {
     nCols: 2,
     nRows: 1,
@@ -16,6 +99,7 @@ describe('DatasetComparisonAnnotationTable', () => {
       },
     },
     selectedAnnotation: 0,
+    datasets,
     annotations: [
       {
         ion: 'c10h11no+na+',
@@ -24,7 +108,7 @@ describe('DatasetComparisonAnnotationTable', () => {
           '2021-03-31_08h41m01s',
           '2021-04-14_07h23m35s',
         ],
-        datasets: [
+        annotations: [
           {
             id: '2021-03-31_08h41m01s_4580',
             sumFormula: 'C10H11NO',
@@ -41,39 +125,7 @@ describe('DatasetComparisonAnnotationTable', () => {
             colocalizationCoeff: null,
             offSample: null,
             offSampleProb: null,
-            dataset: {
-              id: '2021-03-31_08h41m01s',
-              submitter: {
-                id: '19cd5e98-919e-11eb-a246-03c68134260b',
-                name: 'Zed Doe',
-                email: null,
-              },
-              principalInvestigator: {
-                name: 'ZEDX',
-                email: null,
-              },
-              group: null,
-              groupApproved: false,
-              projects: [
-                {
-                  id: '05c6519a-8049-11eb-927e-6bf28a9b25ae',
-                  name: 'Test',
-                },
-              ],
-              name: 'New 2',
-              polarity: 'POSITIVE',
-              metadataJson: '{"Data_Type":"Imaging MS","Sample_Information":'
-                + '{"Condition":"wild","Organism":"Fish","Organism_Part":"tail",'
-                + '"Sample_Growth_Conditions":""},"Sample_Preparation":'
-                + '{"MALDI_Matrix":"none","Tissue_Modification":"chemical",'
-                + '"Sample_Stabilisation":"water","MALDI_Matrix_Application":'
-                + '"none","Solvent":"none"},"MS_Analysis":{"Polarity":"Positive"'
-                + ',"Ionisation_Source":"MALDI","Analyzer":"Orbittrap",'
-                + '"Detector_Resolving_Power":{"Resolving_Power":140000,"mz":200},"'
-                + 'Pixel_Size":{"Xaxis":12,"Yaxis":12}},"Additional_Information":{"Supplementary":""}}',
-              isPublic: true,
-              opticalImages: [],
-            },
+            dataset: datasets[1],
             databaseDetails: {
               id: 1,
             },
@@ -196,47 +248,7 @@ describe('DatasetComparisonAnnotationTable', () => {
             colocalizationCoeff: null,
             offSample: null,
             offSampleProb: null,
-            dataset: {
-              id: '2021-04-14_07h23m35s',
-              submitter: {
-                id: '039801c8-919e-11eb-908e-3b2b8e672707',
-                name: 'John Doe',
-                email: null,
-              },
-              principalInvestigator: {
-                name: 'Jhon Doe',
-                email: null,
-              },
-              group: null,
-              groupApproved: false,
-              projects: [
-                {
-                  id: 'b738905e-9229-11eb-8e15-4fc9140611d2',
-                  name: 'New Test',
-                },
-                {
-                  id: '05c6519a-8049-11eb-927e-6bf28a9b25ae',
-                  name: 'Test',
-                },
-                {
-                  id: '717123c8-9d0b-11eb-a675-eb973178fad8',
-                  name: 'Teste antigo',
-                },
-              ],
-              name: 'New test create',
-              polarity: 'POSITIVE',
-              metadataJson: '{"Data_Type":"Imaging MS","Sample_Information":'
-                + '{"Condition":"wild","Organism":"Fish","Organism_Part":"tail",'
-                + '"Sample_Growth_Conditions":""},"Sample_Preparation":'
-                + '{"MALDI_Matrix":"none","Tissue_Modification":"chemical",'
-                + '"Sample_Stabilisation":"water","MALDI_Matrix_Application":'
-                + '"none","Solvent":"none"},"MS_Analysis":{"Polarity":"Positive"'
-                + ',"Ionisation_Source":"MALDI","Analyzer":"Orbittrap",'
-                + '"Detector_Resolving_Power":{"Resolving_Power":140000,"mz":200},"'
-                + 'Pixel_Size":{"Xaxis":12,"Yaxis":12}},"Additional_Information":{"Supplementary":""}}',
-              isPublic: true,
-              opticalImages: [],
-            },
+            dataset: datasets[0],
             databaseDetails: {
               id: 1,
             },

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
@@ -566,7 +566,11 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
           ? props.datasets.find((dataset: any) => dataset.id === state.grid[`${row}-${col}`])
           : null
       return (
-        <span class='dataset-comparison-grid-ds-name'>{dataset?.name}</span>
+        <div class='dataset-comparison-grid-ds-name'>
+          <span class='ds-name'>
+            {dataset?.name}
+          </span>
+        </div>
       )
     }
 

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
@@ -330,12 +330,14 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       // apply max lock to all grids
       Object.keys(state.gridState).forEach((gridKey) => {
         const gridCell : GridCellState = state.gridState[gridKey]!
-        const maxIntensity = gridCell.intensity.max.clipped || gridCell.intensity.max.image
-        const minIntensity = gridCell.intensity.min.clipped || gridCell.intensity.min.image
-        handleIonIntensityLockChange(undefined, gridKey, 'min')
-        handleIonIntensityLockChange(undefined, gridKey, 'max')
-        handleIonIntensityChange(minIntensity, gridKey, 'min')
-        handleIonIntensityChange(maxIntensity, gridKey, 'max')
+        if (gridCell) {
+          const maxIntensity = gridCell.intensity.max.clipped || gridCell.intensity.max.image
+          const minIntensity = gridCell.intensity.min.clipped || gridCell.intensity.min.image
+          handleIonIntensityLockChange(undefined, gridKey, 'min')
+          handleIonIntensityLockChange(undefined, gridKey, 'max')
+          handleIonIntensityChange(minIntensity, gridKey, 'min')
+          handleIonIntensityChange(maxIntensity, gridKey, 'max')
+        }
       })
     }
 

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
@@ -3,10 +3,10 @@ import './DatasetComparisonGrid.scss'
 import MainImageHeader from '../../Annotations/annotation-widgets/default/MainImageHeader.vue'
 import Vue from 'vue'
 import createColormap from '../../../lib/createColormap'
-import { loadPngFromUrl, processIonImage, renderScaleBar } from '../../../lib/ionImageRendering'
+import { IonImage, loadPngFromUrl, processIonImage, renderScaleBar } from '../../../lib/ionImageRendering'
 import IonImageViewer from '../../../components/IonImageViewer'
 import safeJsonParse from '../../../lib/safeJsonParse'
-import fitImageToArea from '../../../lib/fitImageToArea'
+import fitImageToArea, { FitImageToAreaResult } from '../../../lib/fitImageToArea'
 import FadeTransition from '../../../components/FadeTransition'
 import OpacitySettings from '../../ImageViewer/OpacitySettings.vue'
 import RangeSlider from '../../../components/Slider/RangeSlider.vue'
@@ -14,11 +14,12 @@ import IonIntensity from '../../ImageViewer/IonIntensity.vue'
 import ImageSaver from '../../ImageViewer/ImageSaver.vue'
 import getColorScale from '../../../lib/getColorScale'
 import { THUMB_WIDTH } from '../../../components/Slider'
-import { isEqual } from 'lodash-es'
 import { encodeParams } from '../../Filters'
 import StatefulIcon from '../../../components/StatefulIcon.vue'
 import { ExternalWindowSvg } from '../../../design/refactoringUIIcons'
 import { Popover } from '../../../lib/element-ui'
+import { ImagePosition } from '../../ImageViewer/ionImageState'
+import { range } from 'lodash-es'
 
 const RouterLink = Vue.component('router-link')
 
@@ -36,13 +37,28 @@ interface DatasetComparisonGridProps {
   resetViewPort: boolean
 }
 
+interface GridCellState {
+  intensity: any
+  ionImagePng: any
+  pixelSizeX: number
+  pixelSizeY: number
+  ionImageLayers: any
+  imageFit: Readonly<FitImageToAreaResult>
+  lockedIntensities: [number | undefined, number | undefined]
+  annotImageOpacity: number
+  imagePosition: ImagePosition,
+  pixelAspectRatio: number
+  imageZoom: number
+  showOpticalImage: boolean
+  userScaling: [number, number],
+  imageScaledScaling: [number, number],
+  scaleBarUrl: Readonly<string>,
+}
+
 interface DatasetComparisonGridState {
-  gridState: any,
+  gridState: Record<string, GridCellState | null>,
   grid: any,
   annotationData: any,
-  colormap: string,
-  scaleType: string,
-  scaleBarColor: string
   annotations: any[],
   refsLoaded: boolean,
   showViewer: boolean,
@@ -110,9 +126,6 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       grid: undefined,
       annotations: [],
       annotationData: {},
-      colormap: 'Viridis',
-      scaleType: 'linear',
-      scaleBarColor: '#000000',
       selectedAnnotation: props.selectedAnnotation,
       refsLoaded: false,
       showViewer: false,
@@ -163,34 +176,33 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       return Object.assign(safeJsonParse(annotation.dataset.metadataJson), datasetMetadataExternals)
     }
 
-    const imageFit = async(annotation: any, key: string, pixelAspectRatio: number = 1) => {
-      const finalImage = await ionImage(state.gridState[key]?.ionImagePng, annotation.isotopeImages[0])
-      const { width = dimensions.width, height = dimensions.height } = finalImage || {}
+    const imageFit = (key: string) => {
+      const gridCell = state.gridState[key]
+      const { width = dimensions.width, height = dimensions.height } = gridCell?.ionImagePng || {}
 
       return fitImageToArea({
         imageWidth: width,
-        imageHeight: height / (state.gridState[key]?.pixelAspectRatio || 1),
-        areaWidth: dimensions.height,
-        areaHeight: dimensions.width,
+        imageHeight: height / (gridCell?.pixelAspectRatio || 1),
+        areaWidth: dimensions.width,
+        areaHeight: dimensions.height,
       })
     }
 
     const buildRangeSliderStyle = (key: string, scaleRange: number[] = [0, 1]) => {
-      if (!refs[`range-slider-${key}`] || state.gridState[`${key}`]?.empty || !state.gridState[`${key}`]) {
+      const gridCell = state.gridState[key]
+      if (!refs[`range-slider-${key}`] || !gridCell) {
         return null
       }
 
       const width = refs[`range-slider-${key}`]?.offsetWidth
-      const activeColorMap = state.gridState[`${key}`]?.colormap
-      const ionImage = state.gridState[`${key}`]?.ionImageLayers[0]?.ionImage
-      const cmap = createColormap(activeColorMap)
-      const { range } = getColorScale(activeColorMap)
+      const ionImage = gridCell?.ionImageLayers[0]?.ionImage
+      const { range } = getColorScale(props.colormap)
       const { scaledMinIntensity, scaledMaxIntensity } = ionImage || {}
       const minColor = range[0]
       const maxColor = range[range.length - 1]
       const gradient = scaledMinIntensity === scaledMaxIntensity
         ? `linear-gradient(to right, ${range.join(',')})`
-        : ionImage ? `url(${renderScaleBar(ionImage, cmap, true)})` : ''
+        : ionImage ? `url(${gridCell?.scaleBarUrl})` : ''
       const [minScale, maxScale] = scaleRange
       const minStop = Math.ceil(THUMB_WIDTH + ((width - THUMB_WIDTH * 2) * minScale))
       const maxStop = Math.ceil(THUMB_WIDTH + ((width - THUMB_WIDTH * 2) * maxScale))
@@ -204,111 +216,87 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
     }
 
     const startImageSettings = async(key: string, annotation: any) => {
-      const hasPreviousSettings = state.gridState[key] && !state.gridState[key].empty
+      const hasPreviousSettings = state.gridState[key] != null
       const ionImagePng = await loadPngFromUrl(annotation.isotopeImages[0].url)
-      const ionImageLayersAux = await ionImageLayers(annotation, key)
-      const imageFitAux = await imageFit(annotation, key)
-      const intensity = getIntensity(ionImageLayersAux[0]?.ionImage)
-      const metadata = getMetadata(annotation)
-      const hasPreviousLockedIntensities = hasPreviousSettings && state.gridState[key].lockedIntensities
-        !== undefined
-        && (state.gridState[key].lockedIntensities[0] !== undefined
-          || state.gridState[key].lockedIntensities[1] !== undefined)
 
-      if (intensity) {
-        intensity.min.scaled = 0
-        intensity.max.scaled = intensity.max.status === 'CLIPPED'
-          ? intensity.max.clipped : intensity.max.image
-      }
-
-      const settings = {
-        intensity,
-        ionImagePng,
-        metadata,
+      let gridCell: GridCellState
+      if (hasPreviousSettings) {
+        gridCell = state.gridState[key]!
+        gridCell.ionImagePng = ionImagePng
+      } else {
+        const metadata = getMetadata(annotation)
         // eslint-disable-next-line camelcase
-        pixelSizeX: metadata?.MS_Analysis?.Pixel_Size?.Xaxis || 0,
+        const pixelSizeX = metadata?.MS_Analysis?.Pixel_Size?.Xaxis || 0
         // eslint-disable-next-line camelcase
-        pixelSizeY: metadata?.MS_Analysis?.Pixel_Size?.Yaxis || 0,
-        ionImageLayers: ionImageLayersAux,
-        imageFit: imageFitAux,
-        lockedIntensities: hasPreviousLockedIntensities
-        && state.gridState[key].lockedIntensities !== undefined
-          ? state.gridState[key].lockedIntensities : [undefined, undefined],
-        annotImageOpacity: hasPreviousSettings && state.gridState[key].annotImageOpacity !== undefined
-          ? state.gridState[key].annotImageOpacity : 1.0,
-        opacityMode: hasPreviousSettings && state.gridState[key].opacityMode !== undefined
-          ? state.gridState[key].opacityMode : 'linear',
-        imagePosition: hasPreviousSettings && state.gridState[key].imagePosition !== undefined
-          ? state.gridState[key].imagePosition : defaultImagePosition,
-        pixelAspectRatio: hasPreviousSettings && state.gridState[key].pixelAspectRatio !== undefined
-          ? state.gridState[key].pixelAspectRatio : 1,
-        imageZoom: hasPreviousSettings && state.gridState[key].imageZoom !== undefined
-          ? state.gridState[key].imageZoom : 1,
-        showOpticalImage: hasPreviousSettings && state.gridState[key].showOpticalImage !== undefined
-          ? state.gridState[key].showOpticalImage : true,
-        colormap: hasPreviousSettings && state.gridState[key].colormap !== undefined
-          ? state.gridState[key].colormap : state.colormap,
-        scaleType: hasPreviousSettings && state.gridState[key].scaleType !== undefined
-          ? state.gridState[key].scaleType : 'linear',
-        scaleBarColor: hasPreviousSettings && state.gridState[key].scaleBarColor !== undefined
-          ? state.gridState[key].scaleBarColor : '#000000',
-        userScaling: hasPreviousLockedIntensities && state.gridState[key].userScaling !== undefined
-          ? state.gridState[key].userScaling : [0, 1],
-        imageScaledScaling: hasPreviousLockedIntensities
-        && state.gridState[key].imageScaledScaling !== undefined
-          ? state.gridState[key].imageScaledScaling : [0, 1],
+        const pixelSizeY = metadata?.MS_Analysis?.Pixel_Size?.Yaxis || 0
+
+        gridCell = reactive({
+          intensity: null, // @ts-ignore // Gets set later, because ionImageLayers needs state.gridState[key] set
+          ionImagePng,
+          pixelSizeX,
+          pixelSizeY,
+          // ionImageLayers and imageFit rely on state.gridState[key] to be correctly set - avoid evaluating them
+          // until this has been inserted into state.gridState
+          ionImageLayers: computed(() => ionImageLayers(key)),
+          imageFit: computed(() => imageFit(key)),
+          lockedIntensities: [undefined, undefined],
+          annotImageOpacity: 1.0,
+          imagePosition: defaultImagePosition(),
+          pixelAspectRatio: pixelSizeX && pixelSizeY && pixelSizeX / pixelSizeY,
+          imageZoom: 1,
+          showOpticalImage: true,
+          userScaling: [0, 1],
+          imageScaledScaling: [0, 1],
+          scaleBarUrl: computed(() => renderScaleBar(
+            gridCell.ionImageLayers[0]?.ionImage,
+            createColormap(props.colormap),
+            true,
+          )),
+        })
+        Vue.set(state.gridState, key, gridCell)
       }
+      const intensity = getIntensity(gridCell.ionImageLayers[0]?.ionImage)
 
-      Vue.set(state.gridState, key, settings)
-      Vue.set(state.annotationData, key, annotation)
-      await handleImageLayerUpdate(state.annotationData[key], key)
-
+      intensity.min.scaled = 0
+      intensity.max.scaled = intensity.max.status === 'CLIPPED'
+        ? intensity.max.clipped : intensity.max.image
+      gridCell.intensity = intensity
       // persist ion intensity lock status
-      if (hasPreviousSettings && state.gridState[key].lockedIntensities !== undefined) {
-        if (state.gridState[key].lockedIntensities[0] !== undefined) {
-          await handleIonIntensityLockChange(state.gridState[key].lockedIntensities[0]
-            , key, 'min', false)
+      if (hasPreviousSettings && gridCell.lockedIntensities !== undefined) {
+        if (gridCell.lockedIntensities[0] !== undefined) {
+          await handleIonIntensityLockChange(gridCell.lockedIntensities[0], key, 'min')
         }
-        if (state.gridState[key].lockedIntensities[1] !== undefined) {
-          await handleIonIntensityLockChange(state.gridState[key].lockedIntensities[1]
-            , key, 'max', false)
+        if (gridCell.lockedIntensities[1] !== undefined) {
+          await handleIonIntensityLockChange(gridCell.lockedIntensities[1], key, 'max')
         }
       }
     }
 
-    const unsetAnnotation = (key: string) => {
-      Vue.set(state.annotationData, key, { empty: true })
-      Vue.set(state.gridState, key, { empty: true })
-    }
-
-    const getAnnotationData = (grid: any, annotationIdx = 0) => {
-      if (!grid || !annotations.value || annotations.value.length === 0 || annotationIdx === -1) {
+    const updateAnnotationData = (grid: any, annotationIdx = 0) => {
+      if (!grid || !props.annotations || props.annotations.length === 0 || annotationIdx === -1) {
         state.annotationData = {}
         state.gridState = {}
         state.firstLoaded = true
-        return {}
+        return
       }
 
       const auxGrid = grid
-      const selectedAnnotation = annotations.value[annotationIdx]
-      const settingPromises = Object.keys(auxGrid).map(async(key) => {
+      const selectedAnnotation = props.annotations[annotationIdx]
+      const settingPromises = Object.keys(auxGrid).map((key) => {
         const item = auxGrid[key]
         const dsIndex = selectedAnnotation
           ? selectedAnnotation.datasetIds.findIndex((dsId: string) => dsId === item) : -1
         if (dsIndex !== -1) {
+          Vue.set(state.annotationData, key, selectedAnnotation.annotations[dsIndex])
           return startImageSettings(key, selectedAnnotation.annotations[dsIndex])
         } else {
-          return unsetAnnotation(key)
+          Vue.set(state.annotationData, key, null)
+          Vue.set(state.gridState, key, null)
         }
       })
 
       Promise.all(settingPromises)
-        .then((values) => {
-          // pass
-        })
-        .catch((e) => {
-          // pass
-        })
+        .catch(console.error)
         .finally(() => {
           state.firstLoaded = true
           resizeHandler()
@@ -321,55 +309,28 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       }
       return {}
     })
-    const selectedAnnotation = computed(() => props.selectedAnnotation)
-    const annotations = computed(() => props.annotations)
-    const resetAllViewPort = computed(() => props.resetViewPort)
-    const colormap = computed(() => props.colormap)
-    const scaleType = computed(() => props.scaleType)
-    const scaleBarColor = computed(() => props.scaleBarColor)
 
     // set images and annotation related items when selected annotation changes
-    watch(selectedAnnotation, (newValue) => {
-      getAnnotationData(settings.value.grid, newValue)
+    watch(() => props.selectedAnnotation, (newValue) => {
+      updateAnnotationData(settings.value.grid, newValue)
     })
 
     // reset view port globally
-    watch(resetAllViewPort, (newValue) => {
+    watch(() => props.resetViewPort, (newValue) => {
       if (newValue) {
         emit('resetViewPort', false)
-        resetGlobalViewPort()
+        Object.keys(state.gridState).forEach((key: string) => {
+          resetViewPort(null, key)
+        })
       }
     })
 
-    // change colormap globally
-    watch(colormap, (newValue) => {
-      if (state.colormap !== newValue) {
-        state.colormap = newValue
-        handleGlobalColormapChange(newValue)
-      }
-    })
-
-    // change scaleType globally
-    watch(scaleType, (newValue) => {
-      if (state.scaleType !== newValue) {
-        state.scaleType = newValue
-        handleGlobalScaleTypeChange(newValue)
-      }
-    })
-
-    // change scaleBarColor globally
-    watch(scaleBarColor, (newValue) => {
-      if (state.scaleBarColor !== newValue) {
-        state.scaleBarColor = newValue
-        handleGlobalScaleBarColorChange(newValue)
-      }
-    })
-
-    const defaultImagePosition = {
-      zoom: 0.7,
+    const defaultImagePosition = () => ({
+      // This is a function so that it always makes a separate copy for each image
+      zoom: 1,
       xOffset: 0,
       yOffset: 0,
-    }
+    })
 
     const getIntensityData = (
       image: number, clipped: number, scaled: number, user: number, quantile: number, isLocked?: boolean,
@@ -385,15 +346,15 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       }
     }
 
-    const getIntensity = (ionImage: any, lockedIntensities: any = []) => {
-      if (ionImage !== null) {
+    const getIntensity = (ionImage: IonImage, lockedIntensities: any = []) => {
+      if (ionImage != null) {
         const {
           minIntensity, maxIntensity,
           clippedMinIntensity, clippedMaxIntensity,
           scaledMinIntensity, scaledMaxIntensity,
           userMinIntensity, userMaxIntensity,
           lowQuantile, highQuantile,
-        } = ionImage || {}
+        } = ionImage
         const [lockedMin, lockedMax] = lockedIntensities
 
         return {
@@ -415,63 +376,62 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
           ),
         }
       }
-      return null
+      return {
+        min: getIntensityData(0, 0, 0, 0, 0, false),
+        max: getIntensityData(0, 0, 0, 0, 0, false),
+      }
     }
 
-    const ionImage = async(ionImagePng: any, isotopeImage: any,
+    const ionImage = (ionImagePng: any, isotopeImage: any,
       scaleType: any = 'linear', userScaling: any = [0, 1]) => {
-      if (!isotopeImage) {
+      if (!isotopeImage || !ionImagePng) {
         return null
       }
       const { minIntensity, maxIntensity } = isotopeImage
-      const png = await loadPngFromUrl(isotopeImage.url)
-      return png
-        ? processIonImage(png, minIntensity, maxIntensity, scaleType, userScaling) : null
+      return processIonImage(ionImagePng, minIntensity, maxIntensity, scaleType, userScaling)
     }
 
-    const ionImageLayers = async(annotation: any, key: string,
-      colormap: string = 'Viridis', opacityMode: any = 'linear') => {
-      const finalImage = await ionImage(state.gridState[key]?.ionImagePng,
+    const ionImageLayers = (key: string) => {
+      const annotation = state.annotationData[key]
+      const gridCell = state.gridState[key]
+
+      if (annotation == null || gridCell == null) {
+        return []
+      }
+      const finalImage = ionImage(gridCell.ionImagePng,
         annotation.isotopeImages[0],
-        state.gridState[key]?.scaleType, state.gridState[key]?.imageScaledScaling)
-      const hasOpticalImage = state.annotationData[key]?.dataset?.opticalImages[0]?.url
-        !== undefined
+        props.scaleType, gridCell.imageScaledScaling)
+      const hasOpticalImage = annotation.dataset.opticalImages[0]?.url !== undefined
 
       if (finalImage) {
         return [{
           ionImage: finalImage,
-          colorMap: createColormap(state.gridState[key]?.colormap || colormap,
-            hasOpticalImage && state.gridState[key]?.showOpticalImage
-              ? (state.gridState[key]?.opacityMode || opacityMode) : 'constant',
-            hasOpticalImage && state.gridState[key]?.showOpticalImage
-              ? (state.gridState[key]?.annotImageOpacity || 1) : 1),
+          colorMap: createColormap(props.colormap,
+            hasOpticalImage && gridCell.showOpticalImage
+              ? 'linear' : 'constant',
+            hasOpticalImage && gridCell.showOpticalImage
+              ? (gridCell.annotImageOpacity || 1) : 1),
         }]
       }
       return []
-    }
-
-    const resetGlobalViewPort = () => {
-      Object.keys(state.gridState).forEach((key: string) => {
-        resetViewPort(null, key)
-      })
     }
 
     const resetViewPort = (event: any, key: string) => {
       if (event) {
         event.stopPropagation()
       }
-      Vue.set(state.gridState, key, { ...state.gridState[key], imagePosition: defaultImagePosition })
+      if (state.gridState[key]) {
+        state.gridState[key]!.imagePosition = defaultImagePosition()
+      }
     }
 
-    const toggleOpticalImage = async(event: any, key: string) => {
+    const toggleOpticalImage = (event: any, key: string) => {
       event.stopPropagation()
-      Vue.set(state.gridState, key, {
-        ...state.gridState[key],
-        showOpticalImage: !state.gridState[key].showOpticalImage,
-        annotImageOpacity:
-          !state.gridState[key].showOpticalImage ? state.gridState[key].annotImageOpacity : 1,
-      })
-      await handleImageLayerUpdate(state.annotationData[key], key)
+      const gridCell = state.gridState[key]
+      if (gridCell != null) {
+        gridCell.showOpticalImage = !gridCell.showOpticalImage
+        gridCell.annotImageOpacity = gridCell.showOpticalImage ? gridCell.annotImageOpacity : 1
+      }
     }
     const formatMSM = (value: number) => {
       return value.toFixed(3)
@@ -481,16 +441,13 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       return value ? `${Math.round(value * 100)}%` : '-'
     }
 
-    const handleImageMove = ({ zoom, xOffset, yOffset }: any, imageFit: any, key: string) => {
-      Vue.set(state.gridState, key, {
-        ...state.gridState[key],
-        imagePosition: {
-          ...state.gridState[key].imagePosition,
-          zoom: zoom / imageFit.imageZoom,
-          xOffset,
-          yOffset,
-        },
-      })
+    const handleImageMove = ({ zoom, xOffset, yOffset }: any, key: string) => {
+      const gridCell = state.gridState[key]
+      if (gridCell != null) {
+        gridCell.imagePosition.zoom = zoom / gridCell.imageFit.imageZoom
+        gridCell.imagePosition.xOffset = xOffset
+        gridCell.imagePosition.yOffset = yOffset
+      }
     }
 
     const annotationsLink = (datasetId: string, database?: string, fdrLevel?: number) => {
@@ -514,40 +471,26 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       }
     }
 
-    const handleImageLayerUpdate = async(annotation: any, key: string) => {
-      const ionImageLayersAux = await ionImageLayers(annotation, key)
-      Vue.set(state.gridState, key, { ...state.gridState[key], ionImageLayers: ionImageLayersAux })
+    const handleOpacityChange = (opacity: any, key: string) => {
+      state.gridState[key]!.annotImageOpacity = opacity
     }
 
-    const handleGlobalColormapChange = (colormap: string) => {
-      Object.keys(state.gridState).forEach((key: string) => {
-        handleColormapChange(colormap, key)
-      })
-    }
-
-    const handleColormapChange = async(colormap: string, key: string) => {
-      Vue.set(state.gridState, key, { ...state.gridState[key], colormap })
-      await handleImageLayerUpdate(state.annotationData[key], key)
-    }
-
-    const handleOpacityChange = async(opacity: any, key: string) => {
-      Vue.set(state.gridState, key, { ...state.gridState[key], annotImageOpacity: opacity })
-      await handleImageLayerUpdate(state.annotationData[key], key)
-    }
-
-    const handleUserScalingChange = async(userScaling: any, key: string) => {
-      const maxIntensity = state.gridState[key].intensity.max.status === 'CLIPPED'
-        ? state.gridState[key].intensity.max.clipped : state.gridState[key].intensity.max.image
+    const handleUserScalingChange = (userScaling: any, key: string) => {
+      const gridCell = state.gridState[key]
+      if (gridCell == null) {
+        return
+      }
+      const maxIntensity = gridCell.intensity.max.status === 'CLIPPED'
+        ? gridCell.intensity.max.clipped : gridCell.intensity.max.image
       const minScale =
-        state.gridState[key].intensity?.min?.status === 'LOCKED'
+        gridCell.intensity?.min?.status === 'LOCKED'
           ? userScaling[0] * (1
-          - (state.gridState[key].intensity.min.user / maxIntensity))
-          + (state.gridState[key].intensity.min.user / maxIntensity)
+          - (gridCell.intensity.min.user / maxIntensity))
+          + (gridCell.intensity.min.user / maxIntensity)
           : userScaling[0]
 
-      const maxScale = userScaling[1] * (state.gridState[key].intensity?.max?.status === 'LOCKED'
-        ? state.gridState[key].intensity.max.user / maxIntensity : 1)
-      const scale = [minScale, maxScale]
+      const maxScale = userScaling[1] * (gridCell.intensity?.max?.status === 'LOCKED'
+        ? gridCell.intensity.max.user / maxIntensity : 1)
       const rangeSliderScale = userScaling.slice(0)
 
       // added in order to keep consistency even with ignore boundaries
@@ -558,56 +501,34 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
         rangeSliderScale[1] = 1
       }
 
-      Vue.set(state.gridState, key, {
-        ...state.gridState[key],
-        userScaling: rangeSliderScale,
-        imageScaledScaling: scale,
-        intensity: {
-          ...state.gridState[key].intensity,
-          min:
-            {
-              ...state.gridState[key].intensity.min,
-              scaled:
-                state.gridState[key].intensity?.min?.status === 'LOCKED'
-                && maxIntensity * userScaling[0]
-                < state.gridState[key].intensity.min.user
-                  ? state.gridState[key].intensity.min.user
-                  : maxIntensity * userScaling[0],
-            },
-          max:
-            {
-              ...state.gridState[key].intensity.max,
-              scaled:
+      gridCell.userScaling = rangeSliderScale
+      gridCell.imageScaledScaling = [minScale, maxScale]
 
-                state.gridState[key].intensity?.max?.status === 'LOCKED'
-                && maxIntensity * userScaling[1]
-                > state.gridState[key].intensity.max.user
-                  ? state.gridState[key].intensity.max.user
-                  : maxIntensity * userScaling[1],
-            },
-        },
-      })
+      gridCell.intensity.min.scaled =
+        gridCell.intensity?.min?.status === 'LOCKED'
+        && maxIntensity * userScaling[0]
+        < gridCell.intensity.min.user
+          ? gridCell.intensity.min.user
+          : maxIntensity * userScaling[0]
 
-      await handleImageLayerUpdate(state.annotationData[key], key)
+      gridCell.intensity.max.scaled =
+        gridCell.intensity?.max?.status === 'LOCKED'
+        && maxIntensity * userScaling[1]
+        > gridCell.intensity.max.user
+          ? gridCell.intensity.max.user
+          : maxIntensity * userScaling[1]
     }
 
-    const handleGlobalScaleTypeChange = (scaleType: string) => {
-      Object.keys(state.gridState).forEach((key: string) => {
-        handleScaleTypeChange(scaleType, key)
-      })
-    }
-
-    const handleScaleTypeChange = async(scaleType: string, key: string) => {
-      Vue.set(state.gridState, key, { ...state.gridState[key], scaleType })
-      await handleImageLayerUpdate(state.annotationData[key], key)
-    }
-
-    const handleIonIntensityChange = async(intensity: number, key: string, type: string,
+    const handleIonIntensityChange = (intensity: number, key: string, type: string,
       ignoreBoundaries : boolean = false) => {
-      let minScale = state.gridState[key].userScaling[0]
-      let maxScale = state.gridState[key].userScaling[1]
-      const maxIntensity = state.gridState[key].intensity.max.status === 'CLIPPED'
-        ? state.gridState[key].intensity.max.clipped : state.gridState[key].intensity.max.image
+      const gridCell = state.gridState[key]
+      if (gridCell == null) {
+        return
+      }
+      let minScale = gridCell.userScaling[0]
+      let maxScale = gridCell.userScaling[1]
+      const maxIntensity = gridCell.intensity.max.status === 'CLIPPED'
+        ? gridCell.intensity.max.clipped : gridCell.intensity.max.image
 
       if (type === 'min') {
         minScale = intensity / maxIntensity
@@ -628,13 +549,14 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       handleUserScalingChange([minScale, maxScale], key)
     }
 
-    const handleIonIntensityLockChange = async(value: number, key: string, type: string,
-      applyToAll : boolean = true) => {
-      const minLocked = type === 'min' ? value : state.gridState[key].lockedIntensities[0]
-      const maxLocked = type === 'max' ? value : state.gridState[key].lockedIntensities[1]
-      const lockedIntensities = [minLocked, maxLocked]
-      const intensity = getIntensity(state.gridState[`${key}`]?.ionImageLayers[0]?.ionImage,
-        lockedIntensities)
+    const handleIonIntensityLockChange = (value: number, key: string, type: string) => {
+      const gridCell = state.gridState[key]
+      if (gridCell == null) {
+        return
+      }
+      const minLocked = type === 'min' ? value : gridCell.lockedIntensities[0]
+      const maxLocked = type === 'max' ? value : gridCell.lockedIntensities[1]
+      const intensity = getIntensity(gridCell.ionImageLayers[0]?.ionImage, [minLocked, maxLocked])
 
       if (intensity && intensity.max && maxLocked && intensity.max.status === 'LOCKED') {
         intensity.max.scaled = maxLocked
@@ -649,50 +571,27 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       if (intensity && intensity.min !== undefined && intensity.min.status !== 'LOCKED'
       ) {
         intensity.min.scaled = 0
-        Vue.set(state.gridState, key, {
-          ...state.gridState[key],
-          imageScaledScaling: [0, state.gridState[`${key}`].imageScaledScaling[1]],
-        })
+        gridCell.imageScaledScaling = [0, gridCell.imageScaledScaling[1]]
       }
       if (intensity && intensity.max !== undefined && intensity.max.status !== 'LOCKED') {
         intensity.max.scaled = intensity.max.status === 'CLIPPED'
           ? intensity.max.clipped : intensity.max.image
-        Vue.set(state.gridState, key, {
-          ...state.gridState[key],
-          imageScaledScaling: [state.gridState[`${key}`].imageScaledScaling[0], 1],
-        })
+        gridCell.imageScaledScaling = [gridCell.imageScaledScaling[0], 1]
       }
 
-      Vue.set(state.gridState, key, {
-        ...state.gridState[key],
-        lockedIntensities: lockedIntensities,
-        intensity: intensity,
-        userScaling: [0, 1],
-      })
+      gridCell.lockedIntensities = [minLocked, maxLocked]
+      gridCell.intensity = intensity
+      gridCell.userScaling = [0, 1]
+    }
 
+    const handleIonIntensityLockChangeForAll = (value: number, type: string) => {
       // apply max lock to all grids
-      if (applyToAll) {
-        Object.keys(state.gridState).forEach((gridKey) => {
-          if (gridKey !== key) {
-            handleIonIntensityLockChange(value, gridKey, type, false)
-            if (value) {
-              handleIonIntensityChange(value, gridKey, type, true)
-            }
-          }
-        })
-      }
-
-      await handleImageLayerUpdate(state.annotationData[key], key)
-    }
-
-    const handleGlobalScaleBarColorChange = (scaleBarColor: string) => {
-      Object.keys(state.gridState).forEach((key: string) => {
-        handleScaleBarColorChange(scaleBarColor, key)
+      Object.keys(state.gridState).forEach((gridKey) => {
+        handleIonIntensityLockChange(value, gridKey, type)
+        if (value) {
+          handleIonIntensityChange(value, gridKey, type, true)
+        }
       })
-    }
-
-    const handleScaleBarColorChange = async(scaleBarColor: string, key: string) => {
-      Vue.set(state.gridState, key, { ...state.gridState[key], scaleBarColor })
     }
 
     const renderDatasetName = (row: number, col: number) => {
@@ -706,12 +605,13 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
     }
 
     const renderImageViewerHeaders = (row: number, col: number) => {
+      const key = `${row}-${col}`
+      const gridCell = state.gridState[key]
+      const annData = state.annotationData[key]
       if (
-        (!props.isLoading
-          && state.annotationData[`${row}-${col}`]?.empty
-          && state.gridState[`${row}-${col}`]?.empty)
-        || (!props.isLoading && selectedAnnotation.value === -1)
-        || (selectedAnnotation.value >= annotations.value.length)
+        (!props.isLoading && annData == null && gridCell == null)
+        || (!props.isLoading && props.selectedAnnotation === -1)
+        || (props.selectedAnnotation >= props.annotations.length)
       ) {
         return (
           <div key={col} class='dataset-comparison-grid-col overflow-hidden items-center justify-start'
@@ -724,33 +624,29 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       return (
         <div key={col} class='dataset-comparison-grid-col overflow-hidden relative'
           style={{ height: 200, width: 200 }}>
-          {
-            state.gridState
-            && state.gridState[`${row}-${col}`]
-            && renderDatasetName(row, col)
-          }
+          {gridCell && renderDatasetName(row, col)}
           <MainImageHeader
             class='dataset-comparison-grid-item-header dom-to-image-hidden'
-            annotation={state.annotationData[`${row}-${col}`]}
+            annotation={annData}
             slot="title"
             isActive={false}
             hideOptions={true}
-            showOpticalImage={!!state.gridState[`${row}-${col}`]?.showOpticalImage}
-            toggleOpticalImage={(e: any) => toggleOpticalImage(e, `${row}-${col}`)}
-            resetViewport={(e: any) => resetViewPort(e, `${row}-${col}`)}
+            showOpticalImage={!!gridCell?.showOpticalImage}
+            toggleOpticalImage={(e: any) => toggleOpticalImage(e, key)}
+            resetViewport={(e: any) => resetViewPort(e, key)}
             hasOpticalImage={
-              state.annotationData[`${row}-${col}`]?.dataset?.opticalImages[0]?.url
+              annData?.dataset?.opticalImages[0]?.url
               !== undefined}
           />
           {
-            state.annotationData[`${row}-${col}`]
-            && state.annotationData[`${row}-${col}`].msmScore
+            annData
+            && annData.msmScore
             && <div class="dataset-comparison-extra dom-to-image-hidden">
               <div class="dataset-comparison-msm-badge">
-                MSM <b>{formatMSM(state.annotationData[`${row}-${col}`].msmScore)}</b>
+                MSM <b>{formatMSM(annData.msmScore)}</b>
               </div>
               <div class="dataset-comparison-fdr-badge">
-                FDR <b>{formatFDR(state.annotationData[`${row}-${col}`].fdrLevel)}</b>
+                FDR <b>{formatFDR(annData.fdrLevel)}</b>
               </div>
               <Popover
                 trigger="hover"
@@ -759,10 +655,9 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
                 <div slot="reference" class="dataset-comparison-link">
                   <RouterLink
                     target='_blank'
-                    to={annotationsLink(state.annotationData[`${row}-${col}`].dataset.id.toString(),
-                      state.annotationData[`${row}-${col}`].databaseDetails.id.toString(),
-                      state.annotationData[`${row}-${col}`].databaseDetails.fdrLevel)}>
-
+                    to={annotationsLink(annData.dataset.id.toString(),
+                      annData.databaseDetails.id.toString(),
+                      annData.databaseDetails.fdrLevel)}>
                     <StatefulIcon className="h-6 w-6 pointer-events-none">
                       <ExternalWindowSvg/>
                     </StatefulIcon>
@@ -783,96 +678,91 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
             }
             {
               !props.isLoading
-              && state.gridState[`${row}-${col}`]
-              && state.gridState[`${row}-${col}`].ionImageLayers
+              && gridCell
+              && gridCell.ionImageLayers
               && <IonImageViewer
                 isLoading={props.isLoading || !state.firstLoaded}
-                ionImageLayers={state.gridState[`${row}-${col}`]?.ionImageLayers}
-                scaleBarColor={state.gridState[`${row}-${col}`]?.scaleBarColor}
-                scaleType={state.gridState[`${row}-${col}`]?.scaleType}
-                pixelSizeX={state.gridState[`${row}-${col}`]?.pixelSizeX}
-                pixelSizeY={state.gridState[`${row}-${col}`]?.pixelSizeY}
-                imageHeight={state.gridState[`${row}-${col}`]?.
-                  ionImageLayers[0]?.ionImage?.height }
-                imageWidth={state.gridState[`${row}-${col}`]?.
-                  ionImageLayers[0]?.ionImage?.width }
+                ionImageLayers={gridCell.ionImageLayers}
+                scaleBarColor={props.scaleBarColor}
+                scaleType={props.scaleType}
+                pixelSizeX={gridCell.pixelSizeX}
+                pixelSizeY={gridCell.pixelSizeY}
+                pixelAspectRatio={gridCell.pixelAspectRatio}
+                imageHeight={gridCell.ionImageLayers[0]?.ionImage?.height }
+                imageWidth={gridCell.ionImageLayers[0]?.ionImage?.width }
                 height={dimensions.height}
                 width={dimensions.width}
-                zoom={state.gridState[`${row}-${col}`]?.imagePosition?.zoom
-                * state.gridState[`${row}-${col}`]?.imageFit?.imageZoom}
-                minZoom={state.gridState[`${row}-${col}`]?.imageFit?.imageZoom / 4}
-                maxZoom={state.gridState[`${row}-${col}`]?.imageFit?.imageZoom * 20}
-                xOffset={state.gridState[`${row}-${col}`]?.imagePosition?.xOffset || 0}
-                yOffset={state.gridState[`${row}-${col}`]?.imagePosition?.yOffset || 0}
-                opticalSrc={state.gridState[`${row}-${col}`]?.showOpticalImage
-                  ? state.annotationData[`${row}-${col}`]?.dataset?.opticalImages[0]?.url
+                zoom={gridCell.imagePosition?.zoom
+                * gridCell.imageFit.imageZoom}
+                minZoom={gridCell.imageFit.imageZoom / 4}
+                maxZoom={gridCell.imageFit.imageZoom * 20}
+                xOffset={gridCell.imagePosition?.xOffset || 0}
+                yOffset={gridCell.imagePosition?.yOffset || 0}
+                opticalSrc={gridCell.showOpticalImage
+                  ? annData?.dataset?.opticalImages[0]?.url
                   : undefined}
-                opticalTransform={state.gridState[`${row}-${col}`]?.showOpticalImage
-                  ? state.annotationData[`${row}-${col}`]?.dataset?.opticalImages[0]?.transform
+                opticalTransform={gridCell.showOpticalImage
+                  ? annData?.dataset?.opticalImages[0]?.transform
                   : undefined}
                 scrollBlock
                 showPixelIntensity
-                onMove={(e: any) =>
-                  handleImageMove(e, state.gridState[`${row}-${col}`]?.imageFit,
-                    `${row}-${col}`)}
+                onMove={(e: any) => handleImageMove(e, key)}
               />
             }
             <div class="ds-viewer-controls-wrapper  v-rhythm-3 sm-side-bar">
               <FadeTransition class="absolute bottom-0 right-0 mt-3 ml-3 dom-to-image-hidden">
                 {
-                  state.gridState[`${row}-${col}`]?.showOpticalImage
-                  && state.annotationData[`${row}-${col}`]?.dataset?.opticalImages[0]?.url
+                  gridCell?.showOpticalImage
+                  && annData?.dataset?.opticalImages[0]?.url
                   !== undefined
                   && <OpacitySettings
                     key="opacity"
                     class="ds-comparison-opacity-item sm-leading-trim mt-auto dom-to-image-hidden"
-                    opacity={state.gridState[`${row}-${col}`]?.annotImageOpacity !== undefined
-                      ? state.gridState[`${row}-${col}`]?.annotImageOpacity : 1}
-                    onOpacity={(opacity: number) => handleOpacityChange(opacity, `${row}-${col}`)}
+                    opacity={gridCell.annotImageOpacity !== undefined
+                      ? gridCell.annotImageOpacity : 1}
+                    onOpacity={(opacity: number) => handleOpacityChange(opacity, key)}
                   />
                 }
               </FadeTransition>
               <FadeTransition class="absolute top-0 right-0 mt-3 ml-3 dom-to-image-hidden">
                 {
                   state.refsLoaded
-                  && state.gridState[`${row}-${col}`]
-                  && state.gridState[`${row}-${col}`].userScaling
+                  && gridCell != null
+                  && gridCell.userScaling
                   && <div
                     class="p-3 bg-gray-100 rounded-lg box-border shadow-xs"
                     ref={`range-slider-${row}-${col}`}>
                     <RangeSlider
                       class="ds-comparison-opacity-item"
-                      value={state.gridState[`${row}-${col}`].userScaling}
+                      value={gridCell.userScaling}
                       min={0}
                       max={1}
                       step={0.01}
-                      style={buildRangeSliderStyle(`${row}-${col}`)}
+                      style={buildRangeSliderStyle(key)}
                       onInput={(nextRange: number[]) =>
-                        handleUserScalingChange(nextRange, `${row}-${col}`)}
+                        handleUserScalingChange(nextRange, key)}
                     />
                     <div
                       class="ds-intensities-wrapper">
                       <IonIntensity
-                        intensities={state.gridState[`${row}-${col}`].intensity?.min}
+                        intensities={gridCell.intensity?.min}
                         label="Minimum intensity"
                         placeholder="min."
                         onInput={(value: number) =>
-                          handleIonIntensityChange(value, `${row}-${col}`,
+                          handleIonIntensityChange(value, key,
                             'min')}
                         onLock={(value: number) =>
-                          handleIonIntensityLockChange(value, `${row}-${col}`,
-                            'min')}
+                          handleIonIntensityLockChangeForAll(value, 'min')}
                       />
                       <IonIntensity
-                        intensities={state.gridState[`${row}-${col}`]?.intensity?.max}
+                        intensities={gridCell.intensity?.max}
                         label="Minimum intensity"
                         placeholder="min."
                         onInput={(value: number) =>
-                          handleIonIntensityChange(value, `${row}-${col}`,
+                          handleIonIntensityChange(value, key,
                             'max')}
                         onLock={(value: number) =>
-                          handleIonIntensityLockChange(value, `${row}-${col}`,
-                            'max')}
+                          handleIonIntensityLockChangeForAll(value, 'max')}
                       />
                     </div>
                   </div>
@@ -895,11 +785,11 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       return (
         <div class="dataset-comparison-grid">
           {
-            Array.from(Array(props.nRows).keys()).map((row) => {
+            range(props.nRows).map((row) => {
               return (
                 <div key={row} class='dataset-comparison-grid-row'>
                   {
-                    Array.from(Array(props.nCols).keys()).map((col) => {
+                    range(props.nCols).map((col) => {
                       return renderImageViewerHeaders(row, col)
                     })
                   }

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.scss
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.scss
@@ -1,4 +1,8 @@
 .dataset-comparison-page{
+  .ds-comparison-info{
+    @apply flex items-center justify-center p-2 w-full;
+    min-height: 50px;
+  }
 
   .dataset-comparison-item-header{
     background: #F1F5F8;
@@ -44,7 +48,7 @@
   }
 
   .ds-comparison-opacity-item{
-   min-width: 160px;
+    min-width: 160px;
   }
   #annot-content {
     width: 100%;

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.spec.ts
@@ -12,6 +12,16 @@ describe('DatasetComparisonPage', () => {
     snapshot: '{"nCols":2,"nRows":1,"grid":{"0-0":"2021-04-14_07h23m35s",'
       + '"0-1":"2021-04-06_08h35m04s"}}',
   }))
+  const dsData = [{
+    id: '2021-04-14_07h23m35s',
+    name: 'Mock (1)',
+    uploadDT: '2021-03-31T14:02:28.722Z',
+  },
+  {
+    id: '2021-04-06_08h35m04s',
+    name: 'Mock (2)',
+    uploadDT: '2021-03-30T21:25:18.473Z',
+  }]
 
   const testHarness = Vue.extend({
     components: {
@@ -26,6 +36,9 @@ describe('DatasetComparisonPage', () => {
     initMockGraphqlClient({
       Query: () => ({
         imageViewerSnapshot: snapshotData,
+        allDatasets: () => {
+          return dsData
+        },
       }),
     })
   }

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
@@ -17,7 +17,6 @@ import FilterPanel from '../../Filters/FilterPanel.vue'
 import config from '../../../lib/config'
 import { DatasetListItem, datasetListItemsQuery } from '../../../api/dataset'
 import MainImageHeader from '../../Annotations/annotation-widgets/default/MainImageHeader.vue'
-import Vue from 'vue'
 
 interface GlobalImageSettings {
   resetViewPort: boolean
@@ -135,7 +134,9 @@ export default defineComponent<DatasetComparisonPageProps>({
     }))
     const annotationsQuery = useQuery<any>(comparisonAnnotationListQuery, queryVars, queryOptions)
     const datasetsQuery = useQuery<{allDatasets: DatasetListItem[]}>(datasetListItemsQuery,
-      queryVars, queryOptions)
+      {
+        dFilter: { ids: Object.values(state.grid || {}).join('|') },
+      }, queryOptions)
     const loadAnnotations = () => { queryOptions.enabled = true }
     state.annotations = computed(() => {
       if (annotationsQuery.result.value) {

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
@@ -20,6 +20,7 @@ import MainImageHeader from '../../Annotations/annotation-widgets/default/MainIm
 import CandidateMoleculesPopover from '../../Annotations/annotation-widgets/CandidateMoleculesPopover.vue'
 import MolecularFormula from '../../../components/MolecularFormula'
 import CopyButton from '../../../components/CopyButton.vue'
+import { SimpleShareLink } from './SimpleShareLink'
 
 interface GlobalImageSettings {
   resetViewPort: boolean
@@ -266,6 +267,10 @@ export default defineComponent<DatasetComparisonPageProps>({
               Copy m/z to clipboard
             </CopyButton>
           </span>
+          <SimpleShareLink
+            name={$route.name}
+            params={$route.params}
+            query={$route.query}/>
         </div>
       )
     }

--- a/metaspace/webapp/src/modules/Datasets/comparison/SimpleShareLink.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/SimpleShareLink.tsx
@@ -1,0 +1,58 @@
+import { defineComponent, reactive } from '@vue/composition-api'
+import StatefulIcon from '../../../components/StatefulIcon.vue'
+import { ExternalWindowSvg } from '../../../design/refactoringUIIcons'
+import { Popover } from '../../../lib/element-ui'
+import Vue from 'vue'
+import FadeTransition from '../../../components/FadeTransition'
+
+const RouterLink = Vue.component('router-link')
+
+interface SimpleShareLinkProps {
+  name: string
+  params: any
+  query: any
+}
+
+export const SimpleShareLink = defineComponent<SimpleShareLinkProps>({
+  name: 'SimpleShareLink',
+  props: {
+    name: { type: String, required: true },
+    params: { type: Object },
+    query: { type: Object },
+  },
+  setup(props, ctx) {
+    const getUrl = () => {
+      return {
+        name: props.name,
+        params: props.params,
+        query: props.query,
+      }
+    }
+
+    return () => {
+      return (
+        <Popover
+          trigger="hover"
+          placement="bottom">
+          <div
+            slot="reference"
+            class="button-reset h-6 w-6 block ml-2">
+            <StatefulIcon className="h-6 w-6 pointer-events-none">
+              <ExternalWindowSvg/>
+            </StatefulIcon>
+          </div>
+          <FadeTransition class="m-0 leading-5 text-center">
+            <div>
+              <RouterLink to={getUrl()} target="_blank">
+                  Share this link
+              </RouterLink>
+              <span class="block text-xs tracking-wide">
+                opens in a new window
+              </span>
+            </div>
+          </FadeTransition>
+        </Popover>
+      )
+    }
+  },
+})

--- a/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonAnnotationTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonAnnotationTable.spec.ts.snap
@@ -39,7 +39,7 @@ exports[`DatasetComparisonAnnotationTable it should match snapshot 1`] = `
               <div class="cell">m/z<span class="caret-wrapper"><i class="sort-caret ascending"></i><i class="sort-caret descending"></i></span></div>
             </th>
             <th colspan="1" rowspan="1" class="el-table_1_column_4     is-leaf is-sortable">
-              <div class="cell"># of datasets<span class="caret-wrapper"><i class="sort-caret ascending"></i><i class="sort-caret descending"></i></span></div>
+              <div class="cell">Datasets #<span class="caret-wrapper"><i class="sort-caret ascending"></i><i class="sort-caret descending"></i></span></div>
             </th>
             <th colspan="1" rowspan="1" class="el-table_1_column_5 ascending  fdr-cell  is-leaf is-sortable">
               <div class="cell">

--- a/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonGrid.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonGrid.spec.ts.snap
@@ -1,9 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DatasetComparisonAnnotationTable it should match snapshot 1`] = `
+exports[`DatasetComparisonGrid it should match snapshot 1`] = `
 <div
   annotations="[object Object]"
   class="dataset-comparison-grid"
+  datasets="[object Object],[object Object]"
   ncols="2"
   nrows="1"
   selectedannotation="0"
@@ -16,6 +17,12 @@ exports[`DatasetComparisonAnnotationTable it should match snapshot 1`] = `
       class="dataset-comparison-grid-col overflow-hidden relative"
     >
       <span
+        class="dataset-comparison-grid-ds-name"
+      >
+        New test create
+      </span>
+      <span
+        annotation="[object Object]"
         class="w-full dataset-comparison-grid-item-header dom-to-image-hidden"
         slot="title"
       >
@@ -411,8 +418,94 @@ exports[`DatasetComparisonAnnotationTable it should match snapshot 1`] = `
         />
       </span>
       <div
+        class="dataset-comparison-extra dom-to-image-hidden"
+      >
+        <div
+          class="dataset-comparison-msm-badge"
+        >
+          MSM 
+          <b>
+            0.736
+          </b>
+        </div>
+        <div
+          class="dataset-comparison-fdr-badge"
+        >
+          FDR 
+          <b>
+            5%
+          </b>
+        </div>
+        <mock-el-popover
+          placement="right"
+          trigger="hover"
+        >
+          <div
+            slot-key="default"
+          >
+            Individual dataset annotation page.
+          </div>
+          <div
+            slot-key="reference"
+          >
+            <div
+              class="dataset-comparison-link"
+            >
+              <a
+                class=""
+                href="/annotations?db_id=1&ds=2021-04-14_07h23m35s"
+                target="_blank"
+              >
+                <i
+                  class="flex"
+                  classname="h-6 w-6 pointer-events-none"
+                >
+                  <svg
+                    data-icon="icon-external-window"
+                  />
+                </i>
+              </a>
+            </div>
+          </div>
+        </mock-el-popover>
+      </div>
+      <div
         class="ds-wrapper relative"
       >
+        <div
+          class="relative overflow-hidden"
+          mock-v-loading="false"
+          scaletype="linear"
+          style="width: 410px; height: 300px;"
+        >
+          <div
+            class="scale-bar"
+          >
+            <div
+              class="scale-bar-x"
+              style="color: rgb(0, 0, 0); border-color: #000000; width: 83.33333333333333px;"
+            >
+              <div
+                class="scale-bar-x-text"
+              >
+                
+      1 mm
+    
+              </div>
+            </div>
+             
+            <!---->
+          </div>
+          <div
+            class="absolute inset-0 z-30 pointer-events-none bg-body flex items-center justify-center opacity-0 duration-1000"
+          >
+            <p
+              class="relative block z-40 m-0 text-white text-2xl"
+            >
+              Use CTRL + scroll wheel to zoom the image
+            </p>
+          </div>
+        </div>
         <div
           class="ds-viewer-controls-wrapper  v-rhythm-3 sm-side-bar"
         >
@@ -431,7 +524,95 @@ exports[`DatasetComparisonAnnotationTable it should match snapshot 1`] = `
             leaveactiveclass="duration-150 transition-opacity ease-in-out"
             leavetoclass="opacity-0"
             mode="out-in"
-          />
+          >
+            <div
+              class="p-3 bg-gray-100 rounded-lg box-border shadow-xs"
+            >
+              <div
+                class="box-border h-3 relative rounded-full bg-gray-100 sm-slider-track cursor-pointer ds-comparison-opacity-item"
+              >
+                <div
+                  class="box-border h-3 w-3 absolute bg-gray-100 border-2 border-solid border-gray-300 rounded-full cursor-pointer"
+                  style="left: -1px;"
+                  tabindex="0"
+                />
+                 
+                <div
+                  class="box-border h-3 w-3 absolute bg-gray-100 border-2 border-solid border-gray-300 rounded-full cursor-pointer"
+                  style="left: -11px;"
+                  tabindex="0"
+                />
+              </div>
+              <div
+                class="ds-intensities-wrapper"
+              >
+                <transition-stub
+                  enteractiveclass="duration-150 transition-opacity ease-in-out"
+                  enterclass="opacity-0"
+                  leaveactiveclass="duration-150 transition-opacity ease-in-out"
+                  leavetoclass="opacity-0"
+                  mode="out-in"
+                >
+                  <div
+                    class="h-5 flex items-center sm-flex-direction"
+                  >
+                    <button
+                      class="button-reset h-4 leading-5"
+                      title="Click to edit"
+                    >
+                      
+      0.0e+0
+    
+                    </button>
+                     
+                    <button
+                      class="button-reset h-4 mx-1"
+                      title="Lock intensity"
+                    >
+                      <svg
+                        class="fill-current text-gray-600"
+                        data-icon="icon-lock"
+                      />
+                    </button>
+                     
+                    <!---->
+                  </div>
+                </transition-stub>
+                <transition-stub
+                  enteractiveclass="duration-150 transition-opacity ease-in-out"
+                  enterclass="opacity-0"
+                  leaveactiveclass="duration-150 transition-opacity ease-in-out"
+                  leavetoclass="opacity-0"
+                  mode="out-in"
+                >
+                  <div
+                    class="h-5 flex items-center sm-flex-direction"
+                  >
+                    <button
+                      class="button-reset h-4 leading-5"
+                      title="Click to edit"
+                    >
+                      
+      0.0e+0
+    
+                    </button>
+                     
+                    <button
+                      class="button-reset h-4 mx-1"
+                      title="Lock intensity"
+                    >
+                      <svg
+                        class="fill-current text-gray-600"
+                        data-icon="icon-lock"
+                      />
+                    </button>
+                     
+                    <!---->
+                  </div>
+                </transition-stub>
+              </div>
+            </div>
+          </transition-stub>
         </div>
         <button
           class="button-reset rounded-full bg-gray-100 shadow-xs h-8 w-8 flex items-center justify-center cursor-not-allowed absolute top-0 left-0 mt-3 ml-3 dom-to-image-hidden"
@@ -447,6 +628,12 @@ exports[`DatasetComparisonAnnotationTable it should match snapshot 1`] = `
       class="dataset-comparison-grid-col overflow-hidden relative"
     >
       <span
+        class="dataset-comparison-grid-ds-name"
+      >
+        New 2
+      </span>
+      <span
+        annotation="[object Object]"
         class="w-full dataset-comparison-grid-item-header dom-to-image-hidden"
         slot="title"
       >
@@ -842,8 +1029,94 @@ exports[`DatasetComparisonAnnotationTable it should match snapshot 1`] = `
         />
       </span>
       <div
+        class="dataset-comparison-extra dom-to-image-hidden"
+      >
+        <div
+          class="dataset-comparison-msm-badge"
+        >
+          MSM 
+          <b>
+            0.736
+          </b>
+        </div>
+        <div
+          class="dataset-comparison-fdr-badge"
+        >
+          FDR 
+          <b>
+            5%
+          </b>
+        </div>
+        <mock-el-popover
+          placement="right"
+          trigger="hover"
+        >
+          <div
+            slot-key="default"
+          >
+            Individual dataset annotation page.
+          </div>
+          <div
+            slot-key="reference"
+          >
+            <div
+              class="dataset-comparison-link"
+            >
+              <a
+                class=""
+                href="/annotations?db_id=1&ds=2021-03-31_08h41m01s"
+                target="_blank"
+              >
+                <i
+                  class="flex"
+                  classname="h-6 w-6 pointer-events-none"
+                >
+                  <svg
+                    data-icon="icon-external-window"
+                  />
+                </i>
+              </a>
+            </div>
+          </div>
+        </mock-el-popover>
+      </div>
+      <div
         class="ds-wrapper relative"
       >
+        <div
+          class="relative overflow-hidden"
+          mock-v-loading="false"
+          scaletype="linear"
+          style="width: 410px; height: 300px;"
+        >
+          <div
+            class="scale-bar"
+          >
+            <div
+              class="scale-bar-x"
+              style="color: rgb(0, 0, 0); border-color: #000000; width: 83.33333333333333px;"
+            >
+              <div
+                class="scale-bar-x-text"
+              >
+                
+      1 mm
+    
+              </div>
+            </div>
+             
+            <!---->
+          </div>
+          <div
+            class="absolute inset-0 z-30 pointer-events-none bg-body flex items-center justify-center opacity-0 duration-1000"
+          >
+            <p
+              class="relative block z-40 m-0 text-white text-2xl"
+            >
+              Use CTRL + scroll wheel to zoom the image
+            </p>
+          </div>
+        </div>
         <div
           class="ds-viewer-controls-wrapper  v-rhythm-3 sm-side-bar"
         >
@@ -862,7 +1135,95 @@ exports[`DatasetComparisonAnnotationTable it should match snapshot 1`] = `
             leaveactiveclass="duration-150 transition-opacity ease-in-out"
             leavetoclass="opacity-0"
             mode="out-in"
-          />
+          >
+            <div
+              class="p-3 bg-gray-100 rounded-lg box-border shadow-xs"
+            >
+              <div
+                class="box-border h-3 relative rounded-full bg-gray-100 sm-slider-track cursor-pointer ds-comparison-opacity-item"
+              >
+                <div
+                  class="box-border h-3 w-3 absolute bg-gray-100 border-2 border-solid border-gray-300 rounded-full cursor-pointer"
+                  style="left: -1px;"
+                  tabindex="0"
+                />
+                 
+                <div
+                  class="box-border h-3 w-3 absolute bg-gray-100 border-2 border-solid border-gray-300 rounded-full cursor-pointer"
+                  style="left: -11px;"
+                  tabindex="0"
+                />
+              </div>
+              <div
+                class="ds-intensities-wrapper"
+              >
+                <transition-stub
+                  enteractiveclass="duration-150 transition-opacity ease-in-out"
+                  enterclass="opacity-0"
+                  leaveactiveclass="duration-150 transition-opacity ease-in-out"
+                  leavetoclass="opacity-0"
+                  mode="out-in"
+                >
+                  <div
+                    class="h-5 flex items-center sm-flex-direction"
+                  >
+                    <button
+                      class="button-reset h-4 leading-5"
+                      title="Click to edit"
+                    >
+                      
+      0.0e+0
+    
+                    </button>
+                     
+                    <button
+                      class="button-reset h-4 mx-1"
+                      title="Lock intensity"
+                    >
+                      <svg
+                        class="fill-current text-gray-600"
+                        data-icon="icon-lock"
+                      />
+                    </button>
+                     
+                    <!---->
+                  </div>
+                </transition-stub>
+                <transition-stub
+                  enteractiveclass="duration-150 transition-opacity ease-in-out"
+                  enterclass="opacity-0"
+                  leaveactiveclass="duration-150 transition-opacity ease-in-out"
+                  leavetoclass="opacity-0"
+                  mode="out-in"
+                >
+                  <div
+                    class="h-5 flex items-center sm-flex-direction"
+                  >
+                    <button
+                      class="button-reset h-4 leading-5"
+                      title="Click to edit"
+                    >
+                      
+      0.0e+0
+    
+                    </button>
+                     
+                    <button
+                      class="button-reset h-4 mx-1"
+                      title="Lock intensity"
+                    >
+                      <svg
+                        class="fill-current text-gray-600"
+                        data-icon="icon-lock"
+                      />
+                    </button>
+                     
+                    <!---->
+                  </div>
+                </transition-stub>
+              </div>
+            </div>
+          </transition-stub>
         </div>
         <button
           class="button-reset rounded-full bg-gray-100 shadow-xs h-8 w-8 flex items-center justify-center cursor-not-allowed absolute top-0 left-0 mt-3 ml-3 dom-to-image-hidden"

--- a/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonGrid.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonGrid.spec.ts.snap
@@ -90,6 +90,8 @@ exports[`DatasetComparisonGrid it should match snapshot 1`] = `
                   </div>
                 </div>
                  
+                <!---->
+                 
                 <div
                   class="el-form-item"
                 >
@@ -700,6 +702,8 @@ exports[`DatasetComparisonGrid it should match snapshot 1`] = `
                     </transition-stub>
                   </div>
                 </div>
+                 
+                <!---->
                  
                 <div
                   class="el-form-item"

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
@@ -6,6 +6,7 @@ import DownloadDialog from './DownloadDialog'
 import reportError from '../../../lib/reportError'
 import { formatDatabaseLabel } from '../../MolecularDatabases/formatting'
 import config from '../../../lib/config'
+import NewFeatureBadge, { hideFeatureBadge } from '../../../components/NewFeatureBadge'
 
 const DatasetItemActions = defineComponent({
   name: 'DatasetItemActions',
@@ -235,12 +236,21 @@ const DatasetItemActions = defineComponent({
             props.showOverview
             && <div>
               <i class="el-icon-data-analysis" />
-              <router-link to={{
-                name: 'dataset-overview',
-                params: { dataset_id: props.dataset.id },
-              }}>
-                Dataset overview
-              </router-link>
+              <NewFeatureBadge featureKey="dataset-overview">
+                <router-link
+                  class='mr-2'
+                  to={{
+                    name: 'dataset-overview',
+                    params: { dataset_id: props.dataset.id },
+                  }}>
+                  <span
+                    onClick={(e: any) => {
+                      e.stopPropagation()
+                      hideFeatureBadge('dataset-overview')
+                    }}
+                  >Dataset overview</span>
+                </router-link>
+              </NewFeatureBadge>
             </div>
           }
         </div>

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
@@ -6,6 +6,7 @@ import reportError from '../../../lib/reportError'
 import DownloadDialog from '../list/DownloadDialog'
 import { DatasetComparisonDialog } from '../comparison/DatasetComparisonDialog'
 import config from '../../../lib/config'
+import NewFeatureBadge, { hideFeatureBadge } from '../../../components/NewFeatureBadge'
 
 interface DatasetActionsDropdownProps {
   actionLabel: string
@@ -89,6 +90,7 @@ export const DatasetActionsDropdown = defineComponent<DatasetActionsDropdownProp
     }
 
     const openCompareDialog = () => {
+      hideFeatureBadge('dataset-comparison')
       state.showCompareDialog = true
     }
 
@@ -157,7 +159,7 @@ export const DatasetActionsDropdown = defineComponent<DatasetActionsDropdownProp
           <Button class="p-1" type="primary">
             <span class="ml-2">{actionLabel}</span><i class="el-icon-arrow-down el-icon--right"/>
           </Button>
-          <DropdownMenu class='dataset-overview-menu'>
+          <DropdownMenu class='dataset-overview-menu p-2'>
             {
               canEdit
               && <DropdownItem command="edit">{editActionLabel}</DropdownItem>
@@ -166,7 +168,11 @@ export const DatasetActionsDropdown = defineComponent<DatasetActionsDropdownProp
               canDownload
               && <DropdownItem command="download">{downloadActionLabel}</DropdownItem>
             }
-            <DropdownItem command="compare" >{compareActionLabel}</DropdownItem>
+            <DropdownItem command="compare" >
+              <NewFeatureBadge featureKey="dataset-comparison">
+                {compareActionLabel}
+              </NewFeatureBadge>
+            </DropdownItem>
             {
               canDelete
               && <DropdownItem class='text-red-500' command="delete">{deleteActionLabel}</DropdownItem>

--- a/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/DatasetActionsDropdown.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/DatasetActionsDropdown.spec.ts.snap
@@ -3,10 +3,12 @@
 exports[`DatasetActionsDropdown it should match snapshot 1`] = `
 <eldropdown-stub trigger="click" type="primary" size="" hideonclick="true" placement="bottom-end" visiblearrow="true" showtimeout="250" hidetimeout="150" tabindex="0" dataset="[object Object]" currentuser="[object Object]">
   <elbutton-stub type="primary" icon="" nativetype="button" class="p-1"><span class="ml-2">Actions</span><i class="el-icon-arrow-down el-icon--right"></i></elbutton-stub>
-  <eldropdownmenu-stub transformorigin="true" placement="bottom" boundariespadding="5" offset="0" visiblearrow="true" arrowoffset="0" appendtobody="true" popperoptions="[object Object]" class="dataset-overview-menu">
+  <eldropdownmenu-stub transformorigin="true" placement="bottom" boundariespadding="5" offset="0" visiblearrow="true" arrowoffset="0" appendtobody="true" popperoptions="[object Object]" class="dataset-overview-menu p-2">
     <eldropdownitem-stub command="edit">Edit metadata</eldropdownitem-stub>
     <eldropdownitem-stub command="download">Download</eldropdownitem-stub>
-    <eldropdownitem-stub command="compare">Compare with other datasets...</eldropdownitem-stub>
+    <eldropdownitem-stub command="compare">
+      <el-badge-stub value="New" class="sm-feature-badge">Compare with other datasets...</el-badge-stub>
+    </eldropdownitem-stub>
     <eldropdownitem-stub command="delete" class="text-red-500">Delete</eldropdownitem-stub>
     <eldropdownitem-stub command="reprocess" class="text-red-500">Reprocess data</eldropdownitem-stub>
   </eldropdownmenu-stub>

--- a/metaspace/webapp/src/modules/Filters/url.ts
+++ b/metaspace/webapp/src/modules/Filters/url.ts
@@ -215,6 +215,7 @@ export interface UrlTableSettings {
 export interface UrlAnnotationViewSettings {
   activeSections: string[]
   colormap: string
+  lockTemplate: string | null
   colocalizationAlgo: string | null
   scaleType: ScaleType
 }
@@ -252,6 +253,7 @@ export function decodeSettings(location: Location): UrlSettings | undefined {
       activeSections: DEFAULT_ANNOTATION_VIEW_SECTIONS,
       colormap: DEFAULT_COLORMAP,
       colocalizationAlgo: null,
+      lockTemplate: null,
       scaleType: DEFAULT_SCALE_TYPE,
     },
 
@@ -282,6 +284,9 @@ export function decodeSettings(location: Location): UrlSettings | undefined {
   }
   if (query.alg) {
     settings.annotationView.colocalizationAlgo = query.alg
+  }
+  if (query.lock) {
+    settings.annotationView.lockTemplate = query.lock
   }
   if (query.tab !== undefined) {
     settings.datasets.tab = query.tab

--- a/metaspace/webapp/src/modules/ImageViewer/EditIntensity.vue
+++ b/metaspace/webapp/src/modules/ImageViewer/EditIntensity.vue
@@ -7,6 +7,7 @@
     @submit.prevent="submit"
     @click.stop
     @mousedown.stop
+    @keyup.stop
   >
     <label>
       <span class="sr-only">

--- a/metaspace/webapp/src/modules/ImageViewer/IonIntensity.vue
+++ b/metaspace/webapp/src/modules/ImageViewer/IonIntensity.vue
@@ -83,14 +83,6 @@ export default defineComponent<Props>({
     const editing = ref(false)
 
     const status = computed(() => props.intensities.status)
-    const display = computed(() => {
-      if (status.value === 'LOCKED') {
-        return props.intensities.user
-      } else if (status.value === 'CLIPPED') {
-        return props.intensities.clipped
-      }
-      return props.value
-    })
     const intensity = computed(() => props.intensities.scaled.toExponential(1))
 
     return {

--- a/metaspace/webapp/src/modules/ImageViewer/ionImageState.ts
+++ b/metaspace/webapp/src/modules/ImageViewer/ionImageState.ts
@@ -3,6 +3,7 @@ import { computed, reactive, ref, toRefs } from '@vue/composition-api'
 import { channels as channelToRGB } from '../../lib/getColorScale'
 
 import viewerState from './state'
+import { OpacityMode } from '../../lib/createColormap'
 
 export interface Annotation {
   id: string
@@ -59,6 +60,26 @@ interface Settings {
   isLockActive: boolean
   opacity: number
   opticalOpacity: number
+}
+
+export type ImagePosition = {
+  zoom: number
+  xOffset: number
+  yOffset: number
+}
+
+export type ImageSettings = {
+  annotImageOpacity: number
+  opacityMode: OpacityMode
+  imagePosition: ImagePosition
+  opticalSrc: string | null
+  opticalTransform: number[][] | null
+  pixelAspectRatio: number
+  opticalOpacity: number
+  // scaleType is deliberately not included here, because every time it changes some slow computation occurs,
+  // and the computed getters were being triggered by any part of the ImageSettings object changing, such as opacity,
+  // causing a lot of jank.
+  // scaleType?: ScaleType
 }
 
 const channels = ['magenta', 'green', 'blue', 'red', 'yellow', 'cyan', 'orange', 'violet']

--- a/metaspace/webapp/src/store/mutations.js
+++ b/metaspace/webapp/src/store/mutations.js
@@ -13,8 +13,6 @@ import {
 } from '../modules/Filters';
 import { DEFAULT_ANNOTATION_VIEW_SECTIONS, DEFAULT_COLORMAP, DEFAULT_TABLE_ORDER } from '../modules/Filters/url';
 import { DEFAULT_SCALE_TYPE } from '../lib/constants';
-import {computed} from "@vue/composition-api";
-
 
 function updatedLocation(state, filter) {
   let query = encodeParams(filter, state.route.path, state.filterLists);
@@ -196,6 +194,14 @@ export default {
       query: scaleType !== DEFAULT_SCALE_TYPE
         ? { ...state.route.query, scale: scaleType }
         : omit(state.route.query, 'scale'),
+    });
+  },
+
+  setLockTemplate(state, lockTemplate) {
+    router.replace({
+      query: lockTemplate
+        ? { ...state.route.query, lock: lockTemplate }
+        : omit(state.route.query, 'lock'),
     });
   },
 


### PR DESCRIPTION
### Description

In order to simplify the datasetComparisonGrid readability, the code must be improved to use a lazy ionImage update logic instead of the hard called update and the watcheffect.
 Fix intensity lock system
 Lock all grid images with same intensity once one is locked
 Remove filters from dataset name query (leave only the id one)

#910 

#### Changes

##### Webapp

###### DatasetComparisonGrid
- [x] Show empty cell if selected annotation index is greater than the number of annotations
- [x] Fixes intensity lock system
- [x] Persist intensity lock on row change
- [x] Applies intensity lock to all grid cells
- [x] Changed watcheffect ionImage build system to individual watch effects bases on annotation selection change
- [x] Fixed opacityMode update on toggle optical Image
- [x] Added text overflow with ellipsis  when dataset name too big

###### DatasetComparisonPage
- [x] Displaying selected formula and m/z on top of image grid
- [x] Waiting for datasetIds response to trigger datasetDetail query
- [x] Rendering no data in compounds container if compounds not found


###### EditIntensity
- [x] Stops onKey propagation (so the table do not change pages if moving arrows to edit intensity)


#### Tests
 
##### Front end
 
- [x] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [x] md, lg, lg
- [ ] sm, xl



#### Considerations
* I still wasn't able to remove the handleImageLayerUpdate calls to update the ionImages and update it lazily with computed values. I'm still trying to figure out why the IonImageViewer does not listen to the updates but its wrapper like the MainImage does. My plan is to use the SimpleIonImageViewer created on the browser branch also on the DatasetComparisonGrid, as it is listening to the props update and it can have separated state handlers (not like the ones used on the ImageViewer).

![image](https://user-images.githubusercontent.com/35172605/129418982-331d118f-2e82-4350-bf7d-4f428379e1eb.png)


