### PR TITLE
Feat/ds comparison pre release

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonDialog.scss
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonDialog.scss
@@ -29,4 +29,12 @@
   }
 }
 
+.ds-comparison-step{
+  .el-tag{
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+}
+
 

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonDialog.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonDialog.tsx
@@ -166,7 +166,7 @@ export const DatasetComparisonDialog = defineComponent<DatasetComparisonDialogPr
               </p>
               {
                 state.workflowStep === 1
-                && <form>
+                && <form class='ds-comparison-step'>
                   <Select
                     class={`w-full ${state.firstStepError ? 'sm-form-error' : ''}`}
                     value={state.selectedDatasetIds}

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.scss
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.scss
@@ -46,9 +46,14 @@
     min-height: 300px;
   }
 
-  .dataset-comparison-grid-ds-name{
-    @apply flex flex-row w-full justify-center items-center	font-medium;
+  .ds-comparison-item-line {
+    @apply w-full flex items-center justify-center truncate;
     background: #F1F5F8;
+  }
+
+  .dataset-comparison-grid-ds-name{
+    @apply truncate text-center;
+    width: 400px;
   }
 
   .dataset-comparison-grid-item-header{

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
@@ -20,6 +20,7 @@ import { ExternalWindowSvg } from '../../../design/refactoringUIIcons'
 import { Popover } from '../../../lib/element-ui'
 import { ImagePosition } from '../../ImageViewer/ionImageState'
 import { range } from 'lodash-es'
+import config from '../../../lib/config'
 
 const RouterLink = Vue.component('router-link')
 
@@ -226,6 +227,7 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       const ionImagePng = await loadPngFromUrl(annotation.isotopeImages[0].url)
       let gridCell: GridCellState
 
+      console.log('HALLo')
       if (hasPreviousSettings) {
         gridCell = state.gridState[key]!
         gridCell.ionImagePng = ionImagePng
@@ -235,7 +237,7 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
         const pixelSizeX = metadata?.MS_Analysis?.Pixel_Size?.Xaxis || 0
         // eslint-disable-next-line camelcase
         const pixelSizeY = metadata?.MS_Analysis?.Pixel_Size?.Yaxis || 0
-
+        console.log('pixelSizeXY', pixelSizeX, pixelSizeY)
         gridCell = reactive({
           intensity: null, // @ts-ignore // Gets set later, because ionImageLayers needs state.gridState[key] set
           ionImagePng,
@@ -248,7 +250,9 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
           lockedIntensities: [undefined, undefined],
           annotImageOpacity: 1.0,
           imagePosition: defaultImagePosition(),
-          pixelAspectRatio: pixelSizeX && pixelSizeY && pixelSizeX / pixelSizeY,
+          pixelAspectRatio:
+            config.features.ignore_pixel_aspect_ratio ? 1
+              : pixelSizeX && pixelSizeY && pixelSizeX / pixelSizeY || 1,
           imageZoom: 1,
           showOpticalImage: true,
           userScaling: [0, 1],

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
@@ -271,13 +271,16 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
         ? state.globalLockedIntensities[1] : (intensity.max.clipped || intensity.max.image)
       gridCell.intensity = intensity
       gridCell.lockedIntensities = state.globalLockedIntensities
+
       // persist ion intensity lock status
       if (gridCell.lockedIntensities !== undefined) {
         if (gridCell.lockedIntensities[0] !== undefined) {
           await handleIonIntensityLockChange(gridCell.lockedIntensities[0], key, 'min')
+          // await handleIonIntensityChange(gridCell.lockedIntensities[0], key, 'min')
         }
         if (gridCell.lockedIntensities[1] !== undefined) {
           await handleIonIntensityLockChange(gridCell.lockedIntensities[1], key, 'max')
+          await handleIonIntensityChange(gridCell.lockedIntensities[1], key, 'max')
         }
       }
     }
@@ -543,11 +546,14 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       const maxScaleDisplay = state.globalLockedIntensities && state.globalLockedIntensities[1]
         ? state.globalLockedIntensities[1] : (gridCell.intensity.max.clipped || gridCell.intensity.max.image)
 
+      const minScaleDisplay = state.globalLockedIntensities && state.globalLockedIntensities[0]
+        ? state.globalLockedIntensities[0] : 0
+
       gridCell.intensity.min.scaled =
         gridCell.intensity?.min?.status === 'LOCKED'
         && maxIntensity * userScaling[0]
         < gridCell.intensity.min.user
-          ? maxScaleDisplay
+          ? minScaleDisplay
           : maxIntensity * userScaling[0]
 
       gridCell.intensity.max.scaled =
@@ -559,7 +565,7 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
     }
 
     const handleIonIntensityChange = (intensity: number | undefined, key: string, type: string,
-      ignoreBoundaries : boolean = false) => {
+      ignoreBoundaries : boolean = true) => {
       const gridCell = state.gridState[key]
       if (gridCell == null || intensity === undefined) {
         return

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
@@ -279,7 +279,7 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       if (gridCell.lockedIntensities !== undefined) {
         if (gridCell.lockedIntensities[0] !== undefined) {
           await handleIonIntensityLockChange(gridCell.lockedIntensities[0], key, 'min')
-          // await handleIonIntensityChange(gridCell.lockedIntensities[0], key, 'min')
+          await handleIonIntensityChange(gridCell.lockedIntensities[0], key, 'min')
         }
         if (gridCell.lockedIntensities[1] !== undefined) {
           await handleIonIntensityLockChange(gridCell.lockedIntensities[1], key, 'max')
@@ -681,8 +681,9 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
           ? props.datasets.find((dataset: any) => dataset.id === settings.value.grid[`${row}-${col}`])
           : null
       return (
-        <span class='dataset-comparison-grid-ds-name'>{dataset?.name?.substring(0, 39)}
-          {dataset?.name?.length > 40 ? '...' : ''}</span>
+        <div class='ds-comparison-item-line'>
+          <span class='dataset-comparison-grid-ds-name truncate'>{dataset?.name}</span>
+        </div>
       )
     }
 

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
@@ -227,7 +227,6 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       const ionImagePng = await loadPngFromUrl(annotation.isotopeImages[0].url)
       let gridCell: GridCellState
 
-      console.log('HALLo')
       if (hasPreviousSettings) {
         gridCell = state.gridState[key]!
         gridCell.ionImagePng = ionImagePng
@@ -237,7 +236,6 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
         const pixelSizeX = metadata?.MS_Analysis?.Pixel_Size?.Xaxis || 0
         // eslint-disable-next-line camelcase
         const pixelSizeY = metadata?.MS_Analysis?.Pixel_Size?.Yaxis || 0
-        console.log('pixelSizeXY', pixelSizeX, pixelSizeY)
         gridCell = reactive({
           intensity: null, // @ts-ignore // Gets set later, because ionImageLayers needs state.gridState[key] set
           ionImagePng,
@@ -670,7 +668,8 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
           ? props.datasets.find((dataset: any) => dataset.id === settings.value.grid[`${row}-${col}`])
           : null
       return (
-        <span class='dataset-comparison-grid-ds-name'>{dataset?.name}</span>
+        <span class='dataset-comparison-grid-ds-name'>{dataset?.name?.substring(0, 39)}
+          {dataset?.name?.length > 40 ? '...' : ''}</span>
       )
     }
 

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
@@ -37,6 +37,7 @@ interface DatasetComparisonGridProps {
   isLoading: boolean
   resetViewPort: boolean
   lockedIntensityTemplate: string
+  globalLockedIntensities: [number | undefined, number | undefined]
 }
 
 interface GridCellState {
@@ -61,7 +62,6 @@ interface DatasetComparisonGridState {
   gridState: Record<string, GridCellState | null>,
   grid: any,
   annotationData: any,
-  globalLockedIntensities: [number | undefined, number | undefined]
   annotations: any[],
   refsLoaded: boolean,
   showViewer: boolean,
@@ -122,6 +122,10 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
     lockedIntensityTemplate: {
       type: String,
     },
+    globalLockedIntensities: {
+      type: Array,
+      default: () => [undefined, undefined],
+    },
   },
   // @ts-ignore
   setup: function(props, { refs, emit, root }) {
@@ -131,7 +135,6 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       gridState: {},
       grid: undefined,
       annotations: [],
-      globalLockedIntensities: [undefined, undefined],
       annotationData: {},
       selectedAnnotation: props.selectedAnnotation,
       refsLoaded: false,
@@ -267,10 +270,10 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       const intensity = getIntensity(gridCell.ionImageLayers[0]?.ionImage)
 
       intensity.min.scaled = 0
-      intensity.max.scaled = state.globalLockedIntensities && state.globalLockedIntensities[1]
-        ? state.globalLockedIntensities[1] : (intensity.max.clipped || intensity.max.image)
+      intensity.max.scaled = globalLockedIntensities.value && globalLockedIntensities.value[1]
+        ? globalLockedIntensities.value[1] : (intensity.max.clipped || intensity.max.image)
       gridCell.intensity = intensity
-      gridCell.lockedIntensities = state.globalLockedIntensities
+      gridCell.lockedIntensities = globalLockedIntensities.value as [number | undefined, number | undefined]
 
       // persist ion intensity lock status
       if (gridCell.lockedIntensities !== undefined) {
@@ -326,6 +329,8 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       return {}
     })
 
+    const globalLockedIntensities = computed(() => props.globalLockedIntensities)
+
     // set images and annotation related items when selected annotation changes
     watch(() => props.selectedAnnotation, async(newValue) => {
       await updateAnnotationData(settings.value.grid, newValue)
@@ -337,7 +342,7 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
         const gridCell : GridCellState = state.gridState[gridKey]!
         if (gridCell) {
           const maxIntensity = gridCell.intensity.max.clipped || gridCell.intensity.max.image
-          const minIntensity = gridCell.intensity.min.clipped || gridCell.intensity.min.image
+          const minIntensity = 0
           handleIonIntensityLockChange(undefined, gridKey, 'min')
           handleIonIntensityLockChange(undefined, gridKey, 'max')
           handleIonIntensityChange(minIntensity, gridKey, 'min')
@@ -543,11 +548,11 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       gridCell.userScaling = rangeSliderScale
       gridCell.imageScaledScaling = [minScale, maxScale]
 
-      const maxScaleDisplay = state.globalLockedIntensities && state.globalLockedIntensities[1]
-        ? state.globalLockedIntensities[1] : (gridCell.intensity.max.clipped || gridCell.intensity.max.image)
+      const maxScaleDisplay = globalLockedIntensities.value && globalLockedIntensities.value[1]
+        ? globalLockedIntensities.value[1] : (gridCell.intensity.max.clipped || gridCell.intensity.max.image)
 
-      const minScaleDisplay = state.globalLockedIntensities && state.globalLockedIntensities[0]
-        ? state.globalLockedIntensities[0] : 0
+      const minScaleDisplay = globalLockedIntensities.value && globalLockedIntensities.value[0]
+        ? globalLockedIntensities.value[0] : 0
 
       gridCell.intensity.min.scaled =
         gridCell.intensity?.min?.status === 'LOCKED'
@@ -623,7 +628,8 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       }
 
       gridCell.lockedIntensities = [minLocked, maxLocked]
-      state.globalLockedIntensities = [minLocked, maxLocked]
+      emit('intensitiesChange', [minLocked, maxLocked])
+
       gridCell.intensity = intensity
       gridCell.userScaling = [0, 1]
     }
@@ -632,6 +638,7 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       // apply max lock to all grids
       Object.keys(state.gridState).forEach((gridKey) => {
         handleIonIntensityLockChange(value, gridKey, type)
+
         if (value && gridKey !== key) {
           handleIonIntensityChange(value, gridKey, type, true)
         }
@@ -653,8 +660,8 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
           const gridCell : GridCellState = state.gridState[key]!
           if (gridCell && gridCell.intensity) {
             maxIntensity = gridCell.intensity.max.clipped || gridCell.intensity.max.image
-            minIntensity = gridCell.intensity.min.clipped || gridCell.intensity.min.image
-            state.globalLockedIntensities = [minIntensity, maxIntensity]
+            minIntensity = 0
+            emit('intensitiesChange', [minIntensity, maxIntensity])
           }
         }
       })

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
@@ -20,9 +20,8 @@ import MainImageHeader from '../../Annotations/annotation-widgets/default/MainIm
 import CandidateMoleculesPopover from '../../Annotations/annotation-widgets/CandidateMoleculesPopover.vue'
 import MolecularFormula from '../../../components/MolecularFormula'
 import CopyButton from '../../../components/CopyButton.vue'
-import { SimpleShareLink } from './SimpleShareLink'
-import { invert, uniqBy } from 'lodash-es'
-import { decodeParams, stripFilteringParams } from '../../Filters'
+import { DatasetComparisonShareLink } from './DatasetComparisonShareLink'
+import { uniqBy } from 'lodash-es'
 
 interface GlobalImageSettings {
   resetViewPort: boolean
@@ -319,7 +318,7 @@ export default defineComponent<DatasetComparisonPageProps>({
               Copy m/z to clipboard
             </CopyButton>
           </span>
-          <SimpleShareLink
+          <DatasetComparisonShareLink
             viewId={snapshotId}
             nCols={nCols}
             nRows={nRows}

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonShareLink.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonShareLink.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, reactive } from '@vue/composition-api'
+import { defineComponent, reactive } from '@vue/composition-api'
 import StatefulIcon from '../../../components/StatefulIcon.vue'
 import { ExternalWindowSvg } from '../../../design/refactoringUIIcons'
 import { Button, Popover } from '../../../lib/element-ui'
@@ -15,7 +15,7 @@ const saveSettings = gql`mutation saveImageViewerSnapshotMutation($input: ImageV
   saveImageViewerSnapshot(input: $input)
 }`
 
-interface SimpleShareLinkProps {
+interface DatasetComparisonShareLinkProps {
   name: string
   params: any
   query: any
@@ -28,14 +28,12 @@ interface SimpleShareLinkProps {
   scaleBarColor: string
   sourceDsId: string
   selectedAnnotation: number
-  annotations: any[]
-  datasets: any[]
   lockedIntensityTemplate: string
   globalLockedIntensities: [number | undefined, number | undefined]
 }
 
-export const SimpleShareLink = defineComponent<SimpleShareLinkProps>({
-  name: 'SimpleShareLink',
+export const DatasetComparisonShareLink = defineComponent<DatasetComparisonShareLinkProps>({
+  name: 'DatasetComparisonShareLink',
   props: {
     name: { type: String, required: true },
     params: { type: Object },
@@ -61,7 +59,6 @@ export const SimpleShareLink = defineComponent<SimpleShareLinkProps>({
       viewId: null,
     })
     const { mutate: settingsMutation } = useMutation<any>(saveSettings)
-    const query = computed(() => props.query)
     const getUrl = () => {
       return {
         name: props.name,

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonShareLink.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonShareLink.tsx
@@ -47,8 +47,6 @@ export const DatasetComparisonShareLink = defineComponent<DatasetComparisonShare
     sourceDsId: { type: String },
     scaleBarColor: { type: String },
     selectedAnnotation: { type: Number },
-    annotations: { type: Array },
-    datasets: { type: Array },
     lockedIntensityTemplate: { type: String },
     globalLockedIntensities: { type: Array },
   },

--- a/metaspace/webapp/src/modules/Datasets/comparison/SimpleShareLink.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/SimpleShareLink.tsx
@@ -80,18 +80,14 @@ export const SimpleShareLink = defineComponent<SimpleShareLinkProps>({
       try {
         const datasetIds = props.datasets.map((dataset: any) => dataset.id)
         const filter = $store.getters.filter
-        const annotations = props.annotations[props.selectedAnnotation].annotations || []
-        const annotationIds = annotations.map((annotation: any) => annotation.id)
-        const ionFormulas = annotations.map((annotation: any) => annotation.ion)
-        const dbIds = annotations.map((annotation: any) => annotation.databaseDetails.id.toString())
         const settings = safeJsonParse(props.settings)
         const grid = settings.grid
 
         const variables : any = {
           input: {
             version: 1,
-            ionFormulas,
-            dbIds,
+            ionFormulas: [],
+            dbIds: [],
             annotationIds: datasetIds,
             snapshot: JSON.stringify({
               nRows: props.nRows,
@@ -103,7 +99,6 @@ export const SimpleShareLink = defineComponent<SimpleShareLinkProps>({
               lockedIntensityTemplate: props.lockedIntensityTemplate,
               globalLockedIntensities: props.globalLockedIntensities,
               grid,
-              annotationIds,
               filter,
             }),
             datasetId: props.sourceDsId,

--- a/metaspace/webapp/src/modules/Datasets/comparison/SimpleShareLink.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/SimpleShareLink.tsx
@@ -78,10 +78,10 @@ export const SimpleShareLink = defineComponent<SimpleShareLinkProps>({
       state.status = 'SAVING'
 
       try {
-        const datasetIds = props.datasets.map((dataset: any) => dataset.id)
         const filter = $store.getters.filter
         const settings = safeJsonParse(props.settings)
         const grid = settings.grid
+        const datasetIds = Object.values(grid)
 
         const variables : any = {
           input: {

--- a/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonDialog.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`DatasetComparisonDialog it should match snapshot 1`] = `
         <ol class="sm-workflow leading-6 m-0 p-0">
           <li class="sm-workflow-step flex flex-col relative text-gray-600 max-w-measure-3 ml-8 pl-12 border-solid border-0 border-l-2 border-gray-300 transition-colors ease-in-out duration-300 active">
             <p class="sm-workflow-header">Select the datasets</p>
-            <form>
+            <form class="ds-comparison-step">
               <div class="el-select w-full ">
                 <div class="el-select__tags" style="max-width: -32px; width: 100%;">
                   <!---->

--- a/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonGrid.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonGrid.spec.ts.snap
@@ -16,11 +16,15 @@ exports[`DatasetComparisonGrid it should match snapshot 1`] = `
     <div
       class="dataset-comparison-grid-col overflow-hidden relative"
     >
-      <span
-        class="dataset-comparison-grid-ds-name"
+      <div
+        class="ds-comparison-item-line"
       >
-        New test create
-      </span>
+        <span
+          class="dataset-comparison-grid-ds-name truncate"
+        >
+          New test create
+        </span>
+      </div>
       <span
         annotation="[object Object]"
         class="w-full dataset-comparison-grid-item-header dom-to-image-hidden"
@@ -629,11 +633,15 @@ exports[`DatasetComparisonGrid it should match snapshot 1`] = `
     <div
       class="dataset-comparison-grid-col overflow-hidden relative"
     >
-      <span
-        class="dataset-comparison-grid-ds-name"
+      <div
+        class="ds-comparison-item-line"
       >
-        New 2
-      </span>
+        <span
+          class="dataset-comparison-grid-ds-name truncate"
+        >
+          New 2
+        </span>
+      </div>
       <span
         annotation="[object Object]"
         class="w-full dataset-comparison-grid-item-header dom-to-image-hidden"

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItem.vue
@@ -21,6 +21,7 @@
 
     <DatasetItemActions
       :dataset="dataset"
+      :idx="idx"
       :metadata="metadata"
       :current-user="currentUser"
     />

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.scss
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.scss
@@ -1,0 +1,6 @@
+.featured-action{
+  .el-badge__content.is-fixed{
+    top: 7px;
+    right: 8px;
+  }
+}

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
@@ -15,6 +15,7 @@ const DatasetItemActions = defineComponent({
     dataset: { type: Object as () => DatasetDetailItem, required: true },
     metadata: { type: Object as () => any, required: true },
     currentUser: { type: Object as () => any },
+    idx: { type: Number },
   },
   setup(props, { emit, root: { $apollo, $confirm, $notify } }) {
     const state = reactive({
@@ -234,6 +235,27 @@ const DatasetItemActions = defineComponent({
 
           {
             props.showOverview
+            && props.idx !== 0
+            && <div>
+              <i class="el-icon-data-analysis"/>
+              <router-link
+                className='mr-2'
+                to={{
+                  name: 'dataset-overview',
+                  params: { dataset_id: props.dataset.id },
+                }}>
+                <span
+                  onClick={(e: any) => {
+                    e.stopPropagation()
+                    hideFeatureBadge('dataset-overview')
+                  }}
+                >Dataset overview</span>
+              </router-link>
+            </div>
+          }
+          {
+            props.showOverview
+            && props.idx === 0
             && <div>
               <i class="el-icon-data-analysis" />
               <NewFeatureBadge featureKey="dataset-overview">

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
@@ -7,6 +7,7 @@ import reportError from '../../../lib/reportError'
 import { formatDatabaseLabel } from '../../MolecularDatabases/formatting'
 import config from '../../../lib/config'
 import NewFeatureBadge, { hideFeatureBadge } from '../../../components/NewFeatureBadge'
+import './DatasetItemActions.scss'
 
 const DatasetItemActions = defineComponent({
   name: 'DatasetItemActions',
@@ -256,7 +257,7 @@ const DatasetItemActions = defineComponent({
           {
             props.showOverview
             && props.idx === 0
-            && <div>
+            && <div class='featured-action'>
               <i class="el-icon-data-analysis" />
               <NewFeatureBadge featureKey="dataset-overview">
                 <router-link

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
@@ -90,7 +90,6 @@ export const DatasetActionsDropdown = defineComponent<DatasetActionsDropdownProp
     }
 
     const openCompareDialog = () => {
-      hideFeatureBadge('dataset-comparison')
       state.showCompareDialog = true
     }
 
@@ -156,9 +155,13 @@ export const DatasetActionsDropdown = defineComponent<DatasetActionsDropdownProp
         <Dropdown style={{
           visibility: (!canEdit && !canDelete && !canReprocess && !canDownload) ? 'hidden' : '',
         }} trigger='click' type="primary" onCommand={handleCommand}>
-          <Button class="p-1" type="primary">
-            <span class="ml-2">{actionLabel}</span><i class="el-icon-arrow-down el-icon--right"/>
-          </Button>
+          <NewFeatureBadge featureKey="dataset-overview-actions">
+            <Button class="p-1" type="primary" onClick={() => {
+              hideFeatureBadge('dataset-overview-actions')
+            }}>
+              <span class="ml-2">{actionLabel}</span><i class="el-icon-arrow-down el-icon--right"/>
+            </Button>
+          </NewFeatureBadge>
           <DropdownMenu class='dataset-overview-menu p-2'>
             {
               canEdit
@@ -168,11 +171,7 @@ export const DatasetActionsDropdown = defineComponent<DatasetActionsDropdownProp
               canDownload
               && <DropdownItem command="download">{downloadActionLabel}</DropdownItem>
             }
-            <DropdownItem command="compare" >
-              <NewFeatureBadge featureKey="dataset-comparison">
-                {compareActionLabel}
-              </NewFeatureBadge>
-            </DropdownItem>
+            <DropdownItem command="compare">{compareActionLabel}</DropdownItem>
             {
               canDelete
               && <DropdownItem class='text-red-500' command="delete">{deleteActionLabel}</DropdownItem>

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
@@ -155,7 +155,7 @@ export const DatasetActionsDropdown = defineComponent<DatasetActionsDropdownProp
         <Dropdown style={{
           visibility: (!canEdit && !canDelete && !canReprocess && !canDownload) ? 'hidden' : '',
         }} trigger='click' type="primary" onCommand={handleCommand}>
-          <NewFeatureBadge featureKey="dataset-overview-actionsx">
+          <NewFeatureBadge featureKey="dataset-overview-actions">
             <Button class="p-1" type="primary" onClick={() => {
               hideFeatureBadge('dataset-overview-actions')
             }}>

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
@@ -155,7 +155,7 @@ export const DatasetActionsDropdown = defineComponent<DatasetActionsDropdownProp
         <Dropdown style={{
           visibility: (!canEdit && !canDelete && !canReprocess && !canDownload) ? 'hidden' : '',
         }} trigger='click' type="primary" onCommand={handleCommand}>
-          <NewFeatureBadge featureKey="dataset-overview-actions">
+          <NewFeatureBadge featureKey="dataset-overview-actionsx">
             <Button class="p-1" type="primary" onClick={() => {
               hideFeatureBadge('dataset-overview-actions')
             }}>

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetOverviewPage.scss
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetOverviewPage.scss
@@ -35,6 +35,11 @@ $opt-desc-color: #C4C4C4;
 
 .dataset-overview-header{
   @apply  flex flex-row items-center justify-between px-6;
+
+  .el-badge__content.is-fixed{
+    top: 0px;
+    right: 5px;
+  }
 }
 
 

--- a/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/DatasetActionsDropdown.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/DatasetActionsDropdown.spec.ts.snap
@@ -2,13 +2,13 @@
 
 exports[`DatasetActionsDropdown it should match snapshot 1`] = `
 <eldropdown-stub trigger="click" type="primary" size="" hideonclick="true" placement="bottom-end" visiblearrow="true" showtimeout="250" hidetimeout="150" tabindex="0" dataset="[object Object]" currentuser="[object Object]">
-  <elbutton-stub type="primary" icon="" nativetype="button" class="p-1"><span class="ml-2">Actions</span><i class="el-icon-arrow-down el-icon--right"></i></elbutton-stub>
+  <el-badge-stub value="New" class="sm-feature-badge">
+    <elbutton-stub type="primary" icon="" nativetype="button" class="p-1"><span class="ml-2">Actions</span><i class="el-icon-arrow-down el-icon--right"></i></elbutton-stub>
+  </el-badge-stub>
   <eldropdownmenu-stub transformorigin="true" placement="bottom" boundariespadding="5" offset="0" visiblearrow="true" arrowoffset="0" appendtobody="true" popperoptions="[object Object]" class="dataset-overview-menu p-2">
     <eldropdownitem-stub command="edit">Edit metadata</eldropdownitem-stub>
     <eldropdownitem-stub command="download">Download</eldropdownitem-stub>
-    <eldropdownitem-stub command="compare">
-      <el-badge-stub value="New" class="sm-feature-badge">Compare with other datasets...</el-badge-stub>
-    </eldropdownitem-stub>
+    <eldropdownitem-stub command="compare">Compare with other datasets...</eldropdownitem-stub>
     <eldropdownitem-stub command="delete" class="text-red-500">Delete</eldropdownitem-stub>
     <eldropdownitem-stub command="reprocess" class="text-red-500">Reprocess data</eldropdownitem-stub>
   </eldropdownmenu-stub>


### PR DESCRIPTION
### Description

Improvement of ds comparison page lock intensities and permalink features before release.
#910  


#### Changes

##### Webapp

###### DatasetComparisonPage
- [x] Handling lock all intensities mechanism by props
- [x] Using saved settings by reading snapshot

###### DatasetList
- [x] Showing new feature badge only on first dataset card

#### Tests
 
##### Front end
 
- [x] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [x] md, lg, lg
- [ ] sm, xl
