### PR TITLE
Feat/tic ds comparison and browser page

### DIFF
--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -164,12 +164,40 @@ export interface DatasetListItem {
   uploadDT: string;
 }
 
+export interface DatasetListItemWithDiagnostics {
+  id: string;
+  name: string;
+  uploadDT: string;
+  diagnostics: any;
+}
+
 export const datasetListItemsQuery =
   gql`query GetDatasets($dFilter: DatasetFilter, $query: String, $limit: Int = 10000) {
     allDatasets(offset: 0, limit: $limit, filter: $dFilter, simpleQuery: $query) {
       id
       name
       uploadDT
+    }
+  }`
+
+export const datasetListItemsWithDiagnosticsQuery =
+  gql`query GetDatasets($dFilter: DatasetFilter, $query: String, $limit: Int = 10000) {
+    allDatasets(offset: 0, limit: $limit, filter: $dFilter, simpleQuery: $query) {
+      id
+      name
+      uploadDT
+      diagnostics {
+        id
+        type
+        updatedDT
+        data
+        images {
+          key
+          index
+          url
+          format
+        }
+      }
     }
   }`
 

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -70,6 +70,7 @@ export interface DatasetDetailItem {
   canDelete: boolean;
   canDownload: boolean;
   uploadDT: string;
+  diagnostics: any;
 }
 
 export const datasetDetailItemFragment =
@@ -366,6 +367,18 @@ export const getDatasetByIdWithPathQuery =
     dataset(id: $id) {
       ...DatasetDetailItem
       inputPath
+      diagnostics {
+        id
+        type
+        updatedDT
+        data
+        images {
+          key
+          index
+          url
+          format
+        }
+      }
     }
   }
   ${datasetDetailItemFragment}

--- a/metaspace/webapp/src/lib/ionImageRendering.ts
+++ b/metaspace/webapp/src/lib/ionImageRendering.ts
@@ -288,7 +288,7 @@ export const processIonImage = (
     : extractIntensityAndMask(png, minIntensity, maxIntensity, normalizationData)
 
   // assign normalized intensities
-  if (normalizationData && scaleType !== 'hist') {
+  if (normalizationData && normalizationData.metadata && scaleType !== 'hist') {
     maxIntensity = normalizationData ? maxIntensity / normalizationData.metadata.maxTic * 1000000 : maxIntensity
     userMax = maxIntensity
   }
@@ -326,7 +326,7 @@ export const processIonImage = (
     rankValues = getRankValues(values, lowQuantile, highQuantile)
 
     // reassign intensity values to be displayed if normalized
-    if (normalizationData) {
+    if (normalizationData && normalizationData.metadata) {
       maxIntensity = normalizationData ? maxIntensity / normalizationData.metadata.maxTic * 1000000 : maxIntensity
       userMax = maxIntensity
       max = maxIntensity

--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
@@ -666,7 +666,7 @@ export default Vue.extend({
         const dataset = resp.data.dataset
         const tics = dataset.diagnostics.filter((diagnostic) => diagnostic.type === 'TIC')
         const tic = tics[0].images.filter((image) => image.key === 'TIC' && image.format === 'NPY')
-        const { data, shape, image } = await readNpy(tic[0].url)
+        const { data, shape } = await readNpy(tic[0].url)
         const metadata = safeJsonParse(tics[0].data)
         metadata.maxTic = metadata.max_tic
         metadata.minTic = metadata.min_tic

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImage.vue
@@ -163,7 +163,13 @@ export default class MainImage extends Vue {
     keepPixelSelected?: boolean
 
     @Prop({ type: Boolean })
+    isNormalized?: boolean
+
+    @Prop({ type: Boolean })
     hideColorBar?: boolean
+
+    @Prop({ type: Object })
+    normalizationData?: any
 
     ionImageUrl: string | null = null;
     ionImagePng: Image | null = null;
@@ -213,8 +219,8 @@ export default class MainImage extends Vue {
       if (this.ionImagePng != null) {
         const isotopeImage = get(this.annotation, 'isotopeImages[0]')
         const { minIntensity, maxIntensity } = isotopeImage
-
-        return processIonImage(this.ionImagePng, minIntensity, maxIntensity, this.scaleType, this.userScaling)
+        return processIonImage(this.ionImagePng, minIntensity, maxIntensity, this.scaleType, this.userScaling
+          , undefined, this.isNormalized ? this.normalizationData : null)
       } else {
         return null
       }

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImageHeader.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImageHeader.vue
@@ -130,6 +130,9 @@ export default class MainImageHeader extends Vue {
     @Prop({ required: true, type: Boolean })
     isActive!: boolean
 
+    @Prop({ type: Boolean, default: () => false })
+    showNormalizedBadge: boolean
+
     @Prop({ type: Boolean })
     hideOptions: boolean | undefined
 
@@ -147,7 +150,7 @@ export default class MainImageHeader extends Vue {
     }
 
     get isNormalized() {
-      return this.$store.getters.settings.annotationView.normalization && this.isActive
+      return this.showNormalizedBadge || (this.$store.getters.settings.annotationView.normalization && this.isActive)
     }
 
     onScaleBarColorChange(color: string | null) {

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImageHeader.vue
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/MainImageHeader.vue
@@ -130,8 +130,8 @@ export default class MainImageHeader extends Vue {
     @Prop({ required: true, type: Boolean })
     isActive!: boolean
 
-    @Prop({ type: Boolean, default: () => false })
-    showNormalizedBadge: boolean
+    @Prop({ type: Boolean })
+    showNormalizedBadge: boolean = false
 
     @Prop({ type: Boolean })
     hideOptions: boolean | undefined

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
@@ -357,7 +357,7 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
                 <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-11" dy="0.32em">100</text>
               </g>
             </g><text class="intensity-axis-label" transform="translate(-30, 120) rotate(-90)">Relative intensity</text><text style="text-anchor: middle;" transform="translate(60, 270) ">m/z</text>
-            <g class="sample-graph refSample">
+            <g class="sample-graph soloSample">
               <g>
                 <circle cx="9.999999999999526" cy="0" r="4"></circle>
                 <circle cx="110.00000000000047" cy="96" r="4"></circle>
@@ -371,26 +371,7 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
                 <rect width="0.06060000000047694" height="144" x="109.96970000000023" y="96"></rect>
               </g>
             </g>
-            <g class="sample-graph compSample">
-              <g>
-                <circle cx="9.999999999999526" cy="0" r="4"></circle>
-                <circle cx="110.00000000000047" cy="96" r="4"></circle>
-              </g>
-              <g>
-                <line x1="9.999999999999526" x2="9.999999999999526" y1="0" y2="240"></line>
-                <line x1="110.00000000000047" x2="110.00000000000047" y1="96" y2="240"></line>
-              </g>
-              <g>
-                <rect width="0.0599999999991514" height="240" x="9.969999999999951" y="0"></rect>
-                <rect width="0.06060000000047694" height="144" x="109.96970000000023" y="96"></rect>
-              </g>
-            </g>
-            <g class="theor-graph refTheor">
-              <g>
-                <path d="M0,240L9.999999999999526,237.6L19.99999999999905,240L100.00000000000095,240L110.00000000000047,238.8L120,240"></path>
-              </g>
-            </g>
-            <g class="theor-graph compTheor">
+            <g class="theor-graph soloTheor">
               <g>
                 <path d="M0,240L9.999999999999526,237.6L19.99999999999905,240L100.00000000000095,240L110.00000000000047,238.8L120,240"></path>
               </g>

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/__snapshots__/Diagnostics.spec.ts.snap
@@ -357,7 +357,7 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
                 <line stroke="currentColor" x2="-6"></line><text fill="currentColor" x="-11" dy="0.32em">100</text>
               </g>
             </g><text class="intensity-axis-label" transform="translate(-30, 120) rotate(-90)">Relative intensity</text><text style="text-anchor: middle;" transform="translate(60, 270) ">m/z</text>
-            <g class="sample-graph soloSample">
+            <g class="sample-graph refSample">
               <g>
                 <circle cx="9.999999999999526" cy="0" r="4"></circle>
                 <circle cx="110.00000000000047" cy="96" r="4"></circle>
@@ -371,7 +371,26 @@ exports[`Diagnostics should match snapshot (with isobar) 1`] = `
                 <rect width="0.06060000000047694" height="144" x="109.96970000000023" y="96"></rect>
               </g>
             </g>
-            <g class="theor-graph soloTheor">
+            <g class="sample-graph compSample">
+              <g>
+                <circle cx="9.999999999999526" cy="0" r="4"></circle>
+                <circle cx="110.00000000000047" cy="96" r="4"></circle>
+              </g>
+              <g>
+                <line x1="9.999999999999526" x2="9.999999999999526" y1="0" y2="240"></line>
+                <line x1="110.00000000000047" x2="110.00000000000047" y1="96" y2="240"></line>
+              </g>
+              <g>
+                <rect width="0.0599999999991514" height="240" x="9.969999999999951" y="0"></rect>
+                <rect width="0.06060000000047694" height="144" x="109.96970000000023" y="96"></rect>
+              </g>
+            </g>
+            <g class="theor-graph refTheor">
+              <g>
+                <path d="M0,240L9.999999999999526,237.6L19.99999999999905,240L100.00000000000095,240L110.00000000000047,238.8L120,240"></path>
+              </g>
+            </g>
+            <g class="theor-graph compTheor">
               <g>
                 <path d="M0,240L9.999999999999526,237.6L19.99999999999905,240L100.00000000000095,240L110.00000000000047,238.8L120,240"></path>
               </g>

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.scss
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.scss
@@ -3,6 +3,16 @@
   min-height: 200px;
   overflow-x: auto;
 
+  .normalization-error-wrapper{
+    height: 350px;
+    width: 100%;
+    @apply flex items-center justify-center;
+  }
+
+  .info-icon{
+    font-size: 20px;
+  }
+
   .dataset-comparison-extra{
     position: absolute;
     right: 8px;

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.scss
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.scss
@@ -3,6 +3,18 @@
   min-height: 200px;
   overflow-x: auto;
 
+
+  .ds-comparison-opacity-item{
+    min-width: 170px;
+
+    span{
+      font-size: 10px;
+      line-height: 1.2rem;
+      white-space: nowrap;
+      margin-left: 1px;
+    }
+  }
+
   .normalization-error-wrapper{
     height: 350px;
     width: 100%;

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
@@ -51,6 +51,7 @@ interface GridCellState {
   imageFit: Readonly<FitImageToAreaResult>
   lockedIntensities: [number | undefined, number | undefined]
   annotImageOpacity: number
+  opticalOpacity: number
   imagePosition: ImagePosition,
   pixelAspectRatio: number
   imageZoom: number
@@ -260,6 +261,7 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
           imageFit: computed(() => imageFit(key)),
           lockedIntensities: [undefined, undefined],
           annotImageOpacity: 1.0,
+          opticalOpacity: 1.0,
           imagePosition: defaultImagePosition(),
           pixelAspectRatio:
             config.features.ignore_pixel_aspect_ratio ? 1
@@ -533,6 +535,10 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       state.gridState[key]!.annotImageOpacity = opacity
     }
 
+    const handleOpticalOpacityChange = (opacity: any, key: string) => {
+      state.gridState[key]!.opticalOpacity = opacity
+    }
+
     const handleUserScalingChange = (userScaling: any, key: string, ignoreBoundaries: boolean = false) => {
       const gridCell = state.gridState[key]
       if (gridCell == null) {
@@ -802,6 +808,7 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
                 pixelSizeX={gridCell.pixelSizeX}
                 pixelSizeY={gridCell.pixelSizeY}
                 pixelAspectRatio={gridCell.pixelAspectRatio}
+                opticalOpacity={gridCell.opticalOpacity}
                 imageHeight={gridCell.ionImageLayers[0]?.ionImage?.height }
                 imageWidth={gridCell.ionImageLayers[0]?.ionImage?.width }
                 height={dimensions.height}
@@ -824,20 +831,37 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
               />
             }
             <div class="ds-viewer-controls-wrapper  v-rhythm-3 sm-side-bar">
-              <FadeTransition class="absolute bottom-0 right-0 mt-3 ml-3 dom-to-image-hidden">
-                {
-                  gridCell?.showOpticalImage
-                  && annData?.dataset?.opticalImages[0]?.url
-                  !== undefined
-                  && <OpacitySettings
-                    key="opacity"
-                    class="ds-comparison-opacity-item sm-leading-trim mt-auto dom-to-image-hidden"
-                    opacity={gridCell.annotImageOpacity !== undefined
-                      ? gridCell.annotImageOpacity : 1}
-                    onOpacity={(opacity: number) => handleOpacityChange(opacity, key)}
-                  />
-                }
-              </FadeTransition>
+              <div class="flex absolute bottom-0 right-0 my-3 ml-3 dom-to-image-hidden">
+                <FadeTransition>
+                  {
+                    gridCell?.showOpticalImage
+                    && annData?.dataset?.opticalImages[0]?.url
+                    !== undefined
+                    && <OpacitySettings
+                      key="opticalOpacity"
+                      label="Optical image visibility"
+                      class="ds-comparison-opacity-item m-1 sm-leading-trim mt-auto dom-to-image-hidden"
+                      opacity={gridCell.opticalOpacity !== undefined
+                        ? gridCell.opticalOpacity : 1}
+                      onOpacity={(opacity: number) => handleOpticalOpacityChange(opacity, key)}
+                    />
+                  }
+                </FadeTransition>
+                <FadeTransition>
+                  {
+                    gridCell?.showOpticalImage
+                    && annData?.dataset?.opticalImages[0]?.url
+                    !== undefined
+                    && <OpacitySettings
+                      key="opacity"
+                      class="ds-comparison-opacity-item m-1 sm-leading-trim mt-auto dom-to-image-hidden"
+                      opacity={gridCell.annotImageOpacity !== undefined
+                        ? gridCell.annotImageOpacity : 1}
+                      onOpacity={(opacity: number) => handleOpacityChange(opacity, key)}
+                    />
+                  }
+                </FadeTransition>
+              </div>
               <FadeTransition class="absolute top-0 right-0 mt-3 ml-3 dom-to-image-hidden">
                 {
                   state.refsLoaded

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
@@ -33,9 +33,11 @@ interface DatasetComparisonGridProps {
   scaleBarColor: string
   selectedAnnotation: number
   annotations: any[]
+  normalizationData: any
   datasets: any[]
   isLoading: boolean
   resetViewPort: boolean
+  isNormalized: boolean
   lockedIntensityTemplate: string
   globalLockedIntensities: [number | undefined, number | undefined]
 }
@@ -95,6 +97,10 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       type: Array,
       required: true,
     },
+    normalizationData: {
+      type: Object,
+      default: () => {},
+    },
     datasets: {
       type: Array,
       required: true,
@@ -104,6 +110,10 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       default: false,
     },
     resetViewPort: {
+      type: Boolean,
+      default: false,
+    },
+    isNormalized: {
       type: Boolean,
       default: false,
     },
@@ -428,12 +438,13 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
     }
 
     const ionImage = (ionImagePng: any, isotopeImage: any,
-      scaleType: any = 'linear', userScaling: any = [0, 1]) => {
+      scaleType: any = 'linear', userScaling: any = [0, 1], normalizedData: any = null) => {
       if (!isotopeImage || !ionImagePng) {
         return null
       }
       const { minIntensity, maxIntensity } = isotopeImage
-      return processIonImage(ionImagePng, minIntensity, maxIntensity, scaleType, userScaling)
+      return processIonImage(ionImagePng, minIntensity, maxIntensity, scaleType
+        , userScaling, undefined, normalizedData)
     }
 
     const ionImageLayers = (key: string) => {
@@ -445,7 +456,9 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       }
       const finalImage = ionImage(gridCell.ionImagePng,
         annotation.isotopeImages[0],
-        props.scaleType, gridCell.imageScaledScaling)
+        props.scaleType, gridCell.imageScaledScaling,
+        props.isNormalized && props.normalizationData
+          ? props.normalizationData[annotation.dataset.id] : null)
       const hasOpticalImage = annotation.dataset.opticalImages[0]?.url !== undefined
 
       if (finalImage) {
@@ -705,6 +718,23 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
           </div>)
       }
 
+      if (props.isNormalized && annData && annData.dataset && annData.dataset.id
+        && props.normalizationData[annData.dataset.id] && props.normalizationData[annData.dataset.id].error) {
+        return (
+          <div key={col} class='dataset-comparison-grid-col overflow-hidden relative'
+            style={{ height: 200, width: 200 }}>
+            {gridCell && renderDatasetName(row, col)}
+            <div
+              class="normalization-error-wrapper"
+            >
+              <i class="el-icon-error info-icon mr-2" />
+              <p class="text-lg">
+              There was an error on normalization!
+              </p>
+            </div>
+          </div>
+        )
+      }
       return (
         <div key={col} class='dataset-comparison-grid-col overflow-hidden relative'
           style={{ height: 200, width: 200 }}>

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.scss
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.scss
@@ -47,9 +47,6 @@
     }
   }
 
-  .ds-comparison-opacity-item{
-    min-width: 160px;
-  }
   #annot-content {
     width: 100%;
 

--- a/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonGrid.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonGrid.spec.ts.snap
@@ -519,14 +519,24 @@ exports[`DatasetComparisonGrid it should match snapshot 1`] = `
         <div
           class="ds-viewer-controls-wrapper  v-rhythm-3 sm-side-bar"
         >
-          <transition-stub
-            class="absolute bottom-0 right-0 mt-3 ml-3 dom-to-image-hidden"
-            enteractiveclass="duration-150 transition-opacity ease-in-out"
-            enterclass="opacity-0"
-            leaveactiveclass="duration-150 transition-opacity ease-in-out"
-            leavetoclass="opacity-0"
-            mode="out-in"
-          />
+          <div
+            class="flex absolute bottom-0 right-0 my-3 ml-3 dom-to-image-hidden"
+          >
+            <transition-stub
+              enteractiveclass="duration-150 transition-opacity ease-in-out"
+              enterclass="opacity-0"
+              leaveactiveclass="duration-150 transition-opacity ease-in-out"
+              leavetoclass="opacity-0"
+              mode="out-in"
+            />
+            <transition-stub
+              enteractiveclass="duration-150 transition-opacity ease-in-out"
+              enterclass="opacity-0"
+              leaveactiveclass="duration-150 transition-opacity ease-in-out"
+              leavetoclass="opacity-0"
+              mode="out-in"
+            />
+          </div>
           <transition-stub
             class="absolute top-0 right-0 mt-3 ml-3 dom-to-image-hidden"
             enteractiveclass="duration-150 transition-opacity ease-in-out"
@@ -1140,14 +1150,24 @@ exports[`DatasetComparisonGrid it should match snapshot 1`] = `
         <div
           class="ds-viewer-controls-wrapper  v-rhythm-3 sm-side-bar"
         >
-          <transition-stub
-            class="absolute bottom-0 right-0 mt-3 ml-3 dom-to-image-hidden"
-            enteractiveclass="duration-150 transition-opacity ease-in-out"
-            enterclass="opacity-0"
-            leaveactiveclass="duration-150 transition-opacity ease-in-out"
-            leavetoclass="opacity-0"
-            mode="out-in"
-          />
+          <div
+            class="flex absolute bottom-0 right-0 my-3 ml-3 dom-to-image-hidden"
+          >
+            <transition-stub
+              enteractiveclass="duration-150 transition-opacity ease-in-out"
+              enterclass="opacity-0"
+              leaveactiveclass="duration-150 transition-opacity ease-in-out"
+              leavetoclass="opacity-0"
+              mode="out-in"
+            />
+            <transition-stub
+              enteractiveclass="duration-150 transition-opacity ease-in-out"
+              enterclass="opacity-0"
+              leaveactiveclass="duration-150 transition-opacity ease-in-out"
+              leavetoclass="opacity-0"
+              mode="out-in"
+            />
+          </div>
           <transition-stub
             class="absolute top-0 right-0 mt-3 ml-3 dom-to-image-hidden"
             enteractiveclass="duration-150 transition-opacity ease-in-out"


### PR DESCRIPTION
### Description

Add TIC feature to ds comparison page and imzml browser page and add optical image opacity to ds comparison page. 
#937

### How to test it

* Add the tic feature flag to test it (feat=tic).
* As the imzml browser backend routes are a POC, in order to test the front-end, you need to run the backend as a standalone server. To test it, follow these steps:

1 - Run the metaspace project
2 - Go to the the folder metaspace/metaspace/browser and register the sm dev package:  python3 setup.py develop
3 - Go to the folder /metaspace/metaspace/browser/sm/browser and run the server: uvicorn api:app --reload 
4 - Select the inputPath of the dataset you want to check the functionality, add its value to the attribute s3_path and pre-process it (via postman):
     route: http://127.0.0.1:8000/preprocess
     body: {
             "s3_path": "s3://sm-engine-dev/ddd7f0e5-ff74-4f61-96d4-60f40dfb4c3c",
     }
     * This step is needed, because I still didn't create a back-end route to check if the temp files generated already exists (i didnt do because I dont know how this will be in the production env).
5 - After pre-process the dataset, you can access the imzml browser page on the front-end: http://localhost:8999/dataset/<dataset_id>/browser    

#### Changes

##### Webapp

###### MainImage
- [x] Added normalization props

###### MainImageHeader
- [x] Added show normalization badge props

###### DatasetComparisonPage
- [x] Added  tic normalization

###### DatasetComparisonGrid
- [x] Added normalization
- [x] Added optical Image visibility control

###### DatasetBrowserPage
- [x] Added normalization

#### Tests
 
##### Front end
 
- [ ] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [x] md, lg, lg
- [ ] sm, xl


![image](https://user-images.githubusercontent.com/35172605/134609696-89504584-f28a-422e-8165-201e552a16f2.png)
![image](https://user-images.githubusercontent.com/35172605/134609846-307fe2b3-8443-42dc-9af4-90ec39af7c2c.png)



