### PR TITLE
Fix DatasetGroup.adminNames field

### DIFF
--- a/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
@@ -189,7 +189,7 @@ const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
         shortName: ds._source.ds_group_short_name || 'NULL',
         urlSlug: null,
         members: null,
-        get adminNames(): Promise<string[] | null> {
+        get adminNames(): Promise<string[]> {
           return getGroupAdminNames(ctx, groupId)
         },
       }

--- a/metaspace/graphql/src/modules/group/util/getGroupAdminNames.ts
+++ b/metaspace/graphql/src/modules/group/util/getGroupAdminNames.ts
@@ -5,7 +5,7 @@ import * as _ from 'lodash'
 
 const getGroupAdminNames = async(ctx: Context, groupId: string) => {
   const dataloader = ctx.contextCacheGet('getGroupAdminNamesDataLoader', [], () => {
-    return new DataLoader(async(groupIds: string[]): Promise<(string[] | null)[]> => {
+    return new DataLoader(async(groupIds: string[]): Promise<string[][]> => {
       const results = await ctx.entityManager.createQueryBuilder(UserGroupModel, 'userGroup')
         .leftJoin('userGroup.user', 'user')
         .where('userGroup.groupId = ANY(:groupIds)', { groupIds })
@@ -15,7 +15,7 @@ const getGroupAdminNames = async(ctx: Context, groupId: string) => {
         .addSelect('array_agg(user.name)', 'names')
         .getRawMany()
       const keyedResults = _.keyBy(results, 'groupId')
-      return groupIds.map(id => keyedResults[id] != null ? keyedResults[id].names : null)
+      return groupIds.map(id => keyedResults[id] != null ? keyedResults[id].names : [])
     })
   })
   return dataloader.load(groupId)


### PR DESCRIPTION
If a group has no admins, this returns null, which violates the graphql schema and causes the whole query to fail. This change makes it return an empty array instead of null. 

Currently the CSV export for the datasets list is broken because there is a group with no admins.