### PR TITLE
[DsComparisonPage] Fixed database filter options as props

### DIFF
--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -187,6 +187,16 @@ export const datasetListItemsWithDiagnosticsQuery =
       id
       name
       uploadDT
+      databases {
+        id
+        name
+        version
+        archived
+        group {
+          id
+          shortName
+        }
+      }
       diagnostics {
         id
         type

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
@@ -60,6 +60,7 @@ interface DatasetComparisonPageState {
   annotationLoading: boolean
   isLoading: any
   collapse: string[]
+  databaseOptions: any
   normalizationData: any
 }
 
@@ -93,6 +94,7 @@ export default defineComponent<DatasetComparisonPageProps>({
     const state = reactive<DatasetComparisonPageState>({
       selectedAnnotation: -1,
       gridState: {},
+      databaseOptions: undefined,
       globalImageSettings: {
         resetViewPort: false,
         isNormalized: false,
@@ -177,8 +179,13 @@ export default defineComponent<DatasetComparisonPageProps>({
       const normalizationData : any = {}
       // calculate normalization
       if (result && result.data && result.data.allDatasets) {
+        let databases : any[] = []
+
         for (let i = 0; i < result.data.allDatasets.length; i++) {
-          const dataset = result.data.allDatasets[i]
+          const dataset : any = result.data.allDatasets[i]
+
+          databases = databases.concat(dataset.databases)
+
           try {
             const tics = dataset.diagnostics.filter((diagnostic : any) => diagnostic.type === 'TIC')
             const tic = tics[0].images.filter((image: any) => image.key === 'TIC' && image.format === 'NPY')
@@ -208,6 +215,8 @@ export default defineComponent<DatasetComparisonPageProps>({
             }
           }
         }
+
+        state.databaseOptions = { database: uniqBy(databases, 'id') }
       }
       state.normalizationData = normalizationData
     })
@@ -505,7 +514,12 @@ export default defineComponent<DatasetComparisonPageProps>({
       }
       return (
         <div class='dataset-comparison-page w-full flex flex-wrap flex-row'>
-          <FilterPanel class='w-full' level='annotation' hiddenFilters={['datasetIds']}/>
+          <FilterPanel
+            class='w-full'
+            level='annotation'
+            hiddenFilters={['datasetIds']}
+            fixedOptions={state.databaseOptions}
+          />
           <div class='dataset-comparison-wrapper w-full md:w-6/12 relative'>
             {
               state.annotations

--- a/metaspace/webapp/src/modules/Filters/FilterPanel.vue
+++ b/metaspace/webapp/src/modules/Filters/FilterPanel.vue
@@ -81,7 +81,7 @@ Object.keys(FILTER_SPECIFICATIONS).reduce((accum, cur) => {
 /** @type {ComponentOptions<Vue> & Vue} */
 const FilterPanel = {
   name: 'filter-panel',
-  props: ['level', 'simpleFilterOptions', 'setDatasetOwnerOptions', 'hiddenFilters'],
+  props: ['level', 'simpleFilterOptions', 'setDatasetOwnerOptions', 'hiddenFilters', 'fixedOptions'],
   components: filterComponents,
   mounted() {
     this.$store.dispatch('initFilterLists')
@@ -242,6 +242,7 @@ const FilterPanel = {
           attrs: {
             ...pick(attrs, FILTER_COMPONENT_PROPS),
             value: this.getFilterValue(filterSpec, filterKey),
+            fixedOptions: this.getFixedOptions(filterSpec, filterKey),
             options: this.getFilterOptions(filterSpec, filterKey),
           },
         }
@@ -255,8 +256,16 @@ const FilterPanel = {
       }
     },
 
+    getFixedOptions(filter, filterKey) {
+      if (this.fixedOptions && Object.keys(this.fixedOptions).includes(filterKey)) {
+        return this.fixedOptions[filterKey]
+      }
+      return undefined
+    },
+
     getFilterOptions(filter, filterKey) {
       const { filterLists } = this.$store.state
+
       // dynamically generated options are supported:
       // either specify a function of optionLists or one of its field names
       if (filterKey === 'simpleFilter') {

--- a/metaspace/webapp/src/modules/Filters/filter-components/DatabaseFilter.vue
+++ b/metaspace/webapp/src/modules/Filters/filter-components/DatabaseFilter.vue
@@ -172,6 +172,9 @@ export default class DatabaseFilter extends Vue {
     @Prop()
     value!: string | undefined;
 
+    @Prop()
+    fixedOptions!: any | undefined;
+
     allDBsByGroup: any = null
     datasetDBsByGroup: any = null
 
@@ -219,6 +222,13 @@ export default class DatabaseFilter extends Vue {
       this.filterOptions('')
     }
 
+    @Watch('fixedOptions')
+    updateFixedOptions() {
+      this.previousQuery = null
+      this.options = {}
+      this.filterOptions('')
+    }
+
     filterOptions(query: string) {
       if (query === this.previousQuery || this.dbsByGroup === null) {
         return
@@ -228,9 +238,11 @@ export default class DatabaseFilter extends Vue {
 
       try {
         const groupOptions: GroupOption[] = []
+        const sourceDatabases = Array.isArray(this.fixedOptions) && this.fixedOptions.length > 0
+          ? getDatabasesByGroup(this.fixedOptions) : this.dbsByGroup
         const queryRegex = new RegExp(query, 'i')
 
-        for (const group of this.dbsByGroup) {
+        for (const group of sourceDatabases) {
           const options: Option[] = []
           for (const db of group.molecularDatabases) {
             const id = db.id.toString()


### PR DESCRIPTION
### Description

Fixing bugs reported by users when using dataset comparison feature. 
#970 #969 #971 

The  #969 described a strange behaviour when using custom databases on ds comparison, but after investigating the problem was pointed to the timeout of allAggregationAnnotations depending on the dataset size. 

#### Changes

##### Webapp

###### DatasetComparisonPage
- [x] Removed duplicated isomers, isobars and possibleCompounds that were shown on table and dataset info header
- [x] Showing only databases related to dataset on database filter

#### Tests
 
##### Front end
 
- [x] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [x] md, lg, lg
- [ ] sm, xl

