### PR TITLE
[MetadataEditor] Added template selector for dataset upload

### DIFF
--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -7,47 +7,42 @@
       <div id="md-section-list">
         <div
           v-if="isNew"
-          class="flex flex-row w-full flex-wrap mt-6"
+          class="flex flex-row w-full flex-wrap mt-6 justify-end"
         >
-          <div class="metadata-section__title w-3/12">
-            Metadata template
-            <el-popover
-              trigger="hover"
-              placement="top"
-            >
-              <div class="max-w-sm">
-                Type the name of a previous uploaded dataset and select
-                it to use its metadata as a template for you new upload!
-              </div>
-              <i
-                slot="reference"
-                class="el-icon-question metadata-help-icon"
-              />
-            </el-popover>
-          </div>
-          <div
-            class="ml-1"
+          <el-popover
+            trigger="click"
+            placement="left"
           >
-            <el-select
-              v-model="metadataTemplate"
-              placeholder="Start typing name"
-              remote
-              filterable
-              clearable
-              :remote-method="fetchDatasets"
-              :loading="loadingTemplates"
-              loading-text="Loading matching entries..."
-              no-match-text="No matches"
-              @change="metadataTemplateSelection"
+            <el-button
+              slot="reference"
+              type="primary"
+              class="mr-1"
             >
-              <el-option
-                v-for="option in templateOptions"
-                :key="option.id"
-                :value="option.id"
-                :label="option.name"
-              />
-            </el-select>
-          </div>
+              Copy metadata from another dataset...<i class="el-icon-document-copy ml-1"></i>
+            </el-button>
+
+            <div class="max-w-sm">
+              <el-select
+                v-model="metadataTemplate"
+                placeholder="Start typing name"
+                remote
+                filterable
+                clearable
+                :remote-method="fetchDatasets"
+                :loading="loadingTemplates"
+                loading-text="Loading matching entries..."
+                no-match-text="No matches"
+                @change="metadataTemplateSelection"
+              >
+                <el-option
+                  v-for="option in templateOptions"
+                  :key="option.id"
+                  :value="option.id"
+                  :label="option.name"
+                />
+              </el-select>
+            </div>
+          </el-popover>
         </div>
         <div class="flex flex-row w-full flex-wrap mt-6">
           <div class="metadata-section__title w-3/12">

--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -335,9 +335,11 @@ export default {
           variables: {
             dFilter: {
               metadataType: 'Imaging MS',
-              status: 'FINISHED',
+              submitter: this.submitter.id,
               name,
             },
+            orderBy: 'ORDER_BY_DATE',
+            sortingOrder: 'DESCENDING',
             query: '',
             limit: 10,
           },
@@ -394,6 +396,9 @@ export default {
           : (dataset && dataset.metadata && dataset.metadata.Data_Type)
       ) || defaultMetadataType
       await this.loadForm(dataset, options, mdType)
+      if (this.isNew) {
+        await this.fetchDatasets()
+      }
     },
 
     async reloadForm(mdType) {

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -69,25 +69,21 @@ exports[`MetadataEditor should match snapshot 1`] = `
 <div id="md-editor-container">
   <div mock-v-loading="true" style="position: relative;">
     <div id="md-section-list">
-      <div class="flex flex-row w-full flex-wrap mt-6">
-        <div class="metadata-section__title w-3/12">
-          Metadata template
-          <mock-el-popover trigger="hover" placement="top">
-            <div slot-key="default">
-              <div class="max-w-sm">
-                Type the name of a previous uploaded dataset and select
-                it to use its metadata as a template for you new upload!
-              </div>
+      <div class="flex flex-row w-full flex-wrap mt-6 justify-end">
+        <mock-el-popover trigger="click" placement="left">
+          <div slot-key="default">
+            <div class="max-w-sm">
+              <mock-el-select placeholder="Start typing name" remote="" filterable="" clearable="" remote-method="function () { [native code] }" loading-text="Loading matching entries..." no-match-text="No matches">
+                <mock-el-option value="allDatasets.0.id" label="allDatasets.0.name"></mock-el-option>
+                <mock-el-option value="allDatasets.1.id" label="allDatasets.1.name"></mock-el-option>
+              </mock-el-select>
             </div>
-            <div slot-key="reference"><i class="el-icon-question metadata-help-icon"></i></div>
-          </mock-el-popover>
-        </div>
-        <div class="ml-1">
-          <mock-el-select placeholder="Start typing name" remote="" filterable="" clearable="" remote-method="function () { [native code] }" loading-text="Loading matching entries..." no-match-text="No matches">
-            <mock-el-option value="allDatasets.0.id" label="allDatasets.0.name"></mock-el-option>
-            <mock-el-option value="allDatasets.1.id" label="allDatasets.1.name"></mock-el-option>
-          </mock-el-select>
-        </div>
+          </div>
+          <div slot-key="reference"><button type="button" class="el-button mr-1 el-button--primary">
+              <!---->
+              <!----><span>
+            Copy metadata from another dataset...<i class="el-icon-document-copy ml-1"></i></span></button></div>
+        </mock-el-popover>
       </div>
       <div class="flex flex-row w-full flex-wrap mt-6">
         <div class="metadata-section__title w-3/12">

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -71,6 +71,23 @@ exports[`MetadataEditor should match snapshot 1`] = `
     <div id="md-section-list">
       <div class="flex flex-row w-full flex-wrap mt-6">
         <div class="metadata-section__title w-3/12">
+          Metadata template
+          <mock-el-popover trigger="hover" placement="top">
+            <div slot-key="default">
+              <div class="max-w-sm">
+                Type the name of a previous uploaded dataset and select
+                it to use its metadata as a template for you new upload!
+              </div>
+            </div>
+            <div slot-key="reference"><i class="el-icon-question metadata-help-icon"></i></div>
+          </mock-el-popover>
+        </div>
+        <div class="ml-1">
+          <mock-el-select placeholder="Start typing name" remote="" filterable="" clearable="" remote-method="function () { [native code] }" loading-text="Loading matching entries..." no-match-text="No matches"></mock-el-select>
+        </div>
+      </div>
+      <div class="flex flex-row w-full flex-wrap mt-6">
+        <div class="metadata-section__title w-3/12">
           Dataset description
         </div>
         <section class="sm-RichText" id="description-container">

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -83,7 +83,10 @@ exports[`MetadataEditor should match snapshot 1`] = `
           </mock-el-popover>
         </div>
         <div class="ml-1">
-          <mock-el-select placeholder="Start typing name" remote="" filterable="" clearable="" remote-method="function () { [native code] }" loading-text="Loading matching entries..." no-match-text="No matches"></mock-el-select>
+          <mock-el-select placeholder="Start typing name" remote="" filterable="" clearable="" remote-method="function () { [native code] }" loading-text="Loading matching entries..." no-match-text="No matches">
+            <mock-el-option value="allDatasets.0.id" label="allDatasets.0.name"></mock-el-option>
+            <mock-el-option value="allDatasets.1.id" label="allDatasets.1.name"></mock-el-option>
+          </mock-el-select>
         </div>
       </div>
       <div class="flex flex-row w-full flex-wrap mt-6">


### PR DESCRIPTION
### Description

Added option to pre fill upload metadata info from previous uploaded dataset at upload page #963.


#### Changes

##### Webapp

###### MetadataEditor
- [x] Added remote search to load previous uploaded datasets
- [x] Filling metadata according to selected dataset template

#### Tests
 
##### Front end
 
- [ ] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [x] md, lg, lg
- [ ] sm, xl

![image](https://user-images.githubusercontent.com/35172605/139866137-ef939ebf-ddc5-4445-95b8-0f8c55845956.png)




