### PR TITLE
[MzFilter] Added raw input option to enable trailing zeros

### DIFF
--- a/metaspace/webapp/src/lib/util.ts
+++ b/metaspace/webapp/src/lib/util.ts
@@ -81,7 +81,7 @@ export function decodePayload(jwt: JWT) {
 
 export function mzFilterPrecision(value: number | string): string {
   // Using parseFloat to remove any extra decimal places that won't actually count toward the precision
-  const splitVal = String(parseFloat(String(value))).split('.')
+  const splitVal = String(value).split('.')
   if (splitVal.length === 1) {
     return '1'
   } else {

--- a/metaspace/webapp/src/modules/Filters/FilterPanel.spec.ts
+++ b/metaspace/webapp/src/modules/Filters/FilterPanel.spec.ts
@@ -96,7 +96,7 @@ describe('FilterPanel', () => {
       project: 'abc',
       datasetIds: ['aaa', 'bbb'],
       // compoundName: 'C10H15N3O5',
-      mz: 296.1,
+      mz: '296.1',
     }
     await Vue.nextTick()
 

--- a/metaspace/webapp/src/modules/Filters/__snapshots__/FilterPanel.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Filters/__snapshots__/FilterPanel.spec.ts.snap
@@ -279,14 +279,12 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
     <mock-el-popover trigger="click" placement="bottom" width="256" class="tf-value-container pl-3">
       <div slot-key="default">
         <div>
-          <div class="w-full el-input-number is-controls-right"><span role="button" class="el-input-number__decrease"><i class="el-icon-arrow-down"></i></span><span role="button" class="el-input-number__increase"><i class="el-icon-arrow-up"></i></span>
-            <div class="el-input">
-              <!----><input type="text" autocomplete="off" max="Infinity" min="-Infinity" class="el-input__inner" role="spinbutton" aria-valuemax="Infinity" aria-valuemin="-Infinity" aria-valuenow="296.0659" aria-disabled="false">
-              <!---->
-              <!---->
-              <!---->
-              <!---->
-            </div>
+          <div class="w-full el-input">
+            <!----><input type="text" autocomplete="off" step="0.0001" controls-position="right" class="el-input__inner">
+            <!---->
+            <!---->
+            <!---->
+            <!---->
           </div>
           <p class="leading-5 text-sm m-0 mt-3 text-gray-700"><i class="text-gray-600 mr-1 el-icon-info"></i>
             Press <span class="font-medium">Enter</span> to confirm manual input

--- a/metaspace/webapp/src/modules/Filters/filter-components/MzFilter.vue
+++ b/metaspace/webapp/src/modules/Filters/filter-components/MzFilter.vue
@@ -2,6 +2,7 @@
   <number-filter
     v-bind="$attrs"
     :step="0.0001"
+    :raw-input="true"
     v-on="$listeners"
   >
     <span class="ml-1">
@@ -11,7 +12,7 @@
 </template>
 
 <script>
-import Vue, { ComponentOptions } from 'vue'
+import Vue from 'vue'
 import { mzFilterPrecision } from '../../../lib/util'
 import NumberFilter from './NumberFilter.vue'
 

--- a/metaspace/webapp/src/modules/Filters/filter-components/NumberFilter.vue
+++ b/metaspace/webapp/src/modules/Filters/filter-components/NumberFilter.vue
@@ -7,7 +7,19 @@
     @destroy="destroy"
   >
     <div slot="edit">
+      <el-input
+        v-if="rawInput"
+        ref="input"
+        v-model="localValue"
+        :step="step"
+        :max="max"
+        :min="min"
+        class="w-full"
+        controls-position="right"
+        @change="onChange"
+      />
       <el-input-number
+        v-else
         ref="input"
         v-model="localValue"
         :step="step"
@@ -38,7 +50,7 @@
 </template>
 
 <script>
-import Vue, { ComponentOptions } from 'vue'
+import Vue from 'vue'
 import TagFilter from './TagFilter.vue'
 import { FilterHelpText } from './TagFilterComponents'
 
@@ -56,19 +68,23 @@ export default Vue.extend({
     max: Number,
     maxlength: String,
     step: Number,
+    rawInput: { type: Boolean, default: false },
   },
   data(vm) {
     return {
-      localValue: Number(vm.value) || 0,
+      localValue: (this.rawInput ? vm.value : Number(vm.value)) || 0,
     }
   },
   watch: {
     value: function() {
-      this.localValue = Number(this.value) || 0
+      this.localValue = (this.rawInput ? this.value : Number(this.value)) || 0
     },
   },
   methods: {
     onChange(val) {
+      if (this.rawInput) {
+        val = val.replace(/[^.\d]/g, '').replace(/^(\d*\.?)|(\d*)\.?/g, '$1$2')
+      }
       /* sending undefined causes an issue */
       const v = val === undefined ? 0 : val
       this.$emit('input', v)

--- a/metaspace/webapp/src/modules/Filters/filterSpecs.ts
+++ b/metaspace/webapp/src/modules/Filters/filterSpecs.ts
@@ -184,7 +184,6 @@ export const FILTER_SPECIFICATIONS: Record<FilterKey, FilterSpecification> = {
     description: 'Search by m/z',
     levels: ['annotation', 'dataset-annotation'],
     initialValue: 0,
-    encoding: 'number',
   },
 
   fdrLevel: {

--- a/metaspace/webapp/src/store/getters.js
+++ b/metaspace/webapp/src/store/getters.js
@@ -62,10 +62,10 @@ export default {
 
     if (filter.mz) {
       const mz = parseFloat(filter.mz),
-        deltamz = parseFloat(mzFilterPrecision(mz));
+        deltamz = parseFloat(mzFilterPrecision(filter.mz));
       f.mzFilter = {
-        min: mz - deltamz,
-        max: mz + deltamz
+        min: (mz - deltamz),
+        max: (mz + deltamz)
       };
     }
 


### PR DESCRIPTION
### Description

Changed mz filter to keep trailing zeros  #973 .


#### Changes

##### Webapp

###### NumberFilter
- [x] Added normal input option to enable string input, so the trailing zeros can persist

#### Tests
 
##### Front end
 
- [x] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [x] md, lg, lg
- [ ] sm, xl




