### PR TITLE
[EditProjectForm] fixed validations and enter press bug

### DIFF
--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -687,13 +687,29 @@ exports[`MetadataEditor should match snapshot 1`] = `
           <div mock-v-loading="0">
             <form class="el-form leading-6 v-rhythm-3 el-form--label-top" size="mini">
               <div><label><span class="text-base font-medium">Title</span>
-                  <div class="py-1 el-input">
-                    <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
+                  <div class="el-form-item is-required">
                     <!---->
-                    <!---->
-                    <!---->
-                    <!---->
-                  </div></label></div>
+                    <div class="el-form-item__content">
+                      <div class="py-1 el-input">
+                        <!----><input type="text" autocomplete="off" max-length="50" min-length="2" class="el-input__inner">
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                      </div>
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
+                    </div>
+                  </div></label>
+                <div class="hidden el-input">
+                  <!----><input type="text" autocomplete="off" class="el-input__inner">
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </div>
+              </div>
               <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>
@@ -725,7 +741,7 @@ exports[`MetadataEditor should match snapshot 1`] = `
                 <!---->
                 <!----><span>
         Cancel
-      </span></button> <button type="button" class="el-button el-button--primary">
+      </span></button> <button autofocus="autofocus" type="button" class="el-button el-button--primary">
                 <!---->
                 <!----><span>
         Create project

--- a/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
+++ b/metaspace/webapp/src/modules/Project/CreateProjectDialog.vue
@@ -35,6 +35,7 @@
         </el-button>
         <el-button
           type="primary"
+          autofocus
           :loading="isSubmitting"
           @click="handleCreate"
         >
@@ -118,6 +119,7 @@ export default class CreateProjectDialog extends Vue {
       try {
         const selectedDatasetIds = Object.keys(this.selectedDatasets).filter(key => this.selectedDatasets[key])
         const { name, isPublic, urlSlug } = this.project
+
         const { data } = await this.$apollo.mutate({
           mutation: createProjectMutation,
           variables: {

--- a/metaspace/webapp/src/modules/Project/EditProjectForm.vue
+++ b/metaspace/webapp/src/modules/Project/EditProjectForm.vue
@@ -11,12 +11,20 @@
     <div>
       <label>
         <primary-label-text>Title</primary-label-text>
-        <el-input
-          v-model="value.name"
-          class="py-1"
-          :max-length="50"
-        />
+        <el-form-item prop="name">
+          <el-input
+            v-model="value.name"
+            class="py-1"
+            :max-length="50"
+            :min-length="2"
+            validate-event
+          />
+        </el-form-item>
       </label>
+      <!--      empty and hidden input to prevent press enter reload vue bug-->
+      <el-input
+        class="hidden"
+      />
     </div>
     <div>
       <label>
@@ -71,7 +79,10 @@ export default class EditProjectForm extends Vue {
     isPublished!: Boolean;
 
     rules = {
-      name: [{ type: 'string', required: true, min: 2, message: 'Name is required', trigger: 'manual' }],
+      name: [
+        { required: true, message: 'Name is required', trigger: 'manual' },
+        { min: 2, max: 50, message: 'Length should be 2 to 50', trigger: 'change' },
+      ],
     };
 
     async validate(): Promise<boolean> {

--- a/metaspace/webapp/src/modules/Project/EditProjectForm.vue
+++ b/metaspace/webapp/src/modules/Project/EditProjectForm.vue
@@ -21,7 +21,8 @@
           />
         </el-form-item>
       </label>
-      <!--      empty and hidden input to prevent press enter reload vue bug-->
+      <!--      empty and hidden input to prevent press enter reload vue bug
+       https://forum.framework7.io/t/vue-pressing-enter-key-in-input-causes-app-to-reload/2585 -->
       <el-input
         class="hidden"
       />

--- a/metaspace/webapp/src/modules/Project/ProjectSettings.vue
+++ b/metaspace/webapp/src/modules/Project/ProjectSettings.vue
@@ -7,6 +7,7 @@
       <sm-form @submit="handleSave">
         <h2>Project Details</h2>
         <edit-project-form
+          ref="projectForm"
           v-model="model"
           class="mt-3 mb-6 v-rhythm-6"
           :is-published="isPublished"
@@ -201,6 +202,7 @@ export default class ProjectSettings extends Vue {
       this.errors = {}
       this.isSaving = true
       try {
+        const projectForm : any = await this.$refs.projectForm.validate() as any
         const { name, isPublic, urlSlug, doi } = this.model
         await this.$apollo.mutate<UpdateProjectMutation>({
           mutation: updateProjectMutation,
@@ -239,10 +241,12 @@ export default class ProjectSettings extends Vue {
           })
         }
       } catch (err) {
-        try {
-          this.errors = parseValidationErrors(err)
-        } finally {
-          reportError(err)
+        if (err !== false) { // false is the project validation form
+          try {
+            this.errors = parseValidationErrors(err)
+          } finally {
+            reportError(err)
+          }
         }
       } finally {
         this.isSaving = false

--- a/metaspace/webapp/src/modules/Project/ProjectSettings.vue
+++ b/metaspace/webapp/src/modules/Project/ProjectSettings.vue
@@ -202,7 +202,7 @@ export default class ProjectSettings extends Vue {
       this.errors = {}
       this.isSaving = true
       try {
-        const projectForm : any = await this.$refs.projectForm.validate() as any
+        await (this.$refs.projectForm as any).validate()
         const { name, isPublic, urlSlug, doi } = this.model
         await this.$apollo.mutate<UpdateProjectMutation>({
           mutation: updateProjectMutation,

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -6,13 +6,29 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
     <div mock-v-loading="0">
       <form class="el-form leading-6 v-rhythm-3 el-form--label-top" size="mini">
         <div><label><span class="text-base font-medium">Title</span>
-            <div class="py-1 el-input">
-              <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
+            <div class="el-form-item is-required">
               <!---->
-              <!---->
-              <!---->
-              <!---->
-            </div></label></div>
+              <div class="el-form-item__content">
+                <div class="py-1 el-input">
+                  <!----><input type="text" autocomplete="off" max-length="50" min-length="2" class="el-input__inner">
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </div>
+                <transition-stub name="el-zoom-in-top">
+                  <!---->
+                </transition-stub>
+              </div>
+            </div></label>
+          <div class="hidden el-input">
+            <!----><input type="text" autocomplete="off" class="el-input__inner">
+            <!---->
+            <!---->
+            <!---->
+            <!---->
+          </div>
+        </div>
         <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>
@@ -44,7 +60,7 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
           <!---->
           <!----><span>
         Cancel
-      </span></button> <button type="button" class="el-button el-button--primary">
+      </span></button> <button autofocus="autofocus" type="button" class="el-button el-button--primary">
           <!---->
           <!----><span>
         Create project
@@ -170,13 +186,29 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
     <div mock-v-loading="0">
       <form class="el-form leading-6 v-rhythm-3 el-form--label-top" size="mini">
         <div><label><span class="text-base font-medium">Title</span>
-            <div class="py-1 el-input">
-              <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
+            <div class="el-form-item is-required">
               <!---->
-              <!---->
-              <!---->
-              <!---->
-            </div></label></div>
+              <div class="el-form-item__content">
+                <div class="py-1 el-input">
+                  <!----><input type="text" autocomplete="off" max-length="50" min-length="2" class="el-input__inner">
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </div>
+                <transition-stub name="el-zoom-in-top">
+                  <!---->
+                </transition-stub>
+              </div>
+            </div></label>
+          <div class="hidden el-input">
+            <!----><input type="text" autocomplete="off" class="el-input__inner">
+            <!---->
+            <!---->
+            <!---->
+            <!---->
+          </div>
+        </div>
         <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>
@@ -208,7 +240,7 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
           <!---->
           <!----><span>
         Cancel
-      </span></button> <button type="button" class="el-button el-button--primary">
+      </span></button> <button autofocus="autofocus" type="button" class="el-button el-button--primary">
           <!---->
           <!----><span>
         Create project
@@ -333,13 +365,29 @@ exports[`ProjectsListPage should match snapshot 1`] = `
     <div mock-v-loading="0">
       <form class="el-form leading-6 v-rhythm-3 el-form--label-top" size="mini">
         <div><label><span class="text-base font-medium">Title</span>
-            <div class="py-1 el-input">
-              <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
+            <div class="el-form-item is-required">
               <!---->
-              <!---->
-              <!---->
-              <!---->
-            </div></label></div>
+              <div class="el-form-item__content">
+                <div class="py-1 el-input">
+                  <!----><input type="text" autocomplete="off" max-length="50" min-length="2" class="el-input__inner">
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </div>
+                <transition-stub name="el-zoom-in-top">
+                  <!---->
+                </transition-stub>
+              </div>
+            </div></label>
+          <div class="hidden el-input">
+            <!----><input type="text" autocomplete="off" class="el-input__inner">
+            <!---->
+            <!---->
+            <!---->
+            <!---->
+          </div>
+        </div>
         <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>
@@ -371,7 +419,7 @@ exports[`ProjectsListPage should match snapshot 1`] = `
           <!---->
           <!----><span>
         Cancel
-      </span></button> <button type="button" class="el-button el-button--primary">
+      </span></button> <button autofocus="autofocus" type="button" class="el-button el-button--primary">
           <!---->
           <!----><span>
         Create project

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
@@ -880,13 +880,29 @@ exports[`ViewProjectPage settings tab should disable actions when published 1`] 
                 <h2>Project Details</h2>
                 <form class="el-form leading-6 mt-3 mb-6 v-rhythm-6 el-form--label-top">
                   <div><label><span class="text-base font-medium">Title</span>
-                      <div class="py-1 el-input">
-                        <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
+                      <div class="el-form-item is-required">
                         <!---->
-                        <!---->
-                        <!---->
-                        <!---->
-                      </div></label></div>
+                        <div class="el-form-item__content">
+                          <div class="py-1 el-input">
+                            <!----><input type="text" autocomplete="off" max-length="50" min-length="2" class="el-input__inner">
+                            <!---->
+                            <!---->
+                            <!---->
+                            <!---->
+                          </div>
+                          <transition-stub name="el-zoom-in-top">
+                            <!---->
+                          </transition-stub>
+                        </div>
+                      </div></label>
+                    <div class="hidden el-input">
+                      <!----><input type="text" autocomplete="off" class="el-input__inner">
+                      <!---->
+                      <!---->
+                      <!---->
+                      <!---->
+                    </div>
+                  </div>
                   <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>
@@ -991,13 +1007,29 @@ exports[`ViewProjectPage settings tab should disable actions when under review 1
                 <h2>Project Details</h2>
                 <form class="el-form leading-6 mt-3 mb-6 v-rhythm-6 el-form--label-top">
                   <div><label><span class="text-base font-medium">Title</span>
-                      <div class="py-1 el-input">
-                        <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
+                      <div class="el-form-item is-required">
                         <!---->
-                        <!---->
-                        <!---->
-                        <!---->
-                      </div></label></div>
+                        <div class="el-form-item__content">
+                          <div class="py-1 el-input">
+                            <!----><input type="text" autocomplete="off" max-length="50" min-length="2" class="el-input__inner">
+                            <!---->
+                            <!---->
+                            <!---->
+                            <!---->
+                          </div>
+                          <transition-stub name="el-zoom-in-top">
+                            <!---->
+                          </transition-stub>
+                        </div>
+                      </div></label>
+                    <div class="hidden el-input">
+                      <!----><input type="text" autocomplete="off" class="el-input__inner">
+                      <!---->
+                      <!---->
+                      <!---->
+                      <!---->
+                    </div>
+                  </div>
                   <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>
@@ -1095,13 +1127,29 @@ exports[`ViewProjectPage settings tab should match snapshot 1`] = `
                 <h2>Project Details</h2>
                 <form class="el-form leading-6 mt-3 mb-6 v-rhythm-6 el-form--label-top">
                   <div><label><span class="text-base font-medium">Title</span>
-                      <div class="py-1 el-input">
-                        <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
+                      <div class="el-form-item is-required">
                         <!---->
-                        <!---->
-                        <!---->
-                        <!---->
-                      </div></label></div>
+                        <div class="el-form-item__content">
+                          <div class="py-1 el-input">
+                            <!----><input type="text" autocomplete="off" max-length="50" min-length="2" class="el-input__inner">
+                            <!---->
+                            <!---->
+                            <!---->
+                            <!---->
+                          </div>
+                          <transition-stub name="el-zoom-in-top">
+                            <!---->
+                          </transition-stub>
+                        </div>
+                      </div></label>
+                    <div class="hidden el-input">
+                      <!----><input type="text" autocomplete="off" class="el-input__inner">
+                      <!---->
+                      <!---->
+                      <!---->
+                      <!---->
+                    </div>
+                  </div>
                   <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>

--- a/metaspace/webapp/src/modules/UserProfile/ProjectsTable.vue
+++ b/metaspace/webapp/src/modules/UserProfile/ProjectsTable.vue
@@ -80,6 +80,7 @@
     </table>
     <el-row>
       <el-button
+        ref="createBtn"
         style="float: right; margin: 10px 0;"
         @click="handleOpenCreateProjectDialog"
       >
@@ -201,6 +202,9 @@ export default class ProjectsTable extends Vue {
     }
 
     handleOpenCreateProjectDialog() {
+      // blur on open dialog, so the dialog button can be focused
+      const createBtn : any = this.$refs.createBtn as any
+      createBtn.$el.blur()
       this.showCreateProjectDialog = true
     }
 

--- a/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/UserProfile/__snapshots__/EditUserPage.spec.ts.snap
@@ -164,13 +164,29 @@ exports[`EditUserPage should match snapshot 1`] = `
           <div mock-v-loading="0">
             <form class="el-form leading-6 v-rhythm-3 el-form--label-top" size="mini">
               <div><label><span class="text-base font-medium">Title</span>
-                  <div class="py-1 el-input">
-                    <!----><input type="text" autocomplete="off" max-length="50" class="el-input__inner">
+                  <div class="el-form-item is-required">
                     <!---->
-                    <!---->
-                    <!---->
-                    <!---->
-                  </div></label></div>
+                    <div class="el-form-item__content">
+                      <div class="py-1 el-input">
+                        <!----><input type="text" autocomplete="off" max-length="50" min-length="2" class="el-input__inner">
+                        <!---->
+                        <!---->
+                        <!---->
+                        <!---->
+                      </div>
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
+                    </div>
+                  </div></label>
+                <div class="hidden el-input">
+                  <!----><input type="text" autocomplete="off" class="el-input__inner">
+                  <!---->
+                  <!---->
+                  <!---->
+                  <!---->
+                </div>
+              </div>
               <div><label><span class="text-base font-medium">Privacy</span> <span class="block text-sm text-gray-800">
         Visibility of the project only, does not apply to included datasets
       </span></label>
@@ -202,7 +218,7 @@ exports[`EditUserPage should match snapshot 1`] = `
                 <!---->
                 <!----><span>
         Cancel
-      </span></button> <button type="button" class="el-button el-button--primary">
+      </span></button> <button autofocus="autofocus" type="button" class="el-button el-button--primary">
                 <!---->
                 <!----><span>
         Create project


### PR DESCRIPTION
### Description

Pressing Enter in the Create Project dialog refreshes the page without creating a project #988 

* Highlights
 - It seems there is a bug on vue form where pressing enter key in input causes app to reload when there is only one input in the form (i.e https://forum.framework7.io/t/vue-pressing-enter-key-in-input-causes-app-to-reload/2585), so a hidden input was added to prevent it.
 - The project name validation wasn't being triggered, so I added the validation in the forms submit and the el-form-item wrapper



