### PR TITLE
Return back to lithops 2.5.0

### DIFF
--- a/metaspace/engine/requirements.txt
+++ b/metaspace/engine/requirements.txt
@@ -26,4 +26,4 @@ pyspark[sql]==3.0.1
 pyarrow==1.0.1
 pysparkling==0.6.0
 s3fs
-lithops==2.5.6
+lithops==2.5.0

--- a/metaspace/engine/sm/engine/annotation_lithops/executor.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/executor.py
@@ -24,7 +24,7 @@ TRet = TypeVar('TRet')
 #: manually updating their config files every time it changes. The image must be public on
 #: Docker Hub, and can be rebuilt using the scripts/Dockerfile in `engine/docker/lithops_ibm_cf`.
 #: Note: sci-test changes this constant to force local execution without docker
-RUNTIME_DOCKER_IMAGE = 'metaspace2020/metaspace-lithops:1.9.2'
+RUNTIME_DOCKER_IMAGE = 'metaspace2020/metaspace-lithops:1.9.0'
 MEM_LIMITS = {
     'localhost': 32768,
     'ibm_cf': 4096,


### PR DESCRIPTION
Due to bugs in the latest versions of lithops, we decided to return to the latest stable version for us.