### PR TITLE
[DScomparison] changed to use get allAnnotations

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonAnnotationTable.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonAnnotationTable.tsx
@@ -46,7 +46,7 @@ const SORT_ORDER_TO_COLUMN = {
   ORDER_BY_MSM: 'msmscore',
   ORDER_BY_FDR_MSM: 'fdrlevel',
   ORDER_BY_FORMULA: 'sumformula',
-  ORDER_BY_DS_COUNT: 'datasetCount',
+  ORDER_BY_DS_COUNT: 'datasetcount',
 }
 
 export const DatasetComparisonAnnotationTable = defineComponent<DatasetComparisonAnnotationTableProps>({
@@ -128,7 +128,7 @@ export const DatasetComparisonAnnotationTable = defineComponent<DatasetCompariso
       const { sort, row, page } = $route.query
       const order = sort?.indexOf('-') === 0 ? 'descending' : 'ascending'
       const prop = sort ? sort.replace('-', '') : SORT_ORDER_TO_COLUMN.ORDER_BY_FDR_MSM
-      handleSortChange({ order, prop })
+      handleSortChange({ order, prop }, false)
       state.selectedRow = row ? props.annotations[parseInt(row, 10)]
         : state.processedAnnotations[0]
       onPageChange(page ? parseInt(page, 10) : 1, true)
@@ -287,7 +287,7 @@ export const DatasetComparisonAnnotationTable = defineComponent<DatasetCompariso
 
     const handleSortDsCount = (order: string) => {
       state.processedAnnotations = computed(() => props.annotations.slice().sort((a, b) =>
-        (order === 'ascending' ? 1 : -1) * (a.datasetCount - b.datasetCount)))
+        (order === 'ascending' ? 1 : -1) * (a.datasetcount - b.datasetcount)))
     }
 
     const handleSortFdr = (order: string) => {
@@ -295,7 +295,7 @@ export const DatasetComparisonAnnotationTable = defineComponent<DatasetCompariso
         (order === 'ascending' ? 1 : -1) * (a.fdrLevel - b.fdrLevel)))
     }
 
-    const handleSortChange = (settings: any) => {
+    const handleSortChange = (settings: any, setCurrentRow: boolean = true) => {
       const { prop, order } = settings
 
       if (!order) {
@@ -316,6 +316,11 @@ export const DatasetComparisonAnnotationTable = defineComponent<DatasetCompariso
         by: prop,
         dir: order?.toUpperCase(),
       })
+
+      if (setCurrentRow) {
+        state.selectedRow = state.processedAnnotations[0]
+        onPageChange(1)
+      }
     }
 
     const onPageSizeChange = (newSize: number) => {
@@ -574,7 +579,7 @@ export const DatasetComparisonAnnotationTable = defineComponent<DatasetCompariso
             />
             <TableColumn
               key="datasetCount"
-              property="datasetCount"
+              property="datasetcount"
               label="Datasets #"
               sortable="custom"
               minWidth="100"

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.scss
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.scss
@@ -8,7 +8,6 @@
 
   .dataset-comparison-item-header{
     background: #F1F5F8;
-    padding: 4px 8px;
     width: calc(100% - 16px);
     span{
       @apply mr-1;

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.spec.ts
@@ -12,6 +12,7 @@ describe('DatasetComparisonPage', () => {
     snapshot: '{"nCols":2,"nRows":1,"grid":{"0-0":"2021-04-14_07h23m35s",'
       + '"0-1":"2021-04-06_08h35m04s"}}',
   }))
+
   const dsData = [{
     id: '2021-04-14_07h23m35s',
     name: 'Mock (1)',
@@ -36,6 +37,9 @@ describe('DatasetComparisonPage', () => {
     initMockGraphqlClient({
       Query: () => ({
         imageViewerSnapshot: snapshotData,
+        allAnnotations: () => {
+          return []
+        },
         allDatasets: () => {
           return dsData
         },
@@ -83,22 +87,5 @@ describe('DatasetComparisonPage', () => {
     await Vue.nextTick()
 
     expect(wrapper).toMatchSnapshot()
-  })
-
-  it('it should call snapshot settings query', async() => {
-    router.replace({
-      name: 'datasets-comparison',
-      query: {
-        viewId: 'xxxx',
-      },
-      params: {
-        dataset_id: 'xxxx',
-      },
-    })
-    graphqlWithData()
-    mount(testHarness, { store, router })
-    await Vue.nextTick()
-
-    expect(snapshotData).toHaveBeenCalledTimes(1)
   })
 })

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
@@ -26,10 +26,8 @@ import CandidateMoleculesPopover from '../../Annotations/annotation-widgets/Cand
 import MolecularFormula from '../../../components/MolecularFormula'
 import CopyButton from '../../../components/CopyButton.vue'
 import { DatasetComparisonShareLink } from './DatasetComparisonShareLink'
-import { groupBy, isEqual, uniqBy } from 'lodash-es'
+import { groupBy, isEqual, uniqBy, uniq } from 'lodash-es'
 import { readNpy } from '../../../lib/npyHandler'
-import { resetIonImageState } from '../../ImageViewer/ionImageState'
-import { resetImageViewerState } from '../../ImageViewer/state'
 
 interface GlobalImageSettings {
   resetViewPort: boolean
@@ -188,7 +186,7 @@ export default defineComponent<DatasetComparisonPageProps>({
           const processedAnnotations = Object.keys(annotationsByIon).map((ion: string) => {
             const annotations = annotationsByIon[ion]
             const dbId = annotations[0].databaseDetails.id
-            const datasetIds = annotations.map((annotation: any) => annotation.dataset.id)
+            const datasetIds = uniq(annotations.map((annotation: any) => annotation.dataset.id))
 
             return {
               ion,
@@ -577,7 +575,7 @@ export default defineComponent<DatasetComparisonPageProps>({
                     ...ion.annotations[0],
                     msmScore: Math.max(...ion.annotations.map((annot: any) => annot.msmScore)),
                     fdrlevel: Math.min(...ion.annotations.map((annot: any) => annot.fdrlevel)),
-                    datasetCount: (ion.datasetIds || []).length,
+                    datasetcount: (ion.datasetIds || []).length,
                     rawAnnotations: ion.annotations,
                   }
                 })}

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
@@ -4,11 +4,11 @@ import {
   defineComponent,
   onMounted,
   reactive,
-  ref,
+  ref, watch,
   watchEffect,
 } from '@vue/composition-api'
 import { useQuery } from '@vue/apollo-composable'
-import { comparisonAnnotationListQuery } from '../../../api/annotation'
+import { annotationListQuery, comparisonAnnotationListQuery } from '../../../api/annotation'
 import safeJsonParse from '../../../lib/safeJsonParse'
 import RelatedMolecules from '../../Annotations/annotation-widgets/RelatedMolecules.vue'
 import ImageSaver from '../../ImageViewer/ImageSaver.vue'
@@ -26,8 +26,10 @@ import CandidateMoleculesPopover from '../../Annotations/annotation-widgets/Cand
 import MolecularFormula from '../../../components/MolecularFormula'
 import CopyButton from '../../../components/CopyButton.vue'
 import { DatasetComparisonShareLink } from './DatasetComparisonShareLink'
-import { uniqBy } from 'lodash-es'
+import { groupBy, isEqual, uniqBy } from 'lodash-es'
 import { readNpy } from '../../../lib/npyHandler'
+import { resetIonImageState } from '../../ImageViewer/ionImageState'
+import { resetImageViewerState } from '../../ImageViewer/state'
 
 interface GlobalImageSettings {
   resetViewPort: boolean
@@ -62,7 +64,12 @@ interface DatasetComparisonPageState {
   collapse: string[]
   databaseOptions: any
   normalizationData: any
+  offset: number
+  rawAnnotations: any
+  processedAnnotations: any
 }
+
+const CHUNK_SIZE = 1000
 
 export default defineComponent<DatasetComparisonPageProps>({
   name: 'DatasetComparisonPage',
@@ -105,7 +112,7 @@ export default defineComponent<DatasetComparisonPageProps>({
         selectedLockTemplate: null,
         globalLockedIntensities: [undefined, undefined],
       },
-      annotations: [],
+      annotations: undefined,
       datasets: [],
       collapse: ['images'],
       grid: undefined,
@@ -117,6 +124,9 @@ export default defineComponent<DatasetComparisonPageProps>({
       annotationLoading: true,
       isLoading: false,
       normalizationData: {},
+      offset: 0,
+      rawAnnotations: [],
+      processedAnnotations: [],
     })
     const { dataset_id: sourceDsId } = $route.params
     const { viewId: snapshotId } = $route.query
@@ -145,21 +155,54 @@ export default defineComponent<DatasetComparisonPageProps>({
       }
     }
 
-    const queryOptions = reactive({ enabled: false, fetchPolicy: 'no-cache' as const })
+    const annotationQueryOptions = reactive({ enabled: false, fetchPolicy: 'no-cache' as const })
     const dsQueryOptions = reactive({ enabled: false, fetchPolicy: 'no-cache' as const })
-    const queryVars = computed(() => ({
+    const annotationQueryVars = computed(() => ({
       ...queryVariables(),
       dFilter: { ...queryVariables().dFilter, ids: Object.values(state.grid || {}).join('|') },
+      limit: CHUNK_SIZE,
+      offset: state.offset,
     }))
+
     const {
       result: annotationsResult,
       loading: annotationsLoading,
-      onResult: onAnnotationsResult,
-    } = useQuery<any>(comparisonAnnotationListQuery, queryVars, queryOptions)
+      onResult: onAllAnnotationsResult,
+    } = useQuery<any>(annotationListQuery, annotationQueryVars, annotationQueryOptions)
 
-    onAnnotationsResult(async(result) => {
-      // enable datasets name query, now that the ids where gotten
-      dsQueryOptions.enabled = true
+    onAllAnnotationsResult(async(result) => {
+      let rawAnnotations = state.rawAnnotations
+      if (result && result.data) {
+        if (state.offset === 0) {
+          rawAnnotations = []
+        }
+        rawAnnotations = rawAnnotations.concat(result.data.allAnnotations)
+
+        state.rawAnnotations = rawAnnotations
+        if (state.offset < result.data.countAnnotations) {
+          state.offset += CHUNK_SIZE
+        } else {
+          annotationQueryOptions.enabled = false
+          state.offset = 0
+          const annotationsByIon = groupBy(state.rawAnnotations, 'ion')
+          const processedAnnotations = Object.keys(annotationsByIon).map((ion: string) => {
+            const annotations = annotationsByIon[ion]
+            const dbId = annotations[0].databaseDetails.id
+            const datasetIds = annotations.map((annotation: any) => annotation.dataset.id)
+
+            return {
+              ion,
+              dbId,
+              datasetIds,
+              annotations,
+            }
+          })
+
+          state.annotations = processedAnnotations
+          dsQueryOptions.enabled = true
+          state.annotationLoading = false
+        }
+      }
     })
 
     const {
@@ -221,13 +264,7 @@ export default defineComponent<DatasetComparisonPageProps>({
       state.normalizationData = normalizationData
     })
 
-    const loadAnnotations = () => { queryOptions.enabled = true }
-    state.annotations = computed(() => {
-      if (annotationsResult.value) {
-        return annotationsResult.value.allAggregatedAnnotations
-      }
-      return null
-    })
+    const loadAnnotations = () => { annotationQueryOptions.enabled = true }
     const datasets = computed(() => {
       if (datasetsResult.value) {
         return datasetsResult.value.allDatasets
@@ -238,12 +275,21 @@ export default defineComponent<DatasetComparisonPageProps>({
     const requestAnnotations = async() => {
       state.isLoading = true
       loadAnnotations()
-      state.annotationLoading = false
       state.isLoading = false
     }
 
     onMounted(() => {
       state.refsLoaded = true
+
+      // add listener to query annotations again in case the filters change
+      $store.watch((_, getters) => [getters.gqlAnnotationFilter,
+        $store.getters.gqlDatasetFilter, $store.getters.gqlColocalizationFilter, $store.getters.ftsQuery],
+      (filter, previousFilter) => {
+        if (state.annotations && !isEqual(filter, previousFilter)) {
+          state.offset = 0
+          annotationQueryOptions.enabled = true
+        }
+      })
     })
 
     watchEffect(async() => {
@@ -506,6 +552,7 @@ export default defineComponent<DatasetComparisonPageProps>({
     return () => {
       const nCols = state.nCols
       const nRows = state.nRows
+
       if (!snapshotId) {
         return (
           <div class='dataset-comparison-page w-full flex flex-wrap flex-row items-center justify-center'>
@@ -538,7 +585,7 @@ export default defineComponent<DatasetComparisonPageProps>({
               />
             }
             {
-              (annotationsLoading.value)
+              annotationsLoading.value
               && <div class='w-full absolute text-center top-0'>
                 <i
                   class="el-icon-loading"


### PR DESCRIPTION
### Description

Changed DsComparison page to use allAnnotations query instead of allAggregatedAnnotations #978 


#### Changes

##### Webapp

###### Dataset Comparison Page
- [x] Changed to allAnnotations query

#### Tests
 
##### Front end
 
- [ ] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [x] Safari
- [ ] Firefox
- [x] md, lg, lg
- [ ] sm, xl


