### PR TITLE
[Roi] roi stored according to its dataset

### DIFF
--- a/metaspace/webapp/src/components/RoiSettings.tsx
+++ b/metaspace/webapp/src/components/RoiSettings.tsx
@@ -158,7 +158,12 @@ export default defineComponent<RoiSettingsProps>({
     }
 
     const getRoi = () => {
-      return $store.state.roiInfo || []
+      if (
+        props.annotation && props.annotation.dataset?.id && $store.state.roiInfo
+        && Object.keys($store.state.roiInfo).includes(props.annotation.dataset.id)) {
+        return $store.state.roiInfo[props.annotation.dataset.id] || []
+      }
+      return []
     }
 
     const addRoi = (e: any) => {
@@ -177,7 +182,7 @@ export default defineComponent<RoiSettingsProps>({
         edit: false,
         isDrawing: true,
       })
-      $store.commit('setRoiInfo', roiInfo)
+      $store.commit('setRoiInfo', { key: props.annotation.dataset.id, roi: roiInfo })
     }
 
     const openRoi = (e: any) => {
@@ -194,25 +199,25 @@ export default defineComponent<RoiSettingsProps>({
     const handleNameEdit = (value: any, index: number) => {
       const roiInfo = getRoi()
       Vue.set(roiInfo, index, { ...roiInfo[index], name: value })
-      $store.commit('setRoiInfo', roiInfo)
+      $store.commit('setRoiInfo', { key: props.annotation.dataset.id, roi: roiInfo })
     }
 
     const toggleEdit = (index: number) => {
       const roiInfo = getRoi()
       Vue.set(roiInfo, index, { ...roiInfo[index], edit: !roiInfo[index].edit })
-      $store.commit('setRoiInfo', roiInfo)
+      $store.commit('setRoiInfo', { key: props.annotation.dataset.id, roi: roiInfo })
     }
 
     const toggleHidden = (index: number) => {
       const roiInfo = getRoi()
       Vue.set(roiInfo, index, { ...roiInfo[index], visible: !roiInfo[index].visible })
-      $store.commit('setRoiInfo', roiInfo)
+      $store.commit('setRoiInfo', { key: props.annotation.dataset.id, roi: roiInfo })
     }
 
     const removeRoi = (index: number) => {
       const roiInfo = getRoi()
       roiInfo.splice(index, 1)
-      $store.commit('setRoiInfo', roiInfo)
+      $store.commit('setRoiInfo', { key: props.annotation.dataset.id, roi: roiInfo })
     }
 
     const changeRoi = (channel: any, index: number) => {
@@ -223,7 +228,7 @@ export default defineComponent<RoiSettingsProps>({
         strokeColor: channels[channel].replace('rgb', 'rgba').replace(')', ', 0.6)'),
         color: channels[channel].replace('rgb', 'rgba').replace(')', ', 0.4)'),
       })
-      $store.commit('setRoiInfo', roiInfo)
+      $store.commit('setRoiInfo', { key: props.annotation.dataset.id, roi: roiInfo })
     }
 
     return () => {

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.ts
@@ -120,11 +120,11 @@ export default class AnnotationView extends Vue {
 
    created() {
      this.onImageMove = throttle(this.onImageMove)
-     this.$store.commit('setRoiInfo', [])
+     this.$store.commit('resetRoiInfo')
    }
 
    mounted() {
-     this.$store.commit('setRoiInfo', [])
+     this.$store.commit('resetRoiInfo')
    }
 
    metadataDependentComponent(category: string): any {
@@ -154,7 +154,12 @@ export default class AnnotationView extends Vue {
    }
 
    get roiInfo(): any {
-     return this.$store.state.roiInfo
+     if (
+       this.annotation && this.annotation.dataset?.id && this.$store.state.roiInfo
+       && Object.keys(this.$store.state.roiInfo).includes(this.annotation.dataset.id)) {
+       return this.$store.state.roiInfo[this.annotation.dataset.id] || []
+     }
+     return []
    }
 
    get imageOpacityMode(): OpacityMode {
@@ -370,7 +375,7 @@ export default class AnnotationView extends Vue {
        Vue.set(roi, roiIndex, { ...roi[roiIndex], coordinates })
      }
 
-     this.$store.commit('setRoiInfo', roi)
+     this.$store.commit('setRoiInfo', { key: this.annotation.dataset.id, roi })
    }
 
    filterColocSamples() {

--- a/metaspace/webapp/src/modules/ImageViewer/ImageViewer.vue
+++ b/metaspace/webapp/src/modules/ImageViewer/ImageViewer.vue
@@ -224,6 +224,15 @@ const ImageViewer = defineComponent<Props>({
       return /Trident\/|MSIE/.test(window.navigator.userAgent)
     })
 
+    const roiInfo = computed(() => {
+      if (
+        props.annotation && props.annotation.dataset?.id && root.$store.state.roiInfo
+        && Object.keys(root.$store.state.roiInfo).includes(props.annotation.dataset.id)) {
+        return root.$store.state.roiInfo[props.annotation.dataset.id] || []
+      }
+      return []
+    })
+
     return {
       imageArea,
       dimensions,
@@ -260,7 +269,7 @@ const ImageViewer = defineComponent<Props>({
         root.$store.getters.settings.annotationView.normalization && root.$store.state.normalization
       && root.$store.state.normalization.error),
       showNormalizedIntensity: computed(() => root.$store.getters.settings.annotationView.normalization),
-      roiInfo: computed(() => root.$store.state.roiInfo),
+      roiInfo,
       normalizationData: computed(() => root.$store.state.normalization),
       hasOpticalImage: computed(() => !!props.imageLoaderSettings.opticalSrc),
       lockIntensityEnabled: config.features.lock_intensity,

--- a/metaspace/webapp/src/store/index.js
+++ b/metaspace/webapp/src/store/index.js
@@ -22,7 +22,7 @@ const store = new Vuex.Store({
     normalization: undefined,
 
     // roi settings
-    roiInfo: [],
+    roiInfo: {},
 
     // is annotation table loading?
     tableIsLoading: true,

--- a/metaspace/webapp/src/store/mutations.js
+++ b/metaspace/webapp/src/store/mutations.js
@@ -13,6 +13,7 @@ import {
 } from '../modules/Filters';
 import { DEFAULT_ANNOTATION_VIEW_SECTIONS, DEFAULT_COLORMAP, DEFAULT_TABLE_ORDER } from '../modules/Filters/url';
 import { DEFAULT_SCALE_TYPE } from '../lib/constants';
+import Vue from 'vue'
 
 function updatedLocation(state, filter) {
   let query = encodeParams(filter, state.route.path, state.filterLists);
@@ -159,8 +160,12 @@ export default {
     state.normalization = normalizationMatrix;
   },
 
-  setRoiInfo(state, roi) {
-    state.roiInfo = roi;
+  setRoiInfo(state, {key, roi}) {
+    Vue.set(state.roiInfo, key, roi)
+  },
+
+  resetRoiInfo(state) {
+    state.roiInfo = {};
   },
 
   setSnapshotAnnotationIds(state, annotation) {


### PR DESCRIPTION
### Description

Associate ROI with the dataset it was drawn with #998 

#### Tests
 
##### Front end
 
- [ ] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [x] Safari
- [ ] Firefox
- [x] md, lg, lg
- [ ] sm, xl


