### PR TITLE
[DsComparisonTable] removed onkey hl keys from listener

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonAnnotationTable.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonAnnotationTable.tsx
@@ -28,17 +28,9 @@ interface DatasetComparisonAnnotationTableState {
 
 const KEY_TO_ACTION = {
   ArrowUp: 'up',
-  K: 'up',
-  k: 'up',
   ArrowDown: 'down',
-  J: 'down',
-  j: 'down',
   ArrowLeft: 'left',
-  H: 'left',
-  h: 'left',
   ArrowRight: 'right',
-  L: 'right',
-  l: 'right',
 }
 
 const SORT_ORDER_TO_COLUMN = {

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
@@ -4,11 +4,11 @@ import {
   defineComponent,
   onMounted,
   reactive,
-  ref, watch,
+  ref,
   watchEffect,
 } from '@vue/composition-api'
 import { useQuery } from '@vue/apollo-composable'
-import { annotationListQuery, comparisonAnnotationListQuery } from '../../../api/annotation'
+import { annotationListQuery } from '../../../api/annotation'
 import safeJsonParse from '../../../lib/safeJsonParse'
 import RelatedMolecules from '../../Annotations/annotation-widgets/RelatedMolecules.vue'
 import ImageSaver from '../../ImageViewer/ImageSaver.vue'


### PR DESCRIPTION
### Description

It was reported that when typing some adducts on ds comparison page filter, it is disappearing. i.e hcl #1005 


#### Tests
 
##### Front end
 
- [ ] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [x] Safari
- [ ] Firefox
- [x] md, lg, lg
- [ ] sm, xl


