### PR TITLE
Fix Python Client issue with slow uploading & add save_login function

### DIFF
--- a/metaspace/python-client/docs/source/content/examples/explore-off-sample-results.ipynb
+++ b/metaspace/python-client/docs/source/content/examples/explore-off-sample-results.ipynb
@@ -45,7 +45,6 @@
     "from matplotlib import pyplot as plt\n",
     "import pandas as pd\n",
     "from metaspace import SMInstance\n",
-    "import getpass\n",
     "\n",
     "sm_inst = SMInstance()\n",
     "sm_inst"

--- a/metaspace/python-client/docs/source/content/examples/fetch-dataset-annotations.ipynb
+++ b/metaspace/python-client/docs/source/content/examples/fetch-dataset-annotations.ipynb
@@ -57,9 +57,36 @@
    ],
    "source": [
     "from metaspace import SMInstance\n",
-    "sm = SMInstance()\n",
-    "sm"
+    "sm = SMInstance()\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Enter your API Key (only required for private datasets)\n",
+    "\n",
+    "To access private datasets on METASPACE, generate an API key from your [account page](https://metaspace2020.eu/user/me) and enter it when prompted below.\n",
+    "This step can be skipped for accessing public datasets."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# This will prompt you to enter your API key if needed and it will save it to a config file.\n",
+    "# Note that API keys should be kept secret like passwords.\n",
+    "sm.save_login()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",

--- a/metaspace/python-client/docs/source/content/examples/fetch-dataset-metadata.ipynb
+++ b/metaspace/python-client/docs/source/content/examples/fetch-dataset-metadata.ipynb
@@ -31,11 +31,40 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Provide a path to the main configuration file used by SM engine\n",
-    "sm = SMInstance()\n",
+    "sm = SMInstance()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Log in to METASPACE for access to private datasets. This step can be skipped if you only want to access public datasets.\n",
+    "# This will prompt you to enter your API key if needed and it will save it to a config file.\n",
+    "# Note that API keys should be kept secret like passwords.\n",
+    "sm.save_login()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
     "datasets = sm.datasets()\n",
     "datasets = datasets[0:3]"
-   ]
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "code",

--- a/metaspace/python-client/docs/source/content/examples/fetch-isotopic-images.ipynb
+++ b/metaspace/python-client/docs/source/content/examples/fetch-isotopic-images.ipynb
@@ -45,7 +45,8 @@
    "source": [
     "### Enter your API Key (only required for private datasets)\n",
     "\n",
-    "To access private datasets on METASPACE, generate an API key from your [account page](https://metaspace2020.eu/user/me) and enter it when prompted below"
+    "To access private datasets on METASPACE, generate an API key from your [account page](https://metaspace2020.eu/user/me) and enter it when prompted below.\n",
+    "This step can be skipped for accessing public datasets."
    ]
   },
   {
@@ -54,13 +55,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This will prompt you to enter your API key. \n",
-    "# Note that API keys should be kept secret like passwords. \n",
-    "# You can alternatively save your API key in a config file - see config.template for more details.\n",
-    "if not sm.logged_in():\n",
-    "    # Using getpass here prevents the API key from being accidentally saved with this notebook.\n",
-    "    api_key = getpass.getpass(prompt='API key: ', stream=None)\n",
-    "    sm.login(api_key=api_key)"
+    "# This will prompt you to enter your API key if needed and it will save it to a config file.\n",
+    "# Note that API keys should be kept secret like passwords.\n",
+    "sm.save_login()"
    ]
   },
   {

--- a/metaspace/python-client/docs/source/content/examples/manage-custom-molecular-databases.ipynb
+++ b/metaspace/python-client/docs/source/content/examples/manage-custom-molecular-databases.ipynb
@@ -74,10 +74,24 @@
     }
    ],
    "source": [
-    "api_key = \"API_KEY\"\n",
-    "sm = SMInstance(host=\"https://metaspace2020.eu\", api_key=api_key)\n",
-    "sm"
+    "sm = SMInstance()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# This will prompt you to enter your API key if needed and it will save it to a config file.\n",
+    "# Note that API keys should be kept secret like passwords.\n",
+    "sm.save_login()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",

--- a/metaspace/python-client/docs/source/content/examples/submit-dataset.ipynb
+++ b/metaspace/python-client/docs/source/content/examples/submit-dataset.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import json, getpass\n",
+    "import json\n",
     "from metaspace import SMInstance\n",
     "\n",
     "sm = SMInstance()"
@@ -44,13 +44,9 @@
    },
    "outputs": [],
    "source": [
-    "# This will prompt you to enter your API key. \n",
+    "# This will prompt you to enter your API key if needed and it will save it to a config file.\n",
     "# Note that API keys should be kept secret like passwords. \n",
-    "# You can alternatively save your API key in a config file - see config.template for more details.\n",
-    "if not sm.logged_in():\n",
-    "    # Using getpass here prevents the API key from being accidentally saved with this notebook.\n",
-    "    api_key = getpass.getpass(prompt='API key: ', stream=None)\n",
-    "    sm.login(api_key=api_key)"
+    "sm.save_login()"
    ]
   },
   {

--- a/metaspace/python-client/docs/source/content/examples/update-dataset-databases.ipynb
+++ b/metaspace/python-client/docs/source/content/examples/update-dataset-databases.ipynb
@@ -31,18 +31,11 @@
     }
    ],
    "source": [
-    "import json, pprint, getpass\n",
+    "import json, pprint\n",
     "from metaspace import SMInstance\n",
     "\n",
     "sm = SMInstance()\n",
     "sm"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To authenticate with METASPACE, generate an API key from your [account page](https://metaspace2020.eu/user/me) and enter it below"
    ]
   },
   {
@@ -53,13 +46,9 @@
    },
    "outputs": [],
    "source": [
-    "# This will prompt you to enter your API key. \n",
-    "# Note that API keys should be kept secret like passwords. \n",
-    "# You can alternatively save your API key in a config file - see config.template for more details.\n",
-    "if not sm.logged_in():\n",
-    "    # Using getpass here prevents the API key from being accidentally saved with this notebook.\n",
-    "    api_key = getpass.getpass(prompt='API key: ', stream=None)\n",
-    "    sm.login(api_key=api_key)"
+    "# This will prompt you to enter your API key and will save it to a config file.\n",
+    "# Note that API keys should be kept secret like passwords.\n",
+    "sm.save_login()"
    ]
   },
   {

--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.8.11'
+__version__ = '1.8.12'
 
 from metaspace.sm_annotation_utils import (
     SMInstance,

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -1485,8 +1485,13 @@ class SMInstance(object):
         try:
             self.reconnect()
         except (AssertionError, BadRequestException) as ex:
-            if ('Invalid API key' in ex.message or 'Login failed' in ex.message) and (api_key is None and email is None):
-                print(f'Login failed. Call sm.save_login(overwrite=True) to update your saved credentials.')
+            if ('Invalid API key' in ex.message or 'Login failed' in ex.message) and (
+                api_key is None and email is None
+            ):
+                print(
+                    f'Login failed. Call sm.save_login(overwrite=True) to update your '
+                    f'saved credentials.'
+                )
             else:
                 print(f'Failed to connect to {self._config["host"]}: {ex.message}')
 
@@ -1501,7 +1506,10 @@ class SMInstance(object):
             print(f'{config_path} already exists. Call sm.save_login(overwrite=True) to overwrite.')
             return
 
-        api_key = getpass(f'Please generate an API key at https://metaspace2020.eu/user/me and enter it here (or leave blank to cancel):')
+        api_key = getpass(
+            f'Please generate an API key at https://metaspace2020.eu/user/me and enter it here '
+            f'(or leave blank to cancel):'
+        )
         api_key = api_key.strip()
         if not api_key:
             print('Cancelled')


### PR DESCRIPTION
#### Fixes issue with slow uploads

Måns found that uploads that take longer than 5 minutes would fail because the pre-signed URLs would expire. The cause for this was that `ThreadPoolExecutor` evaluated `iterate_file` eagerly, loading the entire file into memory and pre-signing each of the chunks before there was an uploader thread ready to upload it. 

This was fixed by using a semaphore to prevent `iterate_file` from reading ahead when all the upload threads are busy, and by moving the pre-signing into the `upload_part` function.

#### Adds save_login function

Loading login details from a config file was implemented but never really documented. Many users actually just directly put their api_key in the source code, which is really bad. The config file approach isn't perfect, but it's much better than risking committing the api_keys to a public repository. 

This change adds a public API for creating the config file, and uses it in all the example notebooks.