### PR TITLE
Fix ReadTheDocs automated build

### DIFF
--- a/metaspace/python-client/docs/source/conf.py
+++ b/metaspace/python-client/docs/source/conf.py
@@ -37,7 +37,8 @@ extensions = [
     'sphinx_autodoc_typehints',
 ]
 
-source_suffix = ['.rst', '.ipynb']
+# NOTE: Never add .ipynb to this list: https://github.com/readthedocs/readthedocs.org/issues/8424#issuecomment-903014083
+source_suffix = ['.rst']
 nbsphinx_execute = 'never'
 
 # The name of the Pygments (syntax highlighting) style to use.


### PR DESCRIPTION
Fixes #1008 

The build was failing due to timeouts caused by the bug mentioned here: https://github.com/readthedocs/readthedocs.org/issues/8424#issuecomment-903014083

I also disabled the "Stable" build config for the project, because that seemed to try to rebuild `master` after a commit on any branch, which just cluttered the build list. Now RTD only includes "latest" docs