### PR TITLE
Enforce moldb visibility in dataset diagnostics

### DIFF
--- a/metaspace/graphql/src/modules/dataset/controller/Dataset.spec.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Dataset.spec.ts
@@ -1,0 +1,85 @@
+// ElasticSearch must be mocked before importing any other graphql code. It uses doMock so that it can reference
+// MockElasticSearchClient without jest's "jest.mock hoisting" causing problems.
+class MockElasticSearchClient {
+  static search = jest.fn()
+  search = MockElasticSearchClient.search
+}
+jest.doMock('elasticsearch', () => ({ Client: MockElasticSearchClient }))
+
+import {
+  createTestDataset, createTestDatasetDiagnostic,
+  createTestGroup, createTestJob,
+  createTestMolecularDB,
+  createTestUserGroup,
+} from '../../../tests/testDataCreation'
+import {
+  doQuery, onAfterAll, onAfterEach, onBeforeAll, onBeforeEach,
+  setupTestUsers, testEntityManager,
+  testUser,
+} from '../../../tests/graphqlTestEnvironment'
+import { Group, UserGroupRoleOptions as UGRO } from '../../group/model'
+import { Dataset } from '../model'
+import { getContextForTest } from '../../../getContext'
+
+describe('Dataset: diagnostics permissions', () => {
+  let dataset: Dataset
+  let group: Group
+
+  beforeAll(onBeforeAll)
+  afterAll(onAfterAll)
+  beforeEach(async() => {
+    await onBeforeEach()
+
+    await setupTestUsers()
+    dataset = await createTestDataset()
+    group = await createTestGroup()
+    const otherGroup = await createTestGroup()
+    const databaseDocs = [
+      { name: 'HMDB-v4', isPublic: true, groupId: null },
+      { name: 'custom-db-pub', isPublic: true, groupId: group.id },
+      { name: 'custom-db', isPublic: false, groupId: group.id },
+      { name: 'custom-db-other-pub', isPublic: true, groupId: otherGroup.id },
+      { name: 'custom-db-other-priv', isPublic: false, groupId: otherGroup.id },
+    ]
+    await createTestDatasetDiagnostic({ datasetId: dataset.id, data: { noJobId: true } })
+    for (const dbDoc of databaseDocs) {
+      const moldbId = (await createTestMolecularDB(dbDoc)).id
+      const jobId = (await createTestJob({ datasetId: dataset.id, moldbId })).id
+      await createTestDatasetDiagnostic({ datasetId: dataset.id, jobId })
+    }
+
+    // Mock elasticsearch so that it returns the minimum fields needed to reach the resolvers inside Dataset
+    MockElasticSearchClient.search.mockImplementation(() =>
+      ({ hits: { hits: [{ _source: { ds_id: dataset.id } }] } })
+    )
+  })
+  afterEach(onAfterEach)
+
+  const selectDatasetQuery = `query selectDataset($datasetId: String!) {
+    dataset (id: $datasetId) {
+      diagnostics {
+        data jobId database { name }
+      }
+    }
+  }`
+
+  test("User only sees diagnostics for databases that they're allowed to see", async() => {
+    await createTestUserGroup(testUser.id, group.id, UGRO.MEMBER, true)
+
+    const context = getContextForTest({ ...testUser, groupIds: [group.id] } as any, testEntityManager)
+    const ds = await doQuery(selectDatasetQuery, { datasetId: dataset.id }, { context })
+
+    const noJobDiags = ds.diagnostics.filter((diag: any) => JSON.parse(diag.data).noJobId)
+    const hasJobDiags = ds.diagnostics.filter((diag: any) => !JSON.parse(diag.data).noJobId)
+
+    // Should see the diagnostic that isn't associated with any job/molDB
+    expect(noJobDiags).toHaveLength(1)
+
+    // Should only see molDBs that are visible
+    const expectedMolDbs = ['HMDB-v4', 'custom-db-pub', 'custom-db', 'custom-db-other-pub']
+    const unwantedMolDb = 'custom-db-other-priv'
+    const foundMolDbs = hasJobDiags.map((diag: any) => diag.database.name)
+    expect(foundMolDbs).toEqual(expect.arrayContaining(expectedMolDbs))
+    expect(foundMolDbs).not.toContain(unwantedMolDb)
+  })
+})

--- a/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Dataset.ts
@@ -437,15 +437,29 @@ const DatasetResolvers: FieldResolversFor<Dataset, DatasetSource> = {
             datasetId: In(datasetIds),
             error: IsNull(),
           },
-          relations: ['job', 'job.molecularDB'],
+          relations: ['job'],
         })
-        const formattedResults = results.map(diag => ({
-          ...diag,
-          data: JSON.stringify(diag.data),
-          database: diag.job?.molecularDB ?? null,
-          updatedDT: diag.updatedDT.toISOString(),
+        const molDbRepository = ctx.entityManager.getCustomRepository(MolecularDbRepository)
+
+        const formattedResults = await Promise.all(results.map(async diag => {
+          let database = null
+          // If user isn't allowed to see the moldb, don't let them see the diagnostic
+          if (diag.job != null) {
+            try {
+              database = await molDbRepository.findDatabaseById(ctx, diag.job.moldbId)
+            } catch {
+              return null
+            }
+          }
+          return {
+            ...diag,
+            data: JSON.stringify(diag.data),
+            database,
+            updatedDT: diag.updatedDT.toISOString(),
+          }
         }))
-        const keyedResults = _.groupBy(formattedResults, 'datasetId')
+
+        const keyedResults = _.groupBy(formattedResults.filter(d => d != null), 'datasetId')
         return datasetIds.map(id => keyedResults[id] || [])
       })
     })

--- a/metaspace/graphql/src/tests/testDataCreation.ts
+++ b/metaspace/graphql/src/tests/testDataCreation.ts
@@ -6,7 +6,7 @@ import { Project, UserProject as UserProjectModel, UserProjectRoleOptions as UPR
 import { PublicationStatusOptions as PSO } from '../modules/project/Publishing'
 import { PublicationStatus, UserGroupRole, UserProjectRole } from '../binding'
 import { Dataset, DatasetProject } from '../modules/dataset/model'
-import { EngineDataset } from '../modules/engine/model'
+import { DatasetDiagnostic, EngineDataset, Job } from '../modules/engine/model'
 import { Group, UserGroup as UserGroupModel } from '../modules/group/model'
 import { MolecularDB } from '../modules/moldb/model'
 import { isMemberOfGroup } from '../modules/dataset/operation/isMemberOfGroup'
@@ -152,6 +152,7 @@ export const createTestDataset = async(
 ): Promise<Dataset> => {
   return (await createTestDatasetWithEngineDataset(dataset, engineDataset)).dataset
 }
+
 export const createTestDatasetProject = async(
   projectId: string, datasetId: string, approved = true
 ): Promise<DatasetProject> => {
@@ -177,4 +178,26 @@ export const createTestMolecularDB = async(molecularDb: Partial<MolecularDB> = {
     createdDT: moment.utc(),
     ...molecularDb,
   }) as MolecularDB
+}
+
+type RequiredJobFields = Pick<Job, 'datasetId' | 'moldbId'>
+export const createTestJob = async(job: RequiredJobFields & Partial<Job>): Promise<Job> => {
+  return (await testEntityManager.save(Job, {
+    status: 'FINISHED',
+    start: moment.utc(),
+    finish: moment.utc(),
+    ...job,
+  })) as Job
+}
+
+export const createTestDatasetDiagnostic = async(
+  diag: Pick<DatasetDiagnostic, 'datasetId'> & Partial<DatasetDiagnostic>
+): Promise<DatasetDiagnostic> => {
+  const result = await testEntityManager.save(DatasetDiagnostic, {
+    type: 'TIC',
+    data: { min_tic: 2332547584.0, max_tic: 24486256640.0, sum_tic: 4962219196416.0, is_from_metadata: false },
+    images: [{ key: 'TIC', image_id: 'test_image_id', url: 'test_image_url', format: 'NPY' }],
+    ...diag,
+  })
+  return result as unknown as DatasetDiagnostic
 }


### PR DESCRIPTION
The ML Scoring change adds job-specific Diagnostics, and I found that GraphQL doesn't filter the `DatasetDiagnostic`s  by visibility of molecular DBs. People would be able to get details about any private databases that were used on public datasets.

This PR fixes it by hiding `DatasetDiagnostic`s if the current user isn't allowed to see the molecular database.