### PR TITLE
Feature flag for v2

### DIFF
--- a/metaspace/webapp/src/lib/config.ts
+++ b/metaspace/webapp/src/lib/config.ts
@@ -22,6 +22,7 @@ interface Features {
   neutral_losses_new_ds: boolean; // False prevents neutral losses being set on the first upload
   chem_mods: boolean;
   advanced_ds_config: boolean;
+  v2: boolean;
   isomers: boolean;
   isobars: boolean;
   moldb_mgmt: boolean;
@@ -74,6 +75,7 @@ const defaultConfig: ClientConfig = {
     neutral_losses_new_ds: true,
     chem_mods: true,
     advanced_ds_config: false,
+    v2: true,
     isomers: true,
     isobars: true,
     moldb_mgmt: true,

--- a/metaspace/webapp/src/modules/App/NewFeaturePopups.vue
+++ b/metaspace/webapp/src/modules/App/NewFeaturePopups.vue
@@ -29,6 +29,17 @@
         Use &ldquo;Link to this annotation&rdquo; to preserve the layers and settings for collaborators.
       </p>
     </new-feature-popup>
+    <new-feature-popup
+      feature-key="v2"
+      title="Updated Analysis Engine"
+    >
+      <p>
+        Select &ldquo;v2 (ML-powered MSM)&rdquo; to use the latest version of the METASPACE analysis engine.
+      </p>
+      <p>
+        The new version uses mass accuracy metrics and machine learning to annotate more molecules, with lower False Discovery Rates.
+      </p>
+    </new-feature-popup>
   </div>
 </template>
 <script lang="ts">

--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -247,6 +247,18 @@ export default {
         this.submitter = result.data.user
       }
     },
+    async 'metaspaceOptions.analysisVersion'(newAnalysisVersion) {
+      // Unset scoringModel if changing to analysis_version 1. Reset initial/default scoring model if changing back.
+      if (newAnalysisVersion === 1 && this.metaspaceOptions.scoringModel != null) {
+        this.metaspaceOptions.scoringModel = null
+      } else if (
+        newAnalysisVersion !== 1
+        && this.metaspaceOptions.scoringModel == null
+        && (this.initialMetaspaceOptions?.scoringModel != null || this.scoringModels.some(m => m.name === 'v3_default'))
+      ) {
+        this.metaspaceOptions.scoringModel = this.initialMetaspaceOptions?.scoringModel ?? 'v3_default'
+      }
+    },
   },
 
   created() {

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -1011,15 +1011,15 @@ exports[`MetadataEditor should match snapshot 1`] = `
                       <mock-el-popover trigger="hover" placement="right">
                         <div slot-key="default">
                           <div class="analysis-version-help">
-                            Selects the version of the METASPACE analysis pipeline to use. When comparing data between multiple datasets,
-                            it is recommended to process all datasets with the same analysis version. Otherwise, select the latest stable version.
-                            <h4>Changes between versions:</h4>
+                            When comparing data between multiple datasets, it is recommended to process all datasets with the same
+                            analysis version. Otherwise, select the latest version for best results.
+                            <h4>Changes:</h4>
                             <!---->
                             <!---->
-                            <h5>Version 2:</h5>
+                            <h5>v2 (ML-powered MSM):</h5>
                             <ul>
-                              <li>New ML-powered model for scoring annotations.</li>
                               <li>New metrics for evaluating annotations' mass accuracy.</li>
+                              <li>New ML-powered model for annotation scoring.</li>
                               <li>Fine-grained reporting of FDR values.</li>
                             </ul>
                           </div>

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -1005,7 +1005,40 @@ exports[`MetadataEditor should match snapshot 1`] = `
                     </div>
                   </div>
                 </div>
-                <!---->
+                <div class="el-col el-col-8" style="padding-left: 4px; padding-right: 4px;">
+                  <div class="el-form-item md-form-field el-form-item--medium"><label class="el-form-item__label"><span class="field-label"><span>Analysis version</span>
+                      <!---->
+                      <mock-el-popover trigger="hover" placement="right">
+                        <div slot-key="default">
+                          <div class="analysis-version-help">
+                            Selects the version of the METASPACE analysis pipeline to use. When comparing data between multiple datasets,
+                            it is recommended to process all datasets with the same analysis version. Otherwise, select the latest stable version.
+                            <h4>Changes between versions:</h4>
+                            <!---->
+                            <!---->
+                            <h5>Version 2:</h5>
+                            <ul>
+                              <li>New ML-powered model for scoring annotations.</li>
+                              <li>New metrics for evaluating annotations' mass accuracy.</li>
+                              <li>Fine-grained reporting of FDR values.</li>
+                            </ul>
+                          </div>
+                        </div>
+                        <div slot-key="reference"><i class="el-icon-question metadata-help-icon"></i></div>
+                      </mock-el-popover>
+                      </span></label>
+                    <div class="el-form-item__content">
+                      <mock-el-select>
+                        <mock-el-option value="1" label="v1 (Original MSM)"></mock-el-option>
+                        <mock-el-option value="3" label="v2 (ML-powered MSM)"></mock-el-option>
+                      </mock-el-select>
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
+                    </div>
+                  </div>
+                  <!---->
+                </div>
               </div>
               <!---->
             </div>

--- a/metaspace/webapp/src/modules/MetadataEditor/inputs/AnalysisVersionHelp.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/inputs/AnalysisVersionHelp.vue
@@ -3,17 +3,29 @@
     Selects the version of the METASPACE analysis pipeline to use. When comparing data between multiple datasets,
     it is recommended to process all datasets with the same analysis version. Otherwise, select the latest stable version.
     <h4>Changes between versions:</h4>
-    <h5>Version 2:</h5>
-    <ul>
+    <h5 v-if="showV15">
+      Version 1.5 (unreleased version used for internal testing):
+    </h5>
+    <ul v-if="showV15">
       <li>Improved modeling of instrument mass accuracy at higher m/z values for TOF and Orbitrap.</li>
       <li>Improved isotopic peak calculation algorithm.</li>
+    </ul>
+    <h5>Version 2:</h5>
+    <ul>
+      <li>New ML-powered model for scoring annotations.</li>
+      <li>New metrics for evaluating annotations' mass accuracy.</li>
+      <li>Fine-grained reporting of FDR values.</li>
     </ul>
   </div>
 </template>
 
 <script>
+import config from '../../../lib/config'
 export default {
   name: 'AnalysisVersionHelp',
+  computed: {
+    showV15() { return config.features.advanced_ds_config },
+  },
 }
 </script>
 

--- a/metaspace/webapp/src/modules/MetadataEditor/inputs/AnalysisVersionHelp.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/inputs/AnalysisVersionHelp.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="analysis-version-help">
-    Selects the version of the METASPACE analysis pipeline to use. When comparing data between multiple datasets,
-    it is recommended to process all datasets with the same analysis version. Otherwise, select the latest stable version.
-    <h4>Changes between versions:</h4>
+    When comparing data between multiple datasets, it is recommended to process all datasets with the same
+    analysis version. Otherwise, select the latest version for best results.
+    <h4>Changes:</h4>
     <h5 v-if="showV15">
-      Version 1.5 (unreleased version used for internal testing):
+      v1.5 (Prototype for higher RPs):
     </h5>
     <ul v-if="showV15">
       <li>Improved modeling of instrument mass accuracy at higher m/z values for TOF and Orbitrap.</li>
       <li>Improved isotopic peak calculation algorithm.</li>
     </ul>
-    <h5>Version 2:</h5>
+    <h5>v2 (ML-powered MSM):</h5>
     <ul>
-      <li>New ML-powered model for scoring annotations.</li>
       <li>New metrics for evaluating annotations' mass accuracy.</li>
+      <li>New ML-powered model for annotation scoring.</li>
       <li>Fine-grained reporting of FDR values.</li>
     </ul>
   </div>

--- a/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
@@ -105,7 +105,7 @@
               />
             </el-col>
             <el-col
-              v-if="features.advanced_ds_config"
+              v-if="features.advanced_ds_config || features.v2"
               :span="8"
             >
               <form-field
@@ -114,10 +114,11 @@
                 :help="AnalysisVersionHelp"
                 :value="value.analysisVersion"
                 :error="error && error.analysisVersion"
-                :options="ANALYSIS_VERSION_OPTIONS"
+                :options="analysisVersionOptions"
                 @input="val => onInput('analysisVersion', val)"
               />
               <form-field
+                v-if="features.advanced_ds_config"
                 type="select"
                 name="Scoring model"
                 :value="value.scoringModel || ''"
@@ -234,14 +235,18 @@ export default class MetaspaceOptionsSection extends Vue {
     maxMolDBs = limits.maxMolDBs;
     MAX_NEUTRAL_LOSSES = MAX_NEUTRAL_LOSSES;
     MAX_CHEM_MODS = MAX_CHEM_MODS;
-    ANALYSIS_VERSION_OPTIONS = [
-      { value: 1, label: 'v1 (Stable)' },
-      { value: 2, label: 'v2 (Internal)' }, // Nobody uses v2, it can probably be hidden so that v3 can be "2.0"
-      { value: 3, label: 'v3 (ML-Driven)' },
-    ];
 
     neutralLossOptions: string[] = [];
     chemModOptions: string[] = [];
+
+    get analysisVersionOptions() {
+      const showV15 = config.features.advanced_ds_config || this.value.analysisVersion === 2
+      return [
+        { value: 1, label: 'v1 (Original MSM)' },
+        ...(showV15 ? [{ value: 2, label: 'v1.5 (Prototype for higher RPs)' }] : []),
+        { value: 3, label: 'v2 (ML-powered MSM)' },
+      ]
+    }
 
     get scoringModelOptions() {
       return [

--- a/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
@@ -108,15 +108,22 @@
               v-if="features.advanced_ds_config || features.v2"
               :span="8"
             >
-              <form-field
-                type="select"
-                name="Analysis version"
-                :help="AnalysisVersionHelp"
-                :value="value.analysisVersion"
-                :error="error && error.analysisVersion"
-                :options="analysisVersionOptions"
-                @input="val => onInput('analysisVersion', val)"
-              />
+              <popup-anchor
+                feature-key="v2"
+                placement="top"
+                :show-until="new Date('2022-09-01')"
+                class="block"
+              >
+                <form-field
+                  type="select"
+                  name="Analysis version"
+                  :help="AnalysisVersionHelp"
+                  :value="value.analysisVersion"
+                  :error="error && error.analysisVersion"
+                  :options="analysisVersionOptions"
+                  @input="val => onInput('analysisVersion', val)"
+                />
+              </popup-anchor>
               <form-field
                 v-if="features.advanced_ds_config"
                 type="select"

--- a/metaspace/webapp/src/modules/NewFeaturePopup/useNewFeaturePopups.ts
+++ b/metaspace/webapp/src/modules/NewFeaturePopup/useNewFeaturePopups.ts
@@ -9,6 +9,7 @@ export const FEATURE_KEYS = [
   'uploadCustomDatabases',
   'groupDatabasesTab',
   'multipleIonImages',
+  'v2',
 ]
 
 function getDismissedPopups() {

--- a/metaspace/webapp/src/modules/NewFeaturePopup/useNewFeaturePopups.ts
+++ b/metaspace/webapp/src/modules/NewFeaturePopup/useNewFeaturePopups.ts
@@ -29,7 +29,7 @@ const previousDismissedPopups = getDismissedPopups()
 
 const state = reactive({
   dismissed: [...previousDismissedPopups],
-  queued: [] as string[],
+  queued: [] as (string | null)[],
 })
 
 const activePopup = computed(() => state.queued[0])
@@ -37,6 +37,13 @@ const activePopup = computed(() => state.queued[0])
 function closeActivePopup() {
   const popup = state.queued.shift()
   state.dismissed.push(popup)
+  // WORKAROUND: Popper doesn't handle multiple instances - trying to open one Popper at the same time as closing
+  // the last one will cause layout to break. Use a placeholder item for a few frames to allow the old Popper to close
+  // before a new one is opened.
+  state.queued.unshift(null)
+  setTimeout(() => {
+    if (state.queued[0] === null) { state.queued.shift() }
+  }, 50)
   return popup
 }
 


### PR DESCRIPTION
Adds a separate `v2` feature flag for showing the analysis version dropdown without scoring model or v1.5. Also adds a NewFeaturePopup and improves the descriptive text.

This is enabled by default, but there's another PR against the ansible repository to disable it in prod that I'll merge at the same time as this

# Screenshots

![image](https://user-images.githubusercontent.com/26366936/151867507-8807cc06-d8ab-4f23-906d-0c9d4a257f46.png)

![image](https://user-images.githubusercontent.com/26366936/151866593-e68c70b8-1e52-4b65-9f7b-6cfc208376bd.png)

![image](https://user-images.githubusercontent.com/26366936/151867400-6c95280b-b2b4-4269-8022-5e459de0cecb.png)
