### PR TITLE
[DatasetComparisonDialog] UX improvements

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonDialog.scss
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonDialog.scss
@@ -38,3 +38,18 @@
 }
 
 
+.ds-options-popper {
+  max-width: 30%;
+
+  .el-select-dropdown__wrap {
+    max-height: 186px !important;
+  }
+}
+
+.grid-popper {
+  max-width: 350px;
+
+  .el-select-dropdown__wrap {
+    max-height: 186px !important;
+  }
+}

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonDialog.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonDialog.spec.ts
@@ -99,7 +99,7 @@ describe('DatasetComparisonDialog', () => {
     wrapper.find('.el-button--primary').trigger('click')
     await Vue.nextTick()
 
-    expect(wrapper.find('.text-danger').exists()).toBe(true)
+    expect(wrapper.find('.text-danger').element.style.visibility).not.toBe('hidden')
     expect(wrapper.find('.text-danger').text())
       .toBe('Please select at least two datasets to be compared!')
   })
@@ -111,7 +111,7 @@ describe('DatasetComparisonDialog', () => {
     wrapper.find('.el-button--primary').trigger('click')
     await Vue.nextTick()
 
-    expect(wrapper.find('.text-danger').exists()).toBe(false)
+    expect(wrapper.find('.text-danger').element.style.visibility).toBe('hidden')
     expect(wrapper.findAll('.sm-workflow-step').at(1).classes()
       .includes('active')).toBe(true)
   })
@@ -139,7 +139,7 @@ describe('DatasetComparisonDialog', () => {
     wrapper.find('.el-button--primary').trigger('click')
     await Vue.nextTick()
 
-    expect(wrapper.find('.text-danger').exists()).toBe(true)
+    expect(wrapper.find('.text-danger').element.style.visibility).not.toBe('hidden')
     expect(wrapper.find('.text-danger').text())
       .toBe('The grid must have enough cells to all datasets!')
   })
@@ -156,7 +156,7 @@ describe('DatasetComparisonDialog', () => {
     wrapper.find('.el-button--primary').trigger('click')
     await Vue.nextTick()
 
-    expect(wrapper.find('.text-danger').exists()).toBe(true)
+    expect(wrapper.find('.text-danger').element.style.visibility).not.toBe('hidden')
     expect(wrapper.find('.text-danger').text())
       .toBe('Please place all the selected datasets on the grid!')
   })
@@ -190,7 +190,7 @@ describe('DatasetComparisonDialog', () => {
     wrapper.find('.el-button--primary').trigger('click')
     await Vue.nextTick()
 
-    expect(wrapper.find('.text-danger').exists()).toBe(false)
+    expect(wrapper.find('.text-danger').element.style.visibility).toBe('hidden')
     expect(mockAnnotationAgg).toHaveBeenCalledTimes(1)
     await Vue.nextTick()
 

--- a/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonDialog.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`DatasetComparisonDialog it should match snapshot 1`] = `
 <transition-stub name="dialog-fade" class="dataset-comparison-dialog sm-content-page el-dialog-lean" selecteddatasetids="2021-03-31_11h01m28s,2021-03-30_18h22m18s,2021-04-06_08h33m04s" style="z-index: 2001;">
   <div class="el-dialog__wrapper">
-    <div role="dialog" aria-modal="true" aria-label="dialog" class="el-dialog" style="margin-top: 15vh;">
+    <div role="dialog" aria-modal="true" aria-label="dialog" class="el-dialog w-11/12 lg:w-1/2 xl:w-5/12" style="margin-top: 15vh;">
       <div class="el-dialog__header"><span class="el-dialog__title"></span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
       <div class="el-dialog__body">
         <h1>Datasets Comparison</h1>
@@ -24,7 +24,7 @@ exports[`DatasetComparisonDialog it should match snapshot 1`] = `
                   <!---->
                 </div>
                 <transition-stub name="el-zoom-in-top">
-                  <div class="el-select-dropdown el-popper is-multiple" style="display: none;">
+                  <div class="el-select-dropdown el-popper is-multiple ds-options-popper" style="display: none;">
                     <div class="el-scrollbar" style="">
                       <div class="el-select-dropdown__wrap el-scrollbar__wrap el-scrollbar__wrap--hidden-default">
                         <ul class="el-scrollbar__view el-select-dropdown__list">
@@ -46,7 +46,7 @@ exports[`DatasetComparisonDialog it should match snapshot 1`] = `
                     <!---->
                   </div>
                 </transition-stub>
-              </div><button type="button" class="el-button el-button--primary">
+              </div><span class="block text-sm font-medium text-danger mt-0" style="visibility: hidden;">Only up to 10 datasets can be selected!</span><button type="button" class="el-button el-button--primary">
                 <!---->
                 <!----><span>Next</span></button>
             </form>


### PR DESCRIPTION
### Description

When there are many options (i.e datasets) listed in the select inputs, the popper window position is truncated and hiding the input #1036

#### Solution
A maximum height was set to the select popper. For overflow cases, a scroll behaviour was also added. 
Unrelated: A scroll listener was added so the popper position is updated correctly when the dialog is scrolled in smaller screens.

#### How to test
Access the dataset overview (.../dataset/<ds_id>) page and open the comparison dialog.


#### Changes

##### Webapp

###### DatasetComparisonDialog
- [x] Added scroll and max height to select list options
- [x] Added scroll listener to update popper location on small screens
- [x] Appending select poppers to dialog instead to the body

#### Tests
 
##### Front end
 
- [x] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] md, lg, lg
- [x]  sm, xl


Before:
![image](https://user-images.githubusercontent.com/35172605/152183724-ed63ffe7-b670-4752-8fc1-2efad4bef27c.png)

After:
![image](https://user-images.githubusercontent.com/35172605/152183964-5d261dba-0d53-4262-b960-47279c7b6132.png)

