### PR TITLE
[ImageViewerSnapshot] unpacking annotation es result now that is nece…

### DIFF
--- a/metaspace/graphql/src/modules/annotation/controller/Query.ts
+++ b/metaspace/graphql/src/modules/annotation/controller/Query.ts
@@ -9,7 +9,7 @@ import {
 import { FieldResolversFor } from '../../../bindingTypes'
 import { Query } from '../../../binding'
 
-const unpackAnnotation = (hit: ESAnnotation | ESAnnotationWithColoc) => {
+export const unpackAnnotation = (hit: ESAnnotation | ESAnnotationWithColoc) => {
   const { _id, _source } = hit
   // Extract all directly accessible fields in one place to reduce the overhead of GraphQL having to call lots of
   // per-field resolvers.


### PR DESCRIPTION
### Description

It was reported that when the annotation permalink is generated and loaded, the ion image is not being loaded. #1044 

#### Solution
After the previous merge, it is necessary to unpack the elasticsearch objected returned from esAnnotationByID. The bug was happening because the object was not unpacked for the snapshot get query, which is used on the sharing link feature.

#### How to test
Access the annotation page overview (.../annotations) page and generate a share link and load it.


#### Changes

##### Graphql

###### imageViewerSnapshot
- [x] Using annotation ES object unpack 

#### Tests
 
##### Front end
 
- [x] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [ ]  Safari
- [ ] Firefox
- [x] md, lg, lg
- [ ]  sm, xl
