### PR TITLE
Fixed ZeroDivisionError for a spartial_metric

### DIFF
--- a/metaspace/engine/sm/engine/annotation/metrics.py
+++ b/metaspace/engine/sm/engine/annotation/metrics.py
@@ -24,7 +24,10 @@ def spatial_metric(iso_imgs_flat, n_spectra, intensities, v1_impl=False):
     if v1_impl:
         # Ignore div-by-zero / NaN errors - they're handled internally
         with np.errstate(divide='ignore', invalid='ignore'):
-            return isotope_image_correlation(iso_imgs_flat, weights=intensities[1:])
+            if np.sum(intensities[1:]) == 0:
+                return 0
+            else:
+                return isotope_image_correlation(iso_imgs_flat, weights=intensities[1:])
 
     if (
         len(iso_imgs_flat) < 2


### PR DESCRIPTION
For some molecular databases (KEGG, Chebi) we observe the following exeptions:
```
Traceback (most recent call last):
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/daemons/lithops.py", line 81, in _callback
    self._manager.annotate_lithops(ds=ds, del_first=msg.get('del_first', False))
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/daemons/dataset_manager.py", line 114, in annotate_lithops
    ServerAnnotationJob(executor, ds, perf).run()
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/annotation_job.py", line 317, in run
    self.results_dfs, self.png_cobjs = self.pipe.run_pipeline(**kwargs)
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/pipeline.py", line 103, in run_pipeline
    self.annotate(use_cache=use_cache)
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/cache.py", line 81, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/pipeline.py", line 163, in annotate
    self.formula_metrics_df, self.images_df = process_centr_segments(
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/annotate.py", line 310, in process_centr_segments
    formula_metrics_list, image_lookups_list = fexec.map_unpack(
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/executor.py", line 375, in map_unpack
    results = self.map(func, args, runtime_memory=runtime_memory, **kwargs)
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/executor.py", line 292, in map
    raise exc
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/executor.py", line 328, in run
    return_vals = executor.get_result(futures)
ZeroDivisionError: Weights sum to zero, can't be normalized
```
This is most likely due to the fact that in these bases there are elements that have only one isotope.

### Solution to the problem
Return `if statement` condition for checking the intensity of all peaks for zero, as it was done earlier. This condition is present for **v2** but absent for **v1**.