### PR TITLE
Enable reprocess for common user

### DIFF
--- a/metaspace/graphql/datasetFilters.js
+++ b/metaspace/graphql/datasetFilters.js
@@ -86,6 +86,27 @@ class DatasetIdFilter extends AbstractDatasetFilter {
   }
 }
 
+class DatasetStatusFilter extends AbstractDatasetFilter {
+  constructor() {
+    super('', {})
+  }
+
+  esFilter(status) {
+    status = status.split('|')
+
+    if (status.length > 0) {
+      return { terms: { ds_status: status } }
+    } else {
+      return {}
+    }
+  }
+
+  pgFilter(q, status) {
+    status = status.split('|')
+    return q.whereIn('status', status)
+  }
+}
+
 class NotNullFilter extends AbstractDatasetFilter {
   constructor(schemaPath, options = {}) {
     super(schemaPath, options)
@@ -136,7 +157,7 @@ export const datasetFilters = {
   maldiMatrix: new ExactMatchFilter('Sample_Preparation.MALDI_Matrix', {}),
   name: new SubstringMatchFilter('', { esField: 'ds_name', pgField: 'name' }),
   ids: new DatasetIdFilter(),
-  status: new ExactMatchFilter('', { esField: 'ds_status', pgField: 'status' }),
+  status: new DatasetStatusFilter(),
   submitter: new ExactMatchFilter('', { esField: 'ds_submitter_id' }),
   hasGroup: new NotNullFilter('', { esField: 'ds_group_id' }),
   group: new GroupMatchFilter('', { esField: 'ds_group_id' }),

--- a/metaspace/graphql/esConnector.ts
+++ b/metaspace/graphql/esConnector.ts
@@ -271,9 +271,24 @@ const constructDatasetAuthFilters = async(user: ContextUser) => {
     // Admins can see everything - don't filter
     return []
   } else {
-    // Public datasets
+    // Public datasets, except failed ones
     const datasetOrConditions: any[] = [
-      { term: { ds_is_public: true } },
+      {
+        bool: {
+          must: [
+            {
+              term: {
+                ds_is_public: true,
+              },
+            },
+            {
+              terms: {
+                ds_status: ['ANNOTATING', 'QUEUED', 'FINISHED'],
+              },
+            },
+          ],
+        },
+      },
     ]
     // User is owner
     if (user.id) {

--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -34,7 +34,7 @@ type Dataset {
   acquisitionGeometry: String
   metadataType: String!
 
-  status: JobStatus
+  status: String
   statusUpdateDT: String!
   inputPath: String
   uploadDateTime: String
@@ -192,7 +192,7 @@ input DatasetFilter {
   condition: String
   growthConditions: String
   metadataType: String
-  status: JobStatus
+  status: String # list of JobStatus separated by '|'
   hasAnnotationMatching: AnnotationFilter # Does not support some advanced filters e.g. the colocalization filters
 }
 

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -133,10 +133,10 @@ export const datasetDetailItemFragment =
 
 export const datasetDetailItemsQuery =
   gql`query GetDatasets(
-    $dFilter: DatasetFilter, $query: String, $inpFdrLvls: [Int!]!, $checkLvl: Int!, $offset: Int = 0,
+    $dFilter: DatasetFilter, $query: String, $inpFdrLvls: [Int!]!, $checkLvl: Int!, $offset: Int = 0, $limit: Int = 100,
     $orderBy: DatasetOrderBy = ORDER_BY_DATE, $sortingOrder: SortingOrder = DESCENDING,
   ) {
-    allDatasets(orderBy: $orderBy, sortingOrder: $sortingOrder, offset: $offset, limit: 100, filter: $dFilter,
+    allDatasets(orderBy: $orderBy, sortingOrder: $sortingOrder, offset: $offset, limit: $limit, filter: $dFilter,
     simpleQuery: $query) {
       ...DatasetDetailItem
     }

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
@@ -111,7 +111,9 @@ const DatasetItemActions = defineComponent({
       return null
     })
 
-    const canReprocess = computed(() => props.currentUser?.role === 'admin')
+    const canReprocess = computed(() => {
+      return props.currentUser?.role === 'admin' || (props.dataset?.status === 'FAILED' && props.dataset?.canEdit)
+    })
 
     const canViewPublicationStatus = computed(() =>
       props.dataset.status === 'FINISHED'

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
@@ -210,7 +210,7 @@ export default Vue.extend({
       return datasets
     },
     canSeeFailed() {
-      return this.currentUser != null && this.currentUser.role === 'admin'
+      return this.currentUser != null
     },
   },
   mounted() {

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
@@ -138,7 +138,6 @@ export default Vue.extend({
     return {
       recordsPerPage: 100,
       csvChunkSize: 1000,
-      totalCount: 0,
       categories: ['ANNOTATING', 'QUEUED', 'FINISHED'],
       isExporting: false,
       loading: 0,
@@ -158,6 +157,13 @@ export default Vue.extend({
           return
         }
         this.$store.commit('setCurrentPage', page)
+      },
+    },
+    totalCount: {
+      get() {
+        const counts = this.datasetCounts
+        return !counts ? 0 : Object.keys(counts)
+          .reduce((sum, key) => sum + (this.categories.includes(key) ? parseInt(counts[key] || 0, 10) : 0), 0)
       },
     },
 
@@ -187,6 +193,7 @@ export default Vue.extend({
         query: this.$store.getters.ftsQuery,
         inpFdrLvls: [10],
         checkLvl: 10,
+        limit: this.recordsPerPage,
         offset: (this.currentPage - 1) * this.recordsPerPage, // Math.max(0, (this.$store.getters.settings.datasets.page - 1) * 100),
         orderBy: this.orderBy,
         sortingOrder: this.sortingOrder,
@@ -282,7 +289,13 @@ export default Vue.extend({
       query: datasetDetailItemsQuery,
       throttle: 1000,
       variables() {
-        return this.queryVariables
+        return {
+          ...this.queryVariables,
+          dFilter: {
+            ...this.queryVariables.dFilter,
+            status: this.categories.join('|'),
+          },
+        }
       },
     },
     datasetCounts: {
@@ -291,9 +304,7 @@ export default Vue.extend({
       query: countDatasetsByStatusQuery,
       throttle: 1000,
       update(data) {
-        const counts = extractGroupedStatusCounts(data)
-        this.countSelected(counts)
-        return counts
+        return extractGroupedStatusCounts(data)
       },
       variables() {
         return {
@@ -319,11 +330,6 @@ export default Vue.extend({
       } else {
         return ''
       }
-    },
-
-    countSelected(counts) {
-      this.totalCount = !counts ? 0 : Object.keys(counts)
-        .reduce((sum, key) => sum + parseInt(counts[key] || 0, 10), 0)
     },
 
     async startExport() {

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetTable.vue
@@ -217,7 +217,7 @@ export default Vue.extend({
       return datasets
     },
     canSeeFailed() {
-      return this.currentUser != null
+      return this.currentUser != null && (this.currentUser?.role === 'admin' || this.datasetCounts?.FAILED > 0)
     },
   },
   mounted() {

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -218,7 +218,31 @@ exports[`DatasetTable should match snapshot 1`] = `
           </span>
         </label>
          
-        <!---->
+        <label
+          class="el-checkbox cb-failed"
+        >
+          <span
+            class="el-checkbox__input"
+          >
+            <span
+              class="el-checkbox__inner"
+            />
+            <input
+              aria-hidden="false"
+              class="el-checkbox__original"
+              type="checkbox"
+              value="FAILED"
+            />
+          </span>
+          <span
+            class="el-checkbox__label"
+          >
+            
+          Failed (0)
+        
+            <!---->
+          </span>
+        </label>
       </div>
        
       <div

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -218,31 +218,7 @@ exports[`DatasetTable should match snapshot 1`] = `
           </span>
         </label>
          
-        <label
-          class="el-checkbox cb-failed"
-        >
-          <span
-            class="el-checkbox__input"
-          >
-            <span
-              class="el-checkbox__inner"
-            />
-            <input
-              aria-hidden="false"
-              class="el-checkbox__original"
-              type="checkbox"
-              value="FAILED"
-            />
-          </span>
-          <span
-            class="el-checkbox__label"
-          >
-            
-          Failed (0)
-        
-            <!---->
-          </span>
-        </label>
+        <!---->
       </div>
        
       <div


### PR DESCRIPTION
### Description

Currently when a dataset fails to process, the user can't see the dataset anymore. In order to make if more friendly and let the user know the dataset failed processing, now the user should be able to reprocess and see the failed dataset #1070 

In the dataset page listing if the user selects the categories, the pagination does not reflect only the datasets from the selected category. So in order to make it easier, the category is also considered as a dataset listing filter.

#### Solution
The FAILED category section is been displayed for common users also, if they have at least one failed dataset. The rules applied for the failed dataset reprocessing are the same as the edition one: user submitted the dataset or it in the group in which the dataset belongs. To allow the listing of only the failed datasets that the user can also edit, a change in the elasticsearch common dataset query was made, where it can only see the public datasets that do not failed processing plus the datasets the user is allowed to see (included the failed ones).

#### How to test
Upload a dataset that will fail, access the dataset page and test it as: not logged, admin, user, user in the group of the failed dataset and user without failed datasets


#### Changes

##### Webapp

###### datasets api
- [x] Getting limit parameter from variable

###### DatasetItemActions
- [x] Showing reprocess if user can edit dataset and dataset has failed processing

###### DatasetTable
- [x] Counting pagination total on filter change
- [x] Allowing common user to see failed tab if it has one failed dataset
- [x] Added selected categories as dataset filter


##### Graphql

###### datasetFilters
- [x] Changed status filter to accept multiple values

###### esConnector
- [x] Changed list datasetQuery to return only non failed public datasets


#### Tests
 
##### Front end
 
- [ ] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] md, lg, lg
- [x]  sm, xl


