### PR TITLE
Unflag custom columns and dataset overview

### DIFF
--- a/metaspace/webapp/src/lib/config.ts
+++ b/metaspace/webapp/src/lib/config.ts
@@ -59,10 +59,10 @@ const defaultConfig: ClientConfig = {
   metadataTypes: ['ims'],
   features: {
     coloc: true,
-    show_dataset_overview: false,
+    show_dataset_overview: true,
     roi: false,
     tic: true,
-    custom_cols: false,
+    custom_cols: true,
     ion_thumbs: true,
     off_sample: true,
     off_sample_col: false,

--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
@@ -374,9 +374,19 @@
           v-if="showCustomCols"
           class="mt-1"
         >
-          <el-button slot="reference">
-            Columns <i class="el-icon-arrow-down">
-            </i>
+          <el-button
+            slot="reference"
+            @click="handleColSelectorClick"
+          >
+            <new-feature-badge
+              feature-key="custom-cols"
+              class="new-custom-badge"
+            >
+              <div>
+                Columns <i class="el-icon-arrow-down">
+                </i>
+              </div>
+            </new-feature-badge>
           </el-button>
           <div>
             <div
@@ -485,6 +495,7 @@ import { getDatasetDiagnosticsQuery } from '../../api/dataset'
 import FullScreen from '../../assets/inline/full_screen.svg'
 import ExitFullScreen from '../../assets/inline/exit_full_screen.svg'
 import { getLocalStorage, setLocalStorage } from '../../lib/localStorage'
+import NewFeatureBadge, { hideFeatureBadge } from '../../components/NewFeatureBadge'
 
 // 38 = up, 40 = down, 74 = j, 75 = k
 const KEY_TO_ACTION = {
@@ -531,6 +542,7 @@ export default Vue.extend({
     ExternalWindowSvg,
     ExitFullScreen,
     FullScreen,
+    NewFeatureBadge,
   },
   props: ['hideColumns', 'isFullScreen'],
   data() {
@@ -1149,6 +1161,11 @@ export default Vue.extend({
       this.columns[index].selected = !this.columns[index].selected
       setLocalStorage('annotationTableCols', this.columns)
     },
+
+    handleColSelectorClick(e) {
+      e.stopPropagation()
+      hideFeatureBadge('custom-cols')
+    },
   },
 })
 </script>
@@ -1297,5 +1314,11 @@ export default Vue.extend({
  }
  .el-table table {
    width: 0px; // fix safari dynamic column size bug
+ }
+ .new-custom-badge{
+   .el-badge__content{
+     right: 10px !important;
+     top: -10px !important;
+   }
  }
 </style>

--- a/metaspace/webapp/src/modules/Annotations/__snapshots__/AnnotationTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/__snapshots__/AnnotationTable.spec.ts.snap
@@ -178,7 +178,32 @@ exports[`AnnotationTable should match snapshot 1`] = `
       </div>
     </div>
     <div class="flex w-full items-center justify-end flex-wrap">
-      <!---->
+      <mock-el-popover class="mt-1">
+        <div slot-key="default">
+          <div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check"></i> <span>Lab</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check"></i> <span>Dataset</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check"></i> <span>Annotation</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Adduct</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check"></i> <span>m/z</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Off-sample probability %</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span> ρ<sub>spatial</sub></span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span> ρ<sub>spectral</sub></span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span> ρ<sub>chaos</sub></span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check"></i> <span>MSM</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Database</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Molecules</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Isomers/Isobars</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Max Intensity</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Total Intensity</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check"></i> <span>FDR</span></div>
+          </div>
+        </div>
+        <div slot-key="reference"><button type="button" class="el-button el-button--default">
+            <!---->
+            <!----><span><div class="el-badge new-custom-badge sm-feature-badge"><div>
+              Columns <i class="el-icon-arrow-down"></i></div><transition-stub name="el-zoom-in-center"><sup class="el-badge__content el-badge__content--undefined is-fixed">New</sup></transition-stub></div></span></button></div>
+      </mock-el-popover>
       <mock-el-popover trigger="hover" class="ml-2 mt-1">
         <div slot-key="default">
 
@@ -193,7 +218,9 @@ exports[`AnnotationTable should match snapshot 1`] = `
           </span></button></div>
         </div>
       </mock-el-popover>
-      <!---->
+      <div class="ml-2 mt-1"><button type="button" class="el-button full-screen-btn el-button--default">
+          <!---->
+          <!----><span><svg data-icon="exit_full_screen" class="full-screen-icon"></svg></span></button></div>
     </div>
   </div>
 </div>
@@ -367,7 +394,32 @@ exports[`AnnotationTable should match snapshot when loading snapshot 1`] = `
       </div>
     </div>
     <div class="flex w-full items-center justify-end flex-wrap">
-      <!---->
+      <mock-el-popover class="mt-1">
+        <div slot-key="default">
+          <div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check"></i> <span>Lab</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check"></i> <span>Dataset</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check"></i> <span>Annotation</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Adduct</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check"></i> <span>m/z</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Off-sample probability %</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span> ρ<sub>spatial</sub></span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span> ρ<sub>spectral</sub></span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span> ρ<sub>chaos</sub></span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check"></i> <span>MSM</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Database</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Molecules</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Isomers/Isobars</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Max Intensity</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Total Intensity</span></div>
+            <div class="cursor-pointer select-none"><i class="el-icon-check"></i> <span>FDR</span></div>
+          </div>
+        </div>
+        <div slot-key="reference"><button type="button" class="el-button el-button--default">
+            <!---->
+            <!----><span><div class="el-badge new-custom-badge sm-feature-badge"><div>
+              Columns <i class="el-icon-arrow-down"></i></div><transition-stub name="el-zoom-in-center"><sup class="el-badge__content el-badge__content--undefined is-fixed">New</sup></transition-stub></div></span></button></div>
+      </mock-el-popover>
       <mock-el-popover trigger="hover" class="ml-2 mt-1">
         <div slot-key="default">
 
@@ -382,7 +434,9 @@ exports[`AnnotationTable should match snapshot when loading snapshot 1`] = `
           </span></button></div>
         </div>
       </mock-el-popover>
-      <!---->
+      <div class="ml-2 mt-1"><button type="button" class="el-button full-screen-btn el-button--default">
+          <!---->
+          <!----><span><svg data-icon="exit_full_screen" class="full-screen-icon"></svg></span></button></div>
     </div>
   </div>
 </div>

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetItem.spec.js.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetItem.spec.js.snap
@@ -227,17 +227,18 @@ exports[`DatasetItem should match snapshot 1`] = `
         Edit metadata
       </a>
     </div>
-    <div
-      class="ds-delete"
-    >
+    <div>
       <i
-        class="el-icon-delete"
+        class="el-icon-data-analysis"
       />
       <a
-        class="text-danger"
-        href="#"
+        class=""
+        classname="mr-2"
+        href="/dataset/mockdataset"
       >
-        Delete dataset
+        <span>
+          Dataset overview
+        </span>
       </a>
     </div>
   </div>

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -494,16 +494,32 @@ exports[`DatasetTable should match snapshot 1`] = `
           </a>
         </div>
         <div
-          class="ds-download"
+          class="featured-action"
         >
           <i
-            class="el-icon-download"
+            class="el-icon-data-analysis"
           />
-          <a
-            href="#"
+          <div
+            class="el-badge sm-feature-badge"
           >
-            Download
-          </a>
+            <a
+              class="mr-2"
+              href="/dataset/QUEUED1"
+            >
+              <span>
+                Dataset overview
+              </span>
+            </a>
+            <transition-stub
+              name="el-zoom-in-center"
+            >
+              <sup
+                class="el-badge__content el-badge__content--undefined is-fixed"
+              >
+                New
+              </sup>
+            </transition-stub>
+          </div>
         </div>
       </div>
     </div>
@@ -679,6 +695,20 @@ exports[`DatasetTable should match snapshot 1`] = `
             href="#"
           >
             Show full metadata
+          </a>
+        </div>
+        <div>
+          <i
+            class="el-icon-data-analysis"
+          />
+          <a
+            class=""
+            classname="mr-2"
+            href="/dataset/ANNOTATING1"
+          >
+            <span>
+              Dataset overview
+            </span>
           </a>
         </div>
       </div>
@@ -913,6 +943,20 @@ exports[`DatasetTable should match snapshot 1`] = `
             href="#"
           >
             Show full metadata
+          </a>
+        </div>
+        <div>
+          <i
+            class="el-icon-data-analysis"
+          />
+          <a
+            class=""
+            classname="mr-2"
+            href="/dataset/FINISHED1"
+          >
+            <span>
+              Dataset overview
+            </span>
           </a>
         </div>
       </div>

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetOverviewPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetOverviewPage.tsx
@@ -131,7 +131,8 @@ export default defineComponent<Props>({
             <div class='dataset-overview-holder'>
               <p class='truncate'>{submitter?.name}
                 {group && <a class='ml-1' href={groupLink}>({group?.shortName})</a>}
-                {!group && <a class='ml-1' href={groupLink}>(test)</a>}
+                {!group && submitter?.email
+                && <a class='ml-1' href={`mailto:${submitter?.email}`}>{submitter?.email}</a>}
               </p>
               <div>{upDate}</div>
               {


### PR DESCRIPTION
### Description

Unflagging the dataset overview, dataset comparison and annotation table custom columns as they were already tested in production and approved #1086 #1087  


#### How to test
Test custom columns selection for annotation table on annotation page.
Access dataset page and click in dataset overview on the dataset card to access dataset overview page.


#### Changes

##### Webapp

###### config
- [x] Unflag custom cols feature
- [x] Unflag dataset overview feature



#### Tests
 
##### Front end
 
- [ ] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] md, lg, lg
- [x]  sm, xl


<img width="1601" alt="image" src="https://user-images.githubusercontent.com/35172605/161536750-e96d60c7-9b87-4715-9b9b-dff68bb3ddcc.png">
<img width="1599" alt="image" src="https://user-images.githubusercontent.com/35172605/161536905-c2d6e2f8-bd55-425c-81b7-5ef263d7d356.png">
<img width="1603" alt="image" src="https://user-images.githubusercontent.com/35172605/161537058-d9733e61-6ef8-426d-86fc-4e69ea9553d2.png">
