### PR TITLE
Kendrick plot visualization

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.scss
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.scss
@@ -19,7 +19,7 @@
     @apply flex flex-col items-center justify-start relative;
     min-height: 500px;
     width: 100%;
-    background: rgba(0,0,0,0.01);
+    background: white;//rgba(0,0,0,0.01);
     height: 100%;
   }
 
@@ -27,7 +27,7 @@
     @apply absolute flex flex-row items-start justify-center;
     height: 100%;
     width: 100%;
-    background: rgba(0,0,0,0.02);
+    background: white;//rgba(0,0,0,0.02);
     padding-top: 30%;
   }
 

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.scss
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.scss
@@ -1,0 +1,36 @@
+.dataset-browser-kendrick-container{
+  .echarts {
+    width: 100%;
+    height: 500px;
+  }
+
+  .chart{
+    @apply flex flex-row items-center justify-center;
+    height: 500px;
+    width: 100%;
+  }
+
+  .dataset-browser-empty-spectrum{
+    @apply border-2 border-dashed border-gray-200 relative rounded m-6 p-2 flex flex-row items-center justify-center;
+    background: rgba(224,224,224,0.2);
+  }
+
+  .chart-holder{
+    @apply flex flex-col items-center justify-start relative;
+    min-height: 500px;
+    width: 100%;
+    background: rgba(0,0,0,0.01);
+    height: 100%;
+  }
+
+  .loader-holder{
+    @apply absolute flex flex-row items-start justify-center;
+    height: 100%;
+    width: 100%;
+    background: rgba(0,0,0,0.02);
+    padding-top: 30%;
+  }
+
+}
+
+

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.tsx
@@ -318,9 +318,9 @@ export const DatasetBrowserKendrickPlot = defineComponent<DatasetBrowserKendrick
         }
       }
 
-      auxOptions.xAxis.min = minX
+      auxOptions.xAxis.min = minX - (100) // decrease 100 to give space between axis start and first point
       auxOptions.xAxis.max = maxX
-      auxOptions.yAxis.max = maxY * 1.1
+      auxOptions.yAxis.max = 1 // maxY * 1.1
       auxOptions.series[0].data = data
       // handleZoomReset()
       return auxOptions

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.tsx
@@ -55,6 +55,7 @@ interface DatasetBrowserKendrickPlotState {
 const PEAK_FILTER = {
   ALL: 1,
   FDR: 2,
+  OFF: 3,
 }
 
 export const DatasetBrowserKendrickPlot = defineComponent<DatasetBrowserKendrickPlotProps>({
@@ -283,7 +284,7 @@ export const DatasetBrowserKendrickPlot = defineComponent<DatasetBrowserKendrick
           }
         })
 
-        if (peakFilter.value === PEAK_FILTER.ALL && !isAnnotated) { // add unnanotated peaks
+        if (peakFilter.value !== PEAK_FILTER.FDR && !isAnnotated) { // add unnanotated peaks
           data.push({
             name: xAxis.toFixed(4),
             tooltip,
@@ -295,7 +296,7 @@ export const DatasetBrowserKendrickPlot = defineComponent<DatasetBrowserKendrick
           })
         }
 
-        if (isAnnotated) {
+        if (peakFilter.value !== PEAK_FILTER.OFF && isAnnotated) {
           data.push({
             name: xAxis.toFixed(4),
             tooltip,

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.tsx
@@ -128,6 +128,15 @@ export const DatasetBrowserKendrickPlot = defineComponent<DatasetBrowserKendrick
                 handleZoomReset()
               },
             },
+            myTool2: {
+              show: true,
+              title: 'Download data',
+              icon: 'path://M6 2h6v6c0 1.1.9 2 2 2h6v10a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4c0-1.1.9-2 2-2zm2 11a1 '
+                + '1 0 0 0 0 2h8a1 1 0 0 0 0-2H8zm0 4a1 1 0 0 0 0 2h4a1 1 0 0 0 0-2H8z ',
+              onclick: () => {
+                emit('download')
+              },
+            },
             dataZoom: {
               title: {
                 zoom: 'Zoom',

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.scss
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.scss
@@ -86,6 +86,10 @@ $header-height: 64px;
     }
   }
 
+  .reference-box{
+    max-width: 8rem;
+  }
+
   .select-box{
     max-width: 7rem;
   }

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.scss
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.scss
@@ -5,6 +5,10 @@ $header-height: 64px;
   @apply flex flex-row flex-wrap p-0;
   min-height: calc(100vh - #{$header-height});
 
+  .info{
+    @apply flex justify-center p-2 w-full flex-wrap;
+  }
+
   .mass-ref-label{
     width: 130px;
   }
@@ -113,8 +117,8 @@ $header-height: 64px;
   }
 
   .dataset-browser-holder-filter-box{
-    @apply p-2 max-w-4xl box-border mx-4 leading-6 text-base;
-    min-height: 168px;
+    @apply p-2 max-w-4xl box-border leading-6 text-base;
+    //min-height: 168px;
 
     p{
       @apply mb-2;

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.scss
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.scss
@@ -5,6 +5,10 @@ $header-height: 64px;
   @apply flex flex-row flex-wrap p-0;
   min-height: calc(100vh - #{$header-height});
 
+  .mass-ref-label{
+    width: 130px;
+  }
+
   .dataset-browser-empty-spectrum{
     @apply border-2 border-dashed border-gray-200 relative rounded m-6 p-2 flex flex-row items-center justify-center;
     background: rgba(224,224,224,0.2);
@@ -61,12 +65,15 @@ $header-height: 64px;
     @apply absolute flex flex-row items-start justify-center;
     height: 100%;
     width: 100%;
-    background: rgba(0,0,0,0.02);
+    background: white;//rgba(0,0,0,0.02);
     padding-top: 30%;
   }
 
   .formula-input{
     max-width: 22.05rem;
+  }
+  .max-formula-input{
+    //max-width: 24.2rem;
   }
 
   .formula-input-error{
@@ -106,8 +113,8 @@ $header-height: 64px;
   }
 
   .dataset-browser-holder-filter-box{
-    @apply p-2 max-w-4xl box-border mx-auto leading-6 text-base;
-    min-height: 137px;
+    @apply p-2 max-w-4xl box-border mx-4 leading-6 text-base;
+    min-height: 168px;
 
     p{
       @apply mb-2;

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.scss
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.scss
@@ -5,6 +5,11 @@ $header-height: 64px;
   @apply flex flex-row flex-wrap p-0;
   min-height: calc(100vh - #{$header-height});
 
+  .dataset-browser-empty-spectrum{
+    @apply border-2 border-dashed border-gray-200 relative rounded m-6 p-2 flex flex-row items-center justify-center;
+    background: rgba(224,224,224,0.2);
+  }
+
   .label{
     width: 70px;
   }

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
@@ -13,6 +13,9 @@ import reportError from '../../../lib/reportError'
 import { readNpy } from '../../../lib/npyHandler'
 import { DatasetBrowserKendrickPlot } from './DatasetBrowserKendrickPlot'
 import FadeTransition from '../../../components/FadeTransition'
+import CandidateMoleculesPopover from '../../Annotations/annotation-widgets/CandidateMoleculesPopover.vue'
+import MolecularFormula from '../../../components/MolecularFormula'
+import CopyButton from '../../../components/CopyButton.vue'
 
 interface DatasetBrowserProps {
   className: string
@@ -437,6 +440,50 @@ export default defineComponent<DatasetBrowserProps>({
       )
     }
 
+    const renderInfo = () => {
+      const { annotation } = state
+
+      if (!annotation) {
+        return null
+      }
+
+      // @ts-ignore TS2604
+      const candidateMolecules = () => <CandidateMoleculesPopover
+        placement="bottom"
+        possibleCompounds={annotation.possibleCompounds}
+        isomers={annotation.isomers}
+        isobars={annotation.isobars}>
+        <MolecularFormula
+          class="sf-big text-2xl"
+          ion={annotation.ion}
+        />
+      </CandidateMoleculesPopover>
+
+      return (
+        <div class='info'>
+          {candidateMolecules()}
+          <CopyButton
+            class="ml-1"
+            text={annotation.ion}>
+            Copy ion to clipboard
+          </CopyButton>
+          <span class="text-2xl flex items-baseline ml-4">
+            { annotation.mz.toFixed(4) }
+            <span class="ml-1 text-gray-700 text-sm">m/z</span>
+            <CopyButton
+              class="self-start"
+              text={annotation.mz.toFixed(4)}>
+              Copy m/z to clipboard
+            </CopyButton>
+          </span>
+          <div class="flex items-baseline ml-4 w-full justify-center items-center text-xl"
+            style={{ visibility: state.x === undefined && state.y === undefined ? 'hidden' : '' }}>
+            {`X: ${state.x}, Y: ${state.y}`}
+          </div>
+        </div>
+      )
+    }
+
     const renderImageFilters = () => {
       return (
         <div class='dataset-browser-holder-filter-box'>
@@ -602,6 +649,7 @@ export default defineComponent<DatasetBrowserProps>({
                 Image viewer
               </div>
               {renderImageFilters()}
+              {renderInfo()}
               <div class='ion-image-holder'>
                 {
                   (annotationsLoading.value || state.imageLoading)

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
@@ -33,6 +33,7 @@ interface DatasetBrowserState {
   invalidFormula: boolean
   referenceFormula: any
   invalidReferenceFormula: boolean
+  fixedMassReference: number
   referenceFormulaMz: number
   metadata: any
   annotation: any
@@ -83,7 +84,8 @@ export default defineComponent<DatasetBrowserProps>({
       invalidFormula: false,
       invalidReferenceFormula: false,
       referenceFormula: undefined,
-      referenceFormulaMz: 14.0156, // m_CH2=14.0156,
+      fixedMassReference: 14.01565006, // m_CH2=14.0156,
+      referenceFormulaMz: 14.01565006, // m_CH2=14.0156,
       currentView: VIEWS.KENDRICK,
     })
 
@@ -384,12 +386,26 @@ export default defineComponent<DatasetBrowserProps>({
           </div>
           <FadeTransition>
             <div
-              class='flex flex-row w-full items-start mt-4'
+              class='flex flex-row w-full items-start mt-4 flex-wrap'
               style={{
                 visibility: state.currentView === VIEWS.KENDRICK ? '' : 'hidden',
               }}>
-              <span class='mass-ref-label mr-1'>Mass reference</span>
-              <div class='flex flex-1 flex-col'>
+              <p class='font-semibold w-full'>Mass reference</p>
+              <Select
+                class='select-box mr-4'
+                value={state.fixedMassReference}
+                onChange={(value: number) => {
+                  state.fixedMassReference = value
+                }}
+                placeholder='CH2'
+                size='mini'>
+                <Option label="CH2" value={14.01565006}/>
+                <Option label="13C" value={1.00335484}/>
+                <Option label="Unsaturation" value={2.015650064}/>
+                <Option label="Deuterium" value={1.006276745}/>
+                <Option label="Other" value={-1}/>
+              </Select>
+              <div class='flex flex-1 flex-col' style={{ visibility: state.fixedMassReference === -1 ? '' : 'hidden' }}>
                 <Input
                   class={'max-formula-input' + (state.invalidReferenceFormula ? ' formula-input-error' : '')}
                   value={state.referenceFormula}
@@ -409,7 +425,7 @@ export default defineComponent<DatasetBrowserProps>({
                     }
                   }}
                   size='mini'
-                  placeholder='CH2'
+                  placeholder='Type the formula'
                 />
                 <span class='error-message' style={{ visibility: !state.invalidReferenceFormula ? 'hidden' : '' }}>
                 Invalid formula!
@@ -556,7 +572,7 @@ export default defineComponent<DatasetBrowserProps>({
                 data={state.sampleData}
                 annotatedData={annotatedPeaks.value}
                 peakFilter={state.peakFilter}
-                referenceMz={state.referenceFormulaMz}
+                referenceMz={state.fixedMassReference !== -1 ? state.fixedMassReference : state.referenceFormulaMz}
                 onItemSelected={(mz: number) => {
                   state.mzmScoreFilter = mz
                   requestIonImage()

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
@@ -16,6 +16,7 @@ import FadeTransition from '../../../components/FadeTransition'
 import CandidateMoleculesPopover from '../../Annotations/annotation-widgets/CandidateMoleculesPopover.vue'
 import MolecularFormula from '../../../components/MolecularFormula'
 import CopyButton from '../../../components/CopyButton.vue'
+import Vue from 'vue'
 
 interface DatasetBrowserProps {
   className: string
@@ -41,6 +42,7 @@ interface DatasetBrowserState {
   metadata: any
   annotation: any
   normalizationData: any
+  showFullTIC: boolean
   x: number | undefined
   y: number | undefined
   currentView: string
@@ -90,6 +92,7 @@ export default defineComponent<DatasetBrowserProps>({
       fixedMassReference: 14.01565006, // m_CH2=14.0156,
       referenceFormulaMz: 14.01565006, // m_CH2=14.0156,
       currentView: VIEWS.KENDRICK,
+      showFullTIC: true,
     })
 
     const queryVariables = () => {
@@ -136,7 +139,7 @@ export default defineComponent<DatasetBrowserProps>({
           shape,
           metadata: metadata,
           type: 'TIC',
-          showFullTIC: false,
+          showFullTIC: state.showFullTIC,
           error: false,
         }
       } catch (e) {
@@ -472,7 +475,7 @@ export default defineComponent<DatasetBrowserProps>({
             <span class="ml-1 text-gray-700 text-sm">m/z</span>
             <CopyButton
               class="self-start"
-              text={annotation.mz.toFixed(4)}>
+              text={state.showFullTIC ? 'TIC' : annotation.mz.toFixed(4)}>
               Copy m/z to clipboard
             </CopyButton>
           </span>
@@ -491,8 +494,12 @@ export default defineComponent<DatasetBrowserProps>({
           <div class='filter-holder'>
             <span class='label'>m/z</span>
             <InputNumber
-              value={state.mzmScoreFilter}
+              value={state.showFullTIC ? undefined : state.mzmScoreFilter}
               onInput={(value: number) => {
+                if (value) {
+                  state.showFullTIC = false
+                  Vue.set(state.normalizationData, 'showFullTIC', false)
+                }
                 state.mzmScoreFilter = value
               }}
               onChange={() => {
@@ -621,6 +628,8 @@ export default defineComponent<DatasetBrowserProps>({
                 peakFilter={state.peakFilter}
                 referenceMz={state.fixedMassReference !== -1 ? state.fixedMassReference : state.referenceFormulaMz}
                 onItemSelected={(mz: number) => {
+                  state.showFullTIC = false
+                  Vue.set(state.normalizationData, 'showFullTIC', false)
                   state.mzmScoreFilter = mz
                   requestIonImage()
                 }}
@@ -637,6 +646,8 @@ export default defineComponent<DatasetBrowserProps>({
                 annotatedData={annotatedPeaks.value}
                 peakFilter={state.peakFilter}
                 onItemSelected={(mz: number) => {
+                  state.showFullTIC = false
+                  Vue.set(state.normalizationData, 'showFullTIC', false)
                   state.mzmScoreFilter = mz
                   requestIonImage()
                 }}
@@ -669,6 +680,7 @@ export default defineComponent<DatasetBrowserProps>({
                     ionImageUrl={state.ionImageUrl}
                     pixelSizeX={getPixelSizeX()}
                     pixelSizeY={getPixelSizeY()}
+                    isNormalized={state.showFullTIC}
                     normalizationData={state.normalizationData}
                     onPixelSelected={handlePixelSelect}
                   />

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
@@ -35,6 +35,7 @@ interface DatasetBrowserState {
   sampleData: any[]
   chartLoading: boolean
   imageLoading: boolean
+  isNormalized: boolean
   invalidFormula: boolean
   referenceFormula: any
   invalidReferenceFormula: boolean
@@ -47,6 +48,7 @@ interface DatasetBrowserState {
   x: number | undefined
   y: number | undefined
   currentView: string
+  normalization: number | undefined
 }
 
 const PEAK_FILTER = {
@@ -80,6 +82,7 @@ export default defineComponent<DatasetBrowserProps>({
       metadata: undefined,
       annotation: undefined,
       chartLoading: false,
+      isNormalized: false,
       imageLoading: false,
       moleculeFilter: undefined,
       x: undefined,
@@ -94,6 +97,7 @@ export default defineComponent<DatasetBrowserProps>({
       referenceFormulaMz: 14.01565006, // m_CH2=14.0156,
       currentView: VIEWS.KENDRICK,
       showFullTIC: true,
+      normalization: undefined,
     })
 
     const queryVariables = () => {
@@ -205,8 +209,12 @@ export default defineComponent<DatasetBrowserProps>({
         })
         const content = await response.json()
         state.sampleData = [content]
+
+        const i = (y * state.normalizationData.shape[1]) + x
+        const ticPixel = state.normalizationData.data[i]
         state.x = content.x
         state.y = content.y
+        state.normalization = ticPixel
       } catch (e) {
         reportError(e)
       } finally {
@@ -332,6 +340,10 @@ export default defineComponent<DatasetBrowserProps>({
 
     const handlePixelSelect = (coordinates: any) => {
       requestSpectrum(coordinates.x, coordinates.y)
+    }
+
+    const handleNormalization = (isNormalized: boolean) => {
+      state.isNormalized = !state.showFullTIC && isNormalized
     }
 
     const renderBrowsingFilters = () => {
@@ -472,7 +484,7 @@ export default defineComponent<DatasetBrowserProps>({
         return (
           <div class='info'>
             <span class="text-2xl flex items-baseline ml-4">
-                TIC
+                TIC image
             </span>
             <div class="flex items-baseline ml-4 w-full justify-center items-center text-xl"
               style={{ visibility: state.x === undefined && state.y === undefined ? 'hidden' : '' }}>
@@ -673,6 +685,7 @@ export default defineComponent<DatasetBrowserProps>({
                   height: state.currentView === VIEWS.SPECTRUM ? '' : 0,
                 }}
                 isEmpty={isEmpty}
+                normalization={state.isNormalized ? state.normalization : undefined}
                 isLoading={state.chartLoading}
                 isDataLoading={annotationsLoading.value}
                 data={state.sampleData}
@@ -717,6 +730,7 @@ export default defineComponent<DatasetBrowserProps>({
                     isNormalized={state.showFullTIC}
                     normalizationData={state.normalizationData}
                     onPixelSelected={handlePixelSelect}
+                    onNormalization={handleNormalization}
                   />
                 }
               </div>

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
@@ -45,6 +45,7 @@ interface DatasetBrowserState {
 const PEAK_FILTER = {
   ALL: 1,
   FDR: 2,
+  OFF: 3,
 }
 
 const VIEWS = {
@@ -336,6 +337,7 @@ export default defineComponent<DatasetBrowserProps>({
               value={state.peakFilter}
               size='mini'>
               <Radio class='w-full' label={PEAK_FILTER.ALL}>All Peaks</Radio>
+              <Radio class='w-full mt-1 ' label={PEAK_FILTER.OFF}>Unannotated Peaks</Radio>
               <div>
                 <Radio label={PEAK_FILTER.FDR}>Show annotated at FDR</Radio>
                 <Select

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
@@ -426,9 +426,9 @@ export default defineComponent<DatasetBrowserProps>({
               style={{
                 visibility: state.currentView === VIEWS.KENDRICK ? '' : 'hidden',
               }}>
-              <p class='font-semibold w-full'>Mass reference</p>
+              <div class='font-semibold w-full'>Mass reference</div>
               <Select
-                class='select-box mr-4'
+                class='reference-box mr-4'
                 value={state.fixedMassReference}
                 onChange={(value: number) => {
                   state.fixedMassReference = value

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserSpectrumChart.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserSpectrumChart.tsx
@@ -180,6 +180,7 @@ export const DatasetBrowserSpectrumChart = defineComponent<DatasetBrowserSpectru
         ],
         legend: {
           selectedMode: false,
+          icon: 'roundRect',
         },
         series: [
           {
@@ -227,7 +228,6 @@ export const DatasetBrowserSpectrumChart = defineComponent<DatasetBrowserSpectru
         return state.chartOptions
       }
 
-      console.log('HEY2')
       const auxOptions = state.chartOptions
       const data = []
       const annotatedTheoreticalMzs = annotatedMzs.value

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserSpectrumChart.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserSpectrumChart.tsx
@@ -117,6 +117,15 @@ export const DatasetBrowserSpectrumChart = defineComponent<DatasetBrowserSpectru
                 handleZoomReset()
               },
             },
+            myTool2: {
+              show: true,
+              title: 'Download data',
+              icon: 'path://M6 2h6v6c0 1.1.9 2 2 2h6v10a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4c0-1.1.9-2 2-2zm2 11a1 '
+                + '1 0 0 0 0 2h8a1 1 0 0 0 0-2H8zm0 4a1 1 0 0 0 0 2h4a1 1 0 0 0 0-2H8z ',
+              onclick: () => {
+                emit('download')
+              },
+            },
             dataZoom: {
               title: {
                 zoom: 'Zoom',

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserSpectrumChart.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserSpectrumChart.tsx
@@ -48,6 +48,7 @@ interface DatasetBrowserSpectrumChartState {
 const PEAK_FILTER = {
   ALL: 1,
   FDR: 2,
+  OFF: 3,
 }
 
 export const DatasetBrowserSpectrumChart = defineComponent<DatasetBrowserSpectrumChartProps>({
@@ -287,7 +288,7 @@ export const DatasetBrowserSpectrumChart = defineComponent<DatasetBrowserSpectru
           }
         })
 
-        if (peakFilter.value === PEAK_FILTER.ALL && !isAnnotated) { // add unnanotated peaks
+        if (peakFilter.value !== PEAK_FILTER.FDR && !isAnnotated) { // add unnanotated peaks
           data.push({
             name: xAxis.toFixed(4),
             tooltip,
@@ -309,7 +310,7 @@ export const DatasetBrowserSpectrumChart = defineComponent<DatasetBrowserSpectru
           })
         }
 
-        if (isAnnotated) {
+        if (peakFilter.value !== PEAK_FILTER.OFF && isAnnotated) {
           data.push({
             name: xAxis.toFixed(4),
             tooltip,

--- a/metaspace/webapp/src/modules/Datasets/imzml/SimpleIonImageViewer.scss
+++ b/metaspace/webapp/src/modules/Datasets/imzml/SimpleIonImageViewer.scss
@@ -1,7 +1,7 @@
 .simple-ion-image-container{
   @apply flex flex-col items-center justify-start relative w-full;
   min-height: 500px;
-  background: rgba(0,0,0,0.01);
+  background: white;//rgba(0,0,0,0.01);
   height: 100%;
 
   .simple-ion-image-item-header{
@@ -35,24 +35,11 @@
     width: 100%;
   }
 
-  .dataset-browser-empty-spectrum{
-    @apply border-2 border-dashed border-gray-200 relative rounded m-6 p-2 flex flex-row items-center justify-center;
-    background: rgba(224,224,224,0.2);
-  }
-
-  .chart-holder{
-    @apply flex flex-col items-center justify-start relative;
-    min-height: 500px;
-    width: 100%;
-    background: rgba(0,0,0,0.01);
-    height: 100%;
-  }
-
   .loader-holder{
     @apply absolute flex flex-row items-start justify-center;
     height: 100%;
     width: 100%;
-    background: rgba(0,0,0,0.02);
+    background: white;//rgba(0,0,0,0.02);
     padding-top: 30%;
   }
 

--- a/metaspace/webapp/src/modules/Datasets/imzml/SimpleIonImageViewer.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/SimpleIonImageViewer.tsx
@@ -253,7 +253,8 @@ export default defineComponent<SimpleIonImageViewerProps>({
     }
 
     const handleNormalizationChange = (isNormalized: boolean) => {
-      state.imageSettings.isNormalized = isNormalized
+      emit('normalization', isNormalized)
+      state.imageSettings.isNormalized = props.isNormalized || isNormalized
     }
 
     const buildRangeSliderStyle = (scaleRange: number[] = [0, 1]) => {

--- a/metaspace/webapp/src/modules/Datasets/imzml/SimpleIonImageViewer.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/SimpleIonImageViewer.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, onMounted, reactive } from '@vue/composition-api'
+import { computed, defineComponent, onMounted, reactive, watch } from '@vue/composition-api'
 import config from '../../../lib/config'
 import MainImage from '../../Annotations/annotation-widgets/default/MainImage.vue'
 import MainImageHeader from '../../Annotations/annotation-widgets/default/MainImageHeader.vue'
@@ -33,6 +33,7 @@ interface ImageSettings {
 }
 
 interface SimpleIonImageViewerProps {
+  isNormalized: boolean
   annotation: any
   normalizationData: any
   ionImageUrl: string | null
@@ -71,6 +72,10 @@ export default defineComponent<SimpleIonImageViewerProps>({
       type: Number,
       default: 0,
     },
+    isNormalized: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup: function(props, { emit, root }) {
     const { $route } = root
@@ -79,7 +84,7 @@ export default defineComponent<SimpleIonImageViewerProps>({
       rangeSliderStyle: undefined,
       scaleIntensity: false,
       imageSettings: {
-        isNormalized: !!$route.query.norm,
+        isNormalized: props.isNormalized || !!$route.query.norm,
         lockedIntensities: [undefined, undefined],
         annotImageOpacity: 1.0,
         opticalOpacity: 1.0,
@@ -331,7 +336,7 @@ export default defineComponent<SimpleIonImageViewerProps>({
 
     const startImageLoaderSettings = () => {
       state.imageSettings = {
-        isNormalized: !!$route.query.norm,
+        isNormalized: props.isNormalized || !!$route.query.norm,
         lockedIntensities: [undefined, undefined],
         annotImageOpacity: 1.0,
         opticalOpacity: 1.0,
@@ -353,6 +358,10 @@ export default defineComponent<SimpleIonImageViewerProps>({
       }
       setIonImage()
     }
+
+    watch(() => props.isNormalized, (newValue) => {
+      handleNormalizationChange(newValue)
+    })
 
     return () => {
       return (

--- a/metaspace/webapp/src/modules/Datasets/imzml/SimpleIonImageViewer.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/SimpleIonImageViewer.tsx
@@ -43,8 +43,6 @@ interface SimpleIonImageViewerProps {
 interface SimpleIonImageViewerState {
   scaleIntensity: boolean
   ionImageUrl: any
-  chartLoading: boolean
-  imageLoading: boolean
   ionImage: any
   rangeSliderStyle: any
   imageSettings: ImageSettings
@@ -79,8 +77,6 @@ export default defineComponent<SimpleIonImageViewerProps>({
     const state = reactive<SimpleIonImageViewerState>({
       ionImage: undefined,
       rangeSliderStyle: undefined,
-      chartLoading: false,
-      imageLoading: false,
       scaleIntensity: false,
       imageSettings: {
         isNormalized: !!$route.query.norm,

--- a/metaspace/webapp/src/modules/Datasets/imzml/__snapshots__/DatasetBrowserSpectrumChart.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/imzml/__snapshots__/DatasetBrowserSpectrumChart.spec.ts.snap
@@ -4,33 +4,7 @@ exports[`DatasetBrowserSpectrumChart it should match snapshot when empty 1`] = `
 <div
   class="dataset-browser-spectrum-container"
   isempty="true"
->
-  <div
-    class="dataset-browser-empty-spectrum"
-  >
-    <i
-      class="el-icon-info info-icon mr-6"
-    />
-    <div
-      class="flex flex-col text-xs w-3/4"
-    >
-      <p
-        class="font-semibold mb-2"
-      >
-        Steps:
-      </p>
-      <p>
-        1 - Select a pixel on the image viewer
-      </p>
-      <p>
-        2 - Apply the filter you desire
-      </p>
-      <p>
-        3 - The interaction is multi-way, so you can also update the ion image via spectrum interaction
-      </p>
-    </div>
-  </div>
-</div>
+/>
 `;
 
 exports[`DatasetBrowserSpectrumChart it should match snapshot when loading chart data 1`] = `


### PR DESCRIPTION
### Description

In order to improve the imzml browser page and user experience, a kendrick mass defefect (KMD) visualization mode was added.
#1074  

### How to test it

As the imzml browser backend routes are a POC, in order to test the front-end, you need to run the backend as a standalone server. To test it, follow these steps:

1 - Run the metaspace project
2 - Go to the the folder metaspace/metaspace/browser and register the sm dev package:  python3 setup.py develop
3 - Go to the folder /metaspace/metaspace/browser/sm/browser and run the server: uvicorn api:app --reload 
4 - Select the inputPath of the dataset you want to check the functionality, add its value to the attribute s3_path and pre-process it (via postman):
     route: http://127.0.0.1:8000/preprocess
     body: {
             "s3_path": "s3://sm-engine-dev/ddd7f0e5-ff74-4f61-96d4-60f40dfb4c3c",
     }
     * This step is needed, because I still didn't create a back-end route to check if the temp files generated already exists (i didnt do because I dont know how this will be in the production env).
5 - After pre-process the dataset, you can access the imzml browser page on the front-end: http://localhost:8999/dataset/<dataset_id>/browser    

#### Changes

##### Webapp

###### DatasetBrowserKendrickPlot
- [x] Added KMDxIntensity scatter plot
- [x] Calculates KMD according to mass reference
- [x] Added download chart data option


###### DatasetBrowserPage
- [x] Added kendrick plot visualization
- [x] Added mass reference input
- [x] Added 'Unnanotated' filter
- [x] Showing TIC image when no pixel selected
- [x] Showing selected annotation info
- [x] Showing selected x,y info


###### DatasetSpectrumPlot
- [x] Added download chart data option

#### Tests
 
##### Front end
 
- [ ] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [ ] Safari
- [ ] Firefox
- [x] md, lg, lg
- [ ] sm, xl



<img width="1274" alt="image" src="https://user-images.githubusercontent.com/35172605/161558782-6cf90a00-5660-4fbf-8eaf-c6b38ff1cfd9.png">


