### PR TITLE
Showing  only valid mails on submitter area

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetOverviewPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetOverviewPage.tsx
@@ -58,13 +58,19 @@ export default defineComponent<Props>({
       result: currentUserResult,
       loading: userLoading,
     } = useQuery<CurrentUserRoleResult|any>(currentUserRoleQuery)
-    const currentUser = computed(() => currentUserResult.value != null ? currentUserResult.value.currentUser : null)
+    const currentUser = computed(() => currentUserResult.value != null ? currentUserResult.value.currentUser
+      : null)
 
     const projectLink = (projectIdOrSlug: string) => {
       return ({
         name: 'project',
         params: { projectIdOrSlug },
       })
+    }
+
+    const isValidMail = (email:string) => {
+      const re = /^\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,3}$/
+      return re.test(String(email).toLowerCase())
     }
 
     return () => {
@@ -75,6 +81,8 @@ export default defineComponent<Props>({
       const { annotationLabel, detailLabel, projectLabel, inpFdrLvls } = props
       const showImageViewer = false
       const metadata = safeJsonParse(metadataJson) || {}
+      // eslint-disable-next-line camelcase
+      delete metadata?.Submitted_By
       const groupLink = $router.resolve({ name: 'group', params: { groupIdOrSlug: group?.id || '' } }).href
       const upDate = moment(moment(dataset?.value?.uploadDT)).isValid()
         ? moment(dataset?.value?.uploadDT).format('D MMMM, YYYY') : ''
@@ -131,7 +139,7 @@ export default defineComponent<Props>({
             <div class='dataset-overview-holder'>
               <p class='truncate'>{submitter?.name}
                 {group && <a class='ml-1' href={groupLink}>({group?.shortName})</a>}
-                {!group && submitter?.email
+                {!group && submitter?.email && isValidMail(submitter?.email)
                 && <a class='ml-1' href={`mailto:${submitter?.email}`}>{submitter?.email}</a>}
               </p>
               <div>{upDate}</div>

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetOverviewPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetOverviewPage.tsx
@@ -68,11 +68,6 @@ export default defineComponent<Props>({
       })
     }
 
-    const isValidMail = (email:string) => {
-      const re = /^\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,3}$/
-      return re.test(String(email).toLowerCase())
-    }
-
     return () => {
       const {
         name, submitter, group, projects, annotationCounts, metadataJson, id,
@@ -139,8 +134,6 @@ export default defineComponent<Props>({
             <div class='dataset-overview-holder'>
               <p class='truncate'>{submitter?.name}
                 {group && <a class='ml-1' href={groupLink}>({group?.shortName})</a>}
-                {!group && submitter?.email && isValidMail(submitter?.email)
-                && <a class='ml-1' href={`mailto:${submitter?.email}`}>{submitter?.email}</a>}
               </p>
               <div>{upDate}</div>
               {


### PR DESCRIPTION
### Description

It seems that some old datasets can have submitters with invalid mail fields and submitter data not structured to be displayed in the metadata viewer. So, these cases were treated so It does not look as a bug in the dataset overview page

<img width="394" alt="image" src="https://user-images.githubusercontent.com/35172605/163192602-1eb763e5-ed85-409c-a65f-9c1463b827be.png">
