### PR TITLE
Fixed delete dialog message

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
@@ -35,7 +35,7 @@ const DatasetItemActions = defineComponent({
       try {
         let msg = `Are you sure you want to ${force ? 'FORCE-DELETE' : 'delete'} ${props.dataset.name}?`
         if (props.dataset.status !== 'FINISHED' && props.dataset.status !== 'FAILED') {
-          msg += '\nAs this dataset is currently processing, you may receive an annotation failure email - this can be'
+          msg += '\nAs this dataset is currently processing, you may receive an annotation failure email - this can be '
             + 'safely ignored.'
         }
 

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
@@ -49,11 +49,14 @@ export const DatasetActionsDropdown = defineComponent<DatasetActionsDropdownProp
     })
 
     const openDeleteDialog = async() => {
-      const force = props.currentUser != null
-        && props.currentUser?.role === 'admin'
-        && props.dataset?.status !== 'FINISHED'
+      const force = props.dataset?.status === 'QUEUED' || props.dataset?.status === 'ANNOTATING'
       try {
-        const msg = `Are you sure you want to ${force ? 'FORCE-DELETE' : 'delete'} ${props.dataset.name}?`
+        let msg = `Are you sure you want to ${force ? 'FORCE-DELETE' : 'delete'} ${props.dataset.name}?`
+        if (props.dataset.status !== 'FINISHED' && props.dataset.status !== 'FAILED') {
+          msg += '\nAs this dataset is currently processing, you may receive an annotation failure email - this can be'
+            + 'safely ignored.'
+        }
+
         await $confirm(msg, {
           type: force ? 'warning' : undefined,
           lockScroll: false,

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
@@ -53,7 +53,7 @@ export const DatasetActionsDropdown = defineComponent<DatasetActionsDropdownProp
       try {
         let msg = `Are you sure you want to ${force ? 'FORCE-DELETE' : 'delete'} ${props.dataset.name}?`
         if (props.dataset.status !== 'FINISHED' && props.dataset.status !== 'FAILED') {
-          msg += '\nAs this dataset is currently processing, you may receive an annotation failure email - this can be'
+          msg += '\nAs this dataset is currently processing, you may receive an annotation failure email - this can be '
             + 'safely ignored.'
         }
 


### PR DESCRIPTION
### Description

The message to delete the dataset on the delete pop up should show 'FORCE_DELETE' only if the dataset is queued or processing  #1100 

#### How to test
Access the dataset overview page  (<namespace>/dataset/<ds_id>) -> click on the Actions bitton -> Click on Delete dataset 

#### Changes

##### Webapp

###### DatasetActions dropdown
- [x] Showing force-delete message only id dataset queued or processing
- [x] Added warning in the delete message regarding the fail email the user can receive if the dataset is still processing


#### Tests
 
##### Front end
 
- [ ] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [x] Safari
- [ ] Firefox
- [x] md, lg, lg
- [x]  sm, xl


<img width="1600" alt="image" src="https://user-images.githubusercontent.com/35172605/164725481-b20c1d5d-7a3e-477a-969a-7cf814e32b65.png">


