### PR TITLE
[RoiSettings] fixed active css hierarchy

### DIFF
--- a/metaspace/webapp/src/components/RoiSettings.scss
+++ b/metaspace/webapp/src/components/RoiSettings.scss
@@ -46,14 +46,17 @@ $bgColor: hsl(208, 36%, 96%);
 
 }
 
-.active{
-  color: theme('colors.blue.300') !important;
+.roi-container{
+  .active{
+    color: theme('colors.blue.300') !important;
 
-  &::after {
-    border-bottom-width: 3px;
-    border-bottom-color: theme('colors.blue.700');
+    &::after {
+      border-bottom-width: 3px;
+      border-bottom-color: theme('colors.blue.700');
+    }
   }
 }
+
 
 .roi-badge{
   color: transparent;


### PR DESCRIPTION
### Description

The 'active' class for the icon is affecting other pages 'active' classes, making it slightly more blue, which must be fixed #1114 

bug:
<img width="493" alt="image" src="https://user-images.githubusercontent.com/35172605/170075915-ab8b0e8f-5082-4cdd-9600-1fc87cef8dd9.png">

fixed:
<img width="511" alt="image" src="https://user-images.githubusercontent.com/35172605/170075983-a988771f-1ee9-4f6c-92df-6f1f0443f5c2.png">
