### PR TITLE
Wrong function parameters in python-client

### DIFF
--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 from metaspace.sm_annotation_utils import (
     SMInstance,

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -1851,7 +1851,7 @@ class SMInstance(object):
         e.g. to update a dataset's adducts:
 
         >>> sm.update_dataset(
-        >>>     dataset_id='2018-11-07_14h15m28s',
+        >>>     id='2018-11-07_14h15m28s',
         >>>     adducts=['[M]+', '+H', '+K', '+Na'],
         >>> )
 
@@ -1900,15 +1900,15 @@ class SMInstance(object):
         if chem_mods is not None:
             input_field['chemMods'] = chem_mods
         if is_public is not None:
-            input_field['is_public'] = is_public
+            input_field['isPublic'] = is_public
         if ppm is not None:
             input_field['ppm'] = ppm
         if num_isotopic_peaks is not None:
-            input_field['num_isotopic_peaks'] = num_isotopic_peaks
+            input_field['numPeaks'] = num_isotopic_peaks
         if decoy_sample_size is not None:
-            input_field['decoy_sample_size'] = decoy_sample_size
+            input_field['decoySampleSize'] = decoy_sample_size
         if analysis_version is not None:
-            input_field['analysis_version'] = analysis_version
+            input_field['analysisVersion'] = analysis_version
 
         try:
             self._gqclient.update_dataset(id, input_field, reprocess or False, force)


### PR DESCRIPTION
Veronica discovered that some parameters passed to the `update_dataset` function cause an exception:
![image](https://user-images.githubusercontent.com/16940037/173574775-2a90b831-dca0-4d93-99d0-b31bd8b8c0ae.png)

The reason for this is incorrect key names in the dictionary that is passed to the GraphQL API.