### PR TITLE
Dataset Comparison ShareLink with filter and multichannel bug

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
@@ -205,7 +205,7 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
 
         if (idx !== -1) {
           annotations.push(channel.annotations.annotations[idx])
-        } else if (channel.id) {
+        } else if (channel.id && channel.annotations && Array.isArray(channel.annotations.annotations)) {
           annotations.push({ ...channel.annotations.annotations[0], isEmpty: true })
         }
       })
@@ -285,7 +285,7 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
     }
 
     const formatMSM = (value: number) => {
-      return value.toFixed(3)
+      return value ? value.toFixed(3) : '-'
     }
 
     const formatFDR = (value: number) => {
@@ -346,7 +346,7 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
       }
     }
 
-    const renderDatasetName = (name: string) => {
+    const renderDatasetName = (name: string = '-') => {
       return (
         <div class='ds-comparison-item-line'>
           <span class='dataset-comparison-grid-ds-name truncate'>{name}</span>
@@ -424,43 +424,39 @@ export const DatasetComparisonGrid = defineComponent<DatasetComparisonGridProps>
               !== undefined}
             resetViewport={() => {}}
           />
-          {
-            annData
-            && annData.msmScore
-            && <div class="dataset-comparison-extra dom-to-image-hidden">
-              <div class="dataset-comparison-msm-badge">
-                MSM <b>{formatMSM(annData.msmScore)}</b>
-              </div>
-              <div class="dataset-comparison-fdr-badge">
-                FDR <b>{formatFDR(annData.fdrLevel)}</b>
-              </div>
-              <Popover
-                trigger="hover"
-                placement="right"
-              >
-                <div slot="reference" class="dataset-comparison-link">
-                  <RouterLink
-                    target='_blank'
-                    to={annotationsLink(annData.dataset.id.toString(),
-                      annData.databaseDetails.id.toString(),
-                      annData.databaseDetails.fdrLevel)}>
-                    <StatefulIcon className="h-6 w-6 pointer-events-none">
-                      <ExternalWindowSvg/>
-                    </StatefulIcon>
-                  </RouterLink>
-                </div>
-                Individual dataset annotation page.
-              </Popover>
-              <Button
-                title="Ion image controls"
-                class={`${gridCell?.isActive ? 'active' : ''} button-reset flex h-6 ml-1 channel-toggle`}
-                onClick={(e: any) => toggleMenuButtons(e, key)}>
-                <StatefulIcon class="h-6 w-6 pointer-events-none" active={gridCell?.isActive}>
-                  <MonitorSvg class='fill-blue-700'/>
-                </StatefulIcon>
-              </Button>
+          <div class="dataset-comparison-extra dom-to-image-hidden">
+            <div class="dataset-comparison-msm-badge">
+                MSM <b>{formatMSM(annData?.msmScore)}</b>
             </div>
-          }
+            <div class="dataset-comparison-fdr-badge">
+                FDR <b>{formatFDR(annData?.fdrLevel)}</b>
+            </div>
+            <Popover
+              trigger="hover"
+              placement="right"
+            >
+              <div slot="reference" class="dataset-comparison-link">
+                <RouterLink
+                  target='_blank'
+                  to={annotationsLink(annData?.dataset?.id?.toString(),
+                    annData?.databaseDetails?.id?.toString(),
+                    annData?.databaseDetails?.fdrLevel)}>
+                  <StatefulIcon className="h-6 w-6 pointer-events-none">
+                    <ExternalWindowSvg/>
+                  </StatefulIcon>
+                </RouterLink>
+              </div>
+                Individual dataset annotation page.
+            </Popover>
+            <Button
+              title="Ion image controls"
+              class={`${gridCell?.isActive ? 'active' : ''} button-reset flex h-6 ml-1 channel-toggle`}
+              onClick={(e: any) => toggleMenuButtons(e, key)}>
+              <StatefulIcon class="h-6 w-6 pointer-events-none" active={gridCell?.isActive}>
+                <MonitorSvg class='fill-blue-700'/>
+              </StatefulIcon>
+            </Button>
+          </div>
           <div ref={`image-${row}-${col}`} class='ds-wrapper relative'>
             {
               props.isLoading

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
@@ -443,7 +443,7 @@ export default defineComponent<DatasetComparisonPageProps>({
     }
 
     const handleChannelHighlight = () => {
-      if ($store.state.mode !== 'MULTI') {
+      if ($store.state.mode !== 'MULTI' || !state.annotations) {
         return
       }
 
@@ -473,7 +473,9 @@ export default defineComponent<DatasetComparisonPageProps>({
     const renderInfo = () => {
       const { annotations, currentAnnotationIdx, globalImageSettings, nCols, nRows } = state
 
-      const selectedAnnotation = annotations[currentAnnotationIdx].annotations[0]
+      const selectedAnnotation = annotations && annotations[currentAnnotationIdx]
+      && Array.isArray(annotations[currentAnnotationIdx].annotations)
+        ? annotations[currentAnnotationIdx].annotations[0] : null
       let possibleCompounds : any = []
       let isomers : any = []
       let isobars : any = []
@@ -485,31 +487,37 @@ export default defineComponent<DatasetComparisonPageProps>({
       })
 
       // @ts-ignore TS2604
-      const candidateMolecules = () => <CandidateMoleculesPopover
+      const candidateMolecules = (annotation: any) => <CandidateMoleculesPopover
         placement="bottom"
         possibleCompounds={possibleCompounds}
         isomers={isomers}
         isobars={isobars}>
         <MolecularFormula
           class="sf-big text-2xl"
-          ion={selectedAnnotation.ion}
+          ion={annotation.ion}
         />
       </CandidateMoleculesPopover>
 
       return (
         <div class='ds-comparison-info relative'>
-          {candidateMolecules()}
-          <CopyButton
-            class="ml-1"
-            text={selectedAnnotation.ion}>
-            Copy ion to clipboard
-          </CopyButton>
+          {
+            selectedAnnotation !== null
+            && candidateMolecules(selectedAnnotation)
+          }
+          {
+            selectedAnnotation !== null
+            && <CopyButton
+              class="ml-1"
+              text={selectedAnnotation?.ion}>
+                Copy ion to clipboard
+            </CopyButton>
+          }
           <span class="text-2xl flex items-baseline ml-4">
-            { selectedAnnotation.mz.toFixed(4) }
+            { selectedAnnotation && selectedAnnotation.mz ? selectedAnnotation.mz.toFixed(4) : '-'}
             <span class="ml-1 text-gray-700 text-sm">m/z</span>
             <CopyButton
               class="self-start"
-              text={selectedAnnotation.mz.toFixed(4)}>
+              text={selectedAnnotation && selectedAnnotation.mz ? selectedAnnotation.mz.toFixed(4) : '-'}>
               Copy m/z to clipboard
             </CopyButton>
           </span>

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonShareLink.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonShareLink.tsx
@@ -96,8 +96,10 @@ export const DatasetComparisonShareLink = defineComponent<DatasetComparisonShare
               grid,
               filter,
               mode: $store.state.mode,
-              channels: $store.state.mode === 'MULTI'
-                ? $store.state.channels.map((annotation: any) => omit(annotation, 'annotations')) : [],
+              channels: $store.state.mode === 'MULTI' && Array.isArray($store.state.channels)
+                ? $store.state.channels.map((annotation: any) => {
+                  return annotation ? omit(annotation, 'annotations') : {}
+                }) : [],
             }),
             datasetId: props.sourceDsId,
           },


### PR DESCRIPTION
### Description

After creating a link on Dataset Comparison page with multichannel selected ions, which are not anymore displayed a bug where the ion images are not displayed happens. In order to fix it, if the ion channel is not saved on the snapshot, it is not displayed anymore if accessed from a shared link #1120.




#### How to test
1 - Access the dataset comparison page 
2 - Activate multichannel
3 - Select a annotation, Add another annotation
4 - Filter by annotation name (i.e glucose, or any annotation name) where at least one of the selected annotations disappear
5 - Create a permalink
6 - Access ds comparsion from generated permalink


#### Changes

##### Webapp

###### DatasetComparisonGrid
- [x] Check if channel info exist before adding as empty
- [x] Added verifications to correct render even with empty data

###### DatasetComparisonPage
- [x] Added verifications to correct render even with empty data

###### DatasetShareLink
- [x] Added verifications to correct render even with empty data


#### Tests
 
##### Front end
 
- [x] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] md, lg, lg
- [x]  sm, xl


Example before fix:
<img width="1790" alt="image" src="https://user-images.githubusercontent.com/35172605/175039942-cde2138a-e332-430c-8544-0b130114bb47.png">

