### PR TITLE
TimeoutError when running lithops function

### DIFF
--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -86,7 +86,8 @@
     "code_engine": {
       "region": "eu-de",
       "namespace": "{{ sm_lithops_ce_namespace }}",
-      "runtime": ""
+      "runtime": "",
+      ""runtime_timeout": 1200
     },
     "ibm_vpc": {
       "endpoint": "https://eu-de.iaas.cloud.ibm.com",

--- a/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
@@ -146,6 +146,7 @@ def load_ds(
         _load_ds,
         (imzml_cobject, ibd_cobject, ds_segm_size_mb),
         runtime_memory=runtime_memory,
+        timeout=1200,
     )
 
     logger.info(f'Segmented dataset chunks into {len(ds_segms_cobjs)} segments')

--- a/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
@@ -142,11 +142,14 @@ def load_ds(
         logger.info(f'Found {ibd_size_mb}MB .ibd file. Using VM-based load_ds')
         runtime_memory = 128 * 1024
 
+    # default CE timeout is 600 seconds. For large datasets, sometimes this is not enough.
+    lithops_kwargs = {'timeout': 900}
+
     imzml_reader, ds_segments_bounds, ds_segms_cobjs, ds_segm_lens = executor.call(
         _load_ds,
         (imzml_cobject, ibd_cobject, ds_segm_size_mb),
         runtime_memory=runtime_memory,
-        timeout=1200,
+        **lithops_kwargs,
     )
 
     logger.info(f'Segmented dataset chunks into {len(ds_segms_cobjs)} segments')


### PR DESCRIPTION
From time to time we see a stack trace:

```
Traceback (most recent call last):
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/daemons/lithops.py", line 81, in _callback
    self._manager.annotate_lithops(ds=ds, del_first=msg.get('del_first', False))
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/daemons/dataset_manager.py", line 114, in annotate_lithops
    ServerAnnotationJob(executor, ds, perf).run()
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/annotation_job.py", line 317, in run
    self.results_dfs, self.png_cobjs = self.pipe.run_pipeline(**kwargs)
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/pipeline.py", line 95, in run_pipeline
    self.load_ds(use_cache=use_cache)
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/cache.py", line 81, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/pipeline.py", line 127, in load_ds
    ) = load_ds(
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/load_ds.py", line 202, in load_ds
    ) = executor.call(
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/executor.py", line 397, in call
    return self.map(
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/executor.py", line 292, in map
    raise exc
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/annotation_lithops/executor.py", line 328, in run
    return_vals = executor.get_result(futures)
TimeoutError: Function exceeded maximum time of 595 seconds and was killed
```
This exception was for the following datasets:
```
    dataset_id       |         step
---------------------------------------------
2022-06-22_00h50m49s | load_ds
2021-06-07_17h52m09s | process_centr_segments
2022-05-30_12h26m14s | load_ds
2022-05-25_12h18m35s | calculate_centroids
2022-05-24_17h05m30s | calculate_centroids
2021-09-13_17h07m38s | calculate_centroids
2021-09-11_20h59m06s | calculate_centroids
2021-09-11_20h58m10s | calculate_centroids
2021-09-11_20h54m49s | calculate_centroids
2021-09-11_20h57m08s | calculate_centroids
2022-05-20_21h37m42s | process_centr_segments
2022-05-17_15h40m15s | load_ds
2022-05-16_13h19m36s | run_coloc_job_lithops
2022-05-16_13h19m35s | run_coloc_job_lithops
```

By default, the Code Engine executor timeout is set to 600 seconds. We can change this value if necessary. But for all steps other than `load_ds` this would be a bad idea. Our goal is to speed up the execution time of a step by parallelizing data between functions. That is why I increase timeout only for `load_ds`. For the remaining steps, when this exception appears, we will change the size of the chunks in order to reduce the execution time.