### PR TITLE
IMZML browser graphql/Interface

### DIFF
--- a/metaspace/engine/sm/rest/imzml_browser.py
+++ b/metaspace/engine/sm/rest/imzml_browser.py
@@ -95,9 +95,7 @@ def get_intensity_by_mz_ppm():
         logger.info(f'Creating an image in {round(time.time() - start, 2)} sec')
 
         headers = {'Content-Type': 'application/json'}
-        body = {
-            'image': body,
-        }
+        body = {'image': body}
         return bottle.HTTPResponse(body, **headers)
     except Exception as e:
         logger.exception(f'{bottle.request} - {e}')

--- a/metaspace/engine/sm/rest/imzml_browser.py
+++ b/metaspace/engine/sm/rest/imzml_browser.py
@@ -1,6 +1,7 @@
 import io
 import logging
 import time
+import base64
 
 import bottle
 import PIL
@@ -43,7 +44,8 @@ def create_png_image(rgba_image):
     fp = io.BytesIO()
     image.save(fp, format='PNG')
     fp.seek(0)
-    return fp
+    img_str = base64.b64encode(fp.getvalue())
+    return "data:image/png;base64," + img_str.decode()
 
 
 def get_mzs_ints(x, y, coord_mapping, parser, ds_files):
@@ -92,7 +94,10 @@ def get_intensity_by_mz_ppm():
         body = create_png_image(rgba_image)
         logger.info(f'Creating an image in {round(time.time() - start, 2)} sec')
 
-        headers = {'Content-Type': 'image/png'}
+        headers = {'Content-Type': 'application/json'}
+        body = {
+            'image': body,
+        }
         return bottle.HTTPResponse(body, **headers)
     except Exception as e:
         logger.exception(f'{bottle.request} - {e}')

--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -287,6 +287,13 @@ type RawOpticalImage {
     transform: [[Float]]
 }
 
+type PixelSpectrum {
+    x: Int
+    y: Int
+    mzs: [Float]
+    ints: [Float]
+}
+
 input AddOpticalImageInput {
   datasetId: String!
   imageUrl: String!
@@ -347,6 +354,12 @@ type Query {
   thumbnailOpticalImageUrl(datasetId: String!): String  # @deprecated(reason: "Use Dataset.thumbnailOpticalImageUrl instead")
 
   currentUserLastSubmittedDataset: Dataset
+
+  hasImzmlFiles(datasetId: String!): Boolean
+
+  browserImage(datasetId: String!, mzLow: Float!, mzHigh: Float!): String
+
+  pixelSpectrum(datasetId: String!, x: Int!, y: Int!): PixelSpectrum
 }
 
 type Mutation {

--- a/metaspace/graphql/src/modules/dataset/controller/Query.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Query.ts
@@ -7,6 +7,7 @@ import { Context } from '../../../context'
 import { thumbnailOpticalImageUrl, rawOpticalImage } from './Dataset'
 import { applyQueryFilters } from '../../annotation/queryFilters'
 import { OpticalImage } from '../../engine/model'
+import { smApiDatasetRequest } from '../../../utils'
 
 const resolveDatasetScopeRole = async(ctx: Context, dsId: string) => {
   let scopeRole = SRO.OTHER
@@ -92,6 +93,48 @@ const QueryResolvers: FieldResolversFor<Query, void> = {
     return await thumbnailOpticalImageUrl(ctx, datasetId)
   },
 
+  async hasImzmlFiles(source, { datasetId }) {
+    try {
+      const resp = await smApiDatasetRequest('/v1/browser/peaks_from_pixel', {
+        ds_id: datasetId,
+        x: 0,
+        y: 0,
+      })
+      console.log('resp', resp)
+      return true
+    } catch (e) {
+      console.log('e', e)
+      return false
+    }
+  },
+  async browserImage(source, { datasetId, mzLow, mzHigh }) {
+    try {
+      const resp = await smApiDatasetRequest('/v1/browser/intensity_by_mz', {
+        ds_id: datasetId,
+        mz_low: mzLow,
+        mz_high: mzHigh,
+      })
+      console.log('resp', resp)
+      return resp.image
+    } catch (e) {
+      console.log('e', e)
+      return null
+    }
+  },
+  async pixelSpectrum(source, { datasetId, x, y }) {
+    try {
+      const resp = await smApiDatasetRequest('/v1/browser/peaks_from_pixel', {
+        ds_id: datasetId,
+        x,
+        y,
+      })
+      console.log('resp', resp)
+      return resp
+    } catch (e) {
+      console.log('e', e)
+      return null
+    }
+  },
   async currentUserLastSubmittedDataset(source, args, ctx): Promise<DatasetSource | null> {
     if (ctx.user.id) {
       const results = await esSearchResults({

--- a/metaspace/graphql/src/modules/dataset/controller/Query.ts
+++ b/metaspace/graphql/src/modules/dataset/controller/Query.ts
@@ -95,15 +95,13 @@ const QueryResolvers: FieldResolversFor<Query, void> = {
 
   async hasImzmlFiles(source, { datasetId }) {
     try {
-      const resp = await smApiDatasetRequest('/v1/browser/peaks_from_pixel', {
+      await smApiDatasetRequest('/v1/browser/peaks_from_pixel', {
         ds_id: datasetId,
         x: 0,
         y: 0,
       })
-      console.log('resp', resp)
       return true
     } catch (e) {
-      console.log('e', e)
       return false
     }
   },
@@ -114,10 +112,8 @@ const QueryResolvers: FieldResolversFor<Query, void> = {
         mz_low: mzLow,
         mz_high: mzHigh,
       })
-      console.log('resp', resp)
       return resp.image
     } catch (e) {
-      console.log('e', e)
       return null
     }
   },
@@ -128,10 +124,8 @@ const QueryResolvers: FieldResolversFor<Query, void> = {
         x,
         y,
       })
-      console.log('resp', resp)
       return resp
     } catch (e) {
-      console.log('e', e)
       return null
     }
   },

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -404,3 +404,23 @@ export const getDatasetStatusQuery =
   gql`query getDatasetStatusQuery($id: String!) {
     dataset(id: $id) { id status }
   }`
+
+export const checkIfHasBrowserFiles =
+gql`query checkIfHasBrowserFilesQuery($datasetId: String!) {
+  hasImzmlFiles(datasetId: $datasetId)
+}`
+
+export const getBrowserImage =
+gql`query gerBrowserImageQuery($datasetId: String!, $mzLow: Float!, $mzHigh: Float!) {
+  browserImage(datasetId: $datasetId, mzLow: $mzLow, mzHigh: $mzHigh)
+}`
+
+export const getSpectrum =
+gql`query getSpectrumQuery($datasetId: String!, $x: Int!, $y: Int!) {
+  pixelSpectrum(datasetId: $datasetId, x: $x, y: $y){
+    x
+    y
+    mzs
+    ints
+  }
+}`

--- a/metaspace/webapp/src/lib/config.ts
+++ b/metaspace/webapp/src/lib/config.ts
@@ -7,6 +7,7 @@ const fileConfig = require('../clientConfig.json')
 interface Features {
   coloc: boolean;
   show_dataset_overview: boolean;
+  imzml_browser: boolean;
   spotting: boolean;
   roi: boolean;
   tic: boolean;
@@ -61,6 +62,7 @@ const defaultConfig: ClientConfig = {
   features: {
     coloc: true,
     show_dataset_overview: true,
+    imzml_browser: false,
     spotting: false,
     roi: true,
     tic: true,

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.spec.ts
@@ -1,0 +1,59 @@
+import { mount } from '@vue/test-utils'
+import Vue from 'vue'
+import { DatasetBrowserKendrickPlot } from './DatasetBrowserKendrickPlot'
+import Vuex from 'vuex'
+import { sync } from 'vuex-router-sync'
+import store from '../../../store'
+import router from '../../../router'
+
+jest.mock('vue-echarts', () => ({ default: jest.fn() }))
+jest.mock('echarts', () => ({ default: jest.fn() }))
+jest.mock('echarts/core', () => ({ default: jest.fn(), use: jest.fn() }))
+jest.mock('echarts/renderers', () => ({ default: jest.fn() }))
+jest.mock('echarts/charts', () => ({ default: jest.fn() }))
+jest.mock('echarts/components', () => ({ default: jest.fn() }))
+
+describe('DatasetBrowserKendrickPlot', () => {
+  const testHarness = Vue.extend({
+    components: {
+      DatasetBrowserKendrickPlot,
+    },
+    render(h) {
+      return h(DatasetBrowserKendrickPlot, { props: this.$attrs })
+    },
+  })
+
+  beforeAll(() => {
+    Vue.use(Vuex)
+    sync(store, router)
+  })
+
+  it('it should match snapshot when empty', async() => {
+    const wrapper = mount(testHarness, {
+      store,
+      router,
+      propsData: {
+        isEmpty: true,
+        isLoading: false,
+      },
+    })
+    await Vue.nextTick()
+
+    expect(wrapper.element).toMatchSnapshot()
+  })
+
+  it('it should match snapshot when loading chart data', async() => {
+    const wrapper = mount(testHarness, {
+      store,
+      router,
+      propsData: {
+        isEmpty: false,
+        isLoading: false,
+        isDataLoading: true,
+      },
+    })
+    await Vue.nextTick()
+
+    expect(wrapper.element).toMatchSnapshot()
+  })
+})

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
@@ -199,6 +199,7 @@ export default defineComponent<DatasetBrowserProps>({
       if (result && result.data && result.data.pixelSpectrum) {
         state.sampleData = [{ ints: result.data.pixelSpectrum.ints, mzs: result.data.pixelSpectrum.mzs }]
       }
+      state.chartLoading = false
     })
 
     const b64toBlob = (b64Data: any, contentType = '', sliceSize = 512) => {
@@ -272,8 +273,6 @@ export default defineComponent<DatasetBrowserProps>({
         state.normalization = ticPixel
       } catch (e) {
         reportError(e)
-      } finally {
-        state.chartLoading = false
       }
     }
 

--- a/metaspace/webapp/src/modules/Datasets/imzml/__snapshots__/DatasetBrowserKendrickPlot.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/imzml/__snapshots__/DatasetBrowserKendrickPlot.spec.ts.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DatasetBrowserKendrickPlot it should match snapshot when empty 1`] = `
+<div
+  class="dataset-browser-kendrick-container"
+  isempty="true"
+/>
+`;
+
+exports[`DatasetBrowserKendrickPlot it should match snapshot when loading chart data 1`] = `
+<div
+  class="dataset-browser-kendrick-container"
+  isdataloading="true"
+>
+  <div
+    class="chart-holder"
+  >
+    <div
+      class="loader-holder"
+    >
+      <div>
+        <i
+          class="el-icon-loading"
+        />
+      </div>
+    </div>
+    <!--function (el) {
+      var obj;
+
+      var args = [], len = arguments.length - 1;
+      while ( len-- &gt; 0 ) args[ len ] = arguments[ len + 1 ];
+      if (shouldNotBeStubbed(el, stubs, modifiedComponents)) {
+        return originalCreateElement.apply(void 0, [ el ].concat( args ))
+      }
+
+      if (isConstructor(el) || isComponentOptions(el)) {
+        if (stubAllComponents) {
+          var stub = createStubFromComponent(el, el.name || 'anonymous', _Vue);
+          return originalCreateElement.apply(void 0, [ stub ].concat( args ))
+        }
+        var Constructor = shouldExtend(el) ? extend(el, _Vue) : el;
+
+        return originalCreateElement.apply(void 0, [ Constructor ].concat( args ))
+      }
+
+      if (typeof el === 'string') {
+        var original = resolveComponent(el, originalComponents);
+
+        if (!original) {
+          return originalCreateElement.apply(void 0, [ el ].concat( args ))
+        }
+
+        if (isDynamicComponent(original)) {
+          return originalCreateElement.apply(void 0, [ el ].concat( args ))
+        }
+
+        var stub$1 = createStubIfNeeded(stubAllComponents, original, _Vue, el);
+
+        if (stub$1) {
+          Object.assign(vm.$options.components, ( obj = {}, obj[el] = stub$1, obj ));
+          modifiedComponents.add(el);
+        }
+      }
+
+      return originalCreateElement.apply(void 0, [ el ].concat( args ))
+    }-->
+  </div>
+</div>
+`;

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.spec.ts
@@ -98,26 +98,26 @@ describe('DatasetActionsDropdown', () => {
   it('it show all options to the admin', async() => {
     const wrapper = mount(testHarness, { store, router, apolloProvider, propsData })
     await Vue.nextTick()
-    expect(wrapper.findAll('li').length).toBe(6)
+    expect(wrapper.findAll('li').length).toBe(5)
   })
 
   it('it show all options except reprocess if user is the ds owner, but not admin', async() => {
     const wrapper = mount(testHarness, { store, router, apolloProvider, propsData: propsDataOwner })
     await Vue.nextTick()
-    expect(wrapper.findAll('li').length).toBe(5)
+    expect(wrapper.findAll('li').length).toBe(4)
   })
 
   it('it show only canDownload option for normalUser', async() => {
     const wrapper = mount(testHarness, { store, router, propsData: propsDataNormal })
     await Vue.nextTick()
-    expect(wrapper.findAll('li').length).toBe(3)
+    expect(wrapper.findAll('li').length).toBe(2)
   })
 
   it('it show only canDownload option for normalUser', async() => {
     const wrapper = mount(testHarness, { store, router, apolloProvider, propsData: propsDataNormalNoOptions })
     await Vue.nextTick()
 
-    expect(wrapper.findAll('li').length).toBe(2)
+    expect(wrapper.findAll('li').length).toBe(1)
     expect(wrapper.find('.el-dropdown').element.style.visibility).toBe('hidden')
   })
 })

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.spec.ts
@@ -5,9 +5,8 @@ import Vue from 'vue'
 import Vuex from 'vuex'
 import { sync } from 'vuex-router-sync'
 import { DatasetActionsDropdown } from './DatasetActionsDropdown'
-
-Vue.use(Vuex)
-sync(store, router)
+import { checkIfHasBrowserFiles } from '../../../api/dataset'
+import { initMockGraphqlClient, apolloProvider } from '../../../../tests/utils/mockGraphqlClient'
 
 describe('DatasetActionsDropdown', () => {
   const mockDataset = {
@@ -80,35 +79,45 @@ describe('DatasetActionsDropdown', () => {
     },
   })
 
+  beforeAll(() => {
+    Vue.use(Vuex)
+    sync(store, router)
+    initMockGraphqlClient({
+      Query: () => ({
+        checkIfHasBrowserFiles: () => false, // Prevent automatic mocking
+      }),
+    })
+  })
+
   it('it should match snapshot', async() => {
-    const wrapper = shallowMount(testHarness, { store, router, propsData })
+    const wrapper = shallowMount(testHarness, { store, router, apolloProvider, propsData })
 
     expect(wrapper).toMatchSnapshot()
   })
 
   it('it show all options to the admin', async() => {
-    const wrapper = mount(testHarness, { store, router, propsData })
+    const wrapper = mount(testHarness, { store, router, apolloProvider, propsData })
     await Vue.nextTick()
-    expect(wrapper.findAll('li').length).toBe(5)
+    expect(wrapper.findAll('li').length).toBe(6)
   })
 
   it('it show all options except reprocess if user is the ds owner, but not admin', async() => {
-    const wrapper = mount(testHarness, { store, router, propsData: propsDataOwner })
+    const wrapper = mount(testHarness, { store, router, apolloProvider, propsData: propsDataOwner })
     await Vue.nextTick()
-    expect(wrapper.findAll('li').length).toBe(4)
+    expect(wrapper.findAll('li').length).toBe(5)
   })
 
   it('it show only canDownload option for normalUser', async() => {
     const wrapper = mount(testHarness, { store, router, propsData: propsDataNormal })
     await Vue.nextTick()
-    expect(wrapper.findAll('li').length).toBe(2)
+    expect(wrapper.findAll('li').length).toBe(3)
   })
 
   it('it show only canDownload option for normalUser', async() => {
-    const wrapper = mount(testHarness, { store, router, propsData: propsDataNormalNoOptions })
+    const wrapper = mount(testHarness, { store, router, apolloProvider, propsData: propsDataNormalNoOptions })
     await Vue.nextTick()
 
-    expect(wrapper.findAll('li').length).toBe(1)
+    expect(wrapper.findAll('li').length).toBe(2)
     expect(wrapper.find('.el-dropdown').element.style.visibility).toBe('hidden')
   })
 })

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
@@ -121,7 +121,7 @@ export const DatasetActionsDropdown = defineComponent<DatasetActionsDropdownProp
           mutation: reprocessDatasetQuery,
           variables: {
             id: props.dataset?.id,
-            useLithops: true, // config.features.lithops,
+            useLithops: config.features.lithops,
           },
         })
         $notify.success('Dataset sent for reprocessing')
@@ -216,7 +216,10 @@ export const DatasetActionsDropdown = defineComponent<DatasetActionsDropdownProp
               && <DropdownItem command="download">{downloadActionLabel}</DropdownItem>
             }
             <DropdownItem command="compare">{compareActionLabel}</DropdownItem>
-            <DropdownItem command="browser">{browserActionLabel}</DropdownItem>
+            {
+              config.features.imzml_browser
+              && <DropdownItem command="browser">{browserActionLabel}</DropdownItem>
+            }
             {
               canDelete
               && <DropdownItem class='text-red-500' command="delete">{deleteActionLabel}</DropdownItem>

--- a/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/DatasetActionsDropdown.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/DatasetActionsDropdown.spec.ts.snap
@@ -9,6 +9,7 @@ exports[`DatasetActionsDropdown it should match snapshot 1`] = `
     <eldropdownitem-stub command="edit">Edit metadata</eldropdownitem-stub>
     <eldropdownitem-stub command="download">Download</eldropdownitem-stub>
     <eldropdownitem-stub command="compare">Compare with other datasets...</eldropdownitem-stub>
+    <eldropdownitem-stub command="browser">Imzml Browser</eldropdownitem-stub>
     <eldropdownitem-stub command="delete" class="text-red-500">Delete</eldropdownitem-stub>
     <eldropdownitem-stub command="reprocess" class="text-red-500">Reprocess data</eldropdownitem-stub>
   </eldropdownmenu-stub>

--- a/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/DatasetActionsDropdown.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/DatasetActionsDropdown.spec.ts.snap
@@ -9,7 +9,6 @@ exports[`DatasetActionsDropdown it should match snapshot 1`] = `
     <eldropdownitem-stub command="edit">Edit metadata</eldropdownitem-stub>
     <eldropdownitem-stub command="download">Download</eldropdownitem-stub>
     <eldropdownitem-stub command="compare">Compare with other datasets...</eldropdownitem-stub>
-    <eldropdownitem-stub command="browser">Imzml Browser</eldropdownitem-stub>
     <eldropdownitem-stub command="delete" class="text-red-500">Delete</eldropdownitem-stub>
     <eldropdownitem-stub command="reprocess" class="text-red-500">Reprocess data</eldropdownitem-stub>
   </eldropdownmenu-stub>


### PR DESCRIPTION
### Description

Create graphql interface to communicate with imzml browser api and connect it to the front end #1133 


#### How to test
1 - Access datasets page
2 - Access a specific dataset overview page with feat=imzml_browser: <metaspace>/dataset/<dsId>?feat=imzml_browser
3 - Click on the option 'imzml browser' at the Actions dropdown button

#### Changes

##### Api

###### imzml_browser.py
- [x] Returning image base64 string

##### Graphql

###### Dataset/Query
- [x] Created check imzml browser indexes file existence
- [x] Created get spectrum image interface
- [x] Created get pixel spectrum interface

##### Webapp

###### Config
- [x] Added feature flag 'imzml_browser'


###### DatasetActions dropdown
- [x] Added imzml browser item
- [x] Redirect to imzml browser page if files exist
- [x] Reprocess dataset if imzml browser files do not exist

###### DatasetBrowserPage
- [x] Using graphql interface to new api

#### Tests
 
##### Front end
 
- [ ] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [x] Safari
- [x] Firefox
- [x] md, lg, lg
- [x]  sm, xl


<img width="1223" alt="image" src="https://user-images.githubusercontent.com/35172605/178018559-0b54cff5-0bd5-4e0e-91f9-d96c1213dc0f.png">
<img width="1299" alt="image" src="https://user-images.githubusercontent.com/35172605/178018713-043c7cec-d479-4c77-b877-97127cbb1d38.png">
<img width="1295" alt="image" src="https://user-images.githubusercontent.com/35172605/178019166-ded1f630-c75b-4a8b-9fe1-ddf9fc7daaea.png">
