### PR TITLE
Delete the context manager from imzml browser

### DIFF
--- a/metaspace/engine/sm/rest/imzml_browser_manager.py
+++ b/metaspace/engine/sm/rest/imzml_browser_manager.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from sm.engine.config import SMConfig
-from sm.engine.db import DB, ConnectionPool
+from sm.engine.db import DB
 from sm.engine.storage import get_s3_client
 from sm.engine.annotation_lithops.io import deserialize
 

--- a/metaspace/engine/sm/rest/imzml_browser_manager.py
+++ b/metaspace/engine/sm/rest/imzml_browser_manager.py
@@ -28,11 +28,10 @@ class DatasetFiles:
         self.portable_spectrum_reader_key = f'{self.uuid}/portable_spectrum_reader.pickle'
 
     def _get_bucket_and_uuid(self) -> None:
-        with ConnectionPool(self._sm_config['db']):
-            # add exception for non existed ds_id
-            res = self._db.select_one(DatasetFiles.DS_SEL, params=(self.ds_id,))
-            self.uuid = res[0].split('/')[-1]
-            self.upload_bucket = res[0].split('/')[-2]
+        # add exception for non existed ds_id
+        res = self._db.select_one(DatasetFiles.DS_SEL, params=(self.ds_id,))
+        self.uuid = res[0].split('/')[-1]
+        self.upload_bucket = res[0].split('/')[-2]
 
     def _find_imzml_ibd_keys(self) -> None:
         for obj in self.s3_client.list_objects(Bucket=self.upload_bucket, Prefix=self.uuid)[


### PR DESCRIPTION
After merging the `imzml browser` code, we are seeing an exception. The same exception was observed by Lucas while working on LION. This is due to the fact that when `sm-api` starts, a database `connection pool` is created via a call to `GlobalInit`. My addition of the context manager code closes the connection pool. Because of this, we are seeing this exception.
```
  File "/opt/dev/metaspace/metaspace/engine/sm/rest/datasets.py", line 50, in _func
    res = handler(ds_man, ds_id, params)
  File "/opt/dev/metaspace/metaspace/engine/sm/rest/datasets.py", line 100, in add
    ds_id = ds_man.add(
  File "/opt/dev/metaspace/metaspace/engine/sm/rest/dataset_manager.py", line 74, in add
    ds = Dataset.load(self._db, doc['id'])
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/dataset.py", line 120, in load
    docs = db.select_with_fields(cls.DS_SEL, params=(ds_id,))
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/db.py", line 87, in wrapper
    with transaction_context() as conn:
  File "/opt/dev/miniconda3/envs/sm38/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/opt/dev/metaspace/metaspace/engine/sm/engine/db.py", line 56, in transaction_context
    assert ConnectionPool.is_active(), "'with ConnectionPool(config):' should be used"
AssertionError: 'with ConnectionPool(config):' should be used
```