### PR TITLE
Enabled ppm field

### DIFF
--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -124,10 +124,10 @@
 import { defaultMetadataType, metadataSchemas } from '../../lib/metadataRegistry'
 import { deriveFullSchema } from './formStructure'
 import {
-  get, set, cloneDeep, defaults,
+  get, set, cloneDeep, forOwn, defaultTo, defaults,
   isEmpty, isEqual, isPlainObject,
   mapValues, forEach, without, omit,
-  uniq,
+  uniq, isUndefined, isNull, omitBy, isNil,
 } from 'lodash-es'
 import {
   newDatasetQuery,
@@ -166,6 +166,7 @@ const defaultMetaspaceOptions = {
   submitterId: null,
   groupId: null,
   projectIds: [],
+  ppm: 3,
 }
 
 export default {
@@ -421,7 +422,7 @@ export default {
 
     async loadForm(dataset, options, mdType) {
       const loadedMetadata = dataset.metadata
-      const metaspaceOptions = defaults({}, dataset.metaspaceOptions, defaultMetaspaceOptions)
+      const metaspaceOptions = defaults({}, omitBy(dataset.metaspaceOptions, isNil), defaultMetaspaceOptions)
 
       // in case user just opened a link to metadata editing page w/o navigation in web-app,
       // filters are not set up
@@ -508,7 +509,7 @@ export default {
     validate() {
       const errors = {}
 
-      const { databaseIds, adducts, name, groupId, principalInvestigator } = this.metaspaceOptions
+      const { databaseIds, adducts, name, groupId, principalInvestigator, ppm } = this.metaspaceOptions
 
       if (isEmpty(databaseIds)) {
         set(errors, ['metaspaceOptions', 'databaseIds'], 'should have at least 1 selection')
@@ -521,7 +522,9 @@ export default {
       } else if (name.length > 250) {
         set(errors, ['metaspaceOptions', 'name'], 'should be no more than 250 characters')
       }
-
+      if (!ppm) {
+        set(errors, ['metaspaceOptions', 'ppm'], 'ppm cannot be blank')
+      }
       if (groupId == null && principalInvestigator == null) {
         set(errors, ['metaspaceOptions', 'groupId'], 'select a group')
       }
@@ -562,6 +565,11 @@ export default {
     onInput(path, val) {
       set(this.value, path, val)
 
+      // recommend ppm to 10 if resolving power below 7000
+      if (isEqual(path, ['MS_Analysis', 'Detector_Resolving_Power']) && val.Resolving_Power < 7000) {
+        this.metaspaceOptions.ppm = 10
+      }
+
       if (isEqual(path, ['MS_Analysis', 'Polarity'])) {
         this.updateCurrentAdductOptions()
       }
@@ -572,7 +580,7 @@ export default {
     },
 
     updateCurrentAdductOptions() {
-      const selectedAdducts = this.metaspaceOptions.adducts
+      const selectedAdducts = this.metaspaceOptions.adducts || []
       let newAdducts = selectedAdducts.filter(adduct => this.adductOptions.some(option => option.value === adduct))
       // If no selected adducts are still valid, reset to the default adducts
       if (newAdducts.length === 0) {

--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -565,10 +565,10 @@ export default {
     onInput(path, val) {
       set(this.value, path, val)
 
-      // recommend ppm to 10 if resolving power below 7000 and 3 if greater than 7000
-      if (isEqual(path, ['MS_Analysis', 'Detector_Resolving_Power']) && val.Resolving_Power < 7000) {
+      // recommend ppm to 10 if resolving power below 70000 and 3 if greater than 70000
+      if (isEqual(path, ['MS_Analysis', 'Detector_Resolving_Power']) && val.Resolving_Power < 70000) {
         this.metaspaceOptions.ppm = 10
-      } else if (isEqual(path, ['MS_Analysis', 'Detector_Resolving_Power']) && val.Resolving_Power >= 7000) {
+      } else if (isEqual(path, ['MS_Analysis', 'Detector_Resolving_Power']) && val.Resolving_Power >= 70000) {
         this.metaspaceOptions.ppm = 3
       }
 

--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -565,9 +565,11 @@ export default {
     onInput(path, val) {
       set(this.value, path, val)
 
-      // recommend ppm to 10 if resolving power below 7000
+      // recommend ppm to 10 if resolving power below 7000 and 3 if greater than 7000
       if (isEqual(path, ['MS_Analysis', 'Detector_Resolving_Power']) && val.Resolving_Power < 7000) {
         this.metaspaceOptions.ppm = 10
+      } else if (isEqual(path, ['MS_Analysis', 'Detector_Resolving_Power']) && val.Resolving_Power >= 7000) {
+        this.metaspaceOptions.ppm = 3
       }
 
       if (isEqual(path, ['MS_Analysis', 'Polarity'])) {

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -1043,8 +1043,9 @@ exports[`MetadataEditor should match snapshot 1`] = `
                         <div slot-key="default">
                           <div style="max-width: 500px;">
                             <p>
-                              The usage of ppm = 10 is recommended when the resolving power is below 7000.
-                              Please keep in mind the ambiguity of isobars and isomers when adjusting the ppm.
+                              For mass resolving power below 70K, we recommend using higher m/z tolerance of 5-10 ppm. Please keep in mind that
+                              increasing tolerance leads to increased ambiguity, often lower numbers of annotations at fixed FDR, and increased
+                              numbers of isobaric annotations.
                             </p>
                           </div>
                         </div>

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -45,14 +45,11 @@ Object {
   "databaseIds": Array [
     1,
   ],
-  "decoySampleSize": null,
-  "description": null,
   "groupId": "123",
   "isPublic": true,
   "name": "dataset.name",
   "neutralLosses": Array [],
-  "numPeaks": null,
-  "ppm": null,
+  "ppm": 3,
   "principalInvestigator": Object {
     "email": "dataset.principalInvestigator.email",
     "name": "dataset.principalInvestigator.name",
@@ -61,7 +58,6 @@ Object {
     "dataset.projects.0.id",
     "dataset.projects.1.id",
   ],
-  "scoringModel": null,
   "submitterId": "123",
 }
 `;
@@ -1040,7 +1036,42 @@ exports[`MetadataEditor should match snapshot 1`] = `
                   <!---->
                 </div>
               </div>
-              <!---->
+              <div class="el-row" style="margin-left: -4px; margin-right: -4px;">
+                <div class="el-col el-col-8" style="padding-left: 4px; padding-right: 4px;">
+                  <div class="el-form-item md-form-field el-form-item--medium"><label class="el-form-item__label"><span class="field-label"><span>m/z tolerance (ppm)</span><span style="color: red;">*</span>
+                      <mock-el-popover trigger="hover" placement="right">
+                        <div slot-key="default">
+                          <div style="max-width: 500px;">
+                            <p>
+                              The usage of ppm = 10 is recommended when the resolving power is below 7000.
+                              Please keep in mind the ambiguity of isobars and isomers when adjusting the ppm.
+                            </p>
+                          </div>
+                        </div>
+                        <div slot-key="reference"><i class="el-icon-question metadata-help-icon"></i></div>
+                      </mock-el-popover>
+                      </span></label>
+                    <div class="el-form-item__content">
+                      <div class="el-input-number-overrides el-input-number el-input-number--medium is-without-controls" required="required">
+                        <!---->
+                        <!---->
+                        <div class="el-input el-input--medium">
+                          <!----><input type="text" autocomplete="off" max="50" min="0.01" class="el-input__inner" role="spinbutton" aria-valuemax="50" aria-valuemin="0.01" aria-valuenow="3" aria-disabled="false">
+                          <!---->
+                          <!---->
+                          <!---->
+                          <!---->
+                        </div>
+                      </div>
+                      <transition-stub name="el-zoom-in-top">
+                        <!---->
+                      </transition-stub>
+                    </div>
+                  </div>
+                </div>
+                <!---->
+                <!---->
+              </div>
             </div>
           </div>
         </form>

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -1056,7 +1056,7 @@ exports[`MetadataEditor should match snapshot 1`] = `
                         <!---->
                         <!---->
                         <div class="el-input el-input--medium">
-                          <!----><input type="text" autocomplete="off" max="50" min="0.01" class="el-input__inner" role="spinbutton" aria-valuemax="50" aria-valuemin="0.01" aria-valuenow="3" aria-disabled="false">
+                          <!----><input type="text" autocomplete="off" max="50" min="1" class="el-input__inner" role="spinbutton" aria-valuemax="50" aria-valuemin="1" aria-valuenow="3" aria-disabled="false">
                           <!---->
                           <!---->
                           <!---->

--- a/metaspace/webapp/src/modules/MetadataEditor/inputs/PpmHelp.spec.ts
+++ b/metaspace/webapp/src/modules/MetadataEditor/inputs/PpmHelp.spec.ts
@@ -1,0 +1,14 @@
+import { mount } from '@vue/test-utils'
+import PpmHelp from './PpmHelp.vue'
+import router from '../../../router'
+import store from '../../../store/index'
+import Vue from 'vue'
+
+describe('PpmHelp', () => {
+  it('should match snapshot', async() => {
+    const wrapper = mount(PpmHelp, { store, router })
+    await Vue.nextTick()
+
+    expect(wrapper).toMatchSnapshot()
+  })
+})

--- a/metaspace/webapp/src/modules/MetadataEditor/inputs/PpmHelp.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/inputs/PpmHelp.vue
@@ -1,8 +1,9 @@
 <template>
   <div style="max-width: 500px;">
     <p>
-      The usage of ppm = 10 is recommended when the resolving power is below 7000.
-      Please keep in mind the ambiguity of isobars and isomers when adjusting the ppm.
+      For mass resolving power below 70K, we recommend using higher m/z tolerance of 5-10 ppm. Please keep in mind that
+      increasing tolerance leads to increased ambiguity, often lower numbers of annotations at fixed FDR, and increased
+      numbers of isobaric annotations.
     </p>
   </div>
 </template>

--- a/metaspace/webapp/src/modules/MetadataEditor/inputs/PpmHelp.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/inputs/PpmHelp.vue
@@ -1,0 +1,15 @@
+<template>
+  <div style="max-width: 500px;">
+    <p>
+      The usage of ppm = 10 is recommended when the resolving power is below 7000.
+      Please keep in mind the ambiguity of isobars and isomers when adjusting the ppm.
+    </p>
+  </div>
+</template>
+
+<script>
+
+export default {
+  name: 'PpmHelp',
+}
+</script>

--- a/metaspace/webapp/src/modules/MetadataEditor/inputs/__snapshots__/PpmHelp.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/inputs/__snapshots__/PpmHelp.spec.ts.snap
@@ -3,8 +3,9 @@
 exports[`PpmHelp should match snapshot 1`] = `
 <div style="max-width: 500px;">
   <p>
-    The usage of ppm = 10 is recommended when the resolving power is below 7000.
-    Please keep in mind the ambiguity of isobars and isomers when adjusting the ppm.
+    For mass resolving power below 70K, we recommend using higher m/z tolerance of 5-10 ppm. Please keep in mind that
+    increasing tolerance leads to increased ambiguity, often lower numbers of annotations at fixed FDR, and increased
+    numbers of isobaric annotations.
   </p>
 </div>
 `;

--- a/metaspace/webapp/src/modules/MetadataEditor/inputs/__snapshots__/PpmHelp.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/inputs/__snapshots__/PpmHelp.spec.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PpmHelp should match snapshot 1`] = `
+<div style="max-width: 500px;">
+  <p>
+    The usage of ppm = 10 is recommended when the resolving power is below 7000.
+    Please keep in mind the ambiguity of isobars and isomers when adjusting the ppm.
+  </p>
+</div>
+`;

--- a/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
@@ -146,7 +146,9 @@
                 :value="value.ppm"
                 :error="error && error.ppm"
                 :help="PpmHelp"
-                :min="0.01"
+                :min="1"
+                :step="1"
+                :step-strictly="true"
                 :max="50"
                 @input="val => onInput('ppm', val)"
               />

--- a/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
@@ -136,21 +136,25 @@
             </el-col>
           </el-row>
           <el-row
-            v-if="features.advanced_ds_config"
             :gutter="8"
           >
             <el-col :span="8">
               <form-field
                 type="number"
                 name="m/z tolerance (ppm)"
+                required
                 :value="value.ppm"
                 :error="error && error.ppm"
+                :help="PpmHelp"
                 :min="0.01"
                 :max="50"
                 @input="val => onInput('ppm', val)"
               />
             </el-col>
-            <el-col :span="8">
+            <el-col
+              v-if="features.advanced_ds_config"
+              :span="8"
+            >
               <form-field
                 type="number"
                 name="Isotopic peaks per formula"
@@ -162,7 +166,10 @@
                 @input="val => onInput('numPeaks', val)"
               />
             </el-col>
-            <el-col :span="8">
+            <el-col
+              v-if="features.advanced_ds_config"
+              :span="8"
+            >
               <form-field
                 type="number"
                 name="Decoy adducts per formula"
@@ -189,6 +196,7 @@ import DatabaseHelpLink from '../inputs/DatabaseHelpLink.vue'
 import AnalysisVersionHelp from '../inputs/AnalysisVersionHelp.vue'
 import AdductsHelp from '../inputs/AdductsHelp.vue'
 import NeutralLossesHelp from '../inputs/NeutralLossesHelp.vue'
+import PpmHelp from '../inputs/PpmHelp.vue'
 import ChemModsHelp from '../inputs/ChemModsHelp.vue'
 import { MetaspaceOptions } from '../formStructure'
 import { MAX_CHEM_MODS, MAX_NEUTRAL_LOSSES } from '../../../lib/constants'
@@ -237,6 +245,7 @@ export default class MetaspaceOptionsSection extends Vue {
     dbHelp = DatabaseHelpLink;
     AnalysisVersionHelp = AnalysisVersionHelp;
     NeutralLossesHelp = NeutralLossesHelp;
+    PpmHelp = PpmHelp;
     ChemModsHelp = ChemModsHelp;
     AdductsHelp = AdductsHelp;
     maxMolDBs = limits.maxMolDBs;


### PR DESCRIPTION
### Description

Enabled ppm input for dataset upload and edition #1136    

##### How to test

1 - Access the upload page: <metaspace_url>/upload
2 - Access dataset edition page: <metaspace_url>/datasets/edit/<ds_id>


##### Webapp

###### MetadataEditor
- [x] Removing null and undefined to merge with defaultMetaspaceOptions
- [x] Changed ppm to required field
- [x] Set default ppm to 3
- [x] Added ppm help tooltip
- [x] Set ppm = 10 if resolving power less than 7 thousand

###### PpmHelp
- [x] Created ppm tooltip component


###### MetaspaceOptionsSection
- [x] Enabled ppm field without feature flag

#### Tests
 
##### Front end
 
- [x] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [x] Safari
- [ ]  Firefox
- [x] md, lg, lg
- [x]  sm, xl

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/35172605/179514244-1dd92b46-aed0-491f-8bbf-1be09728e4eb.png">


