### PR TITLE
Changed add dataset to project behaviour

### DIFF
--- a/metaspace/graphql/src/modules/project/controller/Mutation.membership.spec.ts
+++ b/metaspace/graphql/src/modules/project/controller/Mutation.membership.spec.ts
@@ -306,10 +306,11 @@ describe('modules/project/controller (membership-related mutations)', () => {
         datasetsForUserIds: [userId],
       })
 
-      // if manager, should not be able to add datasets from another user
+      // if manager, should not be able to add datasets from another user, if dataset is private
       if (role === UPRO.MANAGER) {
         const anotherUser = await createTestUser()
-        const datasetFromAnotherUser = await createTestDataset({ userId: anotherUser.id })
+        const datasetFromAnotherUser = await createTestDataset({ userId: anotherUser.id },
+          { isPublic: false })
         const anotherUserDatasetId = datasetFromAnotherUser.id
 
         let accessError

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -173,8 +173,8 @@ export interface DatasetListItemWithDiagnostics {
 }
 
 export const datasetListItemsQuery =
-  gql`query GetDatasets($dFilter: DatasetFilter, $query: String, $limit: Int = 10000) {
-    allDatasets(offset: 0, limit: $limit, filter: $dFilter, simpleQuery: $query) {
+  gql`query GetDatasets($dFilter: DatasetFilter, $query: String, $limit: Int = 10000, $offset: Int = 0) {
+    allDatasets(offset: $offset, limit: $limit, filter: $dFilter, simpleQuery: $query) {
       id
       name
       uploadDT

--- a/metaspace/webapp/src/api/dataset.ts
+++ b/metaspace/webapp/src/api/dataset.ts
@@ -178,6 +178,7 @@ export const datasetListItemsQuery =
       id
       name
       uploadDT
+      submitter { name }
     }
   }`
 

--- a/metaspace/webapp/src/api/user.ts
+++ b/metaspace/webapp/src/api/user.ts
@@ -157,6 +157,13 @@ export interface CurrentUserRoleResult {
   role: UserRole;
 }
 
+export interface CurrentUserRoleWithGroupResult {
+  id: string;
+  name: string;
+  role: UserRole;
+  groups: any;
+}
+
 // Always use fetchPolicy: 'cache-first' for this
 export const currentUserRoleQuery =
   gql`query CurrentUserRoleQuery {

--- a/metaspace/webapp/src/modules/Project/DatasetsDialog.scss
+++ b/metaspace/webapp/src/modules/Project/DatasetsDialog.scss
@@ -1,0 +1,12 @@
+.project-datasets-dialog{
+  .filter-box{
+    @apply flex justify-between items-center;
+    .query-filter{
+      max-width: 200px;
+    }
+  }
+  .el-checkbox__inner {
+    &:after {
+    }
+  }
+}

--- a/metaspace/webapp/src/modules/Project/DatasetsDialog.spec.ts
+++ b/metaspace/webapp/src/modules/Project/DatasetsDialog.spec.ts
@@ -1,0 +1,125 @@
+import { mount } from '@vue/test-utils'
+import router from '../../router'
+import store from '../../store/index'
+import Vue from 'vue'
+import Vuex from 'vuex'
+import { sync } from 'vuex-router-sync'
+import { DatasetsDialog } from './DatasetsDialog'
+import { initMockGraphqlClient, apolloProvider } from '../../../tests/utils/mockGraphqlClient'
+
+Vue.use(Vuex)
+sync(store, router)
+
+describe('DatasetsDialog', () => {
+  const propsData = {
+    project: {
+      id: '05c6519a-8049-11eb-927e-6bf28a9b25ae',
+      name: 'Test',
+      currentUserRole: 'MANAGER',
+    },
+    currentUser: {
+      id: '039801c8-919e-11eb-908e-3b2b8e672707',
+      groups: [
+        {
+          group: {
+            id: 'testGroup',
+            label: 'group1',
+          },
+        },
+      ],
+    },
+    visible: true,
+    isManager: true,
+    refreshData: () => {},
+  }
+
+  const testHarness = Vue.extend({
+    components: {
+      DatasetsDialog,
+    },
+    render(h) {
+      return h(DatasetsDialog, { props: this.$attrs })
+    },
+  })
+
+  const graphqlWithData = () => {
+    initMockGraphqlClient({
+      Query: () => ({
+        allDatasets: () => {
+          return [{
+            id: '2021-03-31_11h02m28s',
+            name: 'New 3 (1)',
+            uploadDT: '2021-03-31T14:02:28.722Z',
+          }, {
+            id: '2021-03-30_18h25m18s',
+            name: 'Untreated_3_434_super_lite_19_31 (1)',
+            uploadDT: '2021-03-30T21:25:18.473Z',
+          }]
+        },
+      }),
+    })
+  }
+  const graphqlWithExtraUserData = () => {
+    initMockGraphqlClient({
+      Query: () => ({
+        allDatasets: (src: any, { filter: { project } } : any) => {
+          if (project) {
+            return []
+          }
+
+          return [{
+            id: '2021-03-31_11h02m28s',
+            name: 'New 3 (1)',
+            uploadDT: '2021-03-31T14:02:28.722Z',
+          }, {
+            id: '2021-03-30_18h25m18s',
+            name: 'Untreated_3_434_super_lite_19_31 (1)',
+            uploadDT: '2021-03-30T21:25:18.473Z',
+          }]
+        },
+      }),
+    })
+  }
+
+  const graphqlWithNoData = () => {
+    initMockGraphqlClient({
+      Query: () => ({
+        allDatasets: () => {
+          return []
+        },
+      }),
+    })
+  }
+
+  it('it should match snapshot', async() => {
+    graphqlWithData()
+    const wrapper = mount(testHarness, { store, router, apolloProvider, propsData })
+    await Vue.nextTick()
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('it should match no dataset snapshot', async() => {
+    graphqlWithNoData()
+    const wrapper = mount(testHarness, { store, router, apolloProvider, propsData })
+    await Vue.nextTick()
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('it should have disabled update button when no data available', async() => {
+    graphqlWithNoData()
+    const wrapper = mount(testHarness, { store, router, apolloProvider, propsData })
+    await Vue.nextTick()
+
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(true)
+  })
+
+  it('it should have disabled update button when no dataset selection has changed', async() => {
+    graphqlWithData()
+    const wrapper = mount(testHarness, { store, router, apolloProvider, propsData })
+    await Vue.nextTick()
+
+    expect(wrapper.find('.el-button--primary').props('disabled')).toBe(true)
+  })
+})

--- a/metaspace/webapp/src/modules/Project/DatasetsDialog.tsx
+++ b/metaspace/webapp/src/modules/Project/DatasetsDialog.tsx
@@ -1,0 +1,230 @@
+import { defineComponent, computed, reactive, ref } from '@vue/composition-api'
+import { importDatasetsIntoProjectMutation, ProjectsListProject } from '../../api/project'
+import { Dialog, Checkbox, Button, Select, Option, Input, Table, TableColumn, Pagination } from '../../lib/element-ui'
+import { uniqBy, isEmpty } from 'lodash'
+import './DatasetsDialog.scss'
+import { countDatasetsByStatusQuery, DatasetDetailItem, DatasetListItem, datasetListItemsQuery } from '../../api/dataset'
+import { useQuery } from '@vue/apollo-composable'
+import reportError from '../../lib/reportError'
+import Vue from 'vue'
+import { calculateMzFromFormula, isFormulaValid } from '../../lib/formulaParser'
+import { annotationListQuery } from '../../api/annotation'
+import config from '../../lib/config'
+
+interface CheckOptions {
+  [key: string]: boolean
+}
+
+interface DatasetsDialogState {
+  selectedDatasets: CheckOptions
+  isSubmitting: boolean
+  hasChanged: boolean
+  datasetOwnerFilter: string
+  nameFilter: string | undefined
+  pageSize: number
+  offset: number
+}
+
+interface DatasetsDialogProps {
+  project: ProjectsListProject
+  currentUser: any
+  visible: boolean
+  isManager: boolean
+  refreshData: () => Promise<any>
+}
+
+export const DatasetsDialog = defineComponent<DatasetsDialogProps>({
+  name: 'DatasetsDialog',
+  props: {
+    project: { type: Object, default: undefined },
+    currentUser: { type: Object, default: undefined },
+    visible: { type: Boolean, default: true },
+    isManager: { type: Boolean, default: false },
+    refreshData: { type: Function, required: true },
+  },
+  setup(props, ctx) {
+    const { emit } = ctx
+    const pageSizes = [5, 15, 20, 25, 30]
+    const table = ref(null)
+
+    const state = reactive<DatasetsDialogState>({
+      selectedDatasets: {},
+      isSubmitting: false,
+      hasChanged: false,
+      datasetOwnerFilter: 'all-datasets',
+      nameFilter: undefined,
+      pageSize: 5,
+      offset: 1,
+    })
+
+    const queryVars = computed(() => ({
+      dFilter: {
+        group: state.datasetOwnerFilter !== 'all-datasets'
+        && state.datasetOwnerFilter !== 'my-datasets' && state.datasetOwnerFilter !== 'project-datasets'
+          ? state.datasetOwnerFilter : undefined,
+        submitter: state.datasetOwnerFilter === 'my-datasets' ? props.currentUser.id : undefined,
+        project: state.datasetOwnerFilter === 'project-datasets' ? props.project.id : undefined,
+        metadataType: 'Imaging MS',
+        status: 'FINISHED',
+        name: state.nameFilter,
+      },
+      limit: state.pageSize,
+      offset: (state.offset - 1) * state.pageSize,
+    }))
+
+    const {
+      result: datasetResult,
+      loading: datasetLoading,
+    } = useQuery<{allDatasets: DatasetDetailItem}>(datasetListItemsQuery, queryVars)
+    const datasets = computed(() => datasetResult.value != null ? datasetResult.value.allDatasets : null)
+
+    const {
+      result: datasetCountResult,
+      loading: datasetCountLoading,
+    } = useQuery<{countDatasetsPerGroup: any}>(countDatasetsByStatusQuery, queryVars)
+    const datasetCount = computed(() => datasetCountResult.value != null
+      ? datasetCountResult.value.countDatasetsPerGroup.counts[0].count : null)
+
+    const handleClose = () => {
+      emit('close')
+    }
+
+    const handleGroupSelect = (value: string) => {
+      state.datasetOwnerFilter = value
+    }
+
+    const handleQueryChange = (value: string) => {
+      console.log('dude', value)
+      state.nameFilter = value
+    }
+
+    const handleSelectionChange = (value: any) => {
+      console.log('selected', value)
+      state.selectedDatasets = value
+    }
+
+    const handlePageChange = (value: number) => {
+      console.log('page change', value)
+      state.offset = value
+    }
+
+    const handlePageSizeChange = (value: number) => {
+      console.log('value', value)
+      state.pageSize = value
+    }
+
+    const paginationLayout = () => {
+      const limitedSpace = datasets.value && (datasets.value as any).length === 1
+      if (limitedSpace) {
+        return 'pager'
+      }
+
+      return 'prev,pager,next,sizes'
+    }
+
+    return () => {
+      const {
+        visible, currentUser,
+      } = props
+
+      console.log('quer', queryVars)
+
+      return (
+        <Dialog
+          customClass='project-datasets-dialog'
+          visible={visible}
+          append-to-body
+          title={'Add or remove datasets in this project'}
+          lockScroll={false}
+          onClose={handleClose}>
+          <div class="mt-6">
+            <div class='filter-box'>
+              <Select
+                class='select-box-mini'
+                value={state.datasetOwnerFilter}
+                onChange={handleGroupSelect}
+                placeholder='5%'
+                size='mini'>
+                <Option label="All datasets" value={'all-datasets'}/>
+                <Option label="My datasets" value={'my-datasets'}/>
+                <Option label="Project datasets" value={'project-datasets'}/>
+                {
+                  currentUser
+                && Array.isArray(currentUser.groups)
+                && currentUser.groups.map((item: any) => <Option label={item.group.label} value={item.group.id}/>)
+                }
+              </Select>
+              <Input
+                class='query-filter'
+                value={state.nameFilter}
+                onInput={handleQueryChange}
+                size='mini'
+                placeholder='Enter dataset name'
+              />
+            </div>
+            <div class='table-box'>
+              <Table
+                id="annot-table"
+                ref={table}
+                data={datasets.value || []}
+                size="mini"
+                current
+                elementLoadingText="Loading results …"
+                highlightCurrentRow
+                width="100%"
+                stripe
+                {...{
+                  on: {
+                    'selection-change': handleSelectionChange,
+                  },
+                }}
+                tabindex="1">
+
+                <TableColumn
+                  type="selection"
+                />
+                <TableColumn
+                  key="name"
+                  property="name"
+                  label="Dataset"
+                />
+                <TableColumn
+                  key="submitter.name"
+                  property="submitter.name"
+                  label="Submitter"
+                />
+                <TableColumn
+                  key="uploadDT"
+                  property="uploadDT"
+                  label="Upload date"
+                />
+              </Table>
+            </div>
+            <Pagination
+              total={datasetCount.value}
+              pageSize={state.pageSize}
+              pageSizes={pageSizes}
+              currentPage={state.offset}
+              {...{ on: { 'update:currentPage': handlePageChange } }}
+              {...{ on: { 'update:pageSize': handlePageSizeChange } }}
+              layout={paginationLayout()}
+            />
+            <div class="button-bar">
+              <Button onClick={handleClose}>
+                Cancel
+              </Button>
+              <Button
+                class='w-32'
+                loading={state.isSubmitting}
+                disabled={!state.hasChanged}
+                type="primary"
+                onClick={() => {}}>
+                Update
+              </Button>
+            </div>
+          </div>
+        </Dialog>
+      )
+    }
+  },
+})

--- a/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
+++ b/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
@@ -7,6 +7,12 @@
       v-if="project != null"
       class="page-content"
     >
+      <datasets-dialog
+        :visible="true"
+        :refresh-data="refetch"
+        :current-user="currentUser"
+        :project="project"
+      />
       <project-datasets-dialog
         :visible="showProjectDatasetsDialog && currentUser != null"
         :current-user-id="currentUser && currentUser.id"
@@ -212,7 +218,7 @@ import ConfirmAsync from '../../components/ConfirmAsync'
 import confirmPrompt from '../../components/confirmPrompt'
 import NotificationIcon from '../../components/NotificationIcon.vue'
 import reportError from '../../lib/reportError'
-import { currentUserRoleQuery, CurrentUserRoleResult } from '../../api/user'
+import { currentUserRoleWithGroupQuery, CurrentUserRoleWithGroupResult } from '../../api/user'
 import isUuid from '../../lib/isUuid'
 import ProjectMembersList from './ProjectMembersList.vue'
 import ProjectSettings from './ProjectSettings.vue'
@@ -222,6 +228,7 @@ import RichText from '../../components/RichText'
 import Publishing from './publishing'
 import NewFeatureBadge, { hideFeatureBadge } from '../../components/NewFeatureBadge'
 import { ProjectDatasetsDialog } from '../Project/ProjectDatasetsDialog'
+import { DatasetsDialog } from './DatasetsDialog'
 
   interface ViewProjectPageData {
     allDatasets: DatasetDetailItem[];
@@ -230,6 +237,7 @@ import { ProjectDatasetsDialog } from '../Project/ProjectDatasetsDialog'
 
   @Component<ViewProjectPage>({
     components: {
+      DatasetsDialog,
       DatasetList,
       ProjectMembersList,
       ProjectSettings,
@@ -245,7 +253,7 @@ import { ProjectDatasetsDialog } from '../Project/ProjectDatasetsDialog'
     },
     apollo: {
       currentUser: {
-        query: currentUserRoleQuery,
+        query: currentUserRoleWithGroupQuery,
         fetchPolicy: 'cache-first',
       },
       project: {
@@ -323,7 +331,7 @@ export default class ViewProjectPage extends Vue {
     projectLoaded = false;
     loaded = false;
     isAcceptingInvite = false;
-    currentUser: CurrentUserRoleResult | null = null;
+    currentUser: CurrentUserRoleWithGroupResult | null = null;
     project: ViewProjectResult | null = null;
     data: ViewProjectPageData | null = null;
     showProjectDatasetsDialog: boolean = false;

--- a/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
+++ b/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
@@ -8,17 +8,11 @@
       class="page-content"
     >
       <datasets-dialog
-        :visible="true"
+        :visible="showProjectDatasetsDialog && currentUser != null"
         :refresh-data="refetch"
         :current-user="currentUser"
         :project="project"
-      />
-      <project-datasets-dialog
-        :visible="showProjectDatasetsDialog && currentUser != null"
-        :current-user-id="currentUser && currentUser.id"
-        :project="project"
         :is-manager="isManager"
-        :refresh-data="refetch"
         @close="handleCloseProjectDatasetsDialog"
         @update="handleCloseProjectDatasetsDialog"
       />

--- a/metaspace/webapp/src/modules/Project/__snapshots__/DatasetsDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/DatasetsDialog.spec.ts.snap
@@ -18,7 +18,7 @@ exports[`DatasetsDialog it should match no dataset snapshot 1`] = `
                 <!---->
               </div>
               <transition-stub name="el-zoom-in-top">
-                <div class="el-select-dropdown el-popper" style="display: none;">
+                <div class="el-select-dropdown el-popper" style="display: none; min-width: 200px;">
                   <div class="el-scrollbar" style="">
                     <div class="el-select-dropdown__wrap el-scrollbar__wrap el-scrollbar__wrap--hidden-default">
                       <ul class="el-scrollbar__view el-select-dropdown__list">
@@ -137,7 +137,7 @@ exports[`DatasetsDialog it should match snapshot 1`] = `
                 <!---->
               </div>
               <transition-stub name="el-zoom-in-top">
-                <div class="el-select-dropdown el-popper" style="display: none;">
+                <div class="el-select-dropdown el-popper" style="display: none; min-width: 200px;">
                   <div class="el-scrollbar" style="">
                     <div class="el-select-dropdown__wrap el-scrollbar__wrap el-scrollbar__wrap--hidden-default">
                       <ul class="el-scrollbar__view el-select-dropdown__list">

--- a/metaspace/webapp/src/modules/Project/__snapshots__/DatasetsDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/DatasetsDialog.spec.ts.snap
@@ -1,0 +1,269 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DatasetsDialog it should match no dataset snapshot 1`] = `
+<transition-stub name="dialog-fade" project="[object Object]" currentuser="[object Object]" visible="true" ismanager="true" refreshdata="function () {}" style="z-index: 2003;">
+  <div class="el-dialog__wrapper">
+    <div role="dialog" aria-modal="true" aria-label="Add or remove datasets in this project" class="el-dialog project-datasets-dialog" style="margin-top: 15vh;">
+      <div class="el-dialog__header"><span class="el-dialog__title">Add or remove datasets in this project</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+      <div class="el-dialog__body">
+        <div class="mt-6">
+          <div class="filter-box">
+            <div class="el-select el-select--mini select-box-mini">
+              <!---->
+              <div class="el-input el-input--mini el-input--suffix">
+                <!----><input type="text" readonly="readonly" autocomplete="off" placeholder="5%" class="el-input__inner">
+                <!----><span class="el-input__suffix"><span class="el-input__suffix-inner"><i class="el-select__caret el-input__icon el-icon-arrow-up"></i><!----><!----><!----><!----><!----></span>
+                <!----></span>
+                <!---->
+                <!---->
+              </div>
+              <transition-stub name="el-zoom-in-top">
+                <div class="el-select-dropdown el-popper" style="display: none;">
+                  <div class="el-scrollbar" style="">
+                    <div class="el-select-dropdown__wrap el-scrollbar__wrap el-scrollbar__wrap--hidden-default">
+                      <ul class="el-scrollbar__view el-select-dropdown__list">
+                        <!---->
+                        <li class="el-select-dropdown__item"><span>All datasets</span></li>
+                        <li class="el-select-dropdown__item"><span>My datasets</span></li>
+                        <li class="el-select-dropdown__item selected"><span>Project datasets</span></li>
+                        <li class="el-select-dropdown__item"><span>group1</span></li>
+                      </ul>
+                    </div>
+                    <div class="el-scrollbar__bar is-horizontal">
+                      <div class="el-scrollbar__thumb" style="transform: translateX(0%); webkit-transform: translateX(0%);"></div>
+                    </div>
+                    <div class="el-scrollbar__bar is-vertical">
+                      <div class="el-scrollbar__thumb" style="transform: translateY(0%); webkit-transform: translateY(0%);"></div>
+                    </div>
+                  </div>
+                  <!---->
+                </div>
+              </transition-stub>
+            </div>
+            <div class="el-input el-input--mini query-filter">
+              <!----><input type="text" autocomplete="off" placeholder="Enter dataset name" class="el-input__inner">
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+          <div class="table-box mt-2">
+            <div class="el-table el-table--fit el-table--striped el-table--scrollable-x el-table--enable-row-hover el-table--mini" id="annot-table" current="true" elementloadingtext="Loading results …" tabindex="1">
+              <div class="hidden-columns">
+                <div></div>
+                <div></div>
+                <div></div>
+                <div></div>
+              </div>
+              <div class="el-table__header-wrapper">
+                <table cellspacing="0" cellpadding="0" border="0" class="el-table__header" style="width: 308px;">
+                  <colgroup>
+                    <col name="el-table_2_column_5" width="48">
+                    <col name="el-table_2_column_6" width="100">
+                    <col name="el-table_2_column_7" width="80">
+                    <col name="el-table_2_column_8" width="80">
+                  </colgroup>
+                  <thead class="">
+                    <tr class="">
+                      <th colspan="1" rowspan="1" class="el-table_2_column_5   el-table-column--selection  is-leaf">
+                        <div class="cell"><label class="el-checkbox is-disabled"><span class="el-checkbox__input is-disabled"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" disabled="disabled" class="el-checkbox__original" value=""></span>
+                            <!----></label></div>
+                      </th>
+                      <th colspan="1" rowspan="1" class="el-table_2_column_6     is-leaf">
+                        <div class="cell">Dataset</div>
+                      </th>
+                      <th colspan="1" rowspan="1" class="el-table_2_column_7     is-leaf">
+                        <div class="cell">Submitter</div>
+                      </th>
+                      <th colspan="1" rowspan="1" class="el-table_2_column_8     is-leaf">
+                        <div class="cell">Upload date</div>
+                      </th>
+                    </tr>
+                  </thead>
+                </table>
+              </div>
+              <div class="el-table__body-wrapper is-scrolling-left">
+                <table cellspacing="0" cellpadding="0" border="0" class="el-table__body" style="width: 308px;">
+                  <colgroup>
+                    <col name="el-table_2_column_5" width="48">
+                    <col name="el-table_2_column_6" width="100">
+                    <col name="el-table_2_column_7" width="80">
+                    <col name="el-table_2_column_8" width="80">
+                  </colgroup>
+                  <tbody>
+                    <!---->
+                  </tbody>
+                </table>
+                <div class="el-table__empty-block" style="height: 100%; width: 308px;"><span class="el-table__empty-text">暂无数据</span></div>
+                <!---->
+              </div>
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <div class="el-table__column-resize-proxy" style="display: none;"></div>
+            </div>
+          </div>
+          <mock-el-pagination pagesize="5" pagesizes="5,15,20,25,30" currentpage="1" layout="prev,pager,next,sizes" class="mt-2" total="55"></mock-el-pagination>
+          <div class="button-bar"><button type="button" class="el-button el-button--default">
+              <!---->
+              <!----><span>Cancel</span></button><button disabled="disabled" type="button" class="el-button el-button--primary is-disabled w-32">
+              <!---->
+              <!----><span>Update</span></button></div>
+        </div>
+      </div>
+      <!---->
+    </div>
+  </div>
+</transition-stub>
+`;
+
+exports[`DatasetsDialog it should match snapshot 1`] = `
+<transition-stub name="dialog-fade" project="[object Object]" currentuser="[object Object]" visible="true" ismanager="true" refreshdata="function () {}" style="z-index: 2001;">
+  <div class="el-dialog__wrapper">
+    <div role="dialog" aria-modal="true" aria-label="Add or remove datasets in this project" class="el-dialog project-datasets-dialog" style="margin-top: 15vh;">
+      <div class="el-dialog__header"><span class="el-dialog__title">Add or remove datasets in this project</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+      <div class="el-dialog__body">
+        <div class="mt-6">
+          <div class="filter-box">
+            <div class="el-select el-select--mini select-box-mini">
+              <!---->
+              <div class="el-input el-input--mini el-input--suffix">
+                <!----><input type="text" readonly="readonly" autocomplete="off" placeholder="5%" class="el-input__inner">
+                <!----><span class="el-input__suffix"><span class="el-input__suffix-inner"><i class="el-select__caret el-input__icon el-icon-arrow-up"></i><!----><!----><!----><!----><!----></span>
+                <!----></span>
+                <!---->
+                <!---->
+              </div>
+              <transition-stub name="el-zoom-in-top">
+                <div class="el-select-dropdown el-popper" style="display: none;">
+                  <div class="el-scrollbar" style="">
+                    <div class="el-select-dropdown__wrap el-scrollbar__wrap el-scrollbar__wrap--hidden-default">
+                      <ul class="el-scrollbar__view el-select-dropdown__list">
+                        <!---->
+                        <li class="el-select-dropdown__item"><span>All datasets</span></li>
+                        <li class="el-select-dropdown__item"><span>My datasets</span></li>
+                        <li class="el-select-dropdown__item selected"><span>Project datasets</span></li>
+                        <li class="el-select-dropdown__item"><span>group1</span></li>
+                      </ul>
+                    </div>
+                    <div class="el-scrollbar__bar is-horizontal">
+                      <div class="el-scrollbar__thumb" style="transform: translateX(0%); webkit-transform: translateX(0%);"></div>
+                    </div>
+                    <div class="el-scrollbar__bar is-vertical">
+                      <div class="el-scrollbar__thumb" style="transform: translateY(0%); webkit-transform: translateY(0%);"></div>
+                    </div>
+                  </div>
+                  <!---->
+                </div>
+              </transition-stub>
+            </div>
+            <div class="el-input el-input--mini query-filter">
+              <!----><input type="text" autocomplete="off" placeholder="Enter dataset name" class="el-input__inner">
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+            </div>
+          </div>
+          <div class="table-box mt-2">
+            <div class="el-table el-table--fit el-table--striped el-table--scrollable-x el-table--enable-row-hover el-table--enable-row-transition el-table--mini" id="annot-table" current="true" elementloadingtext="Loading results …" tabindex="1">
+              <div class="hidden-columns">
+                <div></div>
+                <div></div>
+                <div></div>
+                <div></div>
+              </div>
+              <div class="el-table__header-wrapper">
+                <table cellspacing="0" cellpadding="0" border="0" class="el-table__header" style="width: 308px;">
+                  <colgroup>
+                    <col name="el-table_1_column_1" width="48">
+                    <col name="el-table_1_column_2" width="100">
+                    <col name="el-table_1_column_3" width="80">
+                    <col name="el-table_1_column_4" width="80">
+                  </colgroup>
+                  <thead class="">
+                    <tr class="">
+                      <th colspan="1" rowspan="1" class="el-table_1_column_1   el-table-column--selection  is-leaf">
+                        <div class="cell"><label class="el-checkbox"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span>
+                            <!----></label></div>
+                      </th>
+                      <th colspan="1" rowspan="1" class="el-table_1_column_2     is-leaf">
+                        <div class="cell">Dataset</div>
+                      </th>
+                      <th colspan="1" rowspan="1" class="el-table_1_column_3     is-leaf">
+                        <div class="cell">Submitter</div>
+                      </th>
+                      <th colspan="1" rowspan="1" class="el-table_1_column_4     is-leaf">
+                        <div class="cell">Upload date</div>
+                      </th>
+                    </tr>
+                  </thead>
+                </table>
+              </div>
+              <div class="el-table__body-wrapper is-scrolling-left">
+                <table cellspacing="0" cellpadding="0" border="0" class="el-table__body" style="width: 308px;">
+                  <colgroup>
+                    <col name="el-table_1_column_1" width="48">
+                    <col name="el-table_1_column_2" width="100">
+                    <col name="el-table_1_column_3" width="80">
+                    <col name="el-table_1_column_4" width="80">
+                  </colgroup>
+                  <tbody>
+                    <tr class="el-table__row">
+                      <td rowspan="1" colspan="1" class="el-table_1_column_1  el-table-column--selection">
+                        <div class="cell"><label class="el-checkbox"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span>
+                            <!----></label></div>
+                      </td>
+                      <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
+                        <div class="cell">New 3 (1)</div>
+                      </td>
+                      <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
+                        <div class="cell">allDatasets.0.submitter.name</div>
+                      </td>
+                      <td rowspan="1" colspan="1" class="el-table_1_column_4  ">
+                        <div class="cell">31 March, 2021</div>
+                      </td>
+                    </tr>
+                    <tr class="el-table__row el-table__row--striped">
+                      <td rowspan="1" colspan="1" class="el-table_1_column_1  el-table-column--selection">
+                        <div class="cell"><label class="el-checkbox"><span class="el-checkbox__input"><span class="el-checkbox__inner"></span><input type="checkbox" aria-hidden="false" class="el-checkbox__original" value=""></span>
+                            <!----></label></div>
+                      </td>
+                      <td rowspan="1" colspan="1" class="el-table_1_column_2  ">
+                        <div class="cell">Untreated_3_434_super_lite_19_31 (1)</div>
+                      </td>
+                      <td rowspan="1" colspan="1" class="el-table_1_column_3  ">
+                        <div class="cell">allDatasets.1.submitter.name</div>
+                      </td>
+                      <td rowspan="1" colspan="1" class="el-table_1_column_4  ">
+                        <div class="cell">30 March, 2021</div>
+                      </td>
+                    </tr>
+                    <!---->
+                  </tbody>
+                </table>
+                <!---->
+                <!---->
+              </div>
+              <!---->
+              <!---->
+              <!---->
+              <!---->
+              <div class="el-table__column-resize-proxy" style="display: none;"></div>
+            </div>
+          </div>
+          <mock-el-pagination pagesize="5" pagesizes="5,15,20,25,30" currentpage="1" layout="prev,pager,next,sizes" class="mt-2" total="55"></mock-el-pagination>
+          <div class="button-bar"><button type="button" class="el-button el-button--default">
+              <!---->
+              <!----><span>Cancel</span></button><button disabled="disabled" type="button" class="el-button el-button--primary is-disabled w-32">
+              <!---->
+              <!----><span>Update</span></button></div>
+        </div>
+      </div>
+      <!---->
+    </div>
+  </div>
+</transition-stub>
+`;

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ViewProjectPage.spec.ts.snap
@@ -3,10 +3,10 @@
 exports[`ViewProjectPage datasets tab should match snapshot (non-member) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
-    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+    <transition-stub name="dialog-fade">
       <div class="el-dialog__wrapper" style="display: none;">
-        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
-          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+        <div role="dialog" aria-modal="true" aria-label="Add or remove datasets in this project" class="el-dialog project-datasets-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Add or remove datasets in this project</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
           <!---->
           <!---->
         </div>
@@ -69,10 +69,10 @@ exports[`ViewProjectPage datasets tab should match snapshot (non-member) 1`] = `
 exports[`ViewProjectPage members tab should match snapshot (invited) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
-    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+    <transition-stub name="dialog-fade">
       <div class="el-dialog__wrapper" style="display: none;">
-        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
-          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+        <div role="dialog" aria-modal="true" aria-label="Add or remove datasets in this project" class="el-dialog project-datasets-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Add or remove datasets in this project</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
           <!---->
           <!---->
         </div>
@@ -152,10 +152,10 @@ exports[`ViewProjectPage members tab should match snapshot (invited) 1`] = `
 exports[`ViewProjectPage members tab should match snapshot (manager, including table) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
-    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+    <transition-stub name="dialog-fade">
       <div class="el-dialog__wrapper" style="display: none;">
-        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
-          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+        <div role="dialog" aria-modal="true" aria-label="Add or remove datasets in this project" class="el-dialog project-datasets-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Add or remove datasets in this project</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
           <!---->
           <!---->
         </div>
@@ -416,10 +416,10 @@ exports[`ViewProjectPage members tab should match snapshot (manager, including t
 exports[`ViewProjectPage members tab should match snapshot (member) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
-    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+    <transition-stub name="dialog-fade">
       <div class="el-dialog__wrapper" style="display: none;">
-        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
-          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+        <div role="dialog" aria-modal="true" aria-label="Add or remove datasets in this project" class="el-dialog project-datasets-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Add or remove datasets in this project</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
           <!---->
           <!---->
         </div>
@@ -474,10 +474,10 @@ exports[`ViewProjectPage members tab should match snapshot (member) 1`] = `
 exports[`ViewProjectPage members tab should match snapshot (non-member) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
-    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+    <transition-stub name="dialog-fade">
       <div class="el-dialog__wrapper" style="display: none;">
-        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
-          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+        <div role="dialog" aria-modal="true" aria-label="Add or remove datasets in this project" class="el-dialog project-datasets-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Add or remove datasets in this project</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
           <!---->
           <!---->
         </div>
@@ -537,10 +537,10 @@ exports[`ViewProjectPage members tab should match snapshot (non-member) 1`] = `
 exports[`ViewProjectPage publishing tab should match snapshot (published) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
-    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+    <transition-stub name="dialog-fade">
       <div class="el-dialog__wrapper" style="display: none;">
-        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
-          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+        <div role="dialog" aria-modal="true" aria-label="Add or remove datasets in this project" class="el-dialog project-datasets-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Add or remove datasets in this project</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
           <!---->
           <!---->
         </div>
@@ -602,10 +602,10 @@ exports[`ViewProjectPage publishing tab should match snapshot (published) 1`] = 
 exports[`ViewProjectPage publishing tab should match snapshot (under review) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
-    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+    <transition-stub name="dialog-fade">
       <div class="el-dialog__wrapper" style="display: none;">
-        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
-          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+        <div role="dialog" aria-modal="true" aria-label="Add or remove datasets in this project" class="el-dialog project-datasets-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Add or remove datasets in this project</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
           <!---->
           <!---->
         </div>
@@ -720,10 +720,10 @@ exports[`ViewProjectPage publishing tab should match snapshot (under review) 1`]
 exports[`ViewProjectPage publishing tab should match snapshot (unpublished) 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
-    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+    <transition-stub name="dialog-fade">
       <div class="el-dialog__wrapper" style="display: none;">
-        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
-          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+        <div role="dialog" aria-modal="true" aria-label="Add or remove datasets in this project" class="el-dialog project-datasets-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Add or remove datasets in this project</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
           <!---->
           <!---->
         </div>
@@ -826,10 +826,10 @@ exports[`ViewProjectPage publishing tab should match snapshot (unpublished) 1`] 
 exports[`ViewProjectPage settings tab should disable actions when published 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
-    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+    <transition-stub name="dialog-fade">
       <div class="el-dialog__wrapper" style="display: none;">
-        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
-          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+        <div role="dialog" aria-modal="true" aria-label="Add or remove datasets in this project" class="el-dialog project-datasets-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Add or remove datasets in this project</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
           <!---->
           <!---->
         </div>
@@ -953,10 +953,10 @@ exports[`ViewProjectPage settings tab should disable actions when published 1`] 
 exports[`ViewProjectPage settings tab should disable actions when under review 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
-    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+    <transition-stub name="dialog-fade">
       <div class="el-dialog__wrapper" style="display: none;">
-        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
-          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+        <div role="dialog" aria-modal="true" aria-label="Add or remove datasets in this project" class="el-dialog project-datasets-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Add or remove datasets in this project</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
           <!---->
           <!---->
         </div>
@@ -1073,10 +1073,10 @@ exports[`ViewProjectPage settings tab should disable actions when under review 1
 exports[`ViewProjectPage settings tab should match snapshot 1`] = `
 <div class="page" mock-v-loading="false">
   <div class="page-content">
-    <transition-stub name="dialog-fade" class="project-datasets-dialog">
+    <transition-stub name="dialog-fade">
       <div class="el-dialog__wrapper" style="display: none;">
-        <div role="dialog" aria-modal="true" aria-label="Manage project name\`s datasets" class="el-dialog" style="margin-top: 15vh;">
-          <div class="el-dialog__header"><span class="el-dialog__title">Manage project name\`s datasets</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
+        <div role="dialog" aria-modal="true" aria-label="Add or remove datasets in this project" class="el-dialog project-datasets-dialog" style="margin-top: 15vh;">
+          <div class="el-dialog__header"><span class="el-dialog__title">Add or remove datasets in this project</span><button type="button" aria-label="Close" class="el-dialog__headerbtn"><i class="el-dialog__close el-icon el-icon-close"></i></button></div>
           <!---->
           <!---->
         </div>


### PR DESCRIPTION
### Description

Changed manage datasets on group page, so that any project member can add/remove all datasets visible to them #1110     

##### How to test

1 - Access the projects page
2 - Go to the dataset tabs
3 - Click 'manage datasets'


##### Webapp

###### ViewProjectPage
- [x] Getting user groups

###### DatasetsDialog
- [x] List datasets with pagination
- [x] Enabled name filter
- [x] Enabled dataset owner filter

###### api/Dataset
- [x] Added offset as input open


##### Graphql

###### project/controller/mutation
- [x] Enabled public datasets to be added
- [x] Enabled private datasets to be removed if related to the project
- [x] Enabled dataset addition if user can edit it



#### Tests
 
##### Front end
 
- [x] Unit Test
- [ ] e2e Test
 
###### Browsers and resolutions
- [x] Chrome
- [x] Safari
- [ ]  Firefox
- [x] md, lg, lg
- [x]  sm, xl

<img width="1600" alt="image" src="https://user-images.githubusercontent.com/35172605/179567668-96a60056-2354-4c97-8540-66f06156a7c2.png">

