### PR TITLE
Added intensities export feature

### DIFF
--- a/metaspace/webapp/src/components/IonImageViewer.tsx
+++ b/metaspace/webapp/src/components/IonImageViewer.tsx
@@ -131,6 +131,7 @@ const usePixelIntensityDisplay = (
   const zoomY = computed(() => props.zoom / props.pixelAspectRatio)
   const cursorOverLayers = computed(() => {
     const layers = []
+    const TIC_MULTIPLIER = 1000000
     if (props.ionImageLayers.length && cursorPixelPos.value != null) {
       const [x, y] = cursorPixelPos.value
       for (const { ionImage, colorMap } of props.ionImageLayers) {
@@ -140,12 +141,10 @@ const usePixelIntensityDisplay = (
           && mask[y * width + x] !== 0) {
           const idx = y * width + x
           const [r, g, b] = colorMap[colorMap.length - 1]
-          const validNormalization = props.normalizationData && props.normalizationData.data
-            && props.normalizationData.data[idx] && !isNaN(props.normalizationData.data[idx])
           layers.push({
-            intensity: intensityValues[idx].toExponential(1),
-            normalizedIntensity: !validNormalization ? 0
-              : (intensityValues[idx] / props.normalizationData?.data?.[idx] * 1000000).toExponential(1),
+            intensity: (props.showNormalizedIntensity ? ((intensityValues[idx] / TIC_MULTIPLIER)
+              * props.normalizationData?.data?.[idx]) : intensityValues[idx]).toExponential(1),
+            normalizedIntensity: intensityValues[idx].toExponential(1),
             color: props.ionImageLayers.length > 1 ? `rgb(${r},${g},${b})` : null,
           })
         }

--- a/metaspace/webapp/src/components/__snapshots__/IonImageViewer.spec.ts.snap
+++ b/metaspace/webapp/src/components/__snapshots__/IonImageViewer.spec.ts.snap
@@ -142,7 +142,7 @@ exports[`IonImageViewer should match snapshot (with normalization) 1`] = `
                   Intensity: 
                 </span>
                 <span>
-                  9.6e+3
+                  9.3e+1
                 </span>
               </div>
               <div
@@ -152,7 +152,7 @@ exports[`IonImageViewer should match snapshot (with normalization) 1`] = `
                   TIC-relative intensity: 
                 </span>
                 <span>
-                  1.0e+6
+                  9.6e+3
                 </span>
               </div>
             </div>
@@ -172,7 +172,7 @@ exports[`IonImageViewer should match snapshot (with normalization) 1`] = `
                   Intensity: 
                 </span>
                 <span>
-                  9.6e+3
+                  9.3e+1
                 </span>
               </div>
               <div
@@ -182,7 +182,7 @@ exports[`IonImageViewer should match snapshot (with normalization) 1`] = `
                   TIC-relative intensity: 
                 </span>
                 <span>
-                  1.0e+6
+                  9.6e+3
                 </span>
               </div>
             </div>

--- a/metaspace/webapp/src/lib/config.ts
+++ b/metaspace/webapp/src/lib/config.ts
@@ -6,6 +6,7 @@ const fileConfig = require('../clientConfig.json')
 
 interface Features {
   coloc: boolean;
+  export_int: boolean;
   show_dataset_overview: boolean;
   imzml_browser: boolean;
   spotting: boolean;
@@ -61,6 +62,7 @@ const defaultConfig: ClientConfig = {
   metadataTypes: ['ims'],
   features: {
     coloc: true,
+    export_int: false,
     show_dataset_overview: true,
     imzml_browser: false,
     spotting: false,

--- a/metaspace/webapp/src/lib/config.ts
+++ b/metaspace/webapp/src/lib/config.ts
@@ -6,7 +6,6 @@ const fileConfig = require('../clientConfig.json')
 
 interface Features {
   coloc: boolean;
-  export_int: boolean;
   show_dataset_overview: boolean;
   imzml_browser: boolean;
   spotting: boolean;
@@ -62,7 +61,6 @@ const defaultConfig: ClientConfig = {
   metadataTypes: ['ims'],
   features: {
     coloc: true,
-    export_int: false,
     show_dataset_overview: true,
     imzml_browser: false,
     spotting: false,

--- a/metaspace/webapp/src/lib/formatCsvRow.ts
+++ b/metaspace/webapp/src/lib/formatCsvRow.ts
@@ -16,10 +16,10 @@ export const csvExportHeader = () => {
   + `# URL: ${window.location.href}\n`
 }
 
-export const csvExportIntensityHeader = () => {
+export const csvExportIntensityHeader = (isNormalized: boolean = false) => {
   const dateStr = new Date().toLocaleString().replace(/,/g, '')
   return `# Generated at ${dateStr}. Hot-spot removal has been applied and the intensity values might
-  differ from the api results\n`
+  differ from the api results.${isNormalized ? 'The intensities were TIC normalized' : ''}\n`
   + `# URL: ${window.location.href}\n`
 }
 

--- a/metaspace/webapp/src/lib/formatCsvRow.ts
+++ b/metaspace/webapp/src/lib/formatCsvRow.ts
@@ -1,3 +1,5 @@
+import moment from 'moment'
+
 export default (values: string[]): string => {
   const escaped = values.map(v => {
     if (v != null) {
@@ -11,15 +13,15 @@ export default (values: string[]): string => {
 }
 
 export const csvExportHeader = () => {
-  const dateStr = new Date().toLocaleString().replace(/,/g, '')
+  const dateStr = moment().format('YYYY-MM-DD HH:mm:ss')
   return `# Generated at ${dateStr}. For help see https://bit.ly/3Bzs6Z4\n`
   + `# URL: ${window.location.href}\n`
 }
 
 export const csvExportIntensityHeader = (isNormalized: boolean = false) => {
-  const dateStr = new Date().toLocaleString().replace(/,/g, '')
-  return `# Generated at ${dateStr}. Hot-spot removal has been applied and the intensity values might
-  differ from the api results.${isNormalized ? 'The intensities were TIC normalized' : ''}\n`
+  const dateStr = moment().format('YYYY-MM-DD HH:mm:ss')
+  return `# Generated at ${dateStr}. Hot-spot removal has been applied and the intensity values might `
+  + `differ from the api results.${isNormalized ? 'The intensities were TIC normalized' : ''}\n`
   + `# URL: ${window.location.href}\n`
 }
 

--- a/metaspace/webapp/src/lib/formatCsvRow.ts
+++ b/metaspace/webapp/src/lib/formatCsvRow.ts
@@ -16,6 +16,13 @@ export const csvExportHeader = () => {
   + `# URL: ${window.location.href}\n`
 }
 
+export const csvExportIntensityHeader = () => {
+  const dateStr = new Date().toLocaleString().replace(/,/g, '')
+  return `# Generated at ${dateStr}. Hot-spot removal has been applied and the intensity values might
+  differ from the api results\n`
+  + `# URL: ${window.location.href}\n`
+}
+
 /**
  * For arrays of text values, primarily molecule names, follow the pattern defined in /docs/csv_export.md for
  * unambiguously encoding list items: Separate items with `, `, and ensure that items do not contain `, `

--- a/metaspace/webapp/src/lib/ionImageRendering.ts
+++ b/metaspace/webapp/src/lib/ionImageRendering.ts
@@ -488,3 +488,13 @@ export const renderScaleBar = (ionImage: IonImage, cmap: ColorMap, horizontal: b
     return createDataUrl(outputBytes, 1, 256)
   }
 }
+
+export const getIonImage = (ionImagePng: any, isotopeImage: any,
+  scaleType: any = 'linear', userScaling: any = [0, 1], normalizedData: any = null) => {
+  if (!isotopeImage || !ionImagePng) {
+    return null
+  }
+  const { minIntensity, maxIntensity } = isotopeImage
+  return processIonImage(ionImagePng, minIntensity, maxIntensity, scaleType
+    , userScaling, undefined, normalizedData)
+}

--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
@@ -410,7 +410,7 @@
         </el-popover>
 
         <div
-          v-if="showIntExport && isExporting"
+          v-if="isExporting"
           class="select-btn-wrapper ml-2 mt-1"
         >
           <progress-button
@@ -425,7 +425,7 @@
         </div>
 
         <el-popover
-          v-if="showIntExport && !isExporting"
+          v-else
           ref="exportPop"
           class="select-btn-wrapper ml-2 mt-1"
           popper-class="export-pop"
@@ -453,48 +453,6 @@
           >
             Pixel intensities
           </p>
-        </el-popover>
-
-        <el-popover
-          v-if="!showIntExport"
-          class="ml-2 mt-1"
-          trigger="hover"
-        >
-          <div
-            slot="reference"
-            class="select-btn-wrapper"
-          >
-            <progress-button
-              v-if="isExporting && totalCount > 5000"
-              class="export-btn"
-              :width="146"
-              :height="42"
-              :percentage="exportProgress * 100"
-              @click="abortExport"
-            >
-              Cancel
-            </progress-button>
-            <el-button
-              v-else
-              slot="reference"
-              class="export-btn select-btn-wrapper"
-              :width="146"
-              :height="42"
-              :disabled="isExporting"
-              @click="startExport"
-            >
-              Export to CSV
-            </el-button>
-          </div>
-
-          Documentation for the CSV export is available
-          <a
-            href="https://github.com/metaspace2020/metaspace/wiki/CSV-annotations-export"
-            rel="noopener noreferrer nofollow"
-            target="_blank"
-          >
-            here<ExternalWindowSvg class="inline h-4 w-4 -mb-1 fill-current text-gray-800" />
-          </a>
         </el-popover>
 
         <div
@@ -529,7 +487,6 @@
 import ProgressButton from './ProgressButton.vue'
 import AnnotationTableMolName from './AnnotationTableMolName.vue'
 import FilterIcon from '../../assets/inline/filter.svg'
-import ExternalWindowSvg from '../../assets/inline/refactoring-ui/icon-external-window.svg'
 import {
   annotationListQuery,
   tableExportQuery,
@@ -592,7 +549,6 @@ export default Vue.extend({
     ProgressButton,
     AnnotationTableMolName,
     FilterIcon,
-    ExternalWindowSvg,
     ExitFullScreen,
     FullScreen,
     NewFeatureBadge,
@@ -612,7 +568,6 @@ export default Vue.extend({
       nextCurrentRowIndex: null,
       loadedSnapshotAnnotations: false,
       showCustomCols: config.features.custom_cols,
-      showIntExport: config.features.export_int,
       columns: [
         {
           label: 'Lab',
@@ -1118,7 +1073,7 @@ export default Vue.extend({
     },
 
     async startIntensitiesExport() {
-      if (this.$refs.exportPop) {
+      if (this.$refs.exportPop && typeof this.$refs.exportPop.doClose === 'function') {
         this.$refs.exportPop.doClose()
       }
 
@@ -1195,7 +1150,7 @@ export default Vue.extend({
     },
 
     async startExport() {
-      if (this.$refs.exportPop) {
+      if (this.$refs.exportPop && typeof this.$refs.exportPop.doClose === 'function') {
         this.$refs.exportPop.doClose()
       }
 

--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
@@ -1137,7 +1137,7 @@ export default Vue.extend({
           this.exportProgress = offset / totalCount
           const annotation = resp.data.allAnnotations[i]
           const { cols, row, dsName } = await formatIntensitiesRow(annotation,
-            this.$store.getters.settings?.annotationView?.normalization
+            this.isNormalized
               ? this.$store.state.normalization : undefined)
           if (!fileCols) {
             fileCols = formatCsvRow(cols)

--- a/metaspace/webapp/src/modules/Annotations/__snapshots__/AnnotationTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/__snapshots__/AnnotationTable.spec.ts.snap
@@ -207,20 +207,21 @@ exports[`AnnotationTable should match snapshot 1`] = `
             Columns
           <transition-stub name="el-zoom-in-center"><sup class="el-badge__content el-badge__content--undefined is-fixed">New</sup></transition-stub></div> <i class="el-icon-arrow-down select-btn-icon"></i></span></button></div>
       </mock-el-popover>
-      <!---->
-      <!---->
-      <mock-el-popover trigger="hover" class="ml-2 mt-1">
+      <mock-el-popover popper-class="export-pop" class="select-btn-wrapper ml-2 mt-1">
         <div slot-key="default">
-
-          Documentation for the CSV export is available
-          <a href="https://github.com/metaspace2020/metaspace/wiki/CSV-annotations-export" rel="noopener noreferrer nofollow" target="_blank">
-            here<svg data-icon="icon-external-window" class="inline h-4 w-4 -mb-1 fill-current text-gray-800"></svg></a></div>
+          <p class="export-option">
+            Annotations table
+          </p>
+          <p class="export-option">
+            Pixel intensities
+          </p>
+        </div>
         <div slot-key="reference">
-          <div class="select-btn-wrapper"><button type="button" class="el-button export-btn select-btn-wrapper el-button--default" slot="reference" width="146" height="42">
+          <div><button type="button" class="el-button select-btn-wrapper relative el-button--default" width="146" height="42">
               <!---->
               <!----><span>
             Export to CSV
-          </span></button></div>
+            <i class="el-icon-arrow-down select-btn-icon"></i></span></button></div>
         </div>
       </mock-el-popover>
       <div class="ml-2 mt-1"><button type="button" class="el-button full-screen-btn el-button--default">
@@ -428,20 +429,21 @@ exports[`AnnotationTable should match snapshot when loading snapshot 1`] = `
             Columns
           <transition-stub name="el-zoom-in-center"><sup class="el-badge__content el-badge__content--undefined is-fixed">New</sup></transition-stub></div> <i class="el-icon-arrow-down select-btn-icon"></i></span></button></div>
       </mock-el-popover>
-      <!---->
-      <!---->
-      <mock-el-popover trigger="hover" class="ml-2 mt-1">
+      <mock-el-popover popper-class="export-pop" class="select-btn-wrapper ml-2 mt-1">
         <div slot-key="default">
-
-          Documentation for the CSV export is available
-          <a href="https://github.com/metaspace2020/metaspace/wiki/CSV-annotations-export" rel="noopener noreferrer nofollow" target="_blank">
-            here<svg data-icon="icon-external-window" class="inline h-4 w-4 -mb-1 fill-current text-gray-800"></svg></a></div>
+          <p class="export-option">
+            Annotations table
+          </p>
+          <p class="export-option">
+            Pixel intensities
+          </p>
+        </div>
         <div slot-key="reference">
-          <div class="select-btn-wrapper"><button type="button" class="el-button export-btn select-btn-wrapper el-button--default" slot="reference" width="146" height="42">
+          <div><button type="button" class="el-button select-btn-wrapper relative el-button--default" width="146" height="42">
               <!---->
               <!----><span>
             Export to CSV
-          </span></button></div>
+            <i class="el-icon-arrow-down select-btn-icon"></i></span></button></div>
         </div>
       </mock-el-popover>
       <div class="ml-2 mt-1"><button type="button" class="el-button full-screen-btn el-button--default">

--- a/metaspace/webapp/src/modules/Annotations/__snapshots__/AnnotationTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Annotations/__snapshots__/AnnotationTable.spec.ts.snap
@@ -201,11 +201,14 @@ exports[`AnnotationTable should match snapshot 1`] = `
             <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Co-localization coefficient</span></div>
           </div>
         </div>
-        <div slot-key="reference"><button type="button" class="el-button el-button--default">
+        <div slot-key="reference"><button type="button" class="el-button select-btn-wrapper relative el-button--default">
             <!---->
-            <!----><span><div class="el-badge new-custom-badge sm-feature-badge"><div>
-              Columns <i class="el-icon-arrow-down"></i></div><transition-stub name="el-zoom-in-center"><sup class="el-badge__content el-badge__content--undefined is-fixed">New</sup></transition-stub></div></span></button></div>
+            <!----><span><div class="el-badge new-custom-badge sm-feature-badge">
+            Columns
+          <transition-stub name="el-zoom-in-center"><sup class="el-badge__content el-badge__content--undefined is-fixed">New</sup></transition-stub></div> <i class="el-icon-arrow-down select-btn-icon"></i></span></button></div>
       </mock-el-popover>
+      <!---->
+      <!---->
       <mock-el-popover trigger="hover" class="ml-2 mt-1">
         <div slot-key="default">
 
@@ -213,7 +216,7 @@ exports[`AnnotationTable should match snapshot 1`] = `
           <a href="https://github.com/metaspace2020/metaspace/wiki/CSV-annotations-export" rel="noopener noreferrer nofollow" target="_blank">
             here<svg data-icon="icon-external-window" class="inline h-4 w-4 -mb-1 fill-current text-gray-800"></svg></a></div>
         <div slot-key="reference">
-          <div><button type="button" class="el-button export-btn el-button--default" slot="reference">
+          <div class="select-btn-wrapper"><button type="button" class="el-button export-btn select-btn-wrapper el-button--default" slot="reference" width="146" height="42">
               <!---->
               <!----><span>
             Export to CSV
@@ -419,11 +422,14 @@ exports[`AnnotationTable should match snapshot when loading snapshot 1`] = `
             <div class="cursor-pointer select-none"><i class="el-icon-check invisible"></i> <span>Co-localization coefficient</span></div>
           </div>
         </div>
-        <div slot-key="reference"><button type="button" class="el-button el-button--default">
+        <div slot-key="reference"><button type="button" class="el-button select-btn-wrapper relative el-button--default">
             <!---->
-            <!----><span><div class="el-badge new-custom-badge sm-feature-badge"><div>
-              Columns <i class="el-icon-arrow-down"></i></div><transition-stub name="el-zoom-in-center"><sup class="el-badge__content el-badge__content--undefined is-fixed">New</sup></transition-stub></div></span></button></div>
+            <!----><span><div class="el-badge new-custom-badge sm-feature-badge">
+            Columns
+          <transition-stub name="el-zoom-in-center"><sup class="el-badge__content el-badge__content--undefined is-fixed">New</sup></transition-stub></div> <i class="el-icon-arrow-down select-btn-icon"></i></span></button></div>
       </mock-el-popover>
+      <!---->
+      <!---->
       <mock-el-popover trigger="hover" class="ml-2 mt-1">
         <div slot-key="default">
 
@@ -431,7 +437,7 @@ exports[`AnnotationTable should match snapshot when loading snapshot 1`] = `
           <a href="https://github.com/metaspace2020/metaspace/wiki/CSV-annotations-export" rel="noopener noreferrer nofollow" target="_blank">
             here<svg data-icon="icon-external-window" class="inline h-4 w-4 -mb-1 fill-current text-gray-800"></svg></a></div>
         <div slot-key="reference">
-          <div><button type="button" class="el-button export-btn el-button--default" slot="reference">
+          <div class="select-btn-wrapper"><button type="button" class="el-button export-btn select-btn-wrapper el-button--default" slot="reference" width="146" height="42">
               <!---->
               <!----><span>
             Export to CSV


### PR DESCRIPTION
### Description

Implemented 'export intensities' feature at annotation page, fixed displayed intensity value when ion image normalized and exporting TIC normalized intensities on ROI download #1146 #1147  

### Scenarios
1 - Access annotation page
2 - Create an ROI and export it
3 - Create an ROI, normalized the image, and export it
4 - Click Export to CSV and press 'Annotations Table'
5 - Click Export to CSV and press 'Pixel intensities'
6 - Click Export to CSV and press 'Pixel intensities' when annotation is normalized


![image](https://user-images.githubusercontent.com/35172605/183097415-95aee33e-f627-44b8-91b8-b8f9b4e33b4e.png)

