### PR TITLE
[MetadataEditor] removed ppm value update on edition

### DIFF
--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -566,9 +566,11 @@ export default {
       set(this.value, path, val)
 
       // recommend ppm to 10 if resolving power below 70000 and 3 if greater than 70000
-      if (isEqual(path, ['MS_Analysis', 'Detector_Resolving_Power']) && val.Resolving_Power < 70000) {
+      if (this.isNew && isEqual(path, ['MS_Analysis', 'Detector_Resolving_Power'])
+        && val.Resolving_Power < 70000) {
         this.metaspaceOptions.ppm = 10
-      } else if (isEqual(path, ['MS_Analysis', 'Detector_Resolving_Power']) && val.Resolving_Power >= 70000) {
+      } else if (this.isNew && isEqual(path, ['MS_Analysis', 'Detector_Resolving_Power'])
+        && val.Resolving_Power >= 70000) {
         this.metaspaceOptions.ppm = 3
       }
 


### PR DESCRIPTION
Bug reported, where ppm value is being set to 3/10 instead of its original value. I disabled recommendation of ppm according to resolving power to edit page. #1170