### PR TITLE
Added copy dataset id button to annotation page

### DIFF
--- a/metaspace/webapp/src/components/CopyButton.vue
+++ b/metaspace/webapp/src/components/CopyButton.vue
@@ -9,7 +9,7 @@
     <button
       slot="reference"
       class="button-reset flex"
-      :class="isId ? 'w-6 h-6' : 'w-4 h-4'"
+      :class="`${customClass ? customClass : ''} ${isId ? 'w-6 h-6' : 'w-4 h-4'}`"
       @click="handleCopy"
     >
       <copy-id-icon
@@ -54,6 +54,7 @@ export default defineComponent<Props>({
   },
   props: {
     text: { type: String, required: true },
+    customClass: { type: String },
     isId: { type: Boolean, required: false, default: false },
   },
   setup(props) {

--- a/metaspace/webapp/src/modules/Annotations/AnnotationView.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationView.vue
@@ -92,6 +92,14 @@
                 > -->
                 <div>Show representative spatial patterns for dataset</div>
               </el-popover>
+
+              <copy-button
+                is-id
+                :text="annotation.dataset.id"
+                custom-class="dataset-id-copy"
+              >
+                Copy dataset id to clipboard
+              </copy-button>
             </div>
             <mode-button
               v-if="multiImagesEnabled"
@@ -325,5 +333,9 @@
 
   .av-icon-link {
     cursor: pointer;
+  }
+
+  .dataset-id-copy{
+    padding-top: 4px;
   }
 </style>

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetItem.spec.js.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetItem.spec.js.snap
@@ -81,7 +81,7 @@ exports[`DatasetItem should match snapshot 1`] = `
           slot-key="reference"
         >
           <button
-            class="button-reset flex w-6 h-6"
+            class="button-reset flex  w-6 h-6"
           >
             <svg
               class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -378,7 +378,7 @@ exports[`DatasetTable should match snapshot 1`] = `
               slot-key="reference"
             >
               <button
-                class="button-reset flex w-6 h-6"
+                class="button-reset flex  w-6 h-6"
               >
                 <svg
                   class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"
@@ -611,7 +611,7 @@ exports[`DatasetTable should match snapshot 1`] = `
               slot-key="reference"
             >
               <button
-                class="button-reset flex w-6 h-6"
+                class="button-reset flex  w-6 h-6"
               >
                 <svg
                   class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"
@@ -830,7 +830,7 @@ exports[`DatasetTable should match snapshot 1`] = `
               slot-key="reference"
             >
               <button
-                class="button-reset flex w-6 h-6"
+                class="button-reset flex  w-6 h-6"
               >
                 <svg
                   class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"

--- a/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Project/__snapshots__/ProjectsListPage.spec.ts.snap
@@ -121,7 +121,7 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
                     Copy project id to clipboard
                   </p>
                 </div>
-                <div slot-key="reference"><button class="button-reset flex w-6 h-6"><svg data-icon="copy-id" class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"></svg></button></div>
+                <div slot-key="reference"><button class="button-reset flex  w-6 h-6"><svg data-icon="copy-id" class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"></svg></button></div>
               </mock-el-popover>
             </div>
             <div>
@@ -162,7 +162,7 @@ exports[`ProjectsListPage should change actions for projects under review 1`] = 
                     Copy project id to clipboard
                   </p>
                 </div>
-                <div slot-key="reference"><button class="button-reset flex w-6 h-6"><svg data-icon="copy-id" class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"></svg></button></div>
+                <div slot-key="reference"><button class="button-reset flex  w-6 h-6"><svg data-icon="copy-id" class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"></svg></button></div>
               </mock-el-popover>
             </div>
             <div>
@@ -318,7 +318,7 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
                     Copy project id to clipboard
                   </p>
                 </div>
-                <div slot-key="reference"><button class="button-reset flex w-6 h-6"><svg data-icon="copy-id" class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"></svg></button></div>
+                <div slot-key="reference"><button class="button-reset flex  w-6 h-6"><svg data-icon="copy-id" class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"></svg></button></div>
               </mock-el-popover>
             </div>
             <div>
@@ -358,7 +358,7 @@ exports[`ProjectsListPage should change actions for published projects 1`] = `
                     Copy project id to clipboard
                   </p>
                 </div>
-                <div slot-key="reference"><button class="button-reset flex w-6 h-6"><svg data-icon="copy-id" class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"></svg></button></div>
+                <div slot-key="reference"><button class="button-reset flex  w-6 h-6"><svg data-icon="copy-id" class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"></svg></button></div>
               </mock-el-popover>
             </div>
             <div>
@@ -514,7 +514,7 @@ exports[`ProjectsListPage should match snapshot 1`] = `
                     Copy project id to clipboard
                   </p>
                 </div>
-                <div slot-key="reference"><button class="button-reset flex w-6 h-6"><svg data-icon="copy-id" class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"></svg></button></div>
+                <div slot-key="reference"><button class="button-reset flex  w-6 h-6"><svg data-icon="copy-id" class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"></svg></button></div>
               </mock-el-popover>
             </div>
             <div>
@@ -554,7 +554,7 @@ exports[`ProjectsListPage should match snapshot 1`] = `
                     Copy project id to clipboard
                   </p>
                 </div>
-                <div slot-key="reference"><button class="button-reset flex w-6 h-6"><svg data-icon="copy-id" class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"></svg></button></div>
+                <div slot-key="reference"><button class="button-reset flex  w-6 h-6"><svg data-icon="copy-id" class="h-full w-full text-gray-400 hover:text-gray-500 sm-copy-icon"></svg></button></div>
               </mock-el-popover>
             </div>
             <div>


### PR DESCRIPTION
### Description

Added the 'copy id' button to copy dataset id at annotation page, to make user experience better #1202 

<img width="1544" alt="image" src="https://user-images.githubusercontent.com/35172605/195341817-3345d5d4-c572-4814-8a79-f5eecc48b4aa.png">
