### PR TITLE
Checking value length when importing custom db

### DIFF
--- a/metaspace/engine/sm/engine/molecular_db.py
+++ b/metaspace/engine/sm/engine/molecular_db.py
@@ -63,11 +63,20 @@ class MolecularDB:
 
 def _validate_moldb_df(df):
     errors = []
+    max_value_length = 500
     for idx, row in df.iterrows():
         line_n = idx + 2
         for col in df.columns:
             if not row[col] or row[col].isspace():
                 errors.append({'line': line_n, 'row': row.values.tolist(), 'error': 'Empty value'})
+            elif len(row[col]) > max_value_length:
+                errors.append(
+                    {
+                        'line': line_n,
+                        'row': [row[col]],
+                        'error': 'Value exceeded the maximum number ' 'of characters.',
+                    }
+                )
 
         try:
             if '.' in row.formula:

--- a/metaspace/engine/sm/engine/molecular_db.py
+++ b/metaspace/engine/sm/engine/molecular_db.py
@@ -63,7 +63,7 @@ class MolecularDB:
 
 def _validate_moldb_df(df):
     errors = []
-    max_value_length = 500
+    max_value_length = 2500  # based on the max inchi in lipds uploaded
     for idx, row in df.iterrows():
         line_n = idx + 2
         for col in df.columns:


### PR DESCRIPTION
### Description

Add parser when importing custom database so molecular names/id/inchi can not be greater than the allowed size (2500 characters, which was based on the longer value we have that is of 2100 characters) of the field #1196    



