### PR TITLE
Added optical image filter

### DIFF
--- a/metaspace/graphql/datasetFilters.js
+++ b/metaspace/graphql/datasetFilters.js
@@ -1,5 +1,6 @@
 /* eslint-disable */ // Old file, needs a big refactor
 import { capitalize } from 'lodash'
+import {OpticalImage} from "./src/modules/engine/model";
 
 function getPgField(schemaPath) {
   const pathElements = schemaPath.replace(/\./g, ',')
@@ -107,6 +108,26 @@ class DatasetStatusFilter extends AbstractDatasetFilter {
   }
 }
 
+class OpticalImageFilter extends AbstractDatasetFilter {
+  constructor() {
+    super('', {})
+  }
+
+  esFilter() {
+      return {}
+  }
+
+  pgFilter(q, status) {
+    if (status === true) {
+      return q.whereNotNull('optical_image')
+    } else if (status === false) {
+      return q.whereNull('optical_image')
+    } else {
+      return q
+    }
+  }
+}
+
 class NotNullFilter extends AbstractDatasetFilter {
   constructor(schemaPath, options = {}) {
     super(schemaPath, options)
@@ -164,6 +185,7 @@ export const datasetFilters = {
   project: new ExactMatchFilter('', { esField: 'ds_project_ids' }),
   metadataType: new ExactMatchFilter('Data_Type', {}),
   hasAnnotationMatching: null,
+  opticalImage: new OpticalImageFilter(),
 }
 
 export function dsField(hit, alias) {

--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -194,6 +194,7 @@ input DatasetFilter {
   metadataType: String
   status: String # list of JobStatus separated by '|'
   hasAnnotationMatching: AnnotationFilter # Does not support some advanced filters e.g. the colocalization filters
+  opticalImage: Boolean
 }
 
 input DatasetCountPerGroupInput {

--- a/metaspace/graphql/src/modules/annotation/queryFilters/hasOpticalImage.ts
+++ b/metaspace/graphql/src/modules/annotation/queryFilters/hasOpticalImage.ts
@@ -1,0 +1,39 @@
+import { Context } from '../../../context'
+import { QueryFilterArgs, QueryFilterResult } from './types'
+import { EngineDataset } from '../../engine/model'
+import { intersection } from 'lodash'
+
+export const applyHasOpticalImageFilter =
+async(context: Context, args: QueryFilterArgs): Promise<QueryFilterResult> => {
+  const { datasetFilter, ...otherArgs } = args
+
+  if (datasetFilter?.opticalImage !== undefined) {
+    const { opticalImage, ...otherDatasetFilters } = datasetFilter
+    const filterIds = datasetFilter?.ids ? datasetFilter?.ids.split('|') : undefined
+    let qb = context.entityManager.getRepository(EngineDataset)
+      .createQueryBuilder('dataset')
+
+    if (opticalImage === true) {
+      qb = qb.where('optical_image is not null')
+    } else if (opticalImage === false) {
+      qb = qb.where('optical_image is  null')
+    }
+
+    const opticalDatasets = await qb.getMany()
+    const ids = filterIds
+      ? intersection(filterIds, opticalDatasets.map((dataset: any) => dataset.id))
+      : opticalDatasets.map((dataset: any) => dataset.id)
+
+    return {
+      args: {
+        ...otherArgs,
+        datasetFilter: {
+          ...otherDatasetFilters,
+          ids: ids.join('|'),
+        },
+      },
+    }
+  } else {
+    return { args }
+  }
+}

--- a/metaspace/graphql/src/modules/annotation/queryFilters/index.ts
+++ b/metaspace/graphql/src/modules/annotation/queryFilters/index.ts
@@ -2,6 +2,7 @@ import { Context } from '../../../context'
 import { QueryFilterArgs, QueryFilterResult, PostProcessFunc } from './types'
 import { applyColocalizationSamplesFilter } from './colocalizationSamples'
 import { applyColocalizedWithFilter } from './colocalizedWith'
+import { applyHasOpticalImageFilter } from './hasOpticalImage'
 import * as _ from 'lodash'
 import { applyHasAnnotationMatchingFilter } from './hasAnnotationMatching'
 import { mapDatabaseToDatabaseId } from '../../moldb/util/mapDatabaseToDatabaseId'
@@ -14,6 +15,7 @@ const queryFilters = [
   applyColocalizationSamplesFilter,
   applyColocalizedWithFilter,
   applyHasAnnotationMatchingFilter,
+  applyHasOpticalImageFilter,
 ]
 
 const setDatabaseIdInAnnotationFilter = async(entityManager: EntityManager, filter: AnnotationFilter | undefined) => {

--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
@@ -829,7 +829,9 @@ export default Vue.extend({
     },
     '$store.getters.filter.datasetIds'() {
       // hide dataset related filters if dataset filter added
-      if (this.$store.getters.filter.datasetIds && this.showCustomCols) {
+      if (Array.isArray(this.$store.getters.filter.datasetIds)
+        && this.$store.getters.filter.datasetIds.length === 1
+        && this.showCustomCols) {
         this.hideDatasetRelatedColumns()
       } else if (this.showCustomCols) { // show dataset related filters if dataset filter added
         this.showDatasetRelatedColumns()

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetTable.spec.ts.snap
@@ -83,6 +83,10 @@ exports[`DatasetTable should match snapshot 1`] = `
         label="Select data type"
         value="metadataType"
       />
+      <mock-el-option
+        label="Show/hide datasets with optical images"
+        value="opticalImage"
+      />
     </mock-el-select>
      
   </div>

--- a/metaspace/webapp/src/modules/Filters/FilterPanel.vue
+++ b/metaspace/webapp/src/modules/Filters/FilterPanel.vue
@@ -58,6 +58,7 @@ const orderedFilterKeys = [
   'simpleFilter',
   'datasetOwner',
   'metadataType',
+  'opticalImage',
 ]
 
 const dsAnnotationHiddenFilters = [

--- a/metaspace/webapp/src/modules/Filters/__snapshots__/FilterPanel.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Filters/__snapshots__/FilterPanel.spec.ts.snap
@@ -4,6 +4,7 @@ exports[`FilterPanel should match snapshot (all annotation filters) 1`] = `
 <div class="filter-panel">
   <mock-el-select placeholder="Add filter" class="filter-select">
     <mock-el-option value="offSample" label="Show/hide off-sample annotations"></mock-el-option>
+    <mock-el-option value="opticalImage" label="Show/hide datasets with optical images"></mock-el-option>
   </mock-el-select>
   <div class="tf-outer w-auto el-input el-input-group el-input-group--prepend" data-test-key="simpleQuery" filter-key="simpleQuery" name="Simple query" options="">
     <div class="el-input-group__prepend"><i class="el-icon-search -mx-1"></i></div><input type="text" autocomplete="off" placeholder="Enter keywords" class="el-input__inner">
@@ -480,6 +481,7 @@ exports[`FilterPanel should match snapshot (database without dataset) 1`] = `
     <mock-el-option value="minMSM" label="Set minimum MSM score"></mock-el-option>
     <mock-el-option value="simpleQuery" label="Search anything"></mock-el-option>
     <mock-el-option value="metadataType" label="Select data type"></mock-el-option>
+    <mock-el-option value="opticalImage" label="Show/hide datasets with optical images"></mock-el-option>
   </mock-el-select>
   <div class="tf-outer border-gray-300 border border-solid text-sm pr-3" data-test-key="database" filter-key="database" name="Database" options="">
     <div class="tf-name bg-gray-100 text-gray-700 tracking-tight px-3 border-0 border-r border-solid border-gray-300">
@@ -545,6 +547,7 @@ exports[`FilterPanel should match snapshot (no filters) 1`] = `
     <mock-el-option value="minMSM" label="Set minimum MSM score"></mock-el-option>
     <mock-el-option value="simpleQuery" label="Search anything"></mock-el-option>
     <mock-el-option value="metadataType" label="Select data type"></mock-el-option>
+    <mock-el-option value="opticalImage" label="Show/hide datasets with optical images"></mock-el-option>
   </mock-el-select>
 </div>
 `;

--- a/metaspace/webapp/src/modules/Filters/filterSpecs.ts
+++ b/metaspace/webapp/src/modules/Filters/filterSpecs.ts
@@ -390,13 +390,12 @@ export const FILTER_SPECIFICATIONS: Record<FilterKey, FilterSpecification> = {
     type: SingleSelectFilter,
     name: '',
     description: 'Show/hide datasets with optical images',
-    helpComponent: OffSampleHelp,
     levels: ['annotation', 'dataset'],
     defaultInLevels: [],
     initialValue: false,
     options: [true, false],
     encoding: 'bool',
-    optionFormatter: option => `${option ? 'Without' : 'With'} optical images only`,
+    optionFormatter: option => `${option ? 'With' : 'Without'} optical images only`,
   },
 }
 

--- a/metaspace/webapp/src/modules/Filters/filterSpecs.ts
+++ b/metaspace/webapp/src/modules/Filters/filterSpecs.ts
@@ -25,7 +25,7 @@ export type FilterKey = 'annotationIds' | 'database' | 'datasetIds' | 'minMSM' |
   | 'chemMod' | 'neutralLoss' | 'adduct' | 'mz' | 'fdrLevel'
   | 'group' | 'project' | 'submitter' | 'polarity' | 'organism' | 'organismPart' | 'condition' | 'growthConditions'
   | 'ionisationSource' | 'maldiMatrix' | 'analyzerType' | 'simpleFilter' | 'simpleQuery' | 'metadataType'
-  | 'colocalizedWith' | 'colocalizationSamples' | 'offSample' | 'datasetOwner';
+  | 'colocalizedWith' | 'colocalizationSamples' | 'offSample' | 'datasetOwner' | 'opticalImage';
 
 export type MetadataLists = Record<string, any[]>;
 
@@ -385,15 +385,29 @@ export const FILTER_SPECIFICATIONS: Record<FilterKey, FilterSpecification> = {
     optionFormatter: option => `${option ? 'Off' : 'On'}-sample only`,
     hidden: () => !config.features.off_sample,
   },
+
+  opticalImage: {
+    type: SingleSelectFilter,
+    name: '',
+    description: 'Show/hide datasets with optical images',
+    helpComponent: OffSampleHelp,
+    levels: ['annotation', 'dataset'],
+    defaultInLevels: [],
+    initialValue: false,
+    options: [true, false],
+    encoding: 'bool',
+    optionFormatter: option => `${option ? 'Without' : 'With'} optical images only`,
+  },
 }
 
 export const DATASET_FILTERS: FilterKey[] = [
   'datasetIds', 'group', 'project', 'submitter', 'polarity', 'organism', 'organismPart', 'condition',
-  'growthConditions', 'ionisationSource', 'maldiMatrix', 'analyzerType', 'metadataType', 'datasetOwner',
+  'growthConditions', 'ionisationSource', 'maldiMatrix', 'analyzerType', 'metadataType', 'datasetOwner', 'opticalImage',
 ]
 /** = all annotation-affecting filters - dataset-affecting filters */
 export const ANNOTATION_FILTERS: FilterKey[] = [
   'annotationIds', 'database', 'minMSM', 'compoundName', 'adduct', 'mz', 'fdrLevel', 'colocalizedWith', 'offSample',
+  'opticalImage',
 ]
 /** Filters that are very specific to particular annotations and should be cleared when navigating to other annotations */
 export const ANNOTATION_SPECIFIC_FILTERS: FilterKey[] = [

--- a/metaspace/webapp/src/modules/Filters/url.ts
+++ b/metaspace/webapp/src/modules/Filters/url.ts
@@ -44,6 +44,7 @@ const FILTER_TO_URL: Record<FilterKey, string> = {
   colocalizedWith: 'colo',
   colocalizationSamples: 'locs',
   offSample: 'offs',
+  opticalImage: 'opt_img',
 }
 
 const URL_TO_FILTER = invert(FILTER_TO_URL) as Record<string, FilterKey>

--- a/metaspace/webapp/src/store/getters.js
+++ b/metaspace/webapp/src/store/getters.js
@@ -79,7 +79,7 @@ export default {
     const { group, project, submitter, datasetIds, polarity,
       organism, organismPart, condition, growthConditions,
       ionisationSource, analyzerType, maldiMatrix, metadataType,
-      compoundName, datasetOwner } = filter;
+      compoundName, datasetOwner, opticalImage } = filter;
     const level = getters.filterLevel;
     const isLogged = state.currentUser && state.currentUser.id
     const hasAnnotationMatching = level === 'dataset' && compoundName ? { compoundQuery: compoundName } : undefined;
@@ -92,6 +92,7 @@ export default {
       ids: datasetIds ? datasetIds.join("|") : null,
 
       organism,
+      opticalImage,
       organismPart,
       condition,
       growthConditions,


### PR DESCRIPTION
### Description

Added optical image filter to display datasets with/without optical image in annotation and datasets page #1098 


<img width="1294" alt="image" src="https://user-images.githubusercontent.com/35172605/196655117-82845546-3ba9-4ef7-9acb-65c97dfe6de7.png">
<img width="1268" alt="image" src="https://user-images.githubusercontent.com/35172605/196655556-7cd79368-2cd7-435f-a331-64625ed75d29.png">
<img width="1315" alt="image" src="https://user-images.githubusercontent.com/35172605/196655823-3d80c56a-04e9-40e9-ac08-a5117c6220f3.png">
