### PR TITLE
Add connection_retries in code_engine config

### DIFF
--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -86,7 +86,8 @@
     "code_engine": {
       "region": "eu-de",
       "namespace": "{{ sm_lithops_ce_namespace }}",
-      "runtime": ""
+      "runtime": "",
+      "connection_retries": 10
     },
     "ibm_vpc": {
       "endpoint": "https://eu-de.iaas.cloud.ibm.com",


### PR DESCRIPTION
Add the `connection_retries` parameter to CE to re-launch executors in cases of 409 or 500 HTTP error.