### PR TITLE
Increase resources for _load_ds step for a big ds

### DIFF
--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -62,7 +62,7 @@
       "data_cleaner": true,
       "data_limit": false,
       "workers": 1000,
-      "execution_timeout": 3600
+      "execution_timeout": 7200
     },
     "serverless": {
       "backend": "code_engine",

--- a/metaspace/engine/conf/config.json.template
+++ b/metaspace/engine/conf/config.json.template
@@ -71,7 +71,8 @@
     },
     "standalone": {
       "backend": "ibm_vpc",
-      "soft_dismantle_timeout": 30
+      "soft_dismantle_timeout": 30,
+      "hard_dismantle_timeout": 7200
     },
     "localhost": {},
     "ibm": {

--- a/metaspace/engine/sm/engine/annotation_lithops/executor.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/executor.py
@@ -187,7 +187,7 @@ class Executor:
 
         self.storage = Storage(lithops_config)
         self._include_modules = lithops_config['lithops'].get('include_modules', [])
-        self._execution_timeout = lithops_config['lithops'].get('execution_timeout', 3600) + 60
+        self._execution_timeout = lithops_config['lithops'].get('execution_timeout', 7200) + 60
         self._perf = perf or NullProfiler()
 
     def map(

--- a/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 from typing import Tuple, List
 
 import numpy as np
@@ -18,6 +19,11 @@ from sm.engine.storage import get_s3_client
 from sm.engine.utils.perf_profile import SubtaskProfiler
 
 logger = logging.getLogger('annotation-pipeline')
+
+
+def _print_times(start, name):
+    end = datetime.now().replace(microsecond=0)
+    print(f'{end.isoformat(" ")} - {name} - {(end - start).total_seconds()} sec')
 
 
 def _load_spectra(storage, imzml_reader):
@@ -38,10 +44,12 @@ def _load_spectra(storage, imzml_reader):
     chunk_bounds = np.linspace(0, imzml_reader.n_spectra, n_chunks + 1, dtype=np.int64)
     spectrum_chunks = zip(chunk_bounds, chunk_bounds[1:])
 
+    start = datetime.now().replace(microsecond=0)
     with ThreadPoolExecutor(4) as executor:
         for _ in executor.map(read_spectrum_chunk, spectrum_chunks):
             pass
 
+    _print_times(start, '_load_spectra')
     return np.concatenate(mz_arrays), np.concatenate(int_arrays), sp_lens
 
 
@@ -51,20 +59,31 @@ def _sort_spectra(imzml_reader, mzs, ints, sp_lens):
     #   and the underlying "Timsort" implementation is optimized for partially-sorted data.
     # * It's a "stable sort", meaning it will preserve the ordering by spectrum index if mz values
     #   are equal. The order of pixels affects some metrics, so this stability is important.
+    start = datetime.now().replace(microsecond=0)
     by_mz = np.argsort(mzs, kind='mergesort')
+    _print_times(start, 'by_mz')
 
     # The existing `mzs` and `ints` arrays can't be garbage-collected because the calling function
     # holds references to them. Overwrite the original arrays with the temp sorted arrays so that
     # the temp arrays can be freed instead.
+    start = datetime.now().replace(microsecond=0)
     mzs[:] = mzs[by_mz]
+    _print_times(start, 'sort mzs')
+
+    start = datetime.now().replace(microsecond=0)
     ints[:] = ints[by_mz]
+    _print_times(start, 'sort ints')
+
     # Build sp_idxs after sorting mzs. Sorting mzs uses the most memory, so it's best to keep
     # sp_idxs in a compacted form with sp_lens until the last minute.
+    start = datetime.now().replace(microsecond=0)
     sp_idxs = np.empty(len(ints), np.uint32)
     sp_lens = np.insert(np.cumsum(sp_lens), 0, 0)
     for sp_idx, start, end in zip(imzml_reader.pixel_indexes, sp_lens[:-1], sp_lens[1:]):
         sp_idxs[start:end] = sp_idx
     sp_idxs = sp_idxs[by_mz]
+    _print_times(start, 'sort sp_idxs')
+
     return mzs, ints, sp_idxs
 
 
@@ -86,8 +105,11 @@ def _upload_segments(storage, ds_segm_size_mb, imzml_reader, mzs, ints, sp_idxs)
         )
         return save_cobj(storage, df)
 
+    start = datetime.now().replace(microsecond=0)
     with ThreadPoolExecutor(4) as executor:
         ds_segms_cobjs = list(executor.map(upload_segm, segm_ranges))
+    _print_times(start, 'upload_segm')
+
     return ds_segms_cobjs, ds_segments_bounds, ds_segm_lens
 
 
@@ -99,8 +121,10 @@ def _upload_imzml_browser_files_to_cos(storage, imzml_cobject, imzml_reader, mzs
 
     prefix = f'imzml_browser/{imzml_cobject.key.split("/")[1]}'
     keys = [f'{prefix}/{var}.npy' for var in ['mzs', 'ints', 'sp_idxs']]
+    start = datetime.now().replace(microsecond=0)
     with ThreadPoolExecutor(3) as executor:
         cobjs = list(executor.map(upload_file, [mzs, ints, sp_idxs], keys))
+    _print_times(start, 'upload_file')
 
     chunk_records_number = 1024
     data = mzs[::chunk_records_number].astype('f')

--- a/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
@@ -59,30 +59,30 @@ def _sort_spectra(imzml_reader, mzs, ints, sp_lens):
     #   and the underlying "Timsort" implementation is optimized for partially-sorted data.
     # * It's a "stable sort", meaning it will preserve the ordering by spectrum index if mz values
     #   are equal. The order of pixels affects some metrics, so this stability is important.
-    start = datetime.now().replace(microsecond=0)
+    start_t = datetime.now().replace(microsecond=0)
     by_mz = np.argsort(mzs, kind='mergesort')
-    _print_times(start, 'by_mz')
+    _print_times(start_t, 'by_mz')
 
     # The existing `mzs` and `ints` arrays can't be garbage-collected because the calling function
     # holds references to them. Overwrite the original arrays with the temp sorted arrays so that
     # the temp arrays can be freed instead.
-    start = datetime.now().replace(microsecond=0)
+    start_t = datetime.now().replace(microsecond=0)
     mzs[:] = mzs[by_mz]
-    _print_times(start, 'sort mzs')
+    _print_times(start_t, 'sort mzs')
 
-    start = datetime.now().replace(microsecond=0)
+    start_t = datetime.now().replace(microsecond=0)
     ints[:] = ints[by_mz]
-    _print_times(start, 'sort ints')
+    _print_times(start_t, 'sort ints')
 
     # Build sp_idxs after sorting mzs. Sorting mzs uses the most memory, so it's best to keep
     # sp_idxs in a compacted form with sp_lens until the last minute.
-    start = datetime.now().replace(microsecond=0)
+    start_t = datetime.now().replace(microsecond=0)
     sp_idxs = np.empty(len(ints), np.uint32)
     sp_lens = np.insert(np.cumsum(sp_lens), 0, 0)
     for sp_idx, start, end in zip(imzml_reader.pixel_indexes, sp_lens[:-1], sp_lens[1:]):
         sp_idxs[start:end] = sp_idx
     sp_idxs = sp_idxs[by_mz]
-    _print_times(start, 'sort sp_idxs')
+    _print_times(start_t, 'sort sp_idxs')
 
     return mzs, ints, sp_idxs
 
@@ -105,10 +105,10 @@ def _upload_segments(storage, ds_segm_size_mb, imzml_reader, mzs, ints, sp_idxs)
         )
         return save_cobj(storage, df)
 
-    start = datetime.now().replace(microsecond=0)
+    start_t = datetime.now().replace(microsecond=0)
     with ThreadPoolExecutor(4) as executor:
         ds_segms_cobjs = list(executor.map(upload_segm, segm_ranges))
-    _print_times(start, 'upload_segm')
+    _print_times(start_t, 'upload_segm')
 
     return ds_segms_cobjs, ds_segments_bounds, ds_segm_lens
 
@@ -121,10 +121,10 @@ def _upload_imzml_browser_files_to_cos(storage, imzml_cobject, imzml_reader, mzs
 
     prefix = f'imzml_browser/{imzml_cobject.key.split("/")[1]}'
     keys = [f'{prefix}/{var}.npy' for var in ['mzs', 'ints', 'sp_idxs']]
-    start = datetime.now().replace(microsecond=0)
+    start_t = datetime.now().replace(microsecond=0)
     with ThreadPoolExecutor(3) as executor:
         cobjs = list(executor.map(upload_file, [mzs, ints, sp_idxs], keys))
-    _print_times(start, 'upload_file')
+    _print_times(start_t, 'upload_imzml_files')
 
     chunk_records_number = 1024
     data = mzs[::chunk_records_number].astype('f')


### PR DESCRIPTION
For large datasets (60+ GB ibd file size) do not enough 1 hour for the `_load_ds` step. I increased the timeout to 2 hours.