### PR TITLE
Removed duplicate groups from group list page

### DIFF
--- a/metaspace/graphql/src/modules/group/controller.ts
+++ b/metaspace/graphql/src/modules/group/controller.ts
@@ -198,9 +198,9 @@ export const Resolvers = {
       let userGroups : any = []
 
       if (ctx.user.id) {
-        let qb = ctx.entityManager.createQueryBuilder(UserGroupModel,
-          'userGroup')
-          .innerJoinAndSelect('userGroup.group', 'group')
+        let qb = ctx.entityManager.createQueryBuilder(GroupModel,
+          'group')
+          .leftJoinAndSelect('group.members', 'userGroup')
           .where('(group.name ILIKE :query OR group.shortName ILIKE :query)', { query: query ? `%${query}%` : '%' })
 
         if (ctx.user.role !== 'admin') {
@@ -208,10 +208,11 @@ export const Resolvers = {
         }
 
         userGroups = await qb.orderBy('group.name')
+          .distinct(true)
           .getMany()
       }
 
-      return userGroups.map((g: any) => ({ ...g.group, scopeRole: g.role }))
+      return userGroups.map((g: any) => ({ ...g, scopeRole: g.role }))
     },
 
     async groupUrlSlugIsValid(source: any, { urlSlug, existingGroupId }: any, ctx: Context): Promise<boolean> {

--- a/metaspace/webapp/src/modules/Group/GroupsListPage.tsx
+++ b/metaspace/webapp/src/modules/Group/GroupsListPage.tsx
@@ -1,11 +1,11 @@
 import { computed, defineComponent, reactive } from '@vue/composition-api'
-import './GroupsListPage.scss'
 import { Button, Input } from '../../lib/element-ui'
-import { calculateMzFromFormula, isFormulaValid } from '../../lib/formulaParser'
 import { useQuery } from '@vue/apollo-composable'
 import { currentUserRoleQuery, CurrentUserRoleResult } from '../../api/user'
 import { getUserGroupsQuery, ViewGroupResult } from '../../api/group'
+import { uniqBy } from 'lodash-es'
 import GroupsListItem from './GroupsListItem'
+import './GroupsListPage.scss'
 
 interface GroupListPageProps {
   className: string
@@ -95,7 +95,7 @@ export default defineComponent<GroupListPageProps>({
               {
                 groups.value?.length > 0
                 && !groupsLoading.value
-                && groups.value?.map((group: any) => {
+                && uniqBy((groups.value || []) as any[], 'id').map((group: any) => {
                   return <GroupsListItem
                     id={group.id}
                     name={group.name}


### PR DESCRIPTION
When accessing the groups page as an admin, some group duplicates were displayed. This fix remove this duplicates