### PR TITLE
ImzMLError did not move the dataset to FAILED status

### DIFF
--- a/metaspace/engine/sm/engine/daemons/lithops.py
+++ b/metaspace/engine/sm/engine/daemons/lithops.py
@@ -48,14 +48,11 @@ class LithopsDaemon:
 
         # Stop processing in case of problem with imzML file
         if isinstance(e, ImzMLError):
-            self._manager.post_to_slack(
-                'bomb',
-                f" [x] Annotation failed, ImzMLError: {json.dumps(msg)}\n```{e.traceback}```",
-            )
             if 'email' in msg:
                 self._manager.send_failed_email(msg, e.traceback)
 
             os.kill(os.getpid(), signal.SIGINT)
+            self._manager.ds_failure_handler(msg, e)
             return
 
         exc = format_exc(limit=10)


### PR DESCRIPTION
Found a bug created by this task: #1186. Although the processing of the dataset stopped (`lithops daemon`), we did not change the status of the dataset from `ANNOTATION` to `FAILED`. In this case, the processing of the dataset stuck and the user could not understand what the problem was.