### PR TITLE
[ionImageRendering] fixed grayscale intensities parsing

### DIFF
--- a/metaspace/webapp/src/lib/ionImageRendering.spec.ts
+++ b/metaspace/webapp/src/lib/ionImageRendering.spec.ts
@@ -52,7 +52,7 @@ describe('ionImageRendering.ts', () => {
       const bits = is16Bit ? 16 : 8
       const colorType = isRGBA ? 'RGBA' : 'Grayscale'
       test(`processIonImage correctly decodes a ${bits}-bit ${colorType} image`, () => {
-        const png = getGradientPng(is16Bit, isRGBA)
+        const png = getGradientPng(is16Bit, !isRGBA)
 
         const image = processIonImage(png, 0, 1, 'test')
 

--- a/metaspace/webapp/src/lib/ionImageRendering.ts
+++ b/metaspace/webapp/src/lib/ionImageRendering.ts
@@ -135,8 +135,6 @@ const extractIntensityAndMask = (png: Image, min: number, max: number, normaliza
     }
   } else {
     for (let i = 0; i < numPixels; i++) {
-      const y = Math.floor(i / width)
-      const x = i % width
       const byteOffset = i * numComponents * bytesPerComponent
       let intensity = dataView.getUint16(byteOffset) * rangeVal + baseVal
 
@@ -157,8 +155,6 @@ const extractIntensityAndMask = (png: Image, min: number, max: number, normaliza
     if (hasAlpha) {
       const alphaOffset = (numComponents - 1) * bytesPerComponent
       for (let i = 0; i < numPixels; i++) {
-        const y = Math.floor(i / width)
-        const x = i % width
         const byteOffset = i * numComponents * bytesPerComponent + alphaOffset
         mask[i] = dataView.getUint16(byteOffset, !isRGB) < 32768 ? 0 : 255
       }


### PR DESCRIPTION
### Description

Fixed a problem when parsing grayscale 16 bit images to read intensities correctly #1241  


### Problem

When parsing 2 bites per component grayscale with alpha png, the intensity values were being incorrectly parsed. In order to fix it, when parsing this specific type of image, instead of reading the data directly, we convert it using the upng-js function toRGBA8 to read the rgba frames.


