### PR TITLE
Add optical image when first iso image id is null

### DIFF
--- a/metaspace/engine/sm/engine/optical_image.py
+++ b/metaspace/engine/sm/engine/optical_image.py
@@ -49,7 +49,8 @@ class OpticalImageType:
 
 def _annotation_image_shape(db, ds):
     logger.debug(f'Querying annotation image shape for "{ds.id}" dataset')
-    ion_img_id = db.select(IMG_URLS_BY_ID_SEL + ' LIMIT 1', params=(ds.id,))[0][0][0]
+    ion_img_ids = db.select(IMG_URLS_BY_ID_SEL + ' LIMIT 1', params=(ds.id,))[0][0]
+    ion_img_id = next((item for item in ion_img_ids if item is not None), None)
     image_bytes = image_storage.get_image(image_storage.ISO, ds.id, ion_img_id)
     image = Image.open(io.BytesIO(image_bytes))
     result = image.size


### PR DESCRIPTION
### Description

Fixed bug where the user has a problem adding optical image for some datasets where its first iso image id is null  #1261  


### Problem
In order to generate the optical image transforms, it is necessary an iso image to be used as template. The code was getting the first ion image id to do that. In some cases, the first ion image id stored in annotation table is null, so to fix that, now we are getting the first non null id.



