### PR TITLE
Add/remove datasets to project pagination bug fix

### DIFF
--- a/metaspace/graphql/src/modules/project/controller/Mutation.ts
+++ b/metaspace/graphql/src/modules/project/controller/Mutation.ts
@@ -31,6 +31,7 @@ import { validateUrlSlugChange } from '../../groupOrProject/urlSlug'
 import { validateTiptapJson } from '../../../utils/tiptap'
 import { getDatasetForEditing } from '../../dataset/operation/getDatasetForEditing'
 import { EngineDataset } from '../../engine/model'
+import logger from '../../../utils/logger'
 import moment = require('moment')
 
 const asyncAssertCanEditProject = async(ctx: Context, projectId: string) => {
@@ -242,6 +243,13 @@ const MutationResolvers: FieldResolversFor<Mutation, void> = {
           }
         }
       }))
+
+      if (datasetIds && datasetIds.length > 0) {
+        logger.info(`Datasets ${datasetIds} added to ${projectId}`)
+      }
+      if (removedDatasetIds && removedDatasetIds.length > 0) {
+        logger.info(`Datasets ${removedDatasetIds} removed from ${projectId}`)
+      }
 
       const approved = ([UPRO.MEMBER, UPRO.MANAGER].includes(userProjectRole) || ctx.isAdmin)
       await updateProjectDatasets(ctx, projectId, (datasetIds || []), (removedDatasetIds || []),

--- a/metaspace/webapp/src/modules/Project/DatasetsDialog.scss
+++ b/metaspace/webapp/src/modules/Project/DatasetsDialog.scss
@@ -10,3 +10,7 @@
     }
   }
 }
+
+.ds-dialog-bt-bar{
+  justify-content: space-between !important;
+}

--- a/metaspace/webapp/src/modules/Project/DatasetsDialog.tsx
+++ b/metaspace/webapp/src/modules/Project/DatasetsDialog.tsx
@@ -68,7 +68,6 @@ export const DatasetsDialog = defineComponent<DatasetsDialogProps>({
         submitter: state.datasetOwnerFilter === 'my-datasets' ? props.currentUser.id : undefined,
         project: state.datasetOwnerFilter === 'project-datasets' ? props.project.id : undefined,
         metadataType: 'Imaging MS',
-        status: 'FINISHED',
         name: state.nameFilter,
       },
       limit: state.pageSize,

--- a/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
+++ b/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
@@ -14,7 +14,7 @@
         :project="project"
         :is-manager="isManager"
         @close="handleCloseProjectDatasetsDialog"
-        @update="handleCloseProjectDatasetsDialog"
+        @update="handleUpdateProjectDatasetsDialog"
       />
       <div class="header-row">
         <div class="header-names">
@@ -561,6 +561,10 @@ export default class ViewProjectPage extends Vue {
     }
 
     handleCloseProjectDatasetsDialog() {
+      this.showProjectDatasetsDialog = false
+    }
+
+    handleUpdateProjectDatasetsDialog() {
       this.showProjectDatasetsDialog = false
       // TODO: Remove
       window.location.reload()

--- a/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
+++ b/metaspace/webapp/src/modules/Project/ViewProjectPage.vue
@@ -562,6 +562,8 @@ export default class ViewProjectPage extends Vue {
 
     handleCloseProjectDatasetsDialog() {
       this.showProjectDatasetsDialog = false
+      // TODO: Remove
+      window.location.reload()
     }
 }
 


### PR DESCRIPTION
### Description

Add/remove datasets to project pagination bug fix. Showing number of removed and added datasets in the dialog, so the user do not remove them by mistake. Added log of which datasets were removed and added to the project  #1271 


### Problem
When a project has more than the page number from the add dataset to project component, some times a bug removes the datasets not being displayed in the table from the project, if the user remove a project from the first page, what removes all the datasets not displayed in the table.


