### PR TITLE
Showing selected FDR at Dataset browser page

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.scss
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.scss
@@ -10,6 +10,15 @@
     width: 100%;
   }
 
+  .annotated-legend{
+    position: absolute;
+    z-index: 1000;
+    background: white;
+    font-size: 12px;
+    margin-left: 181px;
+    color: rgba(0,0,0,0.7);
+  }
+
   .dataset-browser-empty-spectrum{
     @apply border-2 border-dashed border-gray-200 relative rounded m-6 p-2 flex flex-row items-center justify-center;
     background: rgba(224,224,224,0.2);

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserKendrickPlot.tsx
@@ -46,6 +46,7 @@ interface DatasetBrowserKendrickPlotProps {
   peakFilter: number
   referenceMz: number
   dataRange: any
+  annotatedLabel: string
 }
 
 interface DatasetBrowserKendrickPlotState {
@@ -73,6 +74,9 @@ export const DatasetBrowserKendrickPlot = defineComponent<DatasetBrowserKendrick
     isDataLoading: {
       type: Boolean,
       default: false,
+    },
+    annotatedLabel: {
+      type: String,
     },
     data: {
       type: Array,
@@ -297,6 +301,11 @@ export const DatasetBrowserKendrickPlot = defineComponent<DatasetBrowserKendrick
 
       return (
         <div class='chart-holder'>
+          {
+            !(isLoading || isDataLoading)
+            && props.annotatedLabel
+            && <div class='annotated-legend'>{props.annotatedLabel}</div>
+          }
           {
             (isLoading || isDataLoading)
             && <div class='loader-holder'>

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserPage.tsx
@@ -713,8 +713,8 @@ export default defineComponent<DatasetBrowserProps>({
                 if (value === PEAK_FILTER.FDR && !state.fdrFilter) {
                   state.fdrFilter = 0.05
                 } else if (value === PEAK_FILTER.ALL) {
-                  state.fdrFilter = undefined
-                  state.databaseFilter = undefined
+                  // state.fdrFilter = undefined
+                  // state.databaseFilter = undefined
                 }
               }}
               onChange={() => {
@@ -727,7 +727,7 @@ export default defineComponent<DatasetBrowserProps>({
               <Radio class='w-full' label={PEAK_FILTER.ALL}>All Peaks</Radio>
               <Radio class='w-full mt-1 ' label={PEAK_FILTER.OFF}>Unannotated Peaks</Radio>
               <div>
-                <Radio label={PEAK_FILTER.FDR}>Show annotated at FDR</Radio>
+                <Radio class='mr-1' label={PEAK_FILTER.FDR}>Show annotated at FDR:</Radio>
                 <Select
                   class='select-box-mini'
                   value={state.fdrFilter}
@@ -1038,6 +1038,7 @@ export default defineComponent<DatasetBrowserProps>({
             requestIonImage()
           }}
           onDownload={handleDownload}
+          annotatedLabel={`Annotated at FDR ${(state.fdrFilter || 1) * 100}%`}
         />
       )
     }
@@ -1063,6 +1064,7 @@ export default defineComponent<DatasetBrowserProps>({
             state.mzmScoreFilter = mz
             requestIonImage()
           }}
+          annotatedLabel={`Annotated @ FDR ${(state.fdrFilter || 1) * 100}%`}
           onDownload={handleDownload}
         />
       )

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserSpectrumChart.scss
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserSpectrumChart.scss
@@ -4,6 +4,15 @@
     height: 500px;
   }
 
+  .annotated-legend{
+    position: absolute;
+    z-index: 1000;
+    background: white;
+    font-size: 12px;
+    margin-left: 181px;
+    color: rgba(0,0,0,0.7);
+  }
+
   .chart{
     @apply flex flex-row items-center justify-center;
     height: 500px;

--- a/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserSpectrumChart.tsx
+++ b/metaspace/webapp/src/modules/Datasets/imzml/DatasetBrowserSpectrumChart.tsx
@@ -41,6 +41,7 @@ interface DatasetBrowserSpectrumChartProps {
   peakFilter: number
   normalization: number | undefined
   dataRange: any
+  annotatedLabel: string
 }
 
 interface DatasetBrowserSpectrumChartState {
@@ -68,6 +69,9 @@ export const DatasetBrowserSpectrumChart = defineComponent<DatasetBrowserSpectru
     isDataLoading: {
       type: Boolean,
       default: false,
+    },
+    annotatedLabel: {
+      type: String,
     },
     data: {
       type: Array,
@@ -316,6 +320,11 @@ export const DatasetBrowserSpectrumChart = defineComponent<DatasetBrowserSpectru
 
       return (
         <div class='chart-holder'>
+          {
+            !(isLoading || isDataLoading)
+            && props.annotatedLabel
+            && <div class='annotated-legend'>{props.annotatedLabel}</div>
+          }
           {
             (isLoading || isDataLoading)
             && <div class='loader-holder'>


### PR DESCRIPTION
### Description

Showing selected FDR at Dataset browser charts and persisting FDR filter when peaks option change  #1311   

#### how to test it:
1 - access <metaspace_url>/dataset/<ds_id>/browser
2 - Select a pixel

<img width="1195" alt="image" src="https://user-images.githubusercontent.com/35172605/222519930-8312691e-4387-4f18-97f5-b18bdef5ee2d.png">




