### PR TITLE
[DatasetOverview] hiding additional information field

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetOverviewPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetOverviewPage.tsx
@@ -81,8 +81,12 @@ const DatasetOverviewPage = defineComponent<Props>({
       const metadata = safeJsonParse(metadataJson) || {}
       const config = safeJsonParse(configJson) || {}
 
+      // hide deprecated fields
       // eslint-disable-next-line camelcase
       delete metadata?.Submitted_By
+      // eslint-disable-next-line camelcase
+      delete metadata.Additional_Information
+
       const groupLink = $router.resolve({ name: 'group', params: { groupIdOrSlug: group?.id || '' } }).href
       const upDate = moment(moment(dataset?.value?.uploadDT)).isValid()
         ? moment(dataset?.value?.uploadDT).format('D MMMM, YYYY') : ''

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetOverviewPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetOverviewPage.tsx
@@ -85,7 +85,7 @@ const DatasetOverviewPage = defineComponent<Props>({
       // eslint-disable-next-line camelcase
       delete metadata?.Submitted_By
       // eslint-disable-next-line camelcase
-      delete metadata.Additional_Information
+      delete metadata?.Additional_Information
 
       const groupLink = $router.resolve({ name: 'group', params: { groupIdOrSlug: group?.id || '' } }).href
       const upDate = moment(moment(dataset?.value?.uploadDT)).isValid()


### PR DESCRIPTION
### Description

Hiding the deprecated 'Additional_Information' field from the dataset overview page, as it is still showing data from old datasets with this field or new ones that were created by copying old ones #1316 

#### how to test it:
access <metaspace_url>/dataset/<ds_id>



