### PR TITLE
Save acq_geometry for lithops implementation

### DIFF
--- a/metaspace/engine/sm/engine/annotation/acq_geometry.py
+++ b/metaspace/engine/sm/engine/annotation/acq_geometry.py
@@ -1,3 +1,20 @@
+# TODO: remove all make_*_acq_geometry functions except this one
+def make_acq_geometry_lithops(metadata, dims, n_spectra):
+    pixel_size = metadata.get('MS_Analysis', {}).get('Pixel_Size', {})
+    row_n, col_n = dims
+
+    return {
+        'length_unit': 'nm',
+        'pixel_count': n_spectra,
+        'acquisition_grid': {'regular_grid': True, 'count_x': int(col_n), 'count_y': int(row_n)},
+        'pixel_size': {
+            'regular_size': True,
+            'size_x': pixel_size.get('Xaxis'),
+            'size_y': pixel_size.get('Yaxis'),
+        },
+    }
+
+
 def make_ims_acq_geometry(metadata, dims):
     pixel_size = metadata.get('MS_Analysis', {}).get('Pixel_Size', {})
     row_n, col_n = dims

--- a/metaspace/engine/sm/engine/annotation_lithops/annotation_job.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/annotation_job.py
@@ -327,6 +327,9 @@ class ServerAnnotationJob:
                 perform_enrichment=self.perform_enrichment, **kwargs
             )
 
+            # Save acq_geometry
+            self.pipe.save_acq_geometry(self.ds)
+
             # Save size and hash of imzML/ibd files
             self.pipe.store_ds_size_hash()
 

--- a/metaspace/engine/sm/engine/annotation_lithops/pipeline.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/pipeline.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 from lithops.storage.utils import CloudObject
 
+from sm.engine.annotation.acq_geometry import make_acq_geometry_lithops
 from sm.engine.annotation.diagnostics import FdrDiagnosticBundle
 from sm.engine.annotation.imzml_reader import LithopsImzMLReader
 from sm.engine.annotation.isocalc_wrapper import IsocalcWrapper
@@ -207,6 +208,13 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
     @use_pipeline_cache
     def run_enrichment(self):
         self.enrichment_data = run_enrichment(self.results_dfs)
+
+    def save_acq_geometry(self, ds):
+        """Stores acquisition geometry to DB.
+        Not part of run_pipeline because this is unwanted when running from a LocalAnnotationJob."""
+        dims = (self.imzml_reader.h, self.imzml_reader.w)
+        acq_geometry = make_acq_geometry_lithops(ds.metadata, dims, self.imzml_reader.n_spectra)
+        ds.save_acq_geometry(self._db, acq_geometry)
 
     def store_ds_size_hash(self):
         """Stores size and md5 hash of imzML/ibd files.

--- a/metaspace/engine/sm/engine/tests/annotation/test_acq_geometry.py
+++ b/metaspace/engine/sm/engine/tests/annotation/test_acq_geometry.py
@@ -2,7 +2,7 @@ from os.path import join
 
 import pytest
 
-from sm.engine.annotation.acq_geometry import make_acq_geometry
+from sm.engine.annotation.acq_geometry import make_acq_geometry, make_acq_geometry_lithops
 from sm.engine.config import proj_root
 
 
@@ -40,3 +40,16 @@ def test_lcms_geometry_factory():
     assert not geometry['acquisition_grid']['regular_grid']
     assert len(geometry['acquisition_grid']['coord_list']) == 285
     assert geometry['pixel_size'] == {'regular_size': True, 'size_x': 1, 'size_y': 1}
+
+
+def test_make_acq_geometry_lithops():
+    metadata = {'MS_Analysis': {'Pixel_Size': {'Xaxis': 17, 'Yaxis': 18}}}
+
+    empty_geom = make_acq_geometry_lithops(metadata, (72, 70), 4850)
+
+    assert empty_geom == {
+        'length_unit': 'nm',
+        'pixel_count': 4850,
+        'acquisition_grid': {'regular_grid': True, 'count_x': 72, 'count_y': 70},
+        'pixel_size': {'regular_size': True, 'size_x': 17, 'size_y': 18},
+    }

--- a/metaspace/engine/sm/engine/tests/annotation/test_acq_geometry.py
+++ b/metaspace/engine/sm/engine/tests/annotation/test_acq_geometry.py
@@ -50,6 +50,6 @@ def test_make_acq_geometry_lithops():
     assert empty_geom == {
         'length_unit': 'nm',
         'pixel_count': 4850,
-        'acquisition_grid': {'regular_grid': True, 'count_x': 72, 'count_y': 70},
+        'acquisition_grid': {'regular_grid': True, 'count_x': 70, 'count_y': 72},
         'pixel_size': {'regular_size': True, 'size_x': 17, 'size_y': 18},
     }


### PR DESCRIPTION
1. Refactoring will remove all references to `lcms`.
2. Added the `pixel_count` field - the number of pixels that contain spectra. This will help in estimating the percentage of filling of the plane of the dataset with data.