### PR TITLE
[DsComparison] Increased limit from 10 to 12

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonDialog.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonDialog.tsx
@@ -34,7 +34,7 @@ interface DatasetComparisonDialogState {
   datasetName: string
 }
 
-const MAX_CELLS = 10
+const MAX_CELLS = 12
 
 export const DatasetComparisonDialog = defineComponent<DatasetComparisonDialogProps>({
   name: 'DatasetComparisonDialog',

--- a/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonDialog.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonDialog.spec.ts.snap
@@ -46,7 +46,7 @@ exports[`DatasetComparisonDialog it should match snapshot 1`] = `
                     <!---->
                   </div>
                 </transition-stub>
-              </div><span class="block text-sm font-medium text-danger mt-0" style="visibility: hidden;">Only up to 10 datasets can be selected!</span><button type="button" class="el-button el-button--primary">
+              </div><span class="block text-sm font-medium text-danger mt-0" style="visibility: hidden;">Only up to 12 datasets can be selected!</span><button type="button" class="el-button el-button--primary">
                 <!---->
                 <!----><span>Next</span></button>
             </form>


### PR DESCRIPTION
### Description

Increase datasets comparison limit from 10 datasets to 12 #1353 

#### How to test it

1 - Access https://metaspace2020.eu/dataset/<ds_id>
2 - Click on Actions
3 - Select 'Compare with other datasets...'
4 - Select 12 datasets