### PR TITLE
[WebApp] changed edit metadata label

### DIFF
--- a/metaspace/webapp/src/modules/App/HelpPage.vue
+++ b/metaspace/webapp/src/modules/App/HelpPage.vue
@@ -69,7 +69,7 @@
         <ul>
           <li>owner of their data</li>
           <li>can make their data public</li>
-          <li>can edit metadata</li>
+          <li>can edit dataset</li>
           <li>can delete their data</li>
         </ul>
       </div>

--- a/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
+++ b/metaspace/webapp/src/modules/Datasets/list/DatasetItemActions.tsx
@@ -245,17 +245,6 @@ const DatasetItemActions = defineComponent({
             >Show full metadata</a>
           </div>
 
-          {dataset.canEdit
-          && <div>
-            <i class="el-icon-edit" />
-            <router-link to={{
-              name: 'edit-metadata',
-              params: { dataset_id: props.dataset.id },
-            }}>
-              Edit metadata
-            </router-link>
-          </div>}
-
           {
             !props.showOverview && dataset.canDownload
           && <div class="ds-download">
@@ -336,6 +325,17 @@ const DatasetItemActions = defineComponent({
               </NewFeatureBadge>
             </div>
           }
+
+          {dataset.canEdit
+            && <div>
+              <i class="el-icon-edit" />
+              <router-link to={{
+                name: 'edit-metadata',
+                params: { dataset_id: props.dataset.id },
+              }}>
+                Edit
+              </router-link>
+            </div>}
         </div>
       )
     }

--- a/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetItem.spec.js.snap
+++ b/metaspace/webapp/src/modules/Datasets/list/__snapshots__/DatasetItem.spec.js.snap
@@ -247,17 +247,6 @@ exports[`DatasetItem should match snapshot 1`] = `
     </div>
     <div>
       <i
-        class="el-icon-edit"
-      />
-      <a
-        class=""
-        href="/datasets/edit/mockdataset"
-      >
-        Edit metadata
-      </a>
-    </div>
-    <div>
-      <i
         class="el-icon-data-analysis"
       />
       <a
@@ -268,6 +257,17 @@ exports[`DatasetItem should match snapshot 1`] = `
         <span>
           Dataset overview
         </span>
+      </a>
+    </div>
+    <div>
+      <i
+        class="el-icon-edit"
+      />
+      <a
+        class=""
+        href="/datasets/edit/mockdataset"
+      >
+        Edit
       </a>
     </div>
   </div>

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
@@ -42,7 +42,7 @@ export const DatasetActionsDropdown = defineComponent<DatasetActionsDropdownProp
   props: {
     actionLabel: { type: String, default: 'Actions' },
     deleteActionLabel: { type: String, default: 'Delete' },
-    editActionLabel: { type: String, default: 'Edit metadata' },
+    editActionLabel: { type: String, default: 'Edit' },
     compareActionLabel: { type: String, default: 'Compare with other datasets...' },
     browserActionLabel: { type: String, default: 'Imzml Browser' },
     enrichmentActionLabel: { type: String, default: 'LION enrichment' },
@@ -265,10 +265,6 @@ export const DatasetActionsDropdown = defineComponent<DatasetActionsDropdownProp
           </NewFeatureBadge>
           <DropdownMenu class='dataset-overview-menu p-2'>
             {
-              canEdit
-              && <DropdownItem command="edit">{editActionLabel}</DropdownItem>
-            }
-            {
               canDownload
               && <DropdownItem command="download">{downloadActionLabel}</DropdownItem>
             }
@@ -285,6 +281,10 @@ export const DatasetActionsDropdown = defineComponent<DatasetActionsDropdownProp
               config.features.enrichment
               && (enrichmentRequested.value || canEdit)
               && <DropdownItem command="enrichment">{enrichmentActionLabel}</DropdownItem>
+            }
+            {
+              canEdit
+              && <DropdownItem command="edit">{editActionLabel}</DropdownItem>
             }
             {
               canDelete

--- a/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/DatasetActionsDropdown.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/DatasetActionsDropdown.spec.ts.snap
@@ -6,13 +6,13 @@ exports[`DatasetActionsDropdown it should match snapshot 1`] = `
     <elbutton-stub type="primary" icon="" nativetype="button" class="p-1"><span class="ml-2">Actions</span><i class="el-icon-arrow-down el-icon--right"></i></elbutton-stub>
   </el-badge-stub>
   <eldropdownmenu-stub transformorigin="true" placement="bottom" boundariespadding="5" offset="0" visiblearrow="true" arrowoffset="0" appendtobody="true" popperoptions="[object Object]" class="dataset-overview-menu p-2">
-    <eldropdownitem-stub command="edit">Edit metadata</eldropdownitem-stub>
     <eldropdownitem-stub command="download">Download</eldropdownitem-stub>
     <eldropdownitem-stub command="compare">Compare with other datasets...</eldropdownitem-stub>
     <eldropdownitem-stub command="browser" class="relative">
       <el-badge-stub value="New" class="sm-feature-badge actionBadge">Imzml Browser</el-badge-stub>
     </eldropdownitem-stub>
     <eldropdownitem-stub command="enrichment">LION enrichment</eldropdownitem-stub>
+    <eldropdownitem-stub command="edit">Edit</eldropdownitem-stub>
     <eldropdownitem-stub command="delete" class="text-red-500">Delete</eldropdownitem-stub>
     <eldropdownitem-stub command="reprocess" class="text-red-500">Reprocess data</eldropdownitem-stub>
   </eldropdownmenu-stub>


### PR DESCRIPTION
### Description

Changed 'Edit metadata' label to 'Edit' on webapp pages #1358  

<img width="851" alt="image" src="https://github.com/metaspace2020/metaspace/assets/35172605/589519d6-9ad1-4bbd-b9d0-69c875f6e5a5">
<img width="826" alt="image" src="https://github.com/metaspace2020/metaspace/assets/35172605/575edfea-8ea1-438e-8bcc-ad1e8a6396bc">
<img width="883" alt="image" src="https://github.com/metaspace2020/metaspace/assets/35172605/2c7d97db-ccad-4da8-a6f6-73969fe25b16">
