### PR TITLE
Changed fields for METASPACE ML release

### DIFF
--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/DiagnosticsMetrics.tsx
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/DiagnosticsMetrics.tsx
@@ -82,7 +82,7 @@ const DiagnosticsMetrics = defineComponent({
         } else {
           metricsFormula = (
             <div class="msm-score-calc">
-              {'METASPACE-ML = '}
+              {'METASPACE-ML score = '}
               <span>{ annotation.msmScore.toFixed(3) }</span>
               {' = ML ('}
               {interleave<any>(

--- a/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/DiagnosticsMetrics.tsx
+++ b/metaspace/webapp/src/modules/Annotations/annotation-widgets/default/DiagnosticsMetrics.tsx
@@ -82,9 +82,9 @@ const DiagnosticsMetrics = defineComponent({
         } else {
           metricsFormula = (
             <div class="msm-score-calc">
-              {'MSM score = '}
+              {'METASPACE-ML = '}
               <span>{ annotation.msmScore.toFixed(3) }</span>
-              {` = ${scoringModel.value} (`}
+              {' = ML ('}
               {interleave<any>(
                 metricItems.map(item => ([item.name, ' = ', item.formattedVal])), ', ',
               )}

--- a/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
+++ b/metaspace/webapp/src/modules/MetadataEditor/__snapshots__/MetadataEditor.spec.ts.snap
@@ -1011,8 +1011,6 @@ exports[`MetadataEditor should match snapshot 1`] = `
                             When comparing data between multiple datasets, it is recommended to process all datasets with the same
                             analysis version. Otherwise, select the latest version for best results.
                             <h4>Changes:</h4>
-                            <!---->
-                            <!---->
                             <h5>v2 (ML-powered MSM):</h5>
                             <ul>
                               <li>New metrics for evaluating annotations' mass accuracy.</li>
@@ -1034,7 +1032,6 @@ exports[`MetadataEditor should match snapshot 1`] = `
                       </transition-stub>
                     </div>
                   </div>
-                  <!---->
                 </div>
               </div>
               <div class="el-row" style="margin-left: -4px; margin-right: -4px;">

--- a/metaspace/webapp/src/modules/MetadataEditor/inputs/AnalysisVersionHelp.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/inputs/AnalysisVersionHelp.vue
@@ -3,13 +3,6 @@
     When comparing data between multiple datasets, it is recommended to process all datasets with the same
     analysis version. Otherwise, select the latest version for best results.
     <h4>Changes:</h4>
-    <h5 v-if="showV15">
-      v1.5 (Prototype for higher RPs):
-    </h5>
-    <ul v-if="showV15">
-      <li>Improved modeling of instrument mass accuracy at higher m/z values for TOF and Orbitrap.</li>
-      <li>Improved isotopic peak calculation algorithm.</li>
-    </ul>
     <h5>v2 (ML-powered MSM):</h5>
     <ul>
       <li>New metrics for evaluating annotations' mass accuracy.</li>
@@ -20,12 +13,8 @@
 </template>
 
 <script>
-import config from '../../../lib/config'
 export default {
   name: 'AnalysisVersionHelp',
-  computed: {
-    showV15() { return config.features.advanced_ds_config },
-  },
 }
 </script>
 

--- a/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
@@ -105,7 +105,6 @@
               />
             </el-col>
             <el-col
-              v-if="features.advanced_ds_config || features.v2"
               :span="8"
             >
               <popup-anchor

--- a/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/sections/MetaspaceOptionsSection.vue
@@ -124,15 +124,6 @@
                   @input="val => onInput('analysisVersion', val)"
                 />
               </popup-anchor>
-              <form-field
-                v-if="features.advanced_ds_config"
-                type="select"
-                name="Scoring model"
-                :value="value.scoringModel || ''"
-                :error="error && error.scoringModel"
-                :options="scoringModelOptions"
-                @input="val => onInput('scoringModel', val ? val : null)"
-              />
             </el-col>
           </el-row>
           <el-row
@@ -281,10 +272,8 @@ export default class MetaspaceOptionsSection extends Vue {
     chemModOptions: string[] = [];
 
     get analysisVersionOptions() {
-      const showV15 = config.features.advanced_ds_config || this.value.analysisVersion === 2
       return [
         { value: 1, label: 'v1 (Original MSM)' },
-        ...(showV15 ? [{ value: 2, label: 'v1.5 (Prototype for higher RPs)' }] : []),
         { value: 3, label: 'v2 (ML-powered MSM)' },
       ]
     }


### PR DESCRIPTION
### Description

Changed diagnostics ML label and removed analysis version from update page #1370

<img width="862" alt="image" src="https://github.com/metaspace2020/metaspace/assets/35172605/7e6d5c8c-f116-40fc-947e-d1a926afa818">
<img width="1048" alt="image" src="https://github.com/metaspace2020/metaspace/assets/35172605/e57f6be1-65c5-4887-b41b-ca6b8c833d83">
<img width="1532" alt="image" src="https://github.com/metaspace2020/metaspace/assets/35172605/dad3b388-277c-4218-b588-07ba74945a3f">

