### PR TITLE
Hide unused source on Detectability

### DIFF
--- a/metaspace/webapp/src/modules/SpottingProject/DashboardPage.tsx
+++ b/metaspace/webapp/src/modules/SpottingProject/DashboardPage.tsx
@@ -987,8 +987,6 @@ export default defineComponent({
                 handleDataSrcChange(text)
               }}>
               <RadioButton label='EMBL'/>
-              <RadioButton label='ALL'/>
-              <RadioButton label='INTERLAB'/>
             </RadioGroup>
           </div>
 


### PR DESCRIPTION
### Description

Removed unused data source tabs from Detectability

<img width="1528" alt="image" src="https://github.com/metaspace2020/metaspace/assets/35172605/f7fb907c-1bdd-4ea4-903c-1fc36e7414e0">
