### PR TITLE
Fixed custom db pixel intensities download

### DIFF
--- a/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
+++ b/metaspace/webapp/src/modules/Annotations/AnnotationTable.vue
@@ -1263,15 +1263,19 @@ export default Vue.extend({
           offset += 1
           this.exportProgress = offset / totalCount
           const annotation = resp.data.allAnnotations[i]
-          const { cols, row, dsName } = await formatIntensitiesRow(annotation,
-            this.isNormalized
-              ? this.$store.state.normalization : undefined)
-          if (!fileCols) {
-            fileCols = formatCsvRow(cols)
-            fileName = `${dsName.replace(/\s/g, '_')}_pixel_intensities${this.isNormalized
-              ? '_tic_normalized' : ''}.csv`
+          try {
+            const { cols, row, dsName } = await formatIntensitiesRow(annotation,
+              this.isNormalized
+                ? this.$store.state.normalization : undefined)
+            if (!fileCols) {
+              fileCols = formatCsvRow(cols)
+              fileName = `${dsName.replace(/\s/g, '_')}_pixel_intensities${this.isNormalized
+                ? '_tic_normalized' : ''}.csv`
+            }
+            rows += formatCsvRow(row)
+          } catch (e) {
+            // pass when fail to convert png
           }
-          rows += formatCsvRow(row)
         }
       }
 

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
@@ -580,15 +580,19 @@ export default defineComponent<DatasetComparisonPageProps>({
           const annotation : any = currentAnnotations[i]
           offset += 1
           state.exportProgress = offset / totalCount
-          const { cols, row, dsName } = await formatIntensitiesRow(annotation,
-            state.globalImageSettings.isNormalized
-              ? state.normalizationData[annotation.dataset.id] : undefined)
-          if (!fileCols) {
-            fileCols = formatCsvRow(cols)
-            fileName = `${dsName.replace(/\s/g, '_')}_pixel_intensities${state.globalImageSettings.isNormalized
-              ? '_tic_normalized' : ''}.csv`
+          try {
+            const { cols, row, dsName } = await formatIntensitiesRow(annotation,
+              state.globalImageSettings.isNormalized
+                ? state.normalizationData[annotation.dataset.id] : undefined)
+            if (!fileCols) {
+              fileCols = formatCsvRow(cols)
+              fileName = `${dsName.replace(/\s/g, '_')}_pixel_intensities${state.globalImageSettings.isNormalized
+                ? '_tic_normalized' : ''}.csv`
+            }
+            rows += formatCsvRow(row)
+          } catch (e) {
+            // pass when fail to convert png
           }
-          rows += formatCsvRow(row)
         }
 
         if (state.isExporting) {


### PR DESCRIPTION
### Description

Fixed bug where pixel intensities download was failing with custom db annotated  datasets, as some of the images are null #1375 

#### How to test
1 - Go to the annotation or dataset comparison page
2 - Set db filter to a custom db
3 - Download pixel intensities

