### PR TITLE
Change the time before restart lithops daemon

### DIFF
--- a/ansible/roles/sm_lithops_daemon/templates/sm-lithops-daemon.supervisor.j2
+++ b/ansible/roles/sm_lithops_daemon/templates/sm-lithops-daemon.supervisor.j2
@@ -4,7 +4,7 @@
 process_name = {{ sm_lithops_daemon_app_name }}-%(process_num)s
 environment = PATH="{{ miniconda_prefix }}/envs/{{ miniconda_env.name }}/bin"
 directory = {{ sm_home }}
-command = {{ miniconda_prefix }}/envs/{{ miniconda_env.name }}/bin/python scripts/run_sm_daemon.py --name=lithops --exit-after 86400
+command = {{ miniconda_prefix }}/envs/{{ miniconda_env.name }}/bin/python scripts/run_sm_daemon.py --name=lithops --exit-after 21600
 redirect_stderr = true
 stdout_logfile = {{ sm_home }}/logs/{{ sm_lithops_daemon_app_name }}-%(process_num)s.log
 numprocs = {{ sm_lithops_daemon_nprocs }}


### PR DESCRIPTION
Historically, we have a memory leak in the lithops daemon, so we restarted that daemon every 24 hours. Now we process much more datasets per day, so sometimes these daemons use all RAM, and we have out of memory for other processes.

**Solution**: change the time between restarts from 24 to 6 hours