### PR TITLE
[Detectability] Added source tabs handled by group permission

### DIFF
--- a/metaspace/engine/scripts/db_schema.sql
+++ b/metaspace/engine/scripts/db_schema.sql
@@ -73,6 +73,14 @@ CREATE TABLE "graphql"."user_group" (
   "group_id")
 );
 
+CREATE TABLE "graphql"."group_detectability" (
+  "id" uuid NOT NULL, 
+  "group_id" uuid NOT NULL, 
+  "source" text NOT NULL, 
+  CONSTRAINT "PK_8f4a4b179d5827ec371b10cdae2" PRIMARY KEY ("id", 
+  "group_id")
+);
+
 CREATE TABLE "graphql"."project" (
   "id" uuid NOT NULL DEFAULT uuid_generate_v1mc(), 
   "name" text NOT NULL, 
@@ -398,6 +406,10 @@ ALTER TABLE "graphql"."user_group" ADD CONSTRAINT "FK_24850e25a096ba62e57cf5caf4
 ) ON DELETE NO ACTION ON UPDATE NO ACTION;
 
 ALTER TABLE "graphql"."user_group" ADD CONSTRAINT "FK_3c213a8a5e3ac56e0882320af43" FOREIGN KEY (
+  "group_id") REFERENCES "graphql"."group"("id"
+) ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+ALTER TABLE "graphql"."group_detectability" ADD CONSTRAINT "FK_e065ed4e907d768e8cfbfd00937" FOREIGN KEY (
   "group_id") REFERENCES "graphql"."group"("id"
 ) ON DELETE NO ACTION ON UPDATE NO ACTION;
 

--- a/metaspace/graphql/schemas/group.graphql
+++ b/metaspace/graphql/schemas/group.graphql
@@ -7,6 +7,7 @@ type Group {
   hasPendingRequest: Boolean  # null if current user is not allowed to see
   numMembers: Int!
   members: [UserGroup!]    # null if current user is not allowed to see
+  sources: [GroupDetectability!]
   groupDescriptionAsHtml: String
   molecularDatabases: [MolecularDB!]
   numDatabases: Int!
@@ -38,11 +39,24 @@ type UserGroup {
   numDatasets: Int!
 }
 
+
 enum UserGroupRole {
   INVITED    # User was invited into the group but hasn't confirmed it yet
   PENDING    # User requested to join the group but the PI hasn't confirmed it yet
   MEMBER     # Normal member of the group
   GROUP_ADMIN    # Group administrator
+}
+
+# Many-to-many relationship between Group and Detectability sources
+type GroupDetectability {
+  group: Group!
+  source: UserGroupSource!
+}
+
+enum UserGroupSource {
+  EMBL
+  ALL
+  INTERLAB
 }
 
 type Query {

--- a/metaspace/graphql/src/migrations/1689063013083-DetectabilityPermission.ts
+++ b/metaspace/graphql/src/migrations/1689063013083-DetectabilityPermission.ts
@@ -1,0 +1,15 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class DetectabilityPermission1689063013083 implements MigrationInterface {
+    name = 'DetectabilityPermission1689063013083'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "graphql"."group_detectability" ("id" SERIAL NOT NULL PRIMARY KEY,  "group_id" uuid REFERENCES "graphql"."group"("id") ON DELETE CASCADE ON UPDATE NO ACTION, "source" text NOT NULL UNIQUE)`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "graphql"."group_detectability"`);
+    }
+
+
+}

--- a/metaspace/graphql/src/modules/group/controller.ts
+++ b/metaspace/graphql/src/modules/group/controller.ts
@@ -1,7 +1,7 @@
 import { UserError } from 'graphql-errors'
 import { EntityManager, In } from 'typeorm'
 
-import { Group as GroupModel, UserGroup as UserGroupModel, UserGroupRoleOptions } from './model'
+import { Group as GroupModel, GroupDetectability, UserGroup as UserGroupModel, UserGroupRoleOptions } from './model'
 import { User as UserModel } from '../user/model'
 import { Dataset as DatasetModel } from '../dataset/model'
 import { MolecularDB as MolecularDbModel } from '../moldb/model'
@@ -159,6 +159,14 @@ export const Resolvers = {
         ...ug,
         user: { ...ug.user, scopeRole },
       }))
+    },
+
+    async sources(group: GroupModel, _: any, ctx: Context): Promise<any> {
+      const groupSourcesModels = await ctx.entityManager.getRepository(GroupDetectability)
+        .createQueryBuilder('group_detectability')
+        .where({ groupId: group.id })
+        .getMany()
+      return groupSourcesModels
     },
 
     async molecularDatabases(group: GroupModel, args: any, ctx: Context): Promise<MolecularDbModel[]> {

--- a/metaspace/graphql/src/modules/group/model.ts
+++ b/metaspace/graphql/src/modules/group/model.ts
@@ -38,6 +38,9 @@ export class Group {
   @OneToMany(() => UserGroup, userGroup => userGroup.group)
   members: UserGroup[];
 
+  @OneToMany(() => GroupDetectability, groupDetectability => groupDetectability.group)
+  sources: GroupDetectability[];
+
   @OneToMany(() => MolecularDB, molecularDB => molecularDB.group)
   molecularDBs: MolecularDB[];
 }
@@ -67,8 +70,26 @@ export class UserGroup {
   @Column({ default: true })
   primary: boolean;
 }
+@Entity('group_detectability')
+export class GroupDetectability {
+  @PrimaryColumn({ type: 'uuid' })
+  id: string;
+
+  @PrimaryColumn({ type: 'uuid' })
+  groupId: string;
+
+  @ManyToOne(() => Group)
+  @JoinColumn({ name: 'group_id' })
+  group: Group;
+
+  @Column({ type: 'text', enum: ['EMBL'] })
+  source: 'EMBL' |
+    'ALL' |
+    'INTERLAB';
+}
 
 export const GROUP_ENTITIES = [
   Group,
   UserGroup,
+  GroupDetectability,
 ]

--- a/metaspace/webapp/src/api/user.ts
+++ b/metaspace/webapp/src/api/user.ts
@@ -187,6 +187,24 @@ export const currentUserRoleWithGroupQuery =
           }
         }`
 
+export const currentUserWithGroupDetectabilityQuery =
+  gql`query MyGroupOptions {
+          currentUser {
+            id,
+            name,
+            groups {
+              group {
+                id
+                value: id
+                label: name
+                sources {
+                  source
+                }
+              }
+            }
+          }
+        }`
+
 export const countUsersQuery =
 gql`query countUsers {
   countUsers

--- a/metaspace/webapp/src/modules/SpottingProject/DashboardPage.scss
+++ b/metaspace/webapp/src/modules/SpottingProject/DashboardPage.scss
@@ -10,7 +10,7 @@ $filter-color: #828282;
   margin-top: 0;
 
   .files-link{
-    display: flex;
+    display: none;
     justify-content: center;
     align-items: center;
     color: blue;


### PR DESCRIPTION
### Description

Added source tabs to the Detectability page given user group permission #1387   

#### How to test
1 - Add a group to group_detectability table
2 - Access detectability page logged as user in the added group

<img width="1536" alt="image" src="https://github.com/metaspace2020/metaspace/assets/35172605/68977490-e8bf-4e23-bc9a-691ae3ae08ff">

