### PR TITLE
Feat/txt search special char bug

### DIFF
--- a/metaspace/graphql/esConnector.ts
+++ b/metaspace/graphql/esConnector.ts
@@ -433,7 +433,6 @@ const constructSimpleQueryFilter = (simpleQuery: string) => {
   return {
     simple_query_string: {
       query: simpleQuery,
-      fields: ['_all', 'ds_name.searchable'],
       default_operator: 'and',
     },
   }

--- a/metaspace/graphql/esConnector.ts
+++ b/metaspace/graphql/esConnector.ts
@@ -432,8 +432,9 @@ const constructAnnotationFilters = (filter: AnnotationFilter & ExtraAnnotationFi
 const constructSimpleQueryFilter = (simpleQuery: string) => {
   return {
     simple_query_string: {
-      query: `${simpleQuery}*`,
-      flags: 'OR|PREFIX',
+      query: simpleQuery,
+      fields: ['_all', 'ds_name.searchable'],
+      default_operator: 'and',
     },
   }
 }


### PR DESCRIPTION
### Description

Revert default_operator strategy the free text filter, as some dataset names filters were not working (i.e '_lip_')
