### PR TITLE
Handling deleted dbs on dataset reprocessing

### DIFF
--- a/metaspace/engine/sm/engine/annotation_lithops/annotation_job.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/annotation_job.py
@@ -329,6 +329,7 @@ class ServerAnnotationJob:
                 moldb_to_job_map[moldb_id] = insert_running_job(self.ds.id, moldb_id)
             except Exception:  # db does not exist, continue to next
                 moldb_to_be_removed.append(moldb_id)
+                logger.warning(f'Removed db {moldb_id} from {self.ds.id}')
                 continue
 
         if len(moldb_to_be_removed) > 0:  # remove non-existing moldbs from ds


### PR DESCRIPTION
### Description

Checking if db exists before starting annotation process, as deleted dbs were triggering errors if not checked #1406

## How to test it
1 - Annotate dataset with a custom db
2 - Delete custom db
3 - Reprocess dataset 