### PR TITLE
Added copy optical image to python client

### DIFF
--- a/metaspace/graphql/schemas/dataset.graphql
+++ b/metaspace/graphql/schemas/dataset.graphql
@@ -434,6 +434,8 @@ type Mutation {
 
   addOpticalImage(input: AddOpticalImageInput!): String!
 
+  copyRawOpticalImage(originDatasetId: String!, destinyDatasetId: String!): String!
+
   addRoi(datasetId: String!, geoJson: GeoJson!): String
 
   deleteOpticalImage(datasetId: String!): String!

--- a/metaspace/graphql/src/modules/system/addApiKeyInterceptorToSchema.ts
+++ b/metaspace/graphql/src/modules/system/addApiKeyInterceptorToSchema.ts
@@ -10,6 +10,7 @@ const ALLOWED_MUTATIONS = new Set([
   'deleteDataset',
   'reprocessDataset',
   'addOpticalImage',
+  'copyRawOpticalImage',
   'addRoi',
   'deleteOpticalImage',
   'createProject',

--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.0.4'
+__version__ = '2.0.5'
 
 from metaspace.sm_annotation_utils import (
     SMInstance,

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -2032,6 +2032,37 @@ class SMInstance(object):
         )
         return result['addDatasetExternalLink']['externalLinks']
 
+    def get_optical_image_transform(self, dataset_id: str):
+        """
+        Get optical image transform matrix
+
+        matrix3d(${t[0][0]}, ${t[1][0]}, 0, ${t[2][0]},
+             ${t[0][1]}, ${t[1][1]}, 0, ${t[2][1]},
+                      0,          0, 1,          0,
+             ${t[0][2]}, ${t[1][2]}, 0, ${t[2][2]})
+
+        >>> sm.get_optical_image_transform(
+        >>>     dataset_id='2018-11-07_14h15m28s',
+        >>> )
+
+        :param dataset_id:
+        :return: Returns matrix 3d values
+        """
+        return self._gqclient.getRawOpticalImage(dataset_id)['rawOpticalImage']['transform']
+
+    def get_optical_image_path(self, dataset_id: str):
+        """
+        Get optical image file path
+
+        >>> sm.get_optical_image_path(
+        >>>     dataset_id='2018-11-07_14h15m28s',
+        >>> )
+
+        :param dataset_id:
+        :return: Returns src path
+        """
+        return self._gqclient.getRawOpticalImage(dataset_id)['rawOpticalImage']['url']
+
     def copy_optical_image(self, origin_dataset_id: str, destiny_dataset_id: str):
         """
         Copies an optical image from a dataset to another
@@ -2041,12 +2072,12 @@ class SMInstance(object):
         >>>     destiny_dataset_id='2018-11-07_14h15m30s',
         >>> )
 
-        :param origin_dataset_id: The dataset ID of the origin dataset with the optical image to be copied
-        :param destiny_dataset_id: The dataset ID from the dataset to where the optical image will be copied to
+        :param origin_dataset_id:
+            The dataset ID of the origin dataset with the optical image to be copied
+        :param destiny_dataset_id:
+            The dataset ID from the dataset to where the optical image will be copied to
         :return: The updated list of external links
         """
-
-        origin_opt_img = self._gqclient.getRawOpticalImage(origin_dataset_id)['rawOpticalImage']
 
         query = """
             mutation addOpticalImage($imageUrl: String!,
@@ -2057,8 +2088,8 @@ class SMInstance(object):
         """
         variables = {
             'datasetId': destiny_dataset_id,
-            'imageUrl': origin_opt_img['url'],
-            'transform': origin_opt_img['transform'],
+            'imageUrl': self.get_optical_image_path(origin_dataset_id),
+            'transform': self.get_optical_image_transform(origin_dataset_id),
         }
 
         return self._gqclient.query(query, variables)['addOpticalImage']

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -2079,6 +2079,20 @@ class SMInstance(object):
         :return: The updated list of external links
         """
 
+        copy_file_query = """
+            mutation copyRawOpticalImage($originDatasetId: String!,
+                $destinyDatasetId: String!) {
+                copyRawOpticalImage(originDatasetId: $originDatasetId, 
+                    destinyDatasetId: $destinyDatasetId)
+              }
+        """
+        copy_variables = {
+            'originDatasetId': origin_dataset_id,
+            'destinyDatasetId': destiny_dataset_id,
+        }
+
+        copied_file = self._gqclient.query(copy_file_query, copy_variables)['copyRawOpticalImage']
+
         query = """
             mutation addOpticalImage($imageUrl: String!,
                 $datasetId: String!, $transform: [[Float]]!) {
@@ -2086,9 +2100,10 @@ class SMInstance(object):
                                         imageUrl: $imageUrl, transform: $transform})
               }
         """
+
         variables = {
             'datasetId': destiny_dataset_id,
-            'imageUrl': self.get_optical_image_path(origin_dataset_id),
+            'imageUrl': copied_file,
             'transform': self.get_optical_image_transform(origin_dataset_id),
         }
 

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -2032,6 +2032,37 @@ class SMInstance(object):
         )
         return result['addDatasetExternalLink']['externalLinks']
 
+    def copy_optical_image(self, origin_dataset_id: str, destiny_dataset_id: str):
+        """
+        Copies an optical image from a dataset to another
+
+        >>> sm.copy_optical_image(
+        >>>     origin_dataset_id='2018-11-07_14h15m28s',
+        >>>     destiny_dataset_id='2018-11-07_14h15m30s',
+        >>> )
+
+        :param origin_dataset_id: The dataset ID of the origin dataset with the optical image to be copied
+        :param destiny_dataset_id: The dataset ID from the dataset to where the optical image will be copied to
+        :return: The updated list of external links
+        """
+
+        origin_opt_img = self._gqclient.getRawOpticalImage(origin_dataset_id)['rawOpticalImage']
+
+        query = """
+            mutation addOpticalImage($imageUrl: String!,
+                $datasetId: String!, $transform: [[Float]]!) {
+                addOpticalImage(input: {datasetId: $datasetId,
+                                        imageUrl: $imageUrl, transform: $transform})
+              }
+        """
+        variables = {
+            'datasetId': destiny_dataset_id,
+            'imageUrl': origin_opt_img['url'],
+            'transform': origin_opt_img['transform'],
+        }
+
+        return self._gqclient.query(query, variables)['addOpticalImage']
+
     def remove_dataset_external_link(
         self, dataset_id: str, provider: str, link: Optional[str] = None
     ):


### PR DESCRIPTION
### Description

Added feature to python client, in which the user is able to copy an optical image and its transforms from one dataset to another #1410

## How to test it
1 - Update client
2 - Call the  copy_optical_image function
        >>> sm.copy_optical_image(
        >>>     origin_dataset_id='2018-11-07_14h15m28s',
        >>>     destiny_dataset_id='2018-11-07_14h15m30s',
        >>> )