### PR TITLE
Added one retry to ES update

### DIFF
--- a/metaspace/engine/sm/engine/daemons/dataset_manager.py
+++ b/metaspace/engine/sm/engine/daemons/dataset_manager.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import urllib.parse
+import time
 
 import boto3
 import elasticsearch
@@ -150,8 +151,10 @@ class DatasetManager:
     def update(self, ds, fields):
         try:
             self._es.update_ds(ds.id, fields)
-        except elasticsearch.ConflictError:  # tries to write to elasticsearch one more time
+        except elasticsearch.exceptions.ConflictError:
+            # tries to write to elasticsearch one more time
             self.logger.info(f'Problem updating ES for: {ds.id}, trying again...')
+            time.sleep(5)
             self._es.update_ds(ds.id, fields)
 
     def delete(self, ds):

--- a/metaspace/engine/sm/engine/daemons/dataset_manager.py
+++ b/metaspace/engine/sm/engine/daemons/dataset_manager.py
@@ -3,6 +3,7 @@ import logging
 import urllib.parse
 
 import boto3
+import elasticsearch
 from botocore.exceptions import ClientError
 from requests.api import post
 
@@ -147,7 +148,11 @@ class DatasetManager:
         ds.set_status(self._db, self._es, DatasetStatus.FINISHED)
 
     def update(self, ds, fields):
-        self._es.update_ds(ds.id, fields)
+        try:
+            self._es.update_ds(ds.id, fields)
+        except elasticsearch.ConflictError:  # tries to write to elasticsearch one more time
+            self.logger.info(f'Problem updating ES for: {ds.id}, trying again...')
+            self._es.update_ds(ds.id, fields)
 
     def delete(self, ds):
         """Delete all dataset related data."""


### PR DESCRIPTION
### Description

Retrying ElasticSearch update once more, in case a version conflict (elasticsearch.ConflictError) error is triggered. This error implies that the document has been modified since you last fetched or referenced it, but update_by_query  does not have the option  refresh='wait_for'  like the ES5, so a retry approach will be applied. #1412
