### PR TITLE
Linked to metaspace-converter in python client documentation.

### DIFF
--- a/metaspace/python-client/docs/source/index.rst
+++ b/metaspace/python-client/docs/source/index.rst
@@ -15,6 +15,14 @@ Applications:
     * Exploratory analysis of submitted data
     * Quick access to things hidden from web interface (such as location of files on S3 and other metadata)
 
+If you want to interact with or analyze METASPACE datasets through packages of the `scverse <https://doi.org/10.1038/s41587-023-01733-8>`_ ecosystem, 
+such as:
+`AnnData <https://anndata.readthedocs.io/en/stable/index.html>`_,
+`ScanPy <https://scanpy.readthedocs.io/en/stable/>`_,
+`SquidPy <https://squidpy.readthedocs.io/en/stable/index.html>`_ , or
+`SpatialData <https://spatialdata.scverse.org/en/latest/>`_, 
+have a look at our `METASPACE-converter <https://metaspace2020.github.io/metaspace-converter/>`_ python package.
+
 .. toctree::
    :maxdepth: 1
    :caption: Examples


### PR DESCRIPTION
With the new metaspace-converter package published, I added links in the python client documentation to the package to show this as another alternative to download/analyze metaspace datsets.