### PR TITLE
Duplication in python client documentation

### DIFF
--- a/metaspace/python-client/docs/source/content/examples/manage-custom-molecular-databases.ipynb
+++ b/metaspace/python-client/docs/source/content/examples/manage-custom-molecular-databases.ipynb
@@ -110,13 +110,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Using the new custom databases feature of Metaspace, you can create your own custom database as a TSV text file with just three fields: `id, name, formula`. Once created it will be available on your group page, in the \"Databases\" tab. You will be able to use this database on the dataset upload page alongside the Metaspace public databases for annotation of datasets."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {},

--- a/metaspace/python-client/docs/source/index.rst
+++ b/metaspace/python-client/docs/source/index.rst
@@ -15,6 +15,14 @@ Applications:
     * Exploratory analysis of submitted data
     * Quick access to things hidden from web interface (such as location of files on S3 and other metadata)
 
+If you want to interact with or analyze METASPACE datasets through packages of the `scverse <https://doi.org/10.1038/s41587-023-01733-8>`_ ecosystem, 
+such as:
+`AnnData <https://anndata.readthedocs.io/en/stable/index.html>`_,
+`ScanPy <https://scanpy.readthedocs.io/en/stable/>`_,
+`SquidPy <https://squidpy.readthedocs.io/en/stable/index.html>`_ , or
+`SpatialData <https://spatialdata.scverse.org/en/latest/>`_, 
+have a look at our `METASPACE-converter <https://metaspace2020.github.io/metaspace-converter/>`_ python package.
+
 .. toctree::
    :maxdepth: 1
    :caption: Examples


### PR DESCRIPTION
I found a duplication in the python client documentation: 
![image](https://github.com/metaspace2020/metaspace/assets/34072286/e632e16e-304f-4ae0-a536-a6f273cb81d3)
The same paragraph is written twice. I removed the duplication.