### PR TITLE
Add extra metrics for the off-sample service

### DIFF
--- a/metaspace/off-sample/docker/Dockerfile
+++ b/metaspace/off-sample/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
         libsm6 libxrender1 libxext6 \
         && \
     wget -O ~/get-pip.py \
-        https://bootstrap.pypa.io/get-pip.py && \
+        https://bootstrap.pypa.io/pip/3.6/get-pip.py && \
     python3.6 ~/get-pip.py && \
     ln -s /usr/bin/python3.6 /usr/local/bin/python3 && \
     ln -s /usr/bin/python3.6 /usr/local/bin/python && \
@@ -65,13 +65,11 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
         enum34 \
         pyyaml \
         typing \
-        scikit-learn \
+        scikit-learn==0.20.3 \
         && \
     $PIP_INSTALL \
-#        torch_nightly -f \
-#        https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html \
         https://download.pytorch.org/whl/cpu/torch-1.0.0-cp36-cp36m-linux_x86_64.whl \
-        torchvision \
+        torchvision==0.2.2 \
         fastai==1.0.48 \
         fastprogress==0.1.20 \
         && \
@@ -90,6 +88,8 @@ RUN apt-get -y update && apt-get install -y locales && locale-gen en_US.UTF-8 &&
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
+
+RUN pip install psutil
 
 WORKDIR /app
 COPY models ./models

--- a/metaspace/off-sample/docker/build_and_push.sh
+++ b/metaspace/off-sample/docker/build_and_push.sh
@@ -1,0 +1,13 @@
+if [[ $# -eq 0 ]] ; then
+  echo "Builds and pushes Docker Hub"
+  echo "Usage: $0 new_tag"
+  echo "e.g. $0 1.8.0 pushes to the official repository at "
+  echo "https://hub.docker.com/repository/docker/metaspace2020/off-sample"
+  exit 1
+fi
+
+WORKDIR=$PWD
+pushd ../
+docker build -f docker/Dockerfile -t "metaspace2020/off-sample:$1" .
+docker push "metaspace2020/off-sample:$1"
+popd

--- a/metaspace/off-sample/off_sample/resources.py
+++ b/metaspace/off-sample/off_sample/resources.py
@@ -31,8 +31,10 @@ def cpu_ram_consumption(run, metrics, pid):
         start = round(time.time(), 3)
         cpu = psutil.cpu_percent(percpu=True)
         memory = psutil.virtual_memory()
-        inference_rss_mb = inference_process.memory_info().rss / 1024.0**2
-        metrics.append({start: {'cpu': cpu, 'memory': memory.percent, 'inf_rss_mb': int(inference_rss_mb)}})
+        inference_rss_mb = inference_process.memory_info().rss / 1024.0 ** 2
+        metrics.append(
+            {start: {'cpu': cpu, 'memory': memory.percent, 'inf_rss_mb': int(inference_rss_mb)}}
+        )
         time.sleep(1.0)
 
 
@@ -65,7 +67,7 @@ class PredictResource:
                 'batch_id': req_doc['batch_id'],
                 'n_images': len(req_doc['images']),
                 'start_ts': round(start, 3),
-                'deserialization_time': round(time.time() - start, 3)
+                'deserialization_time': round(time.time() - start, 3),
             }
 
             start = time.time()

--- a/metaspace/off-sample/off_sample/resources.py
+++ b/metaspace/off-sample/off_sample/resources.py
@@ -3,6 +3,9 @@ import json
 from os.path import getmtime
 import shutil
 import socket
+import time
+import psutil
+from multiprocessing import Manager, Process
 from datetime import datetime as dt
 from pathlib import Path
 from uuid import uuid4
@@ -11,6 +14,26 @@ import falcon
 from off_sample.model import OffSamplePredictModel
 from off_sample.utils import logger
 from off_sample.config import config
+
+
+def predict(model, image_paths, run, pred_list):
+    path = Path(image_paths[0]).parent
+    logger.info(f'Running model on {len(image_paths)} images in {path}')
+    probs, labels = model.predict(image_paths)
+    pred_list_ = [{'prob': float(prob), 'label': label} for prob, label in zip(probs, labels)]
+    pred_list.extend(pred_list_)
+    run.clear()
+
+
+def cpu_ram_consumption(run, metrics, pid):
+    inference_process = psutil.Process(pid)
+    while run.is_set():
+        start = round(time.time(), 3)
+        cpu = psutil.cpu_percent(percpu=True)
+        memory = psutil.virtual_memory()
+        inference_rss_mb = inference_process.memory_info().rss / 1024.0**2
+        metrics.append({start: {'cpu': cpu, 'memory': memory.percent, 'inf_rss_mb': int(inference_rss_mb)}})
+        time.sleep(1.0)
 
 
 class PredictResource:
@@ -32,23 +55,44 @@ class PredictResource:
             image_paths.append(image_path)
         return image_paths
 
-    def predict(self, image_paths):
-        path = Path(image_paths[0]).parent
-        logger.info(f'Running model on {len(image_paths)} images in {path}')
-        probs, labels = self.model.predict(image_paths)
-        pred_list = [{'prob': float(prob), 'label': label} for prob, label in zip(probs, labels)]
-        return {'predictions': pred_list}
-
     def on_post(self, req, resp):
         path = None
         try:
+            start = time.time()
             req_doc = json.load(req.bounded_stream)
+            perf = {
+                'ds_id': req_doc['ds_id'],
+                'batch_id': req_doc['batch_id'],
+                'n_images': len(req_doc['images']),
+                'start_ts': round(start, 3),
+                'deserialization_time': round(time.time() - start, 3)
+            }
+
+            start = time.time()
             path = self.data_path / str(uuid4())
             path.mkdir()
             image_paths = self.save_images(req_doc, path)
+            perf['save_images_time'] = round(time.time() - start, 3)
 
-            resp_doc = self.predict(image_paths)
-            resp.body = json.dumps(resp_doc)
+            start = time.time()
+            manager = Manager()
+            metrics = manager.list()
+            resp_list = manager.list()
+            run = manager.Event()
+            run.set()
+
+            process_1 = Process(target=predict, args=(self.model, image_paths, run, resp_list))
+            process_1.start()
+            process_2 = Process(target=cpu_ram_consumption, args=(run, metrics, process_1.pid))
+            process_2.start()
+            process_1.join()
+            process_2.join()
+
+            perf['predict'] = round(time.time() - start, 3)
+            perf['metrics'] = [m for m in metrics]
+            perf['end_ts'] = round(time.time(), 3)
+            logger.info(f'Perf: {perf}')
+            resp.body = json.dumps({'predictions': [r for r in resp_list]})
         except IOError as e:
             logger.error(e, exc_info=True)
             raise falcon.HTTPError('500')


### PR DESCRIPTION
1. Updated the Dockerfile and the script to build the image and push it to DockerHub.
2. In `off_sample_wrapper.py` added logging and forwarding `ds_id` and `batch_id` in off-sample service.
3. In `resources.py`, `predict()` and `cpu_ram_consumption()` are now run in separate processes. The last function collects metrics once per second: CPU, memory consumption, [RSS](https://en.wikipedia.org/wiki/Resident_set_size) by predict process. All of this data is logged for each batch in CloudWatch.