### PR TITLE
[Detectability] Fixed subclass disabled

### DIFF
--- a/metaspace/webapp/src/modules/SpottingProject/DashboardPage.tsx
+++ b/metaspace/webapp/src/modules/SpottingProject/DashboardPage.tsx
@@ -86,7 +86,7 @@ const ALLOWED_COMBINATIONS: any = {
     'Metabolic pathway': ['Adducts', 'Dataset id', 'Sample name', 'MALDI matrix', 'Neutral losses',
       'Polarity'],
     Polarity: ['Adducts', 'Chemical class', 'MALDI matrix', 'Molecule', 'Neutral losses',
-      'Metabolic pathway group', 'Metabolic pathway'],
+      'Metabolic pathway group', 'Metabolic pathway', 'Chemical subclass'],
     'Chemical subclass': ['Adducts', 'Dataset id', 'Sample name', 'MALDI matrix', 'Neutral losses', 'Polarity'],
     'Ionisation source': ['Adducts', 'Chemical class', 'Neutral losses', 'Metabolic pathway group',
       'Metabolic pathway', 'Chemical subclass'],


### PR DESCRIPTION
### Description

Fixed bug where subclass source was disabled when polarity selected as x class on EMBL source


bug:
<img width="413" alt="image" src="https://github.com/metaspace2020/metaspace/assets/35172605/191898d4-3e9e-4a43-8324-41b9423e7efc">
