### PR TITLE
Bump version of python-client

### DIFF
--- a/metaspace/python-client/metaspace/__init__.py
+++ b/metaspace/python-client/metaspace/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.0.6'
+__version__ = '2.0.7'
 
 from metaspace.sm_annotation_utils import (
     SMInstance,


### PR DESCRIPTION
We forgot to upgrade python-client after the last PR:
1. #1456 
2. #1453