### PR TITLE
Update python-client action workflow

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build_and_deploy:
-    - name: Create and publish package to PyPI
+      name: Create and publish package to PyPI
       runs-on: ubuntu-latest
 
     environment:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -5,8 +5,8 @@ on:
 
 jobs:
   build_and_deploy:
-      name: Create and publish package to PyPI
-      runs-on: ubuntu-latest
+    name: Create and publish package to PyPI
+    runs-on: ubuntu-latest
 
     environment:
       name: pypi

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,7 +1,6 @@
 name: Publish python-client
 
-on:
-  workflow_dispatch:  # Manual trigger
+on: workflow_dispatch  # Manual trigger
 
 jobs:
   build_and_deploy:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -4,8 +4,14 @@ on:
   workflow_dispatch:  # Manual trigger
 
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
+  build_and_deploy:
+    - name: Create and publish package to PyPI
+      runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/metaspace
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -7,20 +7,27 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.8'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+
     - name: Build and publish
       working-directory: ./metaspace/python-client
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*
+
+    - name: Publish package on PyPI
+      user: pypa/gh-action-pypi-publish@v1.8.11
+      with:
+        user: __token__
+        password: ${{ secrets.PYTHON_CLIENT_PYPI_API_TOKEN }}

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -27,10 +27,14 @@ jobs:
 
     - name: Build and publish
       working-directory: ./metaspace/python-client
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYTHON_CLIENT_PYPI_API_TOKEN }}
       run: |
         python setup.py sdist bdist_wheel
+        twine upload dist/*
 
-    - name: Publish package on PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.10
-      with:
-        password: ${{ secrets.PYTHON_CLIENT_PYPI_API_TOKEN }}
+#    - name: Publish package on PyPI
+#      uses: pypa/gh-action-pypi-publish@v1.8.10
+#      with:
+#        password: ${{ secrets.PYTHON_CLIENT_PYPI_API_TOKEN }}

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -7,9 +7,9 @@ jobs:
     name: Create and publish package to PyPI
     runs-on: ubuntu-latest
 
-#    environment:
-#      name: pypi
-#      url: https://pypi.org/p/metaspace
+    environment:
+      name: pypi
+      url: https://pypi.org/p/metaspace
 
     steps:
     - name: Checkout repository
@@ -29,11 +29,8 @@ jobs:
       working-directory: ./metaspace/python-client
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
 
     - name: Publish package on PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.11
+      uses: pypa/gh-action-pypi-publish@v1.8.10
       with:
-        user: __token__
         password: ${{ secrets.PYTHON_CLIENT_PYPI_API_TOKEN }}
-        verbose: true

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -32,7 +32,7 @@ jobs:
         twine upload dist/*
 
     - name: Publish package on PyPI
-      user: pypa/gh-action-pypi-publish@v1.8.11
+      uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         user: __token__
         password: ${{ secrets.PYTHON_CLIENT_PYPI_API_TOKEN }}

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -34,4 +34,6 @@ jobs:
     - name: Publish package on PyPI
       uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
+        user: __token__
         password: ${{ secrets.PYTHON_CLIENT_PYPI_API_TOKEN }}
+        verbose: true

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -7,9 +7,9 @@ jobs:
     name: Create and publish package to PyPI
     runs-on: ubuntu-latest
 
-    environment:
-      name: pypi
-      url: https://pypi.org/p/metaspace
+#    environment:
+#      name: pypi
+#      url: https://pypi.org/p/metaspace
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -34,5 +34,4 @@ jobs:
     - name: Publish package on PyPI
       uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
-        user: __token__
         password: ${{ secrets.PYTHON_CLIENT_PYPI_API_TOKEN }}

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -7,10 +7,6 @@ jobs:
     name: Create and publish package to PyPI
     runs-on: ubuntu-latest
 
-    environment:
-      name: pypi
-      url: https://pypi.org/p/metaspace
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -33,8 +29,3 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*
-
-#    - name: Publish package on PyPI
-#      uses: pypa/gh-action-pypi-publish@v1.8.10
-#      with:
-#        password: ${{ secrets.PYTHON_CLIENT_PYPI_API_TOKEN }}


### PR DESCRIPTION
PyPI has disallowed the use of login and password, API_TOKEN should be used instead. What I did:
1. Created API_TOKEN for metaspace2020 package on PyPI and added it to GitHub secrets.
2. Changed the authorization for twine package.
3. Updated the `action/checkout` and `actions/setup-python` versions because they were outdated.