### PR TITLE
Cost calculation script + cloudwatch bugfix

### DIFF
--- a/metaspace/engine/scripts/update_perf_profile_costs.py
+++ b/metaspace/engine/scripts/update_perf_profile_costs.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 from datetime import timedelta
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import boto3
 

--- a/metaspace/engine/scripts/update_perf_profile_costs.py
+++ b/metaspace/engine/scripts/update_perf_profile_costs.py
@@ -1,0 +1,62 @@
+import argparse
+import logging
+from datetime import timedelta
+from typing import Dict, List, Optional
+
+import boto3
+
+from sm.engine.db import DB
+from sm.engine.util import GlobalInit
+from sm.engine.postprocessing.cloudwatch import (
+    get_perf_profile_start_finish_datetime,
+    get_perf_profile_data,
+    get_aws_lambda_request_ids,
+    get_cloudwatch_logs,
+    extract_data_from_cloudwatch_logs,
+    calc_costs,
+    add_cost_to_perf_profile_entries
+)
+
+logger = logging.getLogger('engine')
+
+
+def get_costs(
+    cloudwatch_client: boto3.client, db: DB, log_groups: List[str], profile_id: int, time_delta: int
+) -> Dict[int, float]:
+    """Main function to calculate the cost per step for a given profile_id"""
+
+    start_dt, finish_dt = get_perf_profile_start_finish_datetime(db, profile_id)
+    if time_delta > 0:
+        finish_dt += timedelta(seconds=time_delta)
+    perf_profile_entries = get_perf_profile_data(db, profile_id)
+    aws_lambda_request_ids = get_aws_lambda_request_ids(perf_profile_entries)
+    cloudwatch_logs = get_cloudwatch_logs(
+        cloudwatch_client, log_groups, start_dt, finish_dt, aws_lambda_request_ids, verbose=True
+    )
+    request_ids_stat = extract_data_from_cloudwatch_logs(cloudwatch_logs)
+    costs = calc_costs(perf_profile_entries, request_ids_stat)
+
+    return costs
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Update dataset processing costs')
+    parser.add_argument('--config', default='conf/config.json', help='SM config path')
+    parser.add_argument('--profile-id', type=int, help='Profile ID')
+    parser.add_argument('--time-delta', type=int, default=0, help='Time delta in seconds')
+    parser.add_argument('--update-costs', type=bool, default=False, help='Update costs in Postgre')
+    args = parser.parse_args()
+
+    profile_id = args.profile_id
+
+    with GlobalInit(config_path=args.config) as sm_config:
+        db = DB()
+        cw_client = boto3.client('logs')
+        log_groups = sm_config['lithops']['aws_lambda']['cloudwatch_log_groups']
+
+        costs_by_step = get_costs(cw_client, db, log_groups, profile_id, args.time_delta)
+        logger.info(f'Total costs: ${round(sum(costs_by_step.values()), 4)}')
+
+        if args.update_costs:
+            logger.info('Updating costs ...')
+            add_cost_to_perf_profile_entries(db, costs_by_step)

--- a/metaspace/engine/scripts/update_perf_profile_costs.py
+++ b/metaspace/engine/scripts/update_perf_profile_costs.py
@@ -14,7 +14,7 @@ from sm.engine.postprocessing.cloudwatch import (
     get_cloudwatch_logs,
     extract_data_from_cloudwatch_logs,
     calc_costs,
-    add_cost_to_perf_profile_entries
+    add_cost_to_perf_profile_entries,
 )
 
 logger = logging.getLogger('engine')

--- a/metaspace/engine/sm/engine/annotation_lithops/executor.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/executor.py
@@ -88,7 +88,9 @@ def _save_subtask_perf(
         mem_usages = [int(f.stats.get('worker_peak_memory_end', -1) / 1024 ** 2) for f in futures]
         request_ids = [f.activation_id for f in futures]
         if isinstance(futures.executor, StandaloneExecutor):
-            instance_type = futures.executor.compute_handler.backend.master.get_instance_data()['InstanceType']
+            instance_type = futures.executor.compute_handler.backend.master.get_instance_data()[
+                'InstanceType'
+            ]
     else:
         # debug_run_locally=True doesn't make futures
         exec_times = [sum(perf.entries.values()) for perf in subtask_perfs]

--- a/metaspace/engine/sm/engine/daemons/dataset_manager.py
+++ b/metaspace/engine/sm/engine/daemons/dataset_manager.py
@@ -41,10 +41,9 @@ class DatasetManager:
         self._es: ESExporter = es
         self._status_queue = status_queue
         self.logger = logger or logging.getLogger()
+        self.costs = None
 
         if 'aws' in self._sm_config:
-            self.cost = None
-
             self.ses = boto3.client(
                 'ses',
                 'eu-west-1',
@@ -145,12 +144,12 @@ class DatasetManager:
         )
 
         # costs from Cloudwatch Logs
-        log_groups = self._sm_config['lithops']['aws_lambda'].get('cloudwatch_log_groups')
+        log_groups = self._sm_config['lithops'].get('aws_lambda', {}).get('cloudwatch_log_groups')
         if log_groups:
             costs_by_step = get_costs(self.cloudwatch, self._db, log_groups, profile_id)
             add_cost_to_perf_profile_entries(self._db, costs_by_step)
-            self.cost = round(sum(costs_by_step.values()), 4)
-            self.logger.info(f'Total costs: ${self.cost}')
+            self.costs = round(sum(costs_by_step.values()), 4)
+            self.logger.info(f'Total costs: ${self.costs}')
 
     def index(self, ds: Dataset):
         """Re-index all search results for the dataset.

--- a/metaspace/engine/sm/engine/daemons/lithops.py
+++ b/metaspace/engine/sm/engine/daemons/lithops.py
@@ -40,7 +40,8 @@ class LithopsDaemon:
         )
 
     def _on_success(self, msg):
-        msg['costs'] = f'${self._manager.cost}'
+        if self._manager.costs:
+            msg['costs'] = f'${self._manager.costs}'
         self.logger.info(' SM lithops daemon: success')
         self._manager.post_to_slack('dart', f' [v] Annotation succeeded: {json.dumps(msg)}')
 


### PR DESCRIPTION
1. Added script `update_perf_profile_costs.py`. This script allows you to calculate costs for those `perf_profile_entry` that were not calculated due to processing problems. You can also optionally save costs in PostgreSQL.
2. Fixed an error in `dataset_daemon.py` and `lithops.py` related to the `self.cost` variable.
3. Added information about `instance_type` to `perf_profile_entry` table for StandaloneExecutor.
4. In `cloudwatch.py` redesigned the logic of requests to cloudwatch. Now the entire time period is divided into 10-minute intervals. Details in the comments in the code.