### PR TITLE
Non deterministic behavior of np.random with ThereadPoolExecutor

### DIFF
--- a/metaspace/engine/sm/engine/annotation_lithops/build_moldb.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/build_moldb.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import logging
-from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
-from itertools import repeat
 from typing import List, Tuple, TypedDict, Optional, cast
 
 import numpy as np


### PR DESCRIPTION
### Overview
In the docker image that uses AWS Lambda via remote `/dev/shm`. The problem is explained in more detail [here](https://stackoverflow.com/questions/34005930/multiprocessing-semlock-is-not-implemented-when-running-on-aws-lambda). To work around this situation, when migrating to AWS, I changed `ProcessPoolExecutor` to `ThreadPoolExecutor`.
I didn't consider that in the case of `ThreadPoolExecutor` `numpy.random` would share between all threads running at the same time (see [Good practices with numpy random number generators](https://albertcthomas.github.io/good-practices-random-number-generators/)).

### Solution
Replaced `ThreadPoolExecutor` with the usual `for loop`.