### PR TITLE
Fixed typos in logs

### DIFF
--- a/metaspace/engine/sm/engine/annotation_lithops/run_enrichment.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/run_enrichment.py
@@ -76,8 +76,8 @@ def run_enrichment(results_dfs: Dict[int, pd.DataFrame]) -> Dict[int, pd.DataFra
 
         logger.info(
             (
-                f'Database ID: {moldb_id}, molecules = {len(molecules)}'
-                f'unique molecules = {len(mol_hash)}, metabolites = {len(metabolites)}'
+                f'Database ID: {moldb_id}, molecules = {len(molecules)}, '
+                f'unique molecules = {len(mol_hash)}, metabolites = {len(metabolites)}, '
                 f'time = {round(time.time() - start_time, 1)} s'
             )
         )


### PR DESCRIPTION
We have some typos (absence of spaces and commas between values) in logs:
```
2024-04-19 13:18:49,931 - INFO - annotation-pipeline[Thread-1] - run_enrichment.py:77 - Database ID: 22, molecules = 11020unique molecules = 3298, metabolites = 1630409time = 78.0 s
```