### PR TITLE
Fixed dataset comparison repeated dataset bug

### DIFF
--- a/metaspace/webapp/src/components/MultiChannelController/MultiChannelController.scss
+++ b/metaspace/webapp/src/components/MultiChannelController/MultiChannelController.scss
@@ -2,7 +2,6 @@
 .multi-channel-ctrl-wrapper{
   width: 185px;
   @apply py-3 bg-gray-100 rounded-lg box-border mr-1 overflow-x-hidden overflow-y-auto;
-  max-height: calc(100% - 1.5rem);
 
   .channel-popover{
     @apply w-11/12;

--- a/metaspace/webapp/src/components/MultiChannelController/MultiChannelController.tsx
+++ b/metaspace/webapp/src/components/MultiChannelController/MultiChannelController.tsx
@@ -13,19 +13,11 @@ import ChannelSelector from '../../modules/ImageViewer/ChannelSelector.vue'
 import ClippingNotice from '../../modules/ImageViewer/ClippingNotice.vue'
 import './MultiChannelController.scss'
 
-interface MultiChannelControllerProps {
-  menuItems: any[]
-  activeLayer: boolean
-  showClippingNotice: boolean
-  isNormalized: boolean
-  mode: string
-}
-
 interface MultiChannelControllerState {
   refsLoaded: boolean
 }
 
-export const MultiChannelController = defineComponent<MultiChannelControllerProps>({
+export const MultiChannelController = defineComponent({
   name: 'MultiChannelController',
   props: {
     menuItems: { type: Array, default: () => [] },

--- a/metaspace/webapp/src/components/SimpleIonImageViewer/SimpleIonImageViewer.tsx
+++ b/metaspace/webapp/src/components/SimpleIonImageViewer/SimpleIonImageViewer.tsx
@@ -14,29 +14,6 @@ import { cloneDeep, isEqual } from 'lodash'
 import { MultiChannelController } from '../MultiChannelController/MultiChannelController'
 import { useStore } from 'vuex'
 
-interface SimpleIonImageViewerProps {
-  isActive: boolean
-  resetViewPort: boolean
-  hideClipping: boolean
-  isNormalized: boolean
-  forceUpdate: boolean
-  keepPixelSelected: boolean
-  showOpticalImage: boolean
-  normalizationData: any
-  dataset: any
-  width: number
-  height: number
-  annotations: any[]
-  scaleType: string
-  scaleBarColor: string
-  colormap: string
-  lockedIntensityTemplate: string
-  globalLockedIntensities: [number | undefined, number | undefined]
-  channels: any[]
-  showChannels: boolean
-  imageTitle: string
-}
-
 interface ImageSettings {
   intensities: any
   ionImagePng: any
@@ -80,7 +57,7 @@ const channels: any = {
   white: 'rgb(255, 255, 255)',
 }
 
-export const SimpleIonImageViewer = defineComponent<SimpleIonImageViewerProps>({
+export const SimpleIonImageViewer = defineComponent({
   name: 'SimpleIonImageViewer',
   props: {
     annotations: { type: Array, default: () => [] },
@@ -126,7 +103,7 @@ export const SimpleIonImageViewer = defineComponent<SimpleIonImageViewerProps>({
       default: false,
     },
     normalizationData: {
-      type: Object,
+      type: Object as any,
       default: null,
     },
     globalLockedIntensities: {
@@ -134,7 +111,7 @@ export const SimpleIonImageViewer = defineComponent<SimpleIonImageViewerProps>({
       default: () => [undefined, undefined],
     },
     dataset: {
-      type: Object,
+      type: Object as any,
       default: () => {},
     },
     lockedIntensityTemplate: {
@@ -813,6 +790,8 @@ export const SimpleIonImageViewer = defineComponent<SimpleIonImageViewerProps>({
       const fileName = nonEmptyAnnotations[0]
         ? `${nonEmptyAnnotations[0]?.dataset?.id}_imzml_browser`.replace(/\./g, '_')
         : props.dataset.id
+      const hasOpticalImage = nonEmptyAnnotations[0]?.dataset?.opticalImages[0]?.url
+      const channelWrapperMaxHeight = height * (hasOpticalImage ? 0.7 : 0.9)
 
       if (!imageSettings || !imageSettings.ionImageLayers || !annotations) {
         return null
@@ -888,7 +867,7 @@ export const SimpleIonImageViewer = defineComponent<SimpleIonImageViewerProps>({
           <FadeTransition class="absolute top-0 right-0 mt-3 ml-3 dom-to-image-hidden">
             {imageSettings.userScaling && (
               <MultiChannelController
-                style={{ display: !props.showChannels ? 'none' : '' }}
+                style={{ display: !props.showChannels ? 'none' : '', maxHeight: `${channelWrapperMaxHeight}px` }}
                 showClippingNotice={!props.hideClipping && props.scaleType === 'linear'}
                 menuItems={mode.value === 'MULTI' ? state.menuItems : state.menuItems.slice(0, 1)}
                 mode={mode.value}

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
@@ -223,6 +223,7 @@ export const DatasetComparisonGrid = defineComponent({
       const settingPromises = Object.keys(auxGrid).map((key) => {
         const item = auxGrid[key]
         let dsIndex = selectedAnnotation ? selectedAnnotation.datasetIds.findIndex((dsId: string) => dsId === item) : -1
+
         const { annotations } = getChannels(item)
         state.singleAnnotationId[key] = dsIndex
         dsIndex = store.state.mode === 'MULTI' ? annotations.findIndex((item: any) => !item.isEmpty) : dsIndex
@@ -230,7 +231,6 @@ export const DatasetComparisonGrid = defineComponent({
         if (dsIndex !== -1) {
           const selectedIonAnnotation =
             store.state.mode === 'MULTI' ? annotations[dsIndex] : selectedAnnotation.annotations[dsIndex]
-
           state.annotationData[key] = selectedIonAnnotation
           return startImageSettings(key)
         } else {

--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonPage.tsx
@@ -207,7 +207,7 @@ export default defineComponent({
     const aggregateAnnotations = () => {
       const annotationsByIon = groupBy(state.rawAnnotations, 'ion')
       const processedAnnotations = Object.keys(annotationsByIon).map((ion: string) => {
-        const annotations: any = annotationsByIon[ion]
+        const annotations: any = uniqBy(annotationsByIon[ion], 'dataset.id')
         const dbId = annotations[0].databaseDetails.id
         const datasetIds = uniq(annotations.map((annotation: any) => annotation.dataset.id))
 

--- a/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonGrid.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/comparison/__snapshots__/DatasetComparisonGrid.spec.ts.snap
@@ -46,7 +46,7 @@ exports[`DatasetComparisonGrid > it should match snapshot 1`] = `
             </transition>
           </div>
           <transition mode=\\"out-in\\" enterclass=\\"opacity-0\\" leavetoclass=\\"opacity-0\\" enteractiveclass=\\"duration-150 transition-opacity ease-in-out\\" leaveactiveclass=\\"duration-150 transition-opacity ease-in-out\\" class=\\"absolute top-0 right-0 mt-3 ml-3 dom-to-image-hidden\\">
-            <div class=\\"multi-channel-ctrl-wrapper\\" style=\\"padding-bottom: 0px; padding-top: 0px;\\">
+            <div class=\\"multi-channel-ctrl-wrapper\\" style=\\"padding-bottom: 0px; padding-top: 0px; max-height: 270px;\\">
               <!---->
             </div>
           </transition>
@@ -96,7 +96,7 @@ exports[`DatasetComparisonGrid > it should match snapshot 1`] = `
             </transition>
           </div>
           <transition mode=\\"out-in\\" enterclass=\\"opacity-0\\" leavetoclass=\\"opacity-0\\" enteractiveclass=\\"duration-150 transition-opacity ease-in-out\\" leaveactiveclass=\\"duration-150 transition-opacity ease-in-out\\" class=\\"absolute top-0 right-0 mt-3 ml-3 dom-to-image-hidden\\">
-            <div class=\\"multi-channel-ctrl-wrapper\\" style=\\"padding-bottom: 0px; padding-top: 0px;\\">
+            <div class=\\"multi-channel-ctrl-wrapper\\" style=\\"padding-bottom: 0px; padding-top: 0px; max-height: 270px;\\">
               <!---->
             </div>
           </transition>

--- a/metaspace/webapp/src/modules/Group/ViewGroupPage.spec.ts
+++ b/metaspace/webapp/src/modules/Group/ViewGroupPage.spec.ts
@@ -152,7 +152,6 @@ describe('ViewGroupPage', () => {
           stubs: stubsWithMembersList,
         },
       })
-      await flushPromises()
       await nextTick()
 
       expect(wrapper.html()).toMatchSnapshot()
@@ -203,7 +202,6 @@ describe('ViewGroupPage', () => {
         },
       })
 
-      await flushPromises()
       await nextTick()
 
       expect(wrapper.html()).toMatchSnapshot()
@@ -230,7 +228,6 @@ describe('ViewGroupPage', () => {
         },
       })
 
-      await flushPromises()
       await nextTick()
 
       expect(wrapper.html()).toMatchSnapshot()
@@ -263,7 +260,6 @@ describe('ViewGroupPage', () => {
         },
       })
 
-      await flushPromises()
       await nextTick()
 
       expect(wrapper.html()).toMatchSnapshot()
@@ -290,7 +286,6 @@ describe('ViewGroupPage', () => {
         },
       })
 
-      await flushPromises()
       await nextTick()
 
       expect(wrapper.html()).toMatchSnapshot()
@@ -317,7 +312,6 @@ describe('ViewGroupPage', () => {
         },
       })
 
-      await flushPromises()
       await nextTick()
 
       expect(wrapper.html()).toMatchSnapshot()
@@ -383,7 +377,6 @@ describe('ViewGroupPage', () => {
         },
       })
 
-      await flushPromises()
       await nextTick()
 
       expect(wrapper.html()).toMatchSnapshot()
@@ -410,7 +403,6 @@ describe('ViewGroupPage', () => {
         },
       })
 
-      await flushPromises()
       await nextTick()
 
       expect(wrapper.html()).toMatchSnapshot()
@@ -437,7 +429,6 @@ describe('ViewGroupPage', () => {
         },
       })
 
-      await flushPromises()
       await nextTick()
 
       expect(wrapper.html()).toMatchSnapshot()

--- a/metaspace/webapp/src/modules/Group/__snapshots__/ViewGroupPage.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Group/__snapshots__/ViewGroupPage.spec.ts.snap
@@ -168,7 +168,7 @@ exports[`ViewGroupPage > members tab > should match snapshot (manager, including
           <!---->
           <div class=\\"el-tabs__nav-scroll\\">
             <div class=\\"el-tabs__nav is-top\\" style=\\"transform: translateX(-0px);\\" role=\\"tablist\\">
-              <div class=\\"el-tabs__active-bar is-top\\" style=\\"width: 0px; transform: translateX(NaNpx);\\"></div>
+              <div class=\\"el-tabs__active-bar is-top\\" style=\\"width: 0px; transform: translateX(0px);\\"></div>
               <div class=\\"el-tabs__item is-top\\" id=\\"tab-description\\" aria-controls=\\"pane-description\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\">Description
                 <!---->
               </div>
@@ -231,7 +231,7 @@ exports[`ViewGroupPage > members tab > should match snapshot (manager, including
       </div>
     </div>
   </div>
-  <div class=\\"el-loading-mask el-loading-fade-enter-from el-loading-fade-enter-active\\" style=\\"\\">
+  <div class=\\"el-loading-mask\\" style=\\"display: none;\\">
     <div class=\\"el-loading-spinner\\"><svg class=\\"circular\\" viewBox=\\"0 0 50 50\\">
         <circle class=\\"path\\" cx=\\"25\\" cy=\\"25\\" r=\\"20\\" fill=\\"none\\"></circle>
       </svg>
@@ -264,7 +264,7 @@ exports[`ViewGroupPage > members tab > should match snapshot (member) 1`] = `
           <!---->
           <div class=\\"el-tabs__nav-scroll\\">
             <div class=\\"el-tabs__nav is-top\\" style=\\"transform: translateX(-0px);\\" role=\\"tablist\\">
-              <div class=\\"el-tabs__active-bar is-top\\" style=\\"width: 0px; transform: translateX(NaNpx);\\"></div>
+              <div class=\\"el-tabs__active-bar is-top\\" style=\\"width: 0px; transform: translateX(0px);\\"></div>
               <div class=\\"el-tabs__item is-top\\" id=\\"tab-description\\" aria-controls=\\"pane-description\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\">Description
                 <!---->
               </div>
@@ -293,7 +293,7 @@ exports[`ViewGroupPage > members tab > should match snapshot (member) 1`] = `
       </div>
     </div>
   </div>
-  <div class=\\"el-loading-mask el-loading-fade-enter-from el-loading-fade-enter-active\\" style=\\"\\">
+  <div class=\\"el-loading-mask\\" style=\\"display: none;\\">
     <div class=\\"el-loading-spinner\\"><svg class=\\"circular\\" viewBox=\\"0 0 50 50\\">
         <circle class=\\"path\\" cx=\\"25\\" cy=\\"25\\" r=\\"20\\" fill=\\"none\\"></circle>
       </svg>
@@ -327,7 +327,7 @@ exports[`ViewGroupPage > members tab > should match snapshot (non-member) 1`] = 
           <!---->
           <div class=\\"el-tabs__nav-scroll\\">
             <div class=\\"el-tabs__nav is-top\\" style=\\"transform: translateX(-0px);\\" role=\\"tablist\\">
-              <div class=\\"el-tabs__active-bar is-top\\" style=\\"transform: translateX(NaNpx);\\"></div>
+              <div class=\\"el-tabs__active-bar is-top\\"></div>
               <div class=\\"el-tabs__item is-top\\" id=\\"tab-description\\" aria-controls=\\"pane-description\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\">Description
                 <!---->
               </div>
@@ -353,7 +353,7 @@ exports[`ViewGroupPage > members tab > should match snapshot (non-member) 1`] = 
       </div>
     </div>
   </div>
-  <div class=\\"el-loading-mask el-loading-fade-enter-from el-loading-fade-enter-active\\" style=\\"\\">
+  <div class=\\"el-loading-mask\\" style=\\"display: none;\\">
     <div class=\\"el-loading-spinner\\"><svg class=\\"circular\\" viewBox=\\"0 0 50 50\\">
         <circle class=\\"path\\" cx=\\"25\\" cy=\\"25\\" r=\\"20\\" fill=\\"none\\"></circle>
       </svg>
@@ -386,7 +386,7 @@ exports[`ViewGroupPage > publishing tab > should match snapshot (published) 1`] 
           <!---->
           <div class=\\"el-tabs__nav-scroll\\">
             <div class=\\"el-tabs__nav is-top\\" style=\\"transform: translateX(-0px);\\" role=\\"tablist\\">
-              <div class=\\"el-tabs__active-bar is-top\\" style=\\"width: 0px; transform: translateX(NaNpx);\\"></div>
+              <div class=\\"el-tabs__active-bar is-top\\" style=\\"width: 0px; transform: translateX(0px);\\"></div>
               <div class=\\"el-tabs__item is-top\\" id=\\"tab-description\\" aria-controls=\\"pane-description\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\">Description
                 <!---->
               </div>
@@ -420,7 +420,7 @@ exports[`ViewGroupPage > publishing tab > should match snapshot (published) 1`] 
       </div>
     </div>
   </div>
-  <div class=\\"el-loading-mask el-loading-fade-enter-from el-loading-fade-enter-active\\" style=\\"\\">
+  <div class=\\"el-loading-mask\\" style=\\"display: none;\\">
     <div class=\\"el-loading-spinner\\"><svg class=\\"circular\\" viewBox=\\"0 0 50 50\\">
         <circle class=\\"path\\" cx=\\"25\\" cy=\\"25\\" r=\\"20\\" fill=\\"none\\"></circle>
       </svg>
@@ -453,7 +453,7 @@ exports[`ViewGroupPage > publishing tab > should match snapshot (under review) 1
           <!---->
           <div class=\\"el-tabs__nav-scroll\\">
             <div class=\\"el-tabs__nav is-top\\" style=\\"transform: translateX(-0px);\\" role=\\"tablist\\">
-              <div class=\\"el-tabs__active-bar is-top\\" style=\\"width: 0px; transform: translateX(NaNpx);\\"></div>
+              <div class=\\"el-tabs__active-bar is-top\\" style=\\"width: 0px; transform: translateX(0px);\\"></div>
               <div class=\\"el-tabs__item is-top\\" id=\\"tab-description\\" aria-controls=\\"pane-description\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\">Description
                 <!---->
               </div>
@@ -487,7 +487,7 @@ exports[`ViewGroupPage > publishing tab > should match snapshot (under review) 1
       </div>
     </div>
   </div>
-  <div class=\\"el-loading-mask el-loading-fade-enter-from el-loading-fade-enter-active\\" style=\\"\\">
+  <div class=\\"el-loading-mask\\" style=\\"display: none;\\">
     <div class=\\"el-loading-spinner\\"><svg class=\\"circular\\" viewBox=\\"0 0 50 50\\">
         <circle class=\\"path\\" cx=\\"25\\" cy=\\"25\\" r=\\"20\\" fill=\\"none\\"></circle>
       </svg>
@@ -520,7 +520,7 @@ exports[`ViewGroupPage > publishing tab > should match snapshot (unpublished) 1`
           <!---->
           <div class=\\"el-tabs__nav-scroll\\">
             <div class=\\"el-tabs__nav is-top\\" style=\\"transform: translateX(-0px);\\" role=\\"tablist\\">
-              <div class=\\"el-tabs__active-bar is-top\\" style=\\"width: 0px; transform: translateX(NaNpx);\\"></div>
+              <div class=\\"el-tabs__active-bar is-top\\" style=\\"width: 0px; transform: translateX(0px);\\"></div>
               <div class=\\"el-tabs__item is-top\\" id=\\"tab-description\\" aria-controls=\\"pane-description\\" role=\\"tab\\" aria-selected=\\"false\\" tabindex=\\"-1\\">Description
                 <!---->
               </div>
@@ -554,7 +554,7 @@ exports[`ViewGroupPage > publishing tab > should match snapshot (unpublished) 1`
       </div>
     </div>
   </div>
-  <div class=\\"el-loading-mask el-loading-fade-enter-from el-loading-fade-enter-active\\" style=\\"\\">
+  <div class=\\"el-loading-mask\\" style=\\"display: none;\\">
     <div class=\\"el-loading-spinner\\"><svg class=\\"circular\\" viewBox=\\"0 0 50 50\\">
         <circle class=\\"path\\" cx=\\"25\\" cy=\\"25\\" r=\\"20\\" fill=\\"none\\"></circle>
       </svg>
@@ -610,7 +610,7 @@ exports[`ViewGroupPage > settings tab > should disable actions when under publis
       </div>
     </div>
   </div>
-  <div class=\\"el-loading-mask el-loading-fade-enter-from el-loading-fade-enter-active\\" style=\\"\\">
+  <div class=\\"el-loading-mask\\" style=\\"display: none;\\">
     <div class=\\"el-loading-spinner\\"><svg class=\\"circular\\" viewBox=\\"0 0 50 50\\">
         <circle class=\\"path\\" cx=\\"25\\" cy=\\"25\\" r=\\"20\\" fill=\\"none\\"></circle>
       </svg>
@@ -666,7 +666,7 @@ exports[`ViewGroupPage > settings tab > should disable actions when under review
       </div>
     </div>
   </div>
-  <div class=\\"el-loading-mask el-loading-fade-enter-from el-loading-fade-enter-active\\" style=\\"\\">
+  <div class=\\"el-loading-mask\\" style=\\"display: none;\\">
     <div class=\\"el-loading-spinner\\"><svg class=\\"circular\\" viewBox=\\"0 0 50 50\\">
         <circle class=\\"path\\" cx=\\"25\\" cy=\\"25\\" r=\\"20\\" fill=\\"none\\"></circle>
       </svg>
@@ -722,7 +722,7 @@ exports[`ViewGroupPage > settings tab > should match snapshot 1`] = `
       </div>
     </div>
   </div>
-  <div class=\\"el-loading-mask el-loading-fade-enter-from el-loading-fade-enter-active\\" style=\\"\\">
+  <div class=\\"el-loading-mask\\" style=\\"display: none;\\">
     <div class=\\"el-loading-spinner\\"><svg class=\\"circular\\" viewBox=\\"0 0 50 50\\">
         <circle class=\\"path\\" cx=\\"25\\" cy=\\"25\\" r=\\"20\\" fill=\\"none\\"></circle>
       </svg>

--- a/metaspace/webapp/src/modules/ImageViewer/IonImageMenu.vue
+++ b/metaspace/webapp/src/modules/ImageViewer/IonImageMenu.vue
@@ -75,6 +75,6 @@ export default defineComponent({
 }
 
 .sm-menu-items {
-  max-height: 480px;
+  max-height: 400px;
 }
 </style>


### PR DESCRIPTION
### Description

1. Fixed bug where the dataset grid showed the same dataset on different cells in case one of the datasets had more than one annotation (different FDRs) when annotated with an ML model.
2. Added scroll to multi-channel wrapper on dataset comparison page
3. Fixed bug where multi-channel wrapper pushed opacity controls if many annotations where selected.




