### PR TITLE
Handling of UnknownDSID exeption

### DIFF
--- a/metaspace/engine/sm/engine/daemons/lithops.py
+++ b/metaspace/engine/sm/engine/daemons/lithops.py
@@ -8,7 +8,7 @@ from sm.engine.annotation_lithops.executor import LithopsStalledException
 from sm.engine.config import SMConfig
 from sm.engine.daemons.actions import DaemonActionStage, DaemonAction
 from sm.engine.dataset import DatasetStatus
-from sm.engine.errors import AnnotationError, ImzMLError, IbdError
+from sm.engine.errors import AnnotationError, ImzMLError, IbdError, UnknownDSID
 from sm.engine.queue import QueueConsumer, QueuePublisher
 from sm.rest.dataset_manager import DatasetActionPriority
 
@@ -53,6 +53,12 @@ class LithopsDaemon:
             if 'email' in msg:
                 self._manager.send_failed_email(msg, e.traceback)
 
+            os.kill(os.getpid(), signal.SIGINT)
+            self._manager.ds_failure_handler(msg, e)
+            return
+
+        # Stop processing in case of other exception (without sending an email)
+        if isinstance(e, (UnknownDSID, )):
             os.kill(os.getpid(), signal.SIGINT)
             self._manager.ds_failure_handler(msg, e)
             return

--- a/metaspace/engine/sm/engine/daemons/lithops.py
+++ b/metaspace/engine/sm/engine/daemons/lithops.py
@@ -58,7 +58,7 @@ class LithopsDaemon:
             return
 
         # Stop processing in case of other exception (without sending an email)
-        if isinstance(e, (UnknownDSID, )):
+        if isinstance(e, (UnknownDSID,)):
             os.kill(os.getpid(), signal.SIGINT)
             self._manager.ds_failure_handler(msg, e)
             return
@@ -125,6 +125,8 @@ class LithopsDaemon:
         except IbdError:
             raise
         except LithopsStalledException:
+            raise
+        except UnknownDSID:
             raise
         except Exception as e:
             raise AnnotationError(ds_id=msg['ds_id'], traceback=format_exc(chain=False)) from e

--- a/metaspace/engine/sm/engine/daemons/lithops.py
+++ b/metaspace/engine/sm/engine/daemons/lithops.py
@@ -59,6 +59,10 @@ class LithopsDaemon:
 
         # Stop processing in case of other exception (without sending an email)
         if isinstance(e, (UnknownDSID,)):
+            self._manager.post_to_slack(
+                'bomb',
+                f' [x] Annotation failed, dataset was deleted early: {json.dumps(msg)}\n',
+            )
             os.kill(os.getpid(), signal.SIGINT)
             self._manager.ds_failure_handler(msg, e)
             return


### PR DESCRIPTION
We have an exception `UnknownDSID` in the case when information about the dataset is already in RabbitMQ, the processing of the dataset has not yet started, but the user has deleted this dataset from M\. We have no additional logic for this case, so we try to run this dataset into processing twice.

### Changes
1. Add a check for this exception and stop processing
2. Add a custom message in Slack about such a dataset