### PR TITLE
[DatasetComparison] updating ion image on filter change

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
+++ b/metaspace/webapp/src/modules/Datasets/comparison/DatasetComparisonGrid.tsx
@@ -266,6 +266,14 @@ export const DatasetComparisonGrid = defineComponent({
 
     // set images and annotation related items when selected annotation changes
     watch(
+      () => props.annotations,
+      async () => {
+        await updateAnnotationData(settings.value.grid, props.selectedAnnotation)
+      }
+    )
+
+    // set images and annotation related items when selected annotation changes
+    watch(
       () => props.mode,
       async () => {
         await updateAnnotationData(settings.value.grid, props.selectedAnnotation)

--- a/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
+++ b/metaspace/webapp/src/modules/MetadataEditor/MetadataEditor.vue
@@ -297,11 +297,14 @@ export default defineComponent({
       if (!metaspaceOptions.scoringModelId) {
         metaspaceOptions.scoringModelId = (scoringModels.find((m) => m.type === 'original') || {}).id
       } else {
-        const currentModel =
+        let currentModel =
           scoringModels.find((m) => m.id === metaspaceOptions.scoringModelId) ||
           // keep for backward compatibility to scoring model (v3_default)
           scoringModels.find((m) => m.name === metaspaceOptions.scoringModelId) ||
           {}
+        if (isNew.value && currentModel.isArchived) {
+          currentModel = scoringModels.find((m) => m.type === 'original') || {}
+        }
         metaspaceOptions.scoringModelId = currentModel.id
       }
 


### PR DESCRIPTION
### Description

Fixed bug for dataset comparison where ion image was not updated on filter change.
Disable loading archived scoring models from old datasets as templates to new ones.


