### PR TITLE
Fix AttributeError when checking `logged_in`

### DIFF
--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -348,7 +348,14 @@ class GraphQLClient(object):
         self.logged_in = False
 
         if self._config.get('usr_api_key'):
-            self.logged_in = self.query('query { currentUser { id } }') is not None
+            try:
+                self.logged_in = self.query('query { currentUser { id } }') is not None
+            except BadRequestException as ex:
+                if 'Invalid API key' in ex.message or 'Login failed' in ex.message:
+                    print('Login failed. Only public datasets will be accessible.')
+                    self.logged_in = False
+                else:
+                    raise
         elif self._config['usr_email']:
             login_res = self.session.post(
                 self._config['signin_url'],

--- a/metaspace/python-client/metaspace/sm_annotation_utils.py
+++ b/metaspace/python-client/metaspace/sm_annotation_utils.py
@@ -1648,7 +1648,8 @@ class SMInstance(object):
         try:
             self.reconnect()
         except (AssertionError, BadRequestException) as ex:
-            if ('Invalid API key' in ex.message or 'Login failed' in ex.message) and (
+            message = ex.args[0] if ex.args else ''
+            if ('Invalid API key' in message or 'Login failed' in message) and (
                 api_key is None and email is None
             ):
                 print(
@@ -1656,7 +1657,7 @@ class SMInstance(object):
                     f'saved credentials.'
                 )
             else:
-                print(f'Failed to connect to {self._config["host"]}: {ex.message}')
+                print(f'Failed to connect to {self._config["host"]}: {message}')
 
     def __repr__(self):
         return "SMInstance({})".format(self._config['graphql_url'])

--- a/metaspace/python-client/metaspace/tests/test_sm_instance.py
+++ b/metaspace/python-client/metaspace/tests/test_sm_instance.py
@@ -1,29 +1,33 @@
 import time
 from copy import deepcopy
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import pytest
 
 from metaspace import SMInstance
 from metaspace.tests.utils import config_path, sm, my_ds_id, metadata
+if TYPE_CHECKING:
+    from _pytest.capture import CaptureFixture
+
 
 TEST_DATA_PATH = str((Path(__file__).parent / '../../../engine/tests/data').resolve())
 
 
 @pytest.mark.parametrize(
-    ('config_path', 'expected_logged_in'),
+    ('config_path', 'expected_logged_in', 'expected_stdout'),
     [
-        ('valid', True),
-        ('empty', False),
-        ('invalid-password', False),
-        ('invalid-api_key', False),
+        ('valid', True, ''),
+        ('empty', False, ''),
+        ('invalid-password', False, 'Login failed. Only public datasets will be accessible.\n'),
+        ('invalid-api_key', False, 'Login failed. Only public datasets will be accessible.\n'),
     ],
     indirect=['config_path'],
 )
-def test_sm_instance(config_path: Optional[str], expected_logged_in: bool):
+def test_sm_instance(config_path: Optional[str], expected_logged_in: bool, expected_stdout: str, capsys: 'CaptureFixture'):
     sm = SMInstance(config_path=config_path)
     assert sm.logged_in() == expected_logged_in
+    assert expected_stdout == capsys.readouterr().out
 
 
 def test_add_dataset_external_link(sm, my_ds_id):

--- a/metaspace/python-client/metaspace/tests/test_sm_instance.py
+++ b/metaspace/python-client/metaspace/tests/test_sm_instance.py
@@ -1,13 +1,29 @@
 import time
 from copy import deepcopy
 from pathlib import Path
+from typing import Optional
 
 import pytest
 
 from metaspace import SMInstance
-from metaspace.tests.utils import sm, my_ds_id, metadata
+from metaspace.tests.utils import config_path, sm, my_ds_id, metadata
 
 TEST_DATA_PATH = str((Path(__file__).parent / '../../../engine/tests/data').resolve())
+
+
+@pytest.mark.parametrize(
+    ('config_path', 'expected_logged_in'),
+    [
+        ('valid', True),
+        ('empty', False),
+        ('invalid-password', False),
+        ('invalid-api_key', False),
+    ],
+    indirect=['config_path'],
+)
+def test_sm_instance(config_path: Optional[str], expected_logged_in: bool):
+    sm = SMInstance(config_path=config_path)
+    assert sm.logged_in() == expected_logged_in
 
 
 def test_add_dataset_external_link(sm, my_ds_id):

--- a/metaspace/python-client/metaspace/tests/test_sm_instance.py
+++ b/metaspace/python-client/metaspace/tests/test_sm_instance.py
@@ -1,30 +1,71 @@
 import time
 from copy import deepcopy
+from functools import wraps
 from pathlib import Path
 from typing import Optional, TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
+import requests
 
 from metaspace import SMInstance
 from metaspace.tests.utils import config_path, sm, my_ds_id, metadata
+
 if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
-
+    from _pytest.fixtures import SubRequest
 
 TEST_DATA_PATH = str((Path(__file__).parent / '../../../engine/tests/data').resolve())
 
 
+@pytest.fixture()
+def online(request: 'SubRequest'):
+    """
+    A fixture simulating being offline
+
+    Blocks the requests package from accessing METASPACE.
+
+    :param request: A pytest request, parametrized with a boolean: True = online, False = blocked
+    """
+    is_online = request.param
+    host = "https://metaspace2020.eu"
+    if is_online:
+        yield
+    else:
+        original_session_request = requests.sessions.Session.request
+
+        @wraps(requests.sessions.Session.request)
+        def session_request_wrapper(self: requests.sessions.Session, method: str, url: str, **kwargs):
+            if host is not None and host in url:
+                raise requests.exceptions.ConnectionError(f"{host} connection was blocked")
+            return original_session_request(self, method, url, **kwargs)
+
+        with patch.object(
+            requests.sessions.Session, "request", new=session_request_wrapper
+        ):
+            yield
+
+
 @pytest.mark.parametrize(
-    ('config_path', 'expected_logged_in', 'expected_stdout'),
+    ('config_path', 'online', 'expected_logged_in', 'expected_stdout'),
     [
-        ('valid', True, ''),
-        ('empty', False, ''),
-        ('invalid-password', False, 'Login failed. Only public datasets will be accessible.\n'),
-        ('invalid-api_key', False, 'Login failed. Only public datasets will be accessible.\n'),
+        ('valid', True, True, ''),
+        ('empty', True, False, ''),
+        ('invalid-password', True, False, 'Login failed. Only public datasets will be accessible.\n'),
+        ('invalid-api_key', True, False, 'Login failed. Only public datasets will be accessible.\n'),
+        ('valid', False, False, 'No network connection.\n'),
+        ('empty', False, False, ''),
+        ('invalid-password', False, False, 'No network connection.\n'),
+        ('invalid-api_key', False, False, 'No network connection.\n'),
     ],
-    indirect=['config_path'],
+    indirect=['config_path', 'online'],
 )
-def test_sm_instance(config_path: Optional[str], expected_logged_in: bool, expected_stdout: str, capsys: 'CaptureFixture'):
+def test_sm_instance(
+    config_path: Optional[str],
+    online, expected_logged_in: bool,
+    expected_stdout: str,
+    capsys: 'CaptureFixture'
+):
     sm = SMInstance(config_path=config_path)
     assert sm.logged_in() == expected_logged_in
     assert expected_stdout == capsys.readouterr().out

--- a/metaspace/python-client/metaspace/tests/utils.py
+++ b/metaspace/python-client/metaspace/tests/utils.py
@@ -1,7 +1,26 @@
 from pathlib import Path
+from typing import Optional
+
 import pytest
 
 from metaspace.sm_annotation_utils import SMInstance
+
+
+@pytest.fixture()
+def config_path(tmp_path, request) -> Optional[str]:
+    if request.param == 'invalid-password':
+        config_path = tmp_path / '.metaspace'
+        config_path.write_text(f'email = nobody@example.com\npassword = 0123456789ab\n')
+    elif request.param == "invalid-api_key":
+        config_path = tmp_path / ".metaspace"
+        config_path.write_text(f'email = nobody@example.com\napi_key = 0123456789ab\n')
+    elif request.param == 'empty':
+        config_path = tmp_path / '.metaspace'
+        config_path.touch()
+    else:
+        # Valid .metaspace config file
+        config_path = str((Path(__file__).parent / '../../test_config').resolve())
+    return config_path
 
 
 @pytest.fixture()


### PR DESCRIPTION
When METASPACE login fails in the constructor, the error is silently caught and printed, which goes unnoticed if not using an interactive console/notebook. When checking `logged_in()`, an AttributeError is raised because the instance is only fully initialized after successful login.

## Example

```pycon
>>> from metaspace.sm_annotation_utils import SMInstance
>>> sm = SMInstance(email="partyparrot@ateam.com", api_key="invalid-api_key")
Failed to connect to https://metaspace2020.eu: Invalid API key

>>> sm
SMInstance(https://metaspace2020.eu/graphql)
>>> sm.logged_in()
Traceback (most recent call last):
  File "…/metaspace/metaspace/python-client/metaspace/sm_annotation_utils.py", line 1707, in logged_in
    return self._gqclient.logged_in
AttributeError: 'SMInstance' object has no attribute '_gqclient'
```

- Login with API key and password take different code paths, only invalid API keys make GraphQLClient raise `BadRequestException("None: Invalid API Key.")`.
- Ideally, instance attributes are only defined inside `__init__`.
- An instance should either be completely initialized, or an error should be raised instead of returning a partially initialized instance.
- From `logged_in`, one would expect True/False, almost never an exception.

## Solution

I changed the API key login in `GraphQLClient` to be handled the same as password login: no exception, but setting login status and printing a message. This way, `GraphQLClient` can be instantiated despite invalid API key, and `SMInstance` can be completely initialized.