### PR TITLE
Upgrade ES, nginx, redis, rabbit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     docker:
       - image: metaspace2020/sm-webapp:0.11
 
-      - image: postgres:9.5-alpine
+      - image: postgres:16.3-alpine
         environment:
           POSTGRES_USER: sm
           POSTGRES_PASSWORD: password
@@ -60,7 +60,7 @@ jobs:
     docker:
       - image: metaspace2020/sm-webapp:0.11
 
-      - image: postgres:9.5-alpine
+      - image: postgres:16.3-alpine
         environment:
           POSTGRES_USER: sm
           POSTGRES_PASSWORD: password
@@ -171,20 +171,20 @@ jobs:
     docker:
       - image: metaspace2020/sm-webapp:0.11
 
-      - image: postgres:9.5-alpine
+      - image: postgres:16.3-alpine
         environment:
           POSTGRES_USER: sm
           POSTGRES_PASSWORD: password
 
-      - image: elasticsearch:8.7.1
+      - image: elasticsearch:8.15.1
         environment:
           ES_JAVA_OPTS: "-Xms512m -Xmx512m"
           xpack.security.enabled: "false"
         command: [elasticsearch, -Etransport.host=127.0.0.1]
 
-      - image: redis:3.2-alpine
+      - image: redis:7.4.0-alpine
 
-      - image: rabbitmq:3.6-alpine
+      - image: rabbitmq:3.13.7-management
         environment:
           RABBITMQ_DEFAULT_USER: sm
           RABBITMQ_DEFAULT_PASS: password
@@ -262,20 +262,20 @@ jobs:
     docker:
       - image: metaspace2020/sm-engine:2.0.0
 
-      - image: redis:5.0.3
+      - image: redis:7.4.0-alpine
 
-      - image: postgres:9.5-alpine
+      - image: postgres:16.3-alpine
         environment:
           POSTGRES_USER: sm
           POSTGRES_PASSWORD: password
 
-      - image: elasticsearch:8.7.1
+      - image: elasticsearch:8.15.1
         environment:
           ES_JAVA_OPTS: "-Xms512m -Xmx512m"
           xpack.security.enabled: "false"
         command: [elasticsearch, -Etransport.host=127.0.0.1]
 
-      - image: rabbitmq:3.6-management
+      - image: rabbitmq:3.13.7-management
         environment:
           RABBITMQ_DEFAULT_USER: sm
           RABBITMQ_DEFAULT_PASS: password
@@ -329,20 +329,20 @@ jobs:
     docker:
       - image: metaspace2020/sm-engine:2.0.0
 
-      - image: redis:5.0.3
+      - image: redis:7.4.0-alpine
 
-      - image: postgres:9.5-alpine
+      - image: postgres:16.3-alpine
         environment:
           POSTGRES_USER: sm
           POSTGRES_PASSWORD: password
 
-      - image: elasticsearch:8.7.1
+      - image: elasticsearch:8.15.1
         environment:
           ES_JAVA_OPTS: "-Xms512m -Xmx512m"
           xpack.security.enabled: "false"
         command: [elasticsearch, -Etransport.host=127.0.0.1]
 
-      - image: rabbitmq:3.6-management
+      - image: rabbitmq:3.13.7-management
         environment:
           RABBITMQ_DEFAULT_USER: sm
           RABBITMQ_DEFAULT_PASS: password

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,14 +16,14 @@ services:
       - sm
 
   redis:
-    image: redis:7.2.5-alpine
+    image: redis:7.4.0-alpine
     ports:
       - "6379:6379"
     networks:
       - sm
 
   rabbitmq:
-    image: rabbitmq:3.13-management
+    image: rabbitmq:3.13.7-management
     environment:
       RABBITMQ_DEFAULT_USER: sm
       RABBITMQ_DEFAULT_PASS: password

--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM elasticsearch:8.14.0
+FROM elasticsearch:8.15.1
 
 
 RUN rm -r /usr/share/elasticsearch/config/elasticsearch.yml && \

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.25.4-alpine
+FROM nginx:1.26.2-alpine
 
 RUN rm -rf /etc/nginx/sites-enabled && \
     rm /etc/nginx/nginx.conf && \

--- a/metaspace/engine/requirements.txt
+++ b/metaspace/engine/requirements.txt
@@ -10,7 +10,7 @@ boto3==1.28.64
 fabric3
 pypng==0.0.19    # 0.0.20 introduced incompatible API changes
 pyyaml>=5.1
-elasticsearch==8.7.0
+elasticsearch==8.15.1
 pika==0.13.1
 bottle
 Pillow==9.3.0
@@ -20,7 +20,7 @@ pandas==1.2.0
 cffi
 psycopg2-binary==2.8.6
 cherrypy<9
-redis
+redis==5.0.8
 scikit-learn==0.23.2
 pyspark[sql]==3.0.1
 pyarrow==1.0.1


### PR DESCRIPTION
### Description

Synchronous upgrade of versions (main software) for the local environment and CircleCI:
 - [x] Elasticsearch 8.14.0 -> 8.15.1
 - [x] Nginx 1.25.4 -> 1.26.2
 - [x] RabbitMQ 3.13 -> 3.13.7
 - [x] Redis 7.2.5 -> 7.4.0