### PR TITLE
Fixing a bug related to RAM limits for process_centr_segment step

### DIFF
--- a/metaspace/engine/sm/engine/annotation_lithops/annotate.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/annotate.py
@@ -240,7 +240,6 @@ def process_centr_segments(
     imzml_reader: LithopsImzMLReader,
     ds_config: DSConfig,
     ds_segm_size_mb: float,
-    is_intensive_dataset: bool,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     # pylint: disable=too-many-locals
     # Copy needed fields out of imzml_reader so that the other unneeded fields aren't pulled into

--- a/metaspace/engine/sm/engine/annotation_lithops/annotate.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/annotate.py
@@ -253,7 +253,7 @@ def process_centr_segments(
     compute_metrics = make_compute_image_metrics(imzml_reader, ds_config)
     min_px = image_gen_config['min_px']
     # TODO: Get available memory from Lithops somehow so it updates if memory is increased on retry
-    pw_mem_mb = 4096 if is_intensive_dataset else 2048
+    pw_mem_mb = 2048
 
     def process_centr_segment(
         db_segm_cobject: CObj[pd.DataFrame], *, storage: Storage, perf: Profiler
@@ -311,7 +311,7 @@ def process_centr_segments(
         process_centr_segment,
         [(co,) for co in db_segms_cobjs],
         runtime_memory=pw_mem_mb,
-        max_memory=8196,
+        max_memory=4096,
         # debug_run_locally=True,
     )
     formula_metrics_df = pd.concat(formula_metrics_list)

--- a/metaspace/engine/sm/engine/annotation_lithops/executor.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/executor.py
@@ -281,7 +281,7 @@ class Executor:
             if (
                 isinstance(exc, (MemoryError, TimeoutError, OSError))
                 and runtime_memory <= max(MEM_LIMITS.values())
-                and (max_memory is None or runtime_memory < max_memory)
+                and (max_memory is None or runtime_memory <= max_memory)
             ):
                 attempt += 1
                 old_memory = runtime_memory

--- a/metaspace/engine/sm/engine/annotation_lithops/pipeline.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/pipeline.py
@@ -181,7 +181,6 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
             self.imzml_reader,
             self.ds_config,
             self.ds_segm_size_mb,
-            self.is_intensive_dataset,
         )
         logger.info(f'Metrics calculated: {self.formula_metrics_df.shape[0]}')
 


### PR DESCRIPTION
1. Change `max_memory=8196` to `max_memory=4096`. First there was the bug (8196 -> 8192), which caused this step to run with 2048, 4096 and **8192** MB of RAM. The latter value was too large for normal datasets. In the case of datasets with a lot of noise, this volume would still not be enough. But this amount of memory cost us a lot. Second, I limited the maximum value to 4096 MB, as was the original version by Lachlan.
2. I looked at the statistics in the `perf_profile_entry` table for datasets that used 4096 MB of RAM or more. In most cases, the actual RAM consumption was up to 1.5 GB. This is the most expensive step for us, so changing the base value of `runtime_memory` like this will save 30-40% of money for heavy datasets. You can view the raw data with the following request:
```
SELECT
    id,
    profile_id,
    start,
    finish,
    extra_data ->> 'cost' AS costs,
    extra_data ->> 'runtime_memory' AS runtime_memory,
    extra_data ->> 'max_memory' AS max_memory,
    extra_data ->> 'max_time' AS max_time,
    extra_data
FROM perf_profile_entry
WHERE 
    start >= '2024-11-01' AND 
    finish <= '2024-11-30' AND 
    name='process_centr_segment' AND 
    (extra_data ->> 'runtime_memory')::numeric >= 4096
ORDER BY id DESC;
```