### PR TITLE
Exclude chem_mods and neutral losses from decoy selection

### DIFF
--- a/metaspace/engine/sm/engine/annotation/fdr.py
+++ b/metaspace/engine/sm/engine/annotation/fdr.py
@@ -136,7 +136,7 @@ class FDR:
     fdr_levels = [0.05, 0.1, 0.2, 0.5]
 
     def __init__(self, fdr_config, chem_mods, neutral_losses, target_adducts, analysis_version):
-        self.decoy_adduct_cand = [ad for ad in DECOY_ADDUCTS if ad not in target_adducts]
+        self.decoy_adduct_cand = [ad for ad in DECOY_ADDUCTS if ad not in target_adducts + chem_mods + neutral_losses]
         self.decoy_sample_size = min(fdr_config['decoy_sample_size'], len(self.decoy_adduct_cand))
 
         self.chem_mods = chem_mods

--- a/metaspace/engine/sm/engine/annotation/fdr.py
+++ b/metaspace/engine/sm/engine/annotation/fdr.py
@@ -137,7 +137,7 @@ class FDR:
 
     def __init__(self, fdr_config, chem_mods, neutral_losses, target_adducts, analysis_version):
         self.decoy_adduct_cand = [
-            ad for ad in DECOY_ADDUCTS 
+            ad for ad in DECOY_ADDUCTS
             if ad not in target_adducts + chem_mods + neutral_losses
         ]
         self.decoy_sample_size = min(fdr_config['decoy_sample_size'], len(self.decoy_adduct_cand))

--- a/metaspace/engine/sm/engine/annotation/fdr.py
+++ b/metaspace/engine/sm/engine/annotation/fdr.py
@@ -137,8 +137,7 @@ class FDR:
 
     def __init__(self, fdr_config, chem_mods, neutral_losses, target_adducts, analysis_version):
         self.decoy_adduct_cand = [
-            ad for ad in DECOY_ADDUCTS
-            if ad not in target_adducts + chem_mods + neutral_losses
+            ad for ad in DECOY_ADDUCTS if ad not in target_adducts + chem_mods + neutral_losses
         ]
         self.decoy_sample_size = min(fdr_config['decoy_sample_size'], len(self.decoy_adduct_cand))
 
@@ -194,7 +193,7 @@ class FDR:
         return list(map(tuple, t_ions + d_ions))
 
     def target_modifiers(self):
-        """ List of possible modifier values for target ions """
+        """List of possible modifier values for target ions"""
         return self.target_modifiers_df.index.tolist()
 
     @classmethod

--- a/metaspace/engine/sm/engine/annotation/fdr.py
+++ b/metaspace/engine/sm/engine/annotation/fdr.py
@@ -136,7 +136,10 @@ class FDR:
     fdr_levels = [0.05, 0.1, 0.2, 0.5]
 
     def __init__(self, fdr_config, chem_mods, neutral_losses, target_adducts, analysis_version):
-        self.decoy_adduct_cand = [ad for ad in DECOY_ADDUCTS if ad not in target_adducts + chem_mods + neutral_losses]
+        self.decoy_adduct_cand = [
+            ad for ad in DECOY_ADDUCTS 
+            if ad not in target_adducts + chem_mods + neutral_losses
+        ]
         self.decoy_sample_size = min(fdr_config['decoy_sample_size'], len(self.decoy_adduct_cand))
 
         self.chem_mods = chem_mods


### PR DESCRIPTION
Changed decoy sampling so that chemical modifications and neutral losses won't be sampled from the list of possible decoy adducts. 