### PR TITLE
Enable adding optical image from dataset overview actions

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.spec.ts
@@ -152,7 +152,7 @@ describe('DatasetActionsDropdown', () => {
     await flushPromises()
     await nextTick()
 
-    expect(wrapper.findAll('.mock-el-dropdown-item').length).toBe(7)
+    expect(wrapper.findAll('.mock-el-dropdown-item').length).toBe(8)
   })
 
   it('it show all options except reprocess if user is the ds owner, but not admin', async () => {
@@ -169,7 +169,7 @@ describe('DatasetActionsDropdown', () => {
     await flushPromises()
     await nextTick()
 
-    expect(wrapper.findAll('.mock-el-dropdown-item').length).toBe(6)
+    expect(wrapper.findAll('.mock-el-dropdown-item').length).toBe(7)
   })
 
   it('it show only canDownload option for normalUser', async () => {

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
@@ -36,6 +36,7 @@ interface DatasetActionsDropdownProps {
   compareActionLabel: string
   browserActionLabel: string
   enrichmentActionLabel: string
+  opticalImageActionLabel: string
   dataset: DatasetDetailItem
   currentUser: CurrentUserRoleResult
   isPublishedOrUnderReview: boolean
@@ -58,6 +59,7 @@ export const DatasetActionsDropdown = defineComponent({
     compareActionLabel: { type: String, default: 'Compare with other datasets...' },
     browserActionLabel: { type: String, default: 'Imzml Browser' },
     enrichmentActionLabel: { type: String, default: 'Ontology enrichment' },
+    opticalImageActionLabel: { type: String, default: 'Add optical image' },
     reprocessActionLabel: { type: String, default: 'Reprocess data' },
     downloadActionLabel: { type: String, default: 'Download' },
     recaptchaToken: { type: String, default: () => '' },
@@ -242,6 +244,12 @@ export const DatasetActionsDropdown = defineComponent({
             params: { dataset_id: props.dataset?.id },
           })
           break
+        case 'optical-image':
+          router.push({
+            name: 'add-optical-image',
+            params: { dataset_id: props.dataset?.id },
+          })
+          break
         case 'enrichment':
           await enrichmentRefetch()
           if (enrichmentRequested.value) {
@@ -302,6 +310,7 @@ export const DatasetActionsDropdown = defineComponent({
         compareActionLabel,
         enrichmentActionLabel,
         browserActionLabel,
+        opticalImageActionLabel,
       } = props
       const { role } = currentUser || {}
       const { canEdit, canDelete, canDownload } = dataset || {}
@@ -324,6 +333,7 @@ export const DatasetActionsDropdown = defineComponent({
             <ElDropdownItem command="enrichment">{enrichmentActionLabel}</ElDropdownItem>
           )}
           {canEdit && <ElDropdownItem command="edit">{editActionLabel}</ElDropdownItem>}
+          {canEdit && <ElDropdownItem command="optical-image">{opticalImageActionLabel}</ElDropdownItem>}
           {canDelete && (
             <ElDropdownItem class="text-red-500" command="delete">
               {deleteActionLabel}

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
@@ -318,10 +318,12 @@ export const DatasetActionsDropdown = defineComponent({
 
       return (
         <ElDropdownMenu class="dataset-overview-menu p-2">
+          {canEdit && <ElDropdownItem command="optical-image">{opticalImageActionLabel}</ElDropdownItem>}
+          <ElDropdownItem command="compare">{compareActionLabel}</ElDropdownItem>
           {(!currentUser?.id || canDownload) && (
             <ElDropdownItem command="download">{downloadActionLabel}</ElDropdownItem>
           )}
-          <ElDropdownItem command="compare">{compareActionLabel}</ElDropdownItem>
+          {canEdit && <ElDropdownItem command="edit">{editActionLabel}</ElDropdownItem>}
           {config.features.imzml_browser && (
             <ElDropdownItem command="browser">
               <div class="relative actionBadge">
@@ -332,8 +334,6 @@ export const DatasetActionsDropdown = defineComponent({
           {config.features.enrichment && (enrichmentRequested.value || canEdit) && (
             <ElDropdownItem command="enrichment">{enrichmentActionLabel}</ElDropdownItem>
           )}
-          {canEdit && <ElDropdownItem command="edit">{editActionLabel}</ElDropdownItem>}
-          {canEdit && <ElDropdownItem command="optical-image">{opticalImageActionLabel}</ElDropdownItem>}
           {canDelete && (
             <ElDropdownItem class="text-red-500" command="delete">
               {deleteActionLabel}

--- a/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/DatasetActionsDropdown.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/DatasetActionsDropdown.spec.ts.snap
@@ -13,15 +13,16 @@ exports[`DatasetActionsDropdown > it should match snapshot 1`] = `
     <!---->
   </div>
   <div class=\\"mock-el-dropdown-menu dataset-overview-menu p-2\\">
-    <div class=\\"mock-el-dropdown-item\\" attrs=\\"[object Object]\\">Download</div>
+    <div class=\\"mock-el-dropdown-item\\" attrs=\\"[object Object]\\">Add optical image</div>
     <div class=\\"mock-el-dropdown-item\\" attrs=\\"[object Object]\\">Compare with other datasets...</div>
+    <div class=\\"mock-el-dropdown-item\\" attrs=\\"[object Object]\\">Download</div>
+    <div class=\\"mock-el-dropdown-item\\" attrs=\\"[object Object]\\">Edit</div>
     <div class=\\"mock-el-dropdown-item\\" attrs=\\"[object Object]\\">
       <div class=\\"relative actionBadge\\">
         <div class=\\"el-badge sm-feature-badge\\">Imzml Browser<sup class=\\"el-badge__content el-badge__content--danger is-fixed is-dot\\"></sup></div>
       </div>
     </div>
     <div class=\\"mock-el-dropdown-item\\" attrs=\\"[object Object]\\">Ontology enrichment</div>
-    <div class=\\"mock-el-dropdown-item\\" attrs=\\"[object Object]\\">Edit</div>
     <div class=\\"mock-el-dropdown-item text-red-500\\" attrs=\\"[object Object]\\">Delete</div>
     <div class=\\"mock-el-dropdown-item text-red-500\\" attrs=\\"[object Object]\\">Reprocess data</div>
   </div>

--- a/metaspace/webapp/src/router/index.ts
+++ b/metaspace/webapp/src/router/index.ts
@@ -145,7 +145,7 @@ export const routes: any = [
   },
   { path: '/datasets/edit/:dataset_id', name: 'edit-metadata', component: asyncPages.MetadataEditPage },
   {
-    path: '/datasets/:dataset_id/add-optical-image',
+    path: '/dataset/:dataset_id/add-optical-image',
     name: 'add-optical-image',
     component: asyncPages.ImageAlignmentPage,
   },

--- a/metaspace/webapp/src/router/index.ts
+++ b/metaspace/webapp/src/router/index.ts
@@ -145,6 +145,11 @@ export const routes: any = [
   },
   { path: '/datasets/edit/:dataset_id', name: 'edit-metadata', component: asyncPages.MetadataEditPage },
   {
+    // Legacy URL, to be removed
+    path: '/datasets/:dataset_id/add-optical-image',
+    redirect: { name: 'add-optical-image' },
+  },
+  {
     path: '/dataset/:dataset_id/add-optical-image',
     name: 'add-optical-image',
     component: asyncPages.ImageAlignmentPage,


### PR DESCRIPTION
Add optical image route to `/dataset` prefix and expose via Actions dropdown                                                                                        
                                                                                                                                                                    
  Summary                                                                                                                                                           
                                                                                                                                                                    
  - Moved the add-optical-image route from `/datasets/:dataset_id/add-optical-image` to `/dataset/:dataset_id/add-optical-image` to align with the existing `/dataset/:dataset_id/...` route convention used across the webapp
  - Added an "Add optical image" item to the `DatasetActionsDropdown` on the dataset overview page. 