### PR TITLE
Add stable-isotope labeling support for custom databases

### DIFF
--- a/metaspace/engine/sm/engine/__init__.py
+++ b/metaspace/engine/sm/engine/__init__.py
@@ -1,1 +1,2 @@
 __version__ = '1.7.0'
+import sm.engine.isotope_labels  # noqa: F401 — patches pyMSpec periodic table at package init

--- a/metaspace/engine/sm/engine/annotation/isocalc_wrapper.py
+++ b/metaspace/engine/sm/engine/annotation/isocalc_wrapper.py
@@ -78,8 +78,22 @@ class IsocalcWrapper:
             # noinspection PyPep8Naming
             cpyMSpec = cpyMSpec_0_4_2  # pylint: disable=invalid-name
 
+        # Isotope-labeled pseudo-elements (e.g. X = pure ¹³C) contribute a
+        # fixed mass shift with no isotope spread.  Strip them from the formula,
+        # compute the natural-isotope pattern for the remaining atoms with
+        # cpyMSpec, then shift each centroid m/z by the labeled-element mass
+        # divided by the charge state.
+        from sm.engine.isotope_labels import extract_labeled_mass_shift  # noqa: PLC0415
+        labeled_mass_shift, unlabeled_formula = extract_labeled_mass_shift(formula)
+        if labeled_mass_shift and not unlabeled_formula:
+            logger.warning(
+                f'{formula} - formula consists entirely of labeled elements; '
+                'cannot compute isotope pattern'
+            )
+            return None, None
+
         try:
-            iso_pattern = cpyMSpec.isotopePattern(str(formula))
+            iso_pattern = cpyMSpec.isotopePattern(str(unlabeled_formula or formula))
             iso_pattern.addCharge(int(self.charge))
             fwhm = self.sigma * SIGMA_TO_FWHM
 
@@ -96,6 +110,12 @@ class IsocalcWrapper:
             mzs_ = np.array(centr.masses)
             ints_ = 100.0 * np.array(centr.intensities)
             mzs_, ints_ = self._trim(mzs_, ints_, self.n_peaks)
+
+            # Only for labeled formulas: shift every centroid by the exact mass
+            # of the pure-isotope atoms (delta-function ⊗ natural pattern = shift).
+            # Dividing by |charge| converts Da → m/z units.
+            if labeled_mass_shift:
+                mzs_ += labeled_mass_shift / abs(int(self.charge))
 
             n = len(mzs_)
             mzs = np.zeros(self.n_peaks)

--- a/metaspace/engine/sm/engine/annotation/isocalc_wrapper.py
+++ b/metaspace/engine/sm/engine/annotation/isocalc_wrapper.py
@@ -7,6 +7,7 @@ import cpyMSpec as cpyMSpec_0_4_2
 import cpyMSpec_0_3_5
 
 from sm.engine.ds_config import DSConfig
+from sm.engine.isotope_labels import extract_labeled_mass_shift
 
 assert cpyMSpec_0_4_2.utils.VERSION == '0.4.2'
 assert cpyMSpec_0_3_5.utils.VERSION == '0.3.5'
@@ -83,7 +84,6 @@ class IsocalcWrapper:
         # compute the natural-isotope pattern for the remaining atoms with
         # cpyMSpec, then shift each centroid m/z by the labeled-element mass
         # divided by the charge state.
-        from sm.engine.isotope_labels import extract_labeled_mass_shift  # noqa: PLC0415
         labeled_mass_shift, unlabeled_formula = extract_labeled_mass_shift(formula)
         if labeled_mass_shift and not unlabeled_formula:
             logger.warning(

--- a/metaspace/engine/sm/engine/annotation/isocalc_wrapper.py
+++ b/metaspace/engine/sm/engine/annotation/isocalc_wrapper.py
@@ -79,8 +79,8 @@ class IsocalcWrapper:
             # noinspection PyPep8Naming
             cpyMSpec = cpyMSpec_0_4_2  # pylint: disable=invalid-name
 
-        # Isotope-labeled pseudo-elements (e.g. X = pure ¹³C) contribute a
-        # fixed mass shift with no isotope spread.  Strip them from the formula,
+        # Isotope-labeled pseudo-elements (e.g. Cx = pure ¹³C, Nx = pure ¹⁵N)
+        # contribute a fixed mass shift with no isotope spread.  Strip them from the formula,
         # compute the natural-isotope pattern for the remaining atoms with
         # cpyMSpec, then shift each centroid m/z by the labeled-element mass
         # divided by the charge state.

--- a/metaspace/engine/sm/engine/isotope_labels.py
+++ b/metaspace/engine/sm/engine/isotope_labels.py
@@ -1,0 +1,102 @@
+"""Support for isotope-labeled elements in molecular formulas.
+
+Defines pseudo-element symbols for stable isotope labels and registers them
+into pyMSpec's ``periodic_table`` at import time so that the rest of the
+pipeline (upload validation, mono-mass calculation, centroid generation)
+accepts them transparently.
+
+Currently supported labels
+--------------------------
+``X``  –  pure ¹³C  (monoisotopic mass 13.00335484 Da)
+
+Usage in custom databases
+--------------------------
+Use the symbol exactly like a regular element in the database TSV::
+
+    id    name                  formula
+    1     [U-13C6]-glucose      X6H12O6
+    2     [1,2-13C2]-acetate    X2H3O2
+
+METASPACE computes the correct isotope pattern and m/z by treating each
+``X`` atom as a delta-function at 13.00335484 Da and convolving that with
+the natural-isotope pattern of the remaining atoms (which is equivalent to
+simply shifting every centroid m/z by the total labeled-element mass divided
+by the ion charge state).
+"""
+
+import re
+from typing import Dict, List, Tuple
+
+from pyMSpec.pyisocalc.periodic_table import periodic_table
+
+# ---------------------------------------------------------------------------
+# Label definitions
+# ---------------------------------------------------------------------------
+
+#: Metadata for every pseudo-element symbol.
+#: ``mass`` is the exact monoisotopic mass used for the m/z shift.
+ISOTOPE_LABEL_ELEMENTS: Dict[str, dict] = {
+    'X': {
+        'description': 'pure ¹³C',
+        'natural_element': 'C',
+        'mass': 13.00335484,
+    },
+}
+
+# Register pseudo-elements into pyMSpec's periodic table.
+# Format: [atomic_number, valence, [mass_list], [abundance_list]]
+# Using a single-isotope entry (abundance = 1.0) so that parseSumFormula()
+# and calculate_mono_mz() both see the correct exact mass.
+_PERIODIC_TABLE_ENTRIES: Dict[str, list] = {
+    'X': [6, -4, [13.00335484], [1.0]],
+}
+for _sym, _entry in _PERIODIC_TABLE_ENTRIES.items():
+    if _sym not in periodic_table:
+        periodic_table[_sym] = _entry
+
+# ---------------------------------------------------------------------------
+# Formula helpers
+# ---------------------------------------------------------------------------
+
+_ELEM_RE = re.compile(r'([A-Z][a-z]*)([0-9]*)')
+
+
+def extract_labeled_mass_shift(formula: str) -> Tuple[float, str]:
+    """Separate isotope-labeled atoms from *formula* and return their exact mass.
+
+    Because each pseudo-element represents a 100 %-pure isotope, it contributes
+    a fixed mass offset with no isotope spread.  The isotope pattern of the full
+    compound equals the natural-isotope pattern of the *remaining* atoms, with
+    every centroid m/z shifted by ``mass_shift / |charge|``.
+
+    Args:
+        formula: Ion formula string, e.g. ``'H13O6X6'``.
+
+    Returns:
+        ``(mass_shift, unlabeled_formula)`` where *mass_shift* is the total
+        exact mass of all labeled atoms in Da, and *unlabeled_formula* is the
+        formula string with all labeled atoms removed.
+
+    Examples::
+
+        >>> extract_labeled_mass_shift('H13O6X6')
+        (78.02012904, 'H13O6')
+        >>> extract_labeled_mass_shift('H13O6')
+        (0.0, 'H13O6')
+    """
+    mass_shift = 0.0
+    remaining: List[str] = []
+
+    for elem, n_str in _ELEM_RE.findall(formula):
+        n = int(n_str) if n_str else 1
+        if elem in ISOTOPE_LABEL_ELEMENTS:
+            mass_shift += ISOTOPE_LABEL_ELEMENTS[elem]['mass'] * n
+        else:
+            remaining.append(f'{elem}{n_str}')
+
+    return mass_shift, ''.join(remaining)
+
+
+def has_labeled_elements(formula: str) -> bool:
+    """Return ``True`` if *formula* contains any isotope-label pseudo-elements."""
+    return any(elem in ISOTOPE_LABEL_ELEMENTS for elem, _ in _ELEM_RE.findall(formula))

--- a/metaspace/engine/sm/engine/isotope_labels.py
+++ b/metaspace/engine/sm/engine/isotope_labels.py
@@ -54,11 +54,11 @@ from pyMSpec.pyisocalc.periodic_table import periodic_table
 #: Masses are taken from the same source as pyMSpec's periodic_table entries
 #: (AME / IUPAC values, consistent with periodicTable.ts in the webapp).
 ISOTOPE_LABEL_ELEMENTS: Dict[str, dict] = {
-    'Cx': {'description': 'pure ¹³C',  'natural_element': 'C', 'mass': 13.00335484},
-    'Nx': {'description': 'pure ¹⁵N',  'natural_element': 'N', 'mass': 15.00010889},
-    'Hx': {'description': 'pure ²H',   'natural_element': 'H', 'mass':  2.014101778},
-    'Ox': {'description': 'pure ¹⁸O',  'natural_element': 'O', 'mass': 17.99915961},
-    'Sx': {'description': 'pure ³⁴S',  'natural_element': 'S', 'mass': 33.96786700},
+    'Cx': {'description': 'pure ¹³C', 'natural_element': 'C', 'mass': 13.00335484},
+    'Nx': {'description': 'pure ¹⁵N', 'natural_element': 'N', 'mass': 15.00010889},
+    'Hx': {'description': 'pure ²H', 'natural_element': 'H', 'mass': 2.014101778},
+    'Ox': {'description': 'pure ¹⁸O', 'natural_element': 'O', 'mass': 17.99915961},
+    'Sx': {'description': 'pure ³⁴S', 'natural_element': 'S', 'mass': 33.96786700},
 }
 
 # Register pseudo-elements into pyMSpec's periodic table.
@@ -66,11 +66,11 @@ ISOTOPE_LABEL_ELEMENTS: Dict[str, dict] = {
 # Single-isotope entry (abundance = 1.0) so parseSumFormula() and
 # calculate_mono_mz() both see the correct exact mass.
 _PERIODIC_TABLE_ENTRIES: Dict[str, list] = {
-    'Cx': [6,  -4, [13.00335484],  [1.0]],
-    'Nx': [7,   5, [15.00010889],  [1.0]],
-    'Hx': [1,   1, [ 2.014101778], [1.0]],
-    'Ox': [8,  -2, [17.99915961],  [1.0]],
-    'Sx': [16, -2, [33.96786700],  [1.0]],
+    'Cx': [6, -4, [13.00335484], [1.0]],
+    'Nx': [7, 5, [15.00010889], [1.0]],
+    'Hx': [1, 1, [2.014101778], [1.0]],
+    'Ox': [8, -2, [17.99915961], [1.0]],
+    'Sx': [16, -2, [33.96786700], [1.0]],
 }
 for _sym, _entry in _PERIODIC_TABLE_ENTRIES.items():
     if _sym not in periodic_table:

--- a/metaspace/engine/sm/engine/isotope_labels.py
+++ b/metaspace/engine/sm/engine/isotope_labels.py
@@ -25,7 +25,7 @@ by the ion charge state).
 """
 
 import re
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 
 from pyMSpec.pyisocalc.periodic_table import periodic_table
 
@@ -58,6 +58,12 @@ for _sym, _entry in _PERIODIC_TABLE_ENTRIES.items():
 # Formula helpers
 # ---------------------------------------------------------------------------
 
+# Per-symbol substitution patterns: match the symbol followed by an optional integer count.
+# Built once at import time and reused for every call.
+_LABEL_PATTERNS: Dict[str, re.Pattern] = {
+    sym: re.compile(rf'{re.escape(sym)}(\d*)') for sym in ISOTOPE_LABEL_ELEMENTS
+}
+
 _ELEM_RE = re.compile(r'([A-Z][a-z]*)([0-9]*)')
 
 
@@ -68,6 +74,11 @@ def extract_labeled_mass_shift(formula: str) -> Tuple[float, str]:
     a fixed mass offset with no isotope spread.  The isotope pattern of the full
     compound equals the natural-isotope pattern of the *remaining* atoms, with
     every centroid m/z shifted by ``mass_shift / |charge|``.
+
+    Uses ``re.sub`` to remove only the labeled-element tokens while leaving the
+    rest of the formula string intact.  This preserves any invalid characters
+    (leading numbers, sign prefixes, etc.) so that downstream parsers can still
+    reject ill-formed formulas as they did before.
 
     Args:
         formula: Ion formula string, e.g. ``'H13O6X6'``.
@@ -85,18 +96,22 @@ def extract_labeled_mass_shift(formula: str) -> Tuple[float, str]:
         (0.0, 'H13O6')
     """
     mass_shift = 0.0
-    remaining: List[str] = []
+    unlabeled = formula
 
-    for elem, n_str in _ELEM_RE.findall(formula):
-        n = int(n_str) if n_str else 1
-        if elem in ISOTOPE_LABEL_ELEMENTS:
-            mass_shift += ISOTOPE_LABEL_ELEMENTS[elem]['mass'] * n
-        else:
-            remaining.append(f'{elem}{n_str}')
+    for sym, pattern in _LABEL_PATTERNS.items():
+        elem_mass = ISOTOPE_LABEL_ELEMENTS[sym]['mass']
 
-    return mass_shift, ''.join(remaining)
+        def _replacer(m: re.Match, _mass: float = elem_mass) -> str:
+            nonlocal mass_shift
+            n = int(m.group(1)) if m.group(1) else 1
+            mass_shift += _mass * n
+            return ''
+
+        unlabeled = pattern.sub(_replacer, unlabeled)
+
+    return mass_shift, unlabeled
 
 
 def has_labeled_elements(formula: str) -> bool:
     """Return ``True`` if *formula* contains any isotope-label pseudo-elements."""
-    return any(elem in ISOTOPE_LABEL_ELEMENTS for elem, _ in _ELEM_RE.findall(formula))
+    return any(pattern.search(formula) for pattern in _LABEL_PATTERNS.values())

--- a/metaspace/engine/sm/engine/isotope_labels.py
+++ b/metaspace/engine/sm/engine/isotope_labels.py
@@ -5,23 +5,39 @@ into pyMSpec's ``periodic_table`` at import time so that the rest of the
 pipeline (upload validation, mono-mass calculation, centroid generation)
 accepts them transparently.
 
-Currently supported labels
---------------------------
-``X``  –  pure ¹³C  (monoisotopic mass 13.00335484 Da)
+Each symbol uses the base-element letter followed by ``x`` (for "heavy
+isotope").  All entries have a single isotope at 100 % abundance (a
+delta-function mass), so the isotope pattern of a labeled compound equals
+the natural-isotope pattern of the *remaining* atoms with every centroid m/z
+shifted by ``total_labeled_mass / |charge|``.
+
+Supported labels
+----------------
+
++--------+---------+--------------------+--------------------------------------+
+| Symbol | Isotope | Mono. mass (Da)    | Typical use                          |
++--------+---------+--------------------+--------------------------------------+
+| ``Cx`` | ¹³C     | 13.00335484        | Carbon tracing (glucose, glutamine…) |
+| ``Nx`` | ¹⁵N     | 15.00010889        | Nitrogen labeling, amino acids       |
+| ``Hx`` | ²H      |  2.014101778       | Lipids, drugs, kinetic studies       |
+| ``Ox`` | ¹⁸O     | 17.99915961        | Proteomics, water labeling           |
+| ``Sx`` | ³⁴S     | 33.96786700        | Cysteine / methionine tracing        |
++--------+---------+--------------------+--------------------------------------+
 
 Usage in custom databases
 --------------------------
 Use the symbol exactly like a regular element in the database TSV::
 
-    id    name                  formula
-    1     [U-13C6]-glucose      X6H12O6
-    2     [1,2-13C2]-acetate    X2H3O2
+    id    name                    formula
+    1     [U-¹³C₆]-glucose        Cx6H12O6
+    2     [1,2-¹³C₂]-acetate      Cx2H3O2
+    3     [U-¹⁵N₂]-glutamine      Cx5H8Nx2O3
+    4     [U-²H₇]-cholesterol     C27H38HxO
 
 METASPACE computes the correct isotope pattern and m/z by treating each
-``X`` atom as a delta-function at 13.00335484 Da and convolving that with
-the natural-isotope pattern of the remaining atoms (which is equivalent to
-simply shifting every centroid m/z by the total labeled-element mass divided
-by the ion charge state).
+labeled atom as a delta-function at its exact isotopic mass and convolving
+that with the natural-isotope pattern of the remaining atoms (equivalent to
+a rigid m/z shift per unit charge).
 """
 
 import re
@@ -34,21 +50,27 @@ from pyMSpec.pyisocalc.periodic_table import periodic_table
 # ---------------------------------------------------------------------------
 
 #: Metadata for every pseudo-element symbol.
-#: ``mass`` is the exact monoisotopic mass used for the m/z shift.
+#: ``mass`` is the exact monoisotopic mass in Da used for the m/z shift.
+#: Masses are taken from the same source as pyMSpec's periodic_table entries
+#: (AME / IUPAC values, consistent with periodicTable.ts in the webapp).
 ISOTOPE_LABEL_ELEMENTS: Dict[str, dict] = {
-    'X': {
-        'description': 'pure ¹³C',
-        'natural_element': 'C',
-        'mass': 13.00335484,
-    },
+    'Cx': {'description': 'pure ¹³C',  'natural_element': 'C', 'mass': 13.00335484},
+    'Nx': {'description': 'pure ¹⁵N',  'natural_element': 'N', 'mass': 15.00010889},
+    'Hx': {'description': 'pure ²H',   'natural_element': 'H', 'mass':  2.014101778},
+    'Ox': {'description': 'pure ¹⁸O',  'natural_element': 'O', 'mass': 17.99915961},
+    'Sx': {'description': 'pure ³⁴S',  'natural_element': 'S', 'mass': 33.96786700},
 }
 
 # Register pseudo-elements into pyMSpec's periodic table.
 # Format: [atomic_number, valence, [mass_list], [abundance_list]]
-# Using a single-isotope entry (abundance = 1.0) so that parseSumFormula()
-# and calculate_mono_mz() both see the correct exact mass.
+# Single-isotope entry (abundance = 1.0) so parseSumFormula() and
+# calculate_mono_mz() both see the correct exact mass.
 _PERIODIC_TABLE_ENTRIES: Dict[str, list] = {
-    'X': [6, -4, [13.00335484], [1.0]],
+    'Cx': [6,  -4, [13.00335484],  [1.0]],
+    'Nx': [7,   5, [15.00010889],  [1.0]],
+    'Hx': [1,   1, [ 2.014101778], [1.0]],
+    'Ox': [8,  -2, [17.99915961],  [1.0]],
+    'Sx': [16, -2, [33.96786700],  [1.0]],
 }
 for _sym, _entry in _PERIODIC_TABLE_ENTRIES.items():
     if _sym not in periodic_table:
@@ -58,13 +80,11 @@ for _sym, _entry in _PERIODIC_TABLE_ENTRIES.items():
 # Formula helpers
 # ---------------------------------------------------------------------------
 
-# Per-symbol substitution patterns: match the symbol followed by an optional integer count.
-# Built once at import time and reused for every call.
+# Per-symbol substitution patterns: match the symbol followed by an optional
+# integer count.  Built once at import time and reused for every call.
 _LABEL_PATTERNS: Dict[str, re.Pattern] = {
     sym: re.compile(rf'{re.escape(sym)}(\d*)') for sym in ISOTOPE_LABEL_ELEMENTS
 }
-
-_ELEM_RE = re.compile(r'([A-Z][a-z]*)([0-9]*)')
 
 
 def extract_labeled_mass_shift(formula: str) -> Tuple[float, str]:
@@ -81,7 +101,7 @@ def extract_labeled_mass_shift(formula: str) -> Tuple[float, str]:
     reject ill-formed formulas as they did before.
 
     Args:
-        formula: Ion formula string, e.g. ``'H13O6X6'``.
+        formula: Ion formula string, e.g. ``'H13O6Cx6'``.
 
     Returns:
         ``(mass_shift, unlabeled_formula)`` where *mass_shift* is the total
@@ -90,7 +110,7 @@ def extract_labeled_mass_shift(formula: str) -> Tuple[float, str]:
 
     Examples::
 
-        >>> extract_labeled_mass_shift('H13O6X6')
+        >>> extract_labeled_mass_shift('H13O6Cx6')
         (78.02012904, 'H13O6')
         >>> extract_labeled_mass_shift('H13O6')
         (0.0, 'H13O6')

--- a/metaspace/engine/sm/engine/tests/annotation_lithops/test_moldb_pipeline.py
+++ b/metaspace/engine/sm/engine/tests/annotation_lithops/test_moldb_pipeline.py
@@ -8,6 +8,7 @@ from sm.engine.annotation_lithops.executor import Executor
 from sm.engine.annotation_lithops.io import save_cobj, load_cobjs
 from sm.engine.annotation_lithops.moldb_pipeline import get_moldb_centroids
 
+
 # Mock CentroidsCacheEntry.lock so that a DB connection isn't needed
 @patch('sm.engine.annotation_lithops.moldb_pipeline.CentroidsCacheEntry.lock')
 def test_get_moldb_centroids(LockMock, executor: Executor, sm_config, ds_config):

--- a/metaspace/engine/sm/engine/tests/annotation_spark/test_segmenter.py
+++ b/metaspace/engine/sm/engine/tests/annotation_spark/test_segmenter.py
@@ -17,7 +17,7 @@ from tests.conftest import make_imzml_reader_mock
 
 
 def test_calculate_chunk_sp_n():
-    sample_mzs_bytes = 25 * 2 ** 20
+    sample_mzs_bytes = 25 * 2**20
     sample_sp_n = 10
     max_chunk_size_mb = 500
 
@@ -49,7 +49,7 @@ def test_define_ds_segments():
 
     mz_max = 100
     sample_mzs = np.linspace(0, mz_max, 100)
-    ds_segm_size_mb = 800 / (2 ** 20)  # 1600 b total data size / 2 segments, converted to MB
+    ds_segm_size_mb = 800 / (2**20)  # 1600 b total data size / 2 segments, converted to MB
     ds_segments = define_ds_segments(
         sample_mzs, sample_ratio=1, imzml_reader=imzml_reader, ds_segm_size_mb=ds_segm_size_mb
     )

--- a/metaspace/engine/sm/engine/tests/annotation_spark/test_segmenter.py
+++ b/metaspace/engine/sm/engine/tests/annotation_spark/test_segmenter.py
@@ -1,11 +1,12 @@
+from itertools import product
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
+
 import numpy as np
 import pandas as pd
-from itertools import product
 from numpy.testing import assert_array_almost_equal
 
-from sm.engine.annotation.imzml_reader import FSImzMLReader
+from tests.conftest import make_imzml_reader_mock
 from sm.engine.annotation_spark.segmenter import (
     segment_centroids,
     define_ds_segments,
@@ -13,11 +14,10 @@ from sm.engine.annotation_spark.segmenter import (
     calculate_chunk_sp_n,
     fetch_chunk_spectra_data,
 )
-from tests.conftest import make_imzml_reader_mock
 
 
 def test_calculate_chunk_sp_n():
-    sample_mzs_bytes = 25 * 2**20
+    sample_mzs_bytes = 25 * 2 ** 20
     sample_sp_n = 10
     max_chunk_size_mb = 500
 
@@ -49,7 +49,7 @@ def test_define_ds_segments():
 
     mz_max = 100
     sample_mzs = np.linspace(0, mz_max, 100)
-    ds_segm_size_mb = 800 / (2**20)  # 1600 b total data size / 2 segments, converted to MB
+    ds_segm_size_mb = 800 / (2 ** 20)  # 1600 b total data size / 2 segments, converted to MB
     ds_segments = define_ds_segments(
         sample_mzs, sample_ratio=1, imzml_reader=imzml_reader, ds_segm_size_mb=ds_segm_size_mb
     )
@@ -71,7 +71,7 @@ def test_segment_ds(dump_mock):
     chunk_sp_n = 1000
     segment_ds(imzml_reader, chunk_sp_n, ds_segments, Path('/tmp/abc'))
 
-    for segm_i, ((sp_chunk_df, f), _) in enumerate(dump_mock.call_args_list):
+    for segm_i, ((sp_chunk_df, _f), _) in enumerate(dump_mock.call_args_list):
         min_mz, max_mz = ds_segments[segm_i]
 
         assert sp_chunk_df.shape == (50, 3)

--- a/metaspace/engine/sm/engine/tests/test_formula_parser.py
+++ b/metaspace/engine/sm/engine/tests/test_formula_parser.py
@@ -1,12 +1,16 @@
 import pytest
 from itertools import product
 from pyMSpec.pyisocalc import pyisocalc
+from pyMSpec.pyisocalc.periodic_table import periodic_table
+
+import sm.engine.isotope_labels  # noqa: F401 — ensure periodic table is patched before tests
 
 from sm.engine.formula_parser import (
     generate_ion_formula,
     safe_generate_ion_formula,
     ParseFormulaError,
     format_ion_formula,
+    calculate_mono_mz,
 )
 
 
@@ -56,6 +60,31 @@ def test_generate_ion_formula_with_charge_only_adduct(formula, adduct):
     ion_formula = safe_generate_ion_formula(formula, adduct)
 
     assert ion_formula == formula
+
+
+def test_generate_ion_formula_with_labeled_element():
+    # X = pure 13C; X6H12O6 is fully 13C-labelled glucose.
+    # After +H adduct the ion formula should contain X6, H13, O6 (in CHNOPS order).
+    ion_formula = generate_ion_formula('X6H12O6', '+H')
+    assert ion_formula == 'H13O6X6'
+
+
+def test_generate_ion_formula_labeled_rejects_negative():
+    # Removing more X than are present should raise ParseFormulaError.
+    with pytest.raises(ParseFormulaError):
+        generate_ion_formula('X2H6O', '-X3')
+
+
+def test_calculate_mono_mz_labeled_element():
+    # [U-13C6]-glucose ion formula after +H adduct.
+    # Monoisotopic m/z = 6*M(13C) + 13*M(H) + 6*M(O) - M(electron)
+    M_13C = periodic_table['X'][2][0]   # 13.00335484
+    M_H = periodic_table['H'][2][0]     # 1.007825032
+    M_O = periodic_table['O'][2][0]     # 15.994914620
+    M_e = periodic_table['Ee'][2][0]    # 0.000548580
+
+    expected_mz = 6 * M_13C + 13 * M_H + 6 * M_O - M_e
+    assert calculate_mono_mz('H13O6X6', '+') == pytest.approx(expected_mz, rel=1e-6)
 
 
 def test_format_ion_formula():

--- a/metaspace/engine/sm/engine/tests/test_formula_parser.py
+++ b/metaspace/engine/sm/engine/tests/test_formula_parser.py
@@ -63,28 +63,28 @@ def test_generate_ion_formula_with_charge_only_adduct(formula, adduct):
 
 
 def test_generate_ion_formula_with_labeled_element():
-    # X = pure 13C; X6H12O6 is fully 13C-labelled glucose.
-    # After +H adduct the ion formula should contain X6, H13, O6 (in CHNOPS order).
-    ion_formula = generate_ion_formula('X6H12O6', '+H')
-    assert ion_formula == 'H13O6X6'
+    # Cx = pure ¹³C; Cx6H12O6 is fully ¹³C-labelled glucose.
+    # After +H adduct the ion formula should contain Cx6, H13, O6 (in CHNOPS order).
+    ion_formula = generate_ion_formula('Cx6H12O6', '+H')
+    assert ion_formula == 'H13O6Cx6'
 
 
 def test_generate_ion_formula_labeled_rejects_negative():
-    # Removing more X than are present should raise ParseFormulaError.
+    # Removing more Cx than are present should raise ParseFormulaError.
     with pytest.raises(ParseFormulaError):
-        generate_ion_formula('X2H6O', '-X3')
+        generate_ion_formula('Cx2H6O', '-Cx3')
 
 
 def test_calculate_mono_mz_labeled_element():
-    # [U-13C6]-glucose ion formula after +H adduct.
-    # Monoisotopic m/z = 6*M(13C) + 13*M(H) + 6*M(O) - M(electron)
-    M_13C = periodic_table['X'][2][0]   # 13.00335484
-    M_H = periodic_table['H'][2][0]     # 1.007825032
-    M_O = periodic_table['O'][2][0]     # 15.994914620
-    M_e = periodic_table['Ee'][2][0]    # 0.000548580
+    # [U-¹³C₆]-glucose ion formula after +H adduct.
+    # Monoisotopic m/z = 6*M(¹³C) + 13*M(H) + 6*M(O) - M(electron)
+    M_13C = periodic_table['Cx'][2][0]  # 13.00335484
+    M_H = periodic_table['H'][2][0]  # 1.007825032
+    M_O = periodic_table['O'][2][0]  # 15.994914620
+    M_e = periodic_table['Ee'][2][0]  # 0.000548580
 
     expected_mz = 6 * M_13C + 13 * M_H + 6 * M_O - M_e
-    assert calculate_mono_mz('H13O6X6', '+') == pytest.approx(expected_mz, rel=1e-6)
+    assert calculate_mono_mz('H13O6Cx6', '+') == pytest.approx(expected_mz, rel=1e-6)
 
 
 def test_format_ion_formula():

--- a/metaspace/engine/sm/engine/tests/test_isocalc_wrapper.py
+++ b/metaspace/engine/sm/engine/tests/test_isocalc_wrapper.py
@@ -1,6 +1,9 @@
 import pytest
 import numpy as np
 from numpy.testing import assert_array_almost_equal
+from pyMSpec.pyisocalc.periodic_table import periodic_table
+
+import sm.engine.isotope_labels  # noqa: F401 — ensure periodic table is patched before tests
 
 from tests.conftest import ds_config
 from sm.engine.annotation.isocalc_wrapper import IsocalcWrapper, mass_accuracy_half_width
@@ -28,6 +31,45 @@ def test_centroids_h20(ds_config):
 
     assert_array_almost_equal(mzs, np.array([19.018, 20.022, 20.024, 21.022]), decimal=3)
     assert_array_almost_equal(ints, np.array([1.00e02, 3.83e-02, 3.48e-02, 2.06e-01]), decimal=2)
+
+
+def test_centroids_labeled_element_mz_shift(ds_config):
+    """13C-labelled glucose [U-13C6] should be exactly 6 * (M_13C - M_12C) higher than
+    natural-isotope glucose in m/z."""
+    isocalc_wrapper = IsocalcWrapper(ds_config)
+
+    # Natural glucose +H: C6H12O6 → ion formula C6H13O6 (after adduct applied upstream)
+    # Labelled glucose +H: X6H12O6 → ion formula H13O6X6
+    mzs_natural, ints_natural = isocalc_wrapper.centroids('C6H13O6')
+    mzs_labeled, ints_labeled = isocalc_wrapper.centroids('H13O6X6')
+
+    assert mzs_natural is not None, 'natural glucose centroids should not be None'
+    assert mzs_labeled is not None, '13C-glucose centroids should not be None'
+
+    # Expected m/z shift: 6 × (M_13C − M_12C)
+    M_12C = periodic_table['C'][2][0]   # 12.0 (exactly)
+    M_13C = periodic_table['X'][2][0]   # 13.00335484
+    expected_shift = 6 * (M_13C - M_12C)
+
+    # The monoisotopic (highest-intensity) peak carries the shift.
+    mono_natural = mzs_natural[np.argmax(ints_natural)]
+    mono_labeled = mzs_labeled[np.argmax(ints_labeled)]
+    assert mono_labeled - mono_natural == pytest.approx(expected_shift, abs=1e-4)
+
+
+def test_centroids_unlabeled_formula_unchanged(ds_config):
+    """Formulas without X must produce the same centroids as before."""
+    isocalc_wrapper = IsocalcWrapper(ds_config)
+    mzs, ints = isocalc_wrapper.centroids('H2O+H')
+    assert_array_almost_equal(mzs, np.array([19.018, 20.022, 20.024, 21.022]), decimal=3)
+
+
+def test_centroids_all_labeled_returns_none(ds_config):
+    """A formula made entirely of labeled atoms has no natural-isotope backbone
+    and must return (None, None) rather than crash."""
+    isocalc_wrapper = IsocalcWrapper(ds_config)
+    mzs, ints = isocalc_wrapper.centroids('X6')
+    assert mzs is None and ints is None
 
 
 def test_mass_accuracy_half_width():

--- a/metaspace/engine/sm/engine/tests/test_isocalc_wrapper.py
+++ b/metaspace/engine/sm/engine/tests/test_isocalc_wrapper.py
@@ -39,16 +39,16 @@ def test_centroids_labeled_element_mz_shift(ds_config):
     isocalc_wrapper = IsocalcWrapper(ds_config)
 
     # Natural glucose +H: C6H12O6 → ion formula C6H13O6 (after adduct applied upstream)
-    # Labelled glucose +H: X6H12O6 → ion formula H13O6X6
+    # Labelled glucose +H: Cx6H12O6 → ion formula H13O6Cx6
     mzs_natural, ints_natural = isocalc_wrapper.centroids('C6H13O6')
-    mzs_labeled, ints_labeled = isocalc_wrapper.centroids('H13O6X6')
+    mzs_labeled, ints_labeled = isocalc_wrapper.centroids('H13O6Cx6')
 
     assert mzs_natural is not None, 'natural glucose centroids should not be None'
     assert mzs_labeled is not None, '13C-glucose centroids should not be None'
 
     # Expected m/z shift: 6 × (M_13C − M_12C)
-    M_12C = periodic_table['C'][2][0]   # 12.0 (exactly)
-    M_13C = periodic_table['X'][2][0]   # 13.00335484
+    M_12C = periodic_table['C'][2][0]  # 12.0 (exactly)
+    M_13C = periodic_table['Cx'][2][0]  # 13.00335484
     expected_shift = 6 * (M_13C - M_12C)
 
     # The monoisotopic (highest-intensity) peak carries the shift.
@@ -68,7 +68,7 @@ def test_centroids_all_labeled_returns_none(ds_config):
     """A formula made entirely of labeled atoms has no natural-isotope backbone
     and must return (None, None) rather than crash."""
     isocalc_wrapper = IsocalcWrapper(ds_config)
-    mzs, ints = isocalc_wrapper.centroids('X6')
+    mzs, ints = isocalc_wrapper.centroids('Cx6')
     assert mzs is None and ints is None
 
 

--- a/metaspace/engine/sm/engine/tests/test_isotope_labels.py
+++ b/metaspace/engine/sm/engine/tests/test_isotope_labels.py
@@ -1,0 +1,86 @@
+"""Unit tests for sm.engine.isotope_labels."""
+
+import pytest
+from pyMSpec.pyisocalc.periodic_table import periodic_table
+from pyMSpec.pyisocalc.pyisocalc import parseSumFormula
+
+import sm.engine.isotope_labels  # noqa: F401 — patches periodic table
+from sm.engine.isotope_labels import extract_labeled_mass_shift, has_labeled_elements
+
+M_13C = 13.00335484
+
+
+# ---------------------------------------------------------------------------
+# Periodic table patch
+# ---------------------------------------------------------------------------
+
+
+def test_x_registered_in_periodic_table():
+    assert 'X' in periodic_table
+
+
+def test_x_periodic_table_entry():
+    entry = periodic_table['X']
+    assert entry[0] == 6               # atomic number (carbon)
+    assert entry[2] == [M_13C]         # single exact mass
+    assert entry[3] == [1.0]           # 100 % abundance
+
+
+def test_x_accepted_by_parseSumFormula():
+    """parseSumFormula must not raise for formulas containing X."""
+    result = parseSumFormula('X6H12O6')
+    assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# extract_labeled_mass_shift
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'formula, expected_shift, expected_remainder',
+    [
+        # No labeled elements → zero shift, formula unchanged
+        ('H13O6', 0.0, 'H13O6'),
+        ('C6H13O6', 0.0, 'C6H13O6'),
+        # All 6 13C atoms
+        ('H13O6X6', 6 * M_13C, 'H13O6'),
+        # Single 13C atom
+        ('XH3', M_13C, 'H3'),
+        # Mixed labeled and natural carbon (partial label)
+        ('X2C4H12O6', 2 * M_13C, 'C4H12O6'),
+        # Labeled element at the start of the formula
+        ('X6H13O6', 6 * M_13C, 'H13O6'),
+        # Count of 1 omitted from formula string
+        ('XH2O', M_13C, 'H2O'),
+    ],
+)
+def test_extract_labeled_mass_shift(formula, expected_shift, expected_remainder):
+    shift, remainder = extract_labeled_mass_shift(formula)
+    assert shift == pytest.approx(expected_shift, rel=1e-9)
+    assert remainder == expected_remainder
+
+
+def test_extract_labeled_mass_shift_entirely_labeled():
+    """Formula with only X atoms: mass shift is correct, remainder is empty."""
+    shift, remainder = extract_labeled_mass_shift('X6')
+    assert shift == pytest.approx(6 * M_13C, rel=1e-9)
+    assert remainder == ''
+
+
+# ---------------------------------------------------------------------------
+# has_labeled_elements
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'formula, expected',
+    [
+        ('C6H12O6', False),
+        ('H13O6X6', True),
+        ('XH3', True),
+        ('H2O', False),
+    ],
+)
+def test_has_labeled_elements(formula, expected):
+    assert has_labeled_elements(formula) is expected

--- a/metaspace/engine/sm/engine/tests/test_isotope_labels.py
+++ b/metaspace/engine/sm/engine/tests/test_isotope_labels.py
@@ -7,33 +7,57 @@ from pyMSpec.pyisocalc.pyisocalc import parseSumFormula
 import sm.engine.isotope_labels  # noqa: F401 — patches periodic table
 from sm.engine.isotope_labels import extract_labeled_mass_shift, has_labeled_elements
 
-M_13C = 13.00335484
+# Exact masses used in assertions (must match ISOTOPE_LABEL_ELEMENTS)
+M_CX = 13.00335484  # ¹³C
+M_NX = 15.00010889  # ¹⁵N
+M_HX = 2.014101778  # ²H
+M_OX = 17.99915961  # ¹⁸O
+M_SX = 33.96786700  # ³⁴S
 
 
 # ---------------------------------------------------------------------------
-# Periodic table patch
+# Periodic table registration
 # ---------------------------------------------------------------------------
 
 
-def test_x_registered_in_periodic_table():
-    assert 'X' in periodic_table
+@pytest.mark.parametrize('sym', ['Cx', 'Nx', 'Hx', 'Ox', 'Sx'])
+def test_symbol_registered_in_periodic_table(sym):
+    assert sym in periodic_table
 
 
-def test_x_periodic_table_entry():
-    entry = periodic_table['X']
-    assert entry[0] == 6               # atomic number (carbon)
-    assert entry[2] == [M_13C]         # single exact mass
-    assert entry[3] == [1.0]           # 100 % abundance
+@pytest.mark.parametrize(
+    'sym, atomic_number, mass',
+    [
+        ('Cx', 6, M_CX),
+        ('Nx', 7, M_NX),
+        ('Hx', 1, M_HX),
+        ('Ox', 8, M_OX),
+        ('Sx', 16, M_SX),
+    ],
+)
+def test_periodic_table_entry(sym, atomic_number, mass):
+    entry = periodic_table[sym]
+    assert entry[0] == atomic_number  # atomic number
+    assert entry[2] == pytest.approx([mass], rel=1e-9)  # single exact mass
+    assert entry[3] == [1.0]  # 100 % abundance
 
 
-def test_x_accepted_by_parseSumFormula():
-    """parseSumFormula must not raise for formulas containing X."""
-    result = parseSumFormula('X6H12O6')
+@pytest.mark.parametrize(
+    'formula',
+    [
+        'Cx6H12O6',  # [U-¹³C₆]-glucose
+        'Cx5H8Nx2O3',  # partially labeled (¹³C + ¹⁵N)
+        'Hx3C5H7O',  # deuterium-labeled
+    ],
+)
+def test_parseSumFormula_accepts_labeled_formulas(formula):
+    """parseSumFormula must not raise for any formula containing labeled elements."""
+    result = parseSumFormula(formula)
     assert result is not None
 
 
 # ---------------------------------------------------------------------------
-# extract_labeled_mass_shift
+# extract_labeled_mass_shift — ¹³C (Cx)
 # ---------------------------------------------------------------------------
 
 
@@ -43,28 +67,56 @@ def test_x_accepted_by_parseSumFormula():
         # No labeled elements → zero shift, formula unchanged
         ('H13O6', 0.0, 'H13O6'),
         ('C6H13O6', 0.0, 'C6H13O6'),
-        # All 6 13C atoms
-        ('H13O6X6', 6 * M_13C, 'H13O6'),
-        # Single 13C atom
-        ('XH3', M_13C, 'H3'),
+        # All 6 ¹³C atoms
+        ('H13O6Cx6', 6 * M_CX, 'H13O6'),
+        # Single ¹³C atom (count omitted)
+        ('CxH3', M_CX, 'H3'),
         # Mixed labeled and natural carbon (partial label)
-        ('X2C4H12O6', 2 * M_13C, 'C4H12O6'),
-        # Labeled element at the start of the formula
-        ('X6H13O6', 6 * M_13C, 'H13O6'),
-        # Count of 1 omitted from formula string
-        ('XH2O', M_13C, 'H2O'),
+        ('Cx2C4H12O6', 2 * M_CX, 'C4H12O6'),
+        # Labeled element at start
+        ('Cx6H13O6', 6 * M_CX, 'H13O6'),
+        # Count of 1 omitted
+        ('CxH2O', M_CX, 'H2O'),
     ],
 )
-def test_extract_labeled_mass_shift(formula, expected_shift, expected_remainder):
+def test_extract_labeled_mass_shift_13C(formula, expected_shift, expected_remainder):
     shift, remainder = extract_labeled_mass_shift(formula)
     assert shift == pytest.approx(expected_shift, rel=1e-9)
     assert remainder == expected_remainder
 
 
+# ---------------------------------------------------------------------------
+# extract_labeled_mass_shift — other isotopes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'formula, expected_shift, expected_remainder',
+    [
+        ('H12Nx2O3', 2 * M_NX, 'H12O3'),  # ¹⁵N
+        ('Hx3C5H7O', 3 * M_HX, 'C5H7O'),  # ²H
+        ('C6H12OxO5', 1 * M_OX, 'C6H12O5'),  # ¹⁸O
+        ('C2H4SxO', 1 * M_SX, 'C2H4O'),  # ³⁴S
+    ],
+)
+def test_extract_labeled_mass_shift_other_isotopes(formula, expected_shift, expected_remainder):
+    shift, remainder = extract_labeled_mass_shift(formula)
+    assert shift == pytest.approx(expected_shift, rel=1e-9)
+    assert remainder == expected_remainder
+
+
+def test_extract_labeled_mass_shift_mixed_labels():
+    """Formula with both Cx and Nx labels."""
+    # Cx5H8Nx2O3: 5 ¹³C + 2 ¹⁵N
+    shift, remainder = extract_labeled_mass_shift('Cx5H8Nx2O3')
+    assert shift == pytest.approx(5 * M_CX + 2 * M_NX, rel=1e-9)
+    assert remainder == 'H8O3'
+
+
 def test_extract_labeled_mass_shift_entirely_labeled():
-    """Formula with only X atoms: mass shift is correct, remainder is empty."""
-    shift, remainder = extract_labeled_mass_shift('X6')
-    assert shift == pytest.approx(6 * M_13C, rel=1e-9)
+    """Formula with only Cx atoms: mass shift is correct, remainder is empty."""
+    shift, remainder = extract_labeled_mass_shift('Cx6')
+    assert shift == pytest.approx(6 * M_CX, rel=1e-9)
     assert remainder == ''
 
 
@@ -77,9 +129,11 @@ def test_extract_labeled_mass_shift_entirely_labeled():
     'formula, expected',
     [
         ('C6H12O6', False),
-        ('H13O6X6', True),
-        ('XH3', True),
+        ('H13O6Cx6', True),
+        ('CxH3', True),
         ('H2O', False),
+        ('Cx5H8Nx2O3', True),
+        ('Hx3C5H7O', True),
     ],
 )
 def test_has_labeled_elements(formula, expected):

--- a/metaspace/engine/sm/rest/isotopic_pattern.py
+++ b/metaspace/engine/sm/rest/isotopic_pattern.py
@@ -10,11 +10,19 @@ logger = logging.getLogger('api')
 
 
 class Centroids:
-    def __init__(self, isotope_pattern, instrument_model, pts_per_mz=None, n_peaks=ISOTOPIC_PEAK_N):
+    def __init__(
+        self,
+        isotope_pattern,
+        instrument_model,
+        pts_per_mz=None,
+        n_peaks=ISOTOPIC_PEAK_N,
+        mz_shift=0.0,
+    ):
         self._isotope_pattern = isotope_pattern
         self._instrument_model = instrument_model
         self._pts_per_mz = pts_per_mz
         self._n_peaks = n_peaks
+        self._mz_shift = mz_shift
 
         if isotope_pattern is not None:
             centroids = isotope_pattern.centroids(instrument_model)
@@ -43,10 +51,16 @@ class Centroids:
 
     def spectrum_chart(self):
         centr_mzs, _ = self._trim_centroids(self.mzs, self.ints, self._n_peaks)
-        min_mz = min(centr_mzs) - 0.25
-        max_mz = max(centr_mzs) + 0.25
+        # For isotope-labeled compounds, shift all display m/z values by the
+        # exact mass of the pure-isotope atoms divided by the charge state.
+        display_centr_mzs = centr_mzs + self._mz_shift
+        min_mz = min(display_centr_mzs) - 0.25
+        max_mz = max(display_centr_mzs) + 0.25
         prof_mzs = np.arange(min_mz, max_mz, 1.0 / self._pts_per_mz)
-        prof_ints = self._envelope(prof_mzs)
+        # The envelope function is defined in the unlabeled (natural) m/z space.
+        # Evaluate it at (display_mz - shift) so the profile curve lines up with the
+        # shifted centroids.
+        prof_ints = self._envelope(prof_mzs - self._mz_shift)
         nnz_idx = prof_ints > 1e-9
         prof_mzs = prof_mzs[nnz_idx]
         prof_ints = prof_ints[nnz_idx]
@@ -54,7 +68,7 @@ class Centroids:
         return {
             'mz_grid': {'min_mz': min_mz, 'max_mz': max_mz},
             'theor': {
-                'centroid_mzs': centr_mzs.tolist(),
+                'centroid_mzs': display_centr_mzs.tolist(),
                 'mzs': prof_mzs.tolist(),
                 'ints': (prof_ints * 100.0).tolist(),
             },
@@ -66,8 +80,24 @@ class Centroids:
 
 
 def generate(ion, instr, res_power, at_mz, charge):
-    isotopes = isotopePattern(ion)
+    # Isotope-labeled pseudo-elements (e.g. X = pure ¹³C) contribute a fixed
+    # mass offset with no isotope spread.  Strip them from the ion formula,
+    # compute the natural-isotope pattern for the remaining atoms, then shift
+    # every centroid by labeled_mass / |charge|.
+    from sm.engine.isotope_labels import extract_labeled_mass_shift  # noqa: PLC0415
+
+    labeled_mass_shift, unlabeled_ion = extract_labeled_mass_shift(ion)
+
+    if labeled_mass_shift and not unlabeled_ion:
+        raise ValueError(
+            f'{ion}: formula consists entirely of labeled elements; isotope pattern unavailable'
+        )
+
+    effective_ion = unlabeled_ion if labeled_mass_shift else ion
+    mz_shift = labeled_mass_shift / abs(int(charge)) if labeled_mass_shift else 0.0
+
+    isotopes = isotopePattern(effective_ion)
     isotopes.addCharge(int(charge))
     instrument = InstrumentModel(instr, float(res_power), float(at_mz))
-    centroids = Centroids(isotopes, instrument)
+    centroids = Centroids(isotopes, instrument, mz_shift=mz_shift)
     return centroids.spectrum_chart()

--- a/metaspace/engine/sm/rest/isotopic_pattern.py
+++ b/metaspace/engine/sm/rest/isotopic_pattern.py
@@ -82,8 +82,8 @@ class Centroids:
 
 
 def generate(ion, instr, res_power, at_mz, charge):
-    # Isotope-labeled pseudo-elements (e.g. X = pure ¹³C) contribute a fixed
-    # mass offset with no isotope spread.  Strip them from the ion formula,
+    # Isotope-labeled pseudo-elements (e.g. Cx = pure ¹³C, Nx = pure ¹⁵N)
+    # contribute a fixed mass offset with no isotope spread.  Strip them from the ion formula,
     # compute the natural-isotope pattern for the remaining atoms, then shift
     # every centroid by labeled_mass / |charge|.
     labeled_mass_shift, unlabeled_ion = extract_labeled_mass_shift(ion)

--- a/metaspace/engine/sm/rest/isotopic_pattern.py
+++ b/metaspace/engine/sm/rest/isotopic_pattern.py
@@ -3,6 +3,8 @@ import logging
 import numpy as np
 from cpyMSpec import isotopePattern, InstrumentModel
 
+from sm.engine.isotope_labels import extract_labeled_mass_shift
+
 ISOTOPIC_PEAK_N = 4
 SIGMA_TO_FWHM = 2.3548200450309493  # 2 \sqrt{2 \log 2}
 
@@ -84,8 +86,6 @@ def generate(ion, instr, res_power, at_mz, charge):
     # mass offset with no isotope spread.  Strip them from the ion formula,
     # compute the natural-isotope pattern for the remaining atoms, then shift
     # every centroid by labeled_mass / |charge|.
-    from sm.engine.isotope_labels import extract_labeled_mass_shift  # noqa: PLC0415
-
     labeled_mass_shift, unlabeled_ion = extract_labeled_mass_shift(ion)
 
     if labeled_mass_shift and not unlabeled_ion:

--- a/metaspace/engine/sm/rest/tests/test_isotopic_pattern.py
+++ b/metaspace/engine/sm/rest/tests/test_isotopic_pattern.py
@@ -1,4 +1,5 @@
 """Tests for the isotopic_pattern REST helper, including labeled-element support."""
+
 import pytest
 import sm.engine.isotope_labels  # noqa: F401 — patches pyMSpec periodic_table
 
@@ -32,14 +33,16 @@ class TestGenerateUnlabeled:
 
     def test_unlabeled_produces_multiple_peaks(self):
         result = generate('C6H13O6', _INSTR, _RP, _AT_MZ, _CHARGE)
-        assert len(result['theor']['centroid_mzs']) > 1, 'Expected M+1, M+2, … peaks for natural glucose'
+        assert (
+            len(result['theor']['centroid_mzs']) > 1
+        ), 'Expected M+1, M+2, … peaks for natural glucose'
 
 
 class TestGenerateLabeled:
     def test_labeled_glucose_shift_equals_six_delta_masses(self):
-        """[U-¹³C6]-glucose + H = X6H13O6 must be exactly 6 × (¹³C − ¹²C) heavier than C6H13O6."""
+        """[U-¹³C6]-glucose + H = Cx6H13O6 must be exactly 6 × (¹³C − ¹²C) heavier than C6H13O6."""
         natural = generate('C6H13O6', _INSTR, _RP, _AT_MZ, _CHARGE)
-        labeled = generate('X6H13O6', _INSTR, _RP, _AT_MZ, _CHARGE)
+        labeled = generate('Cx6H13O6', _INSTR, _RP, _AT_MZ, _CHARGE)
 
         natural_mz0 = natural['theor']['centroid_mzs'][0]
         labeled_mz0 = labeled['theor']['centroid_mzs'][0]
@@ -49,33 +52,35 @@ class TestGenerateLabeled:
         # The M peak centroid is offset slightly by the M+1 tail, and this offset differs
         # between the natural compound (C contributes ~7 % M+1) and the labeled compound
         # (no C → much smaller M+1).  Allow 1 mDa of centroid-induced bias.
-        assert abs((labeled_mz0 - natural_mz0) - expected_shift) < 1e-3, (
-            f'Expected shift {expected_shift:.5f}, got {labeled_mz0 - natural_mz0:.5f}'
-        )
+        assert (
+            abs((labeled_mz0 - natural_mz0) - expected_shift) < 1e-3
+        ), f'Expected shift {expected_shift:.5f}, got {labeled_mz0 - natural_mz0:.5f}'
 
     def test_labeled_produces_multiple_peaks(self):
         """M+1, M+2 from unlabeled H/O atoms must still appear."""
-        result = generate('X6H13O6', _INSTR, _RP, _AT_MZ, _CHARGE)
-        assert len(result['theor']['centroid_mzs']) > 1, 'Expected isotope peaks from H/O natural isotopes'
+        result = generate('Cx6H13O6', _INSTR, _RP, _AT_MZ, _CHARGE)
+        assert (
+            len(result['theor']['centroid_mzs']) > 1
+        ), 'Expected isotope peaks from H/O natural isotopes'
 
     def test_profile_mzs_consistent_with_centroid_mzs(self):
         """Profile envelope must cover the same m/z range as the shifted centroids."""
-        result = generate('X6H13O6', _INSTR, _RP, _AT_MZ, _CHARGE)
+        result = generate('Cx6H13O6', _INSTR, _RP, _AT_MZ, _CHARGE)
         mz_min = result['mz_grid']['min_mz']
         mz_max = result['mz_grid']['max_mz']
         for mz in result['theor']['centroid_mzs']:
             assert mz_min < mz < mz_max, f'Centroid {mz} outside mz_grid [{mz_min}, {mz_max}]'
 
     def test_partial_label_shift(self):
-        """Partially labeled compound X2H4 should shift by 2 × (¹³C − ¹²C) vs C2H4."""
+        """Partially labeled compound Cx2H4 should shift by 2 × (¹³C − ¹²C) vs C2H4."""
         natural = generate('C2H4', _INSTR, _RP, _AT_MZ, _CHARGE)
-        labeled = generate('X2H4', _INSTR, _RP, _AT_MZ, _CHARGE)
+        labeled = generate('Cx2H4', _INSTR, _RP, _AT_MZ, _CHARGE)
         natural_mz0 = natural['theor']['centroid_mzs'][0]
         labeled_mz0 = labeled['theor']['centroid_mzs'][0]
         expected_shift = 2 * (M_13C - M_12C)
         assert abs((labeled_mz0 - natural_mz0) - expected_shift) < 5e-4
 
     def test_all_labeled_raises(self):
-        """A formula consisting entirely of X atoms has no natural isotope pattern."""
+        """A formula consisting entirely of labeled atoms has no natural isotope pattern."""
         with pytest.raises(ValueError, match='entirely of labeled elements'):
-            generate('X6', _INSTR, _RP, _AT_MZ, _CHARGE)
+            generate('Cx6', _INSTR, _RP, _AT_MZ, _CHARGE)

--- a/metaspace/engine/sm/rest/tests/test_isotopic_pattern.py
+++ b/metaspace/engine/sm/rest/tests/test_isotopic_pattern.py
@@ -1,0 +1,81 @@
+"""Tests for the isotopic_pattern REST helper, including labeled-element support."""
+import pytest
+import sm.engine.isotope_labels  # noqa: F401 — patches pyMSpec periodic_table
+
+from sm.rest.isotopic_pattern import generate
+
+M_13C = 13.00335484
+M_12C = 12.0
+
+# Shared instrument args used in every call
+_INSTR = 'tof'
+_RP = '1000'
+_AT_MZ = '200'
+_CHARGE = '+1'
+
+
+class TestGenerateUnlabeled:
+    def test_returns_dict_with_expected_keys(self):
+        result = generate('H2O', _INSTR, _RP, _AT_MZ, _CHARGE)
+        assert 'theor' in result
+        assert 'mz_grid' in result
+        theor = result['theor']
+        assert 'centroid_mzs' in theor
+        assert 'mzs' in theor
+        assert 'ints' in theor
+
+    def test_natural_glucose_centroid_near_expected_mz(self):
+        # [U-12C6]-glucose + H: C6H13O6, monoisotopic ~181.07 Da
+        result = generate('C6H13O6', _INSTR, _RP, _AT_MZ, _CHARGE)
+        mz0 = result['theor']['centroid_mzs'][0]
+        assert abs(mz0 - 181.07) < 0.05, f'Unexpected M centroid: {mz0}'
+
+    def test_unlabeled_produces_multiple_peaks(self):
+        result = generate('C6H13O6', _INSTR, _RP, _AT_MZ, _CHARGE)
+        assert len(result['theor']['centroid_mzs']) > 1, 'Expected M+1, M+2, … peaks for natural glucose'
+
+
+class TestGenerateLabeled:
+    def test_labeled_glucose_shift_equals_six_delta_masses(self):
+        """[U-¹³C6]-glucose + H = X6H13O6 must be exactly 6 × (¹³C − ¹²C) heavier than C6H13O6."""
+        natural = generate('C6H13O6', _INSTR, _RP, _AT_MZ, _CHARGE)
+        labeled = generate('X6H13O6', _INSTR, _RP, _AT_MZ, _CHARGE)
+
+        natural_mz0 = natural['theor']['centroid_mzs'][0]
+        labeled_mz0 = labeled['theor']['centroid_mzs'][0]
+
+        expected_shift = 6 * (M_13C - M_12C)
+        # cpyMSpec returns peak centroids (intensity-weighted), not exact monoisotopic masses.
+        # The M peak centroid is offset slightly by the M+1 tail, and this offset differs
+        # between the natural compound (C contributes ~7 % M+1) and the labeled compound
+        # (no C → much smaller M+1).  Allow 1 mDa of centroid-induced bias.
+        assert abs((labeled_mz0 - natural_mz0) - expected_shift) < 1e-3, (
+            f'Expected shift {expected_shift:.5f}, got {labeled_mz0 - natural_mz0:.5f}'
+        )
+
+    def test_labeled_produces_multiple_peaks(self):
+        """M+1, M+2 from unlabeled H/O atoms must still appear."""
+        result = generate('X6H13O6', _INSTR, _RP, _AT_MZ, _CHARGE)
+        assert len(result['theor']['centroid_mzs']) > 1, 'Expected isotope peaks from H/O natural isotopes'
+
+    def test_profile_mzs_consistent_with_centroid_mzs(self):
+        """Profile envelope must cover the same m/z range as the shifted centroids."""
+        result = generate('X6H13O6', _INSTR, _RP, _AT_MZ, _CHARGE)
+        mz_min = result['mz_grid']['min_mz']
+        mz_max = result['mz_grid']['max_mz']
+        for mz in result['theor']['centroid_mzs']:
+            assert mz_min < mz < mz_max, f'Centroid {mz} outside mz_grid [{mz_min}, {mz_max}]'
+
+    def test_partial_label_shift(self):
+        """Partially labeled compound X2H4 should shift by 2 × (¹³C − ¹²C) vs C2H4."""
+        natural = generate('C2H4', _INSTR, _RP, _AT_MZ, _CHARGE)
+        labeled = generate('X2H4', _INSTR, _RP, _AT_MZ, _CHARGE)
+        natural_mz0 = natural['theor']['centroid_mzs'][0]
+        labeled_mz0 = labeled['theor']['centroid_mzs'][0]
+        expected_shift = 2 * (M_13C - M_12C)
+        assert abs((labeled_mz0 - natural_mz0) - expected_shift) < 5e-4
+
+    def test_all_labeled_raises(self):
+        """A formula consisting entirely of X atoms has no natural isotope pattern."""
+        with pytest.raises(ValueError, match='entirely of labeled elements'):
+            generate('X6', _INSTR, _RP, _AT_MZ, _CHARGE)

--- a/metaspace/graphql/src/modules/annotation/lib/periodicTable.ts
+++ b/metaspace/graphql/src/modules/annotation/lib/periodicTable.ts
@@ -131,7 +131,12 @@ export const periodicTable : any = {
     [0.000054, 0.007204, 0.992742]],
   Ee: [0, 0, [0.000548597], [1.0]],
   D: [1, 1, [1.007825032, 2.014101778], [0.001, 0.999]],
-  // Pseudo-element for isotope labeling: X = pure ¹³C (100 % abundance at 13.00335484 Da).
-  // Mirrors the entry added to pyMSpec's periodic_table in sm.engine.isotope_labels.
-  X: [6, -4, [13.00335484], [1.0]],
+  // Pseudo-elements for isotope labeling (100 % pure single isotope).
+  // Symbol convention: base-element letter + 'x'.  Mirrors the entries in
+  // sm.engine.isotope_labels (Python) which patches pyMSpec's periodic_table.
+  Cx: [6,  -4, [13.00335484],  [1.0]],  // ¹³C — carbon tracing
+  Nx: [7,   5, [15.00010889],  [1.0]],  // ¹⁵N — nitrogen labeling
+  Hx: [1,   1, [ 2.014101778], [1.0]],  // ²H  — lipids, drugs
+  Ox: [8,  -2, [17.99915961],  [1.0]],  // ¹⁸O  — proteomics / water labeling
+  Sx: [16, -2, [33.96786700],  [1.0]],  // ³⁴S  — cysteine / methionine tracing
 }

--- a/metaspace/graphql/src/modules/annotation/lib/periodicTable.ts
+++ b/metaspace/graphql/src/modules/annotation/lib/periodicTable.ts
@@ -134,9 +134,9 @@ export const periodicTable : any = {
   // Pseudo-elements for isotope labeling (100 % pure single isotope).
   // Symbol convention: base-element letter + 'x'.  Mirrors the entries in
   // sm.engine.isotope_labels (Python) which patches pyMSpec's periodic_table.
-  Cx: [6,  -4, [13.00335484],  [1.0]],  // ¹³C — carbon tracing
-  Nx: [7,   5, [15.00010889],  [1.0]],  // ¹⁵N — nitrogen labeling
-  Hx: [1,   1, [ 2.014101778], [1.0]],  // ²H  — lipids, drugs
-  Ox: [8,  -2, [17.99915961],  [1.0]],  // ¹⁸O  — proteomics / water labeling
-  Sx: [16, -2, [33.96786700],  [1.0]],  // ³⁴S  — cysteine / methionine tracing
+  Cx: [6, -4, [13.00335484], [1.0]], // ¹³C — carbon tracing
+  Nx: [7, 5, [15.00010889], [1.0]], // ¹⁵N — nitrogen labeling
+  Hx: [1, 1, [2.014101778], [1.0]], // ²H — lipids, drugs
+  Ox: [8, -2, [17.99915961], [1.0]], // ¹⁸O — proteomics / water labeling
+  Sx: [16, -2, [33.96786700], [1.0]], // ³⁴S — cysteine / methionine tracing
 }

--- a/metaspace/graphql/src/modules/annotation/lib/periodicTable.ts
+++ b/metaspace/graphql/src/modules/annotation/lib/periodicTable.ts
@@ -131,4 +131,7 @@ export const periodicTable : any = {
     [0.000054, 0.007204, 0.992742]],
   Ee: [0, 0, [0.000548597], [1.0]],
   D: [1, 1, [1.007825032, 2.014101778], [0.001, 0.999]],
+  // Pseudo-element for isotope labeling: X = pure ¹³C (100 % abundance at 13.00335484 Da).
+  // Mirrors the entry added to pyMSpec's periodic_table in sm.engine.isotope_labels.
+  X: [6, -4, [13.00335484], [1.0]],
 }

--- a/metaspace/webapp/docs/src/features/tools-and-integrations/custom-databases.md
+++ b/metaspace/webapp/docs/src/features/tools-and-integrations/custom-databases.md
@@ -41,6 +41,40 @@ Follow the steps in this video to upload your custom database:
 
 <YouTubeEmbed id="L43lYp10vNg" />
 
+## Isotope-labeled compounds
+
+If your experiment uses stable-isotope labeling (e.g. ¹³C metabolic tracing or ¹⁵N amino-acid labeling), you can encode labeled atoms directly in the `formula` column using the pseudo-element symbols below. METASPACE will compute the correct m/z by treating each labeled atom as a delta-function at its exact isotopic mass and convolving that with the natural-isotope pattern of the remaining atoms — mathematically equivalent to a rigid m/z shift.
+
+### Supported isotope labels
+
+| Symbol | Isotope | Monoisotopic mass (Da) | Typical use                                        |
+|--------|---------|------------------------|----------------------------------------------------|
+| `Cx`   | ¹³C     | 13.00335484            | Carbon tracing — glucose, glutamine, acetate, etc. |
+| `Nx`   | ¹⁵N     | 15.00010889            | Nitrogen labeling — amino acids, nucleotides       |
+| `Hx`   | ²H      | 2.014101778            | Lipid and drug metabolism, kinetic isotope studies |
+| `Ox`   | ¹⁸O     | 17.99915961            | Water labeling, proteomics                         |
+| `Sx`   | ³⁴S     | 33.96786700            | Cysteine / methionine tracing                      |
+
+### How to write labeled formulas
+
+Use the symbol exactly like any other element in the `formula` column. Replace only the labeled atoms; leave all remaining atoms as their natural-element symbols.
+
+```tsv
+id  name                        formula
+1   [U-¹³C₆]-glucose            Cx6H12O6
+2   [1,2-¹³C₂]-acetate          Cx2H3O2
+3   [U-¹³C₅,¹⁵N₂]-glutamine    Cx5H8Nx2O3
+4   d7-cholesterol (7 × ²H)     C27H38Hx7O
+5   [¹⁸O₁]-palmitate            C16H31OxO
+6   [³⁴S]-methionine            C5H11NHxSxO2
+```
+
+> **Tip:** Only the labeled atoms need the `x` suffix. Natural-abundance atoms of the same element use their normal symbol alongside the labeled ones (e.g. `Cx2C4H12O6` for [1,2-¹³C₂]-glucose where only 2 of the 6 carbons are labeled).
+
+### What the isotope pattern looks like
+
+The M+1 and M+2 peaks visible in the diagnostic plot come from the **natural-abundance isotopes of the unlabeled atoms** (hydrogens, oxygens, etc.). For example, fully ¹³C-labeled glucose (`Cx6H12O6`) shows a much flatter isotope envelope than natural glucose, because the ¹³C contribution to M+1 is absent — only H and O contribute.
+
 ## What results look like
 
 Once uploaded, your custom database appears alongside the public databases in the database selector on the upload page. Annotation results against your custom database are displayed in the same way as any other database, with ion images, FDR-filtered hits, and molecule matches in the dataset viewer.


### PR DESCRIPTION
## Add stable-isotope labeling support for custom databases

  Enables annotation of isotope-labeled compounds by introducing pseudo-element symbols that can be used directly in custom database formulas
  (e.g. `Cx6H12O6` for [U-¹³C₆]-glucose).

  ### Supported symbols

  | Symbol | Isotope | Typical use |
  |--------|---------|-------------|
  | `Cx` | ¹³C | Carbon tracing |
  | `Nx` | ¹⁵N | Nitrogen labeling |
  | `Hx` | ²H | Lipids, drugs |
  | `Ox` | ¹⁸O | Water labeling |
  | `Sx` | ³⁴S | Cysteine / methionine |

  ### How it works

  Each labeled atom is a 100%-pure single isotope (delta-function mass), so its contribution to the isotope pattern is a rigid m/z shift. The pipeline strips labeled atoms from the formula, computes the natural-isotope pattern for the remaining atoms via `cpyMSpec`, then shifts every centroid by `total_labeled_mass / |charge|`.

  ### Changes

  - `sm/engine/isotope_labels.py` *(new)* — symbol definitions, pyMSpec periodic table patch, `extract_labeled_mass_shift()`
  - `sm/engine/__init__.py` — imports `isotope_labels` at package init
  - `sm/engine/annotation/isocalc_wrapper.py` — strip-and-shift in `_centroids_uncached()`
  - `sm/rest/isotopic_pattern.py` — same logic for the diagnostic plot REST endpoint
  - `graphql/.../periodicTable.ts` — adds all five symbols so frontend formula parsing accepts them
  - `webapp/docs/.../custom-databases.md` — new isotope labeling section with examples and symbol reference table
  - Tests for all of the above

  ---

  🤖 Generated with [Claude Code](https://claude.com/claude-code)