### PR TITLE
Reduce dense arrays 

### DIFF
--- a/metaspace/engine/sm/engine/annotation/formula_validator.py
+++ b/metaspace/engine/sm/engine/annotation/formula_validator.py
@@ -123,8 +123,23 @@ def make_compute_image_metrics(
 
     sample_area_mask = imzml_reader.mask
     n_spectra = np.count_nonzero(sample_area_mask)
-    empty_matrix = np.zeros(sample_area_mask.shape, dtype=np.float32)
-    sample_area_mask_flat = sample_area_mask.flatten()
+    pixel_to_flat_idx = imzml_reader.pixel_to_flat_idx
+    img_w = imzml_reader.w
+    empty_flat = np.zeros(n_spectra, dtype=np.float32)
+
+    def _coo_to_flat(img):
+        """Scatter a coo_matrix directly into a 1D masked-flat array of size n_spectra.
+
+        Equivalent to img.toarray().flatten()[sample_area_mask_flat] but without ever
+        allocating the full h×w bounding box. np.add.at correctly sums duplicate coordinates
+        that arise from concat_coo_matrices for split formulas.
+        """
+        if img is None or img.nnz == 0:
+            return empty_flat
+        flat = np.zeros(n_spectra, dtype=np.float32)
+        flat_positions = pixel_to_flat_idx[img.row * img_w + img.col]
+        np.add.at(flat, flat_positions, img.data)
+        return flat
 
     def compute_metrics(image_set: FormulaImageSet):
         # pylint: disable=unused-variable  # benchmark is used in commented-out dev code
@@ -136,8 +151,7 @@ def make_compute_image_metrics(
 
         # with benchmark('overall'):
 
-        iso_imgs = [img.toarray() if img is not None else empty_matrix for img in image_set.images]
-        iso_imgs_flat = np.array([img.flatten()[sample_area_mask_flat] for img in iso_imgs])
+        iso_imgs_flat = np.array([_coo_to_flat(img) for img in image_set.images])
 
         doc = Metrics(formula_i=image_set.formula_i)
 

--- a/metaspace/engine/sm/engine/annotation/imzml_reader.py
+++ b/metaspace/engine/sm/engine/annotation/imzml_reader.py
@@ -57,6 +57,13 @@ class ImzMLReader:
         sample_area_mask[self.pixel_indexes] = True
         self.mask = sample_area_mask.reshape(self.h, self.w)
 
+        # pixel_to_flat_idx: maps flat pixel coord (Y*W+X) → position in the masked-flat array.
+        # Positions are assigned in ascending pixel_index order to match the semantics of
+        # mask.flatten()[sample_area_mask_flat] used elsewhere in the pipeline.
+        # -1 for pixels that have no spectrum.
+        self.pixel_to_flat_idx = np.full(self.h * self.w, -1, dtype=np.intp)
+        self.pixel_to_flat_idx[sample_area_mask] = np.arange(self.n_spectra)
+
         # raw_coord_bounds is the RAW min/max coordinates, purely for diagnostics
         self.raw_coord_bounds = (
             np.min(imzml_parser.coordinates, axis=0),

--- a/metaspace/engine/sm/engine/annotation/imzml_reader.py
+++ b/metaspace/engine/sm/engine/annotation/imzml_reader.py
@@ -28,7 +28,7 @@ METADATA_FIELDS = [TIC_ACCESSION, MIN_MZ_ACCESSION, MAX_MZ_ACCESSION]
 _process_spectrum_lock = Lock()
 
 
-class ImzMLReader:
+class ImzMLReader:  # pylint: disable=too-many-instance-attributes
     """This class bundles the ability to somehow access ImzML data (implemented in subclasses)
     with some commonly-used pre-computed data such as the mask image and the mapping between
     spectrum index and pixel index.  Additionally, it provides a central place to efficiently

--- a/metaspace/engine/sm/engine/annotation_lithops/pipeline.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/pipeline.py
@@ -121,6 +121,15 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
                 f'The bounding box area exceeds the maximum allowed pixel count of ({pixel_limit}). Contact contact@metaspace2020.org.'
             )
 
+        sparsity_ratio = nz_pixels / n_pixels
+        if sparsity_ratio < 0.05:
+            logger.warning(
+                f'Low pixel density detected: {nz_pixels} spectra in a '
+                f'{self.imzml_reader.h}×{self.imzml_reader.w} bounding box '
+                f'(density={sparsity_ratio:.3f}). This dataset may have isolated blobs '
+                f'with large empty areas.'
+            )
+
         self.segment_centroids(use_cache=use_cache)
         if debug_validate:
             self.validate_segment_centroids()

--- a/metaspace/engine/sm/engine/tests/annotation/test_formula_validator.py
+++ b/metaspace/engine/sm/engine/tests/annotation/test_formula_validator.py
@@ -26,7 +26,7 @@ def _test_compute_metrics():
         isotope_generation=None,
         fdr=None,
     )
-    imzml_reader = make_imzml_reader_mock(list(product(range(2), range(3))))
+    imzml_reader = make_imzml_reader_mock(list(product(range(3), range(2))))
     compute_metrics = make_compute_image_metrics(imzml_reader, ds_config)
     return compute_metrics
 


### PR DESCRIPTION
## Problem

Follow-up to #1718 . The annotation pipeline sometimes crashes with OOM on datasets where spectra form isolated blobs inside a large bounding box. After #1718 fixed `chaos_metric`, the remaining crash point is `formula_validator.py` which still materialises the full h×w dense array for every peak of every formula when building iso_imgs_flat.
             
## Change

  - `imzml_reader` gets a `pixel_to_flat_idx` lookup table built once at init — maps any pixel coordinate directly to its position in the           
  masked-flat metrics array.
  - `formula_validator.py` uses it to scatter sparse `coo` values directly into a 1D array of size `n_spectra`, removing the `toarray()` call and the intermediate dense `iso_imgs` list entirely.
  - `pipeline.py` logs a warning when pixel density is below 5% so blob datasets are visible in logs.