### PR TITLE
Fixed annotation count table

### DIFF
--- a/metaspace/webapp/src/modules/Datasets/overview/AnnotationCountTable.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/overview/AnnotationCountTable.spec.ts
@@ -163,6 +163,121 @@ describe('AnnotationCountTable', () => {
     expect(JSON.parse(wrapper.findAll('.mock-router-link').at(1).attributes('to')).params.dataset_id).toBe('xxxx')
   })
 
+  it('it should scope Total Annotations FDR links to the non-targeted database when targeted DBs exist', async () => {
+    const mixedData = [
+      {
+        databaseId: 1,
+        dbName: 'HMDB',
+        dbVersion: 'v4',
+        isTargeted: false,
+        total: 224,
+        counts: [
+          { level: 5, n: 55 },
+          { level: 10, n: 104 },
+          { level: 20, n: 196 },
+          { level: 50, n: 224 },
+        ],
+      },
+      {
+        databaseId: 99,
+        dbName: 'Custom',
+        dbVersion: '1',
+        isTargeted: true,
+        total: 300,
+        counts: [
+          { level: 5, n: 0 },
+          { level: 10, n: 0 },
+          { level: 20, n: 0 },
+          { level: 50, n: 0 },
+        ],
+      },
+    ]
+    const wrapper = mount(testHarness, {
+      global: {
+        plugins: [store, router, ElementPlus],
+        stubs,
+      },
+      props: { data: mixedData, id, header: mockFdrLevels },
+    })
+    await flushPromises()
+    await nextTick()
+
+    const footerLinks = wrapper.findAll('tfoot').at(0).findAll('.mock-router-link')
+    footerLinks.forEach((col, colIndex) => {
+      const toProp = JSON.parse(col.attributes('to'))
+      expect(toProp.params.dataset_id).toBe('xxxx')
+      if (colIndex < mockFdrLevels.length) {
+        // FDR-level summary cells exclude targeted DBs by scoping to the single non-targeted DB
+        expect(toProp.query.db_id).toBe('1')
+        expect(toProp.query.fdr).toBe((mockFdrLevels[colIndex] / 100).toString())
+      } else {
+        // Total column links to all databases at the highest FDR level
+        expect(toProp.query.db_id).toBeUndefined()
+        expect(toProp.query.fdr).toBe('0.5')
+      }
+    })
+  })
+
+  it('should not link Total FDR cells when targeted mixes with multiple non-targeted DBs', async () => {
+    const multiNonTargeted = [
+      {
+        databaseId: 1,
+        dbName: 'HMDB',
+        dbVersion: 'v4',
+        isTargeted: false,
+        total: 101,
+        counts: [
+          { level: 5, n: 42 },
+          { level: 10, n: 71 },
+          { level: 20, n: 101 },
+          { level: 50, n: 101 },
+        ],
+      },
+      {
+        databaseId: 6,
+        dbName: 'SwissLipids',
+        dbVersion: '2018-02-02',
+        isTargeted: false,
+        total: 138,
+        counts: [
+          { level: 5, n: 4 },
+          { level: 10, n: 74 },
+          { level: 20, n: 125 },
+          { level: 50, n: 138 },
+        ],
+      },
+      {
+        databaseId: 33,
+        dbName: 'Test',
+        dbVersion: '1',
+        isTargeted: true,
+        total: 118,
+        counts: [
+          { level: 5, n: 0 },
+          { level: 10, n: 0 },
+          { level: 20, n: 0 },
+          { level: 50, n: 0 },
+        ],
+      },
+    ]
+    const wrapper = mount(testHarness, {
+      global: {
+        plugins: [store, router, ElementPlus],
+        stubs,
+      },
+      props: { data: multiNonTargeted, id, header: mockFdrLevels },
+    })
+    await flushPromises()
+    await nextTick()
+
+    // Only the Total column summary remains a link (all databases at the highest FDR level).
+    const footerLinks = wrapper.findAll('tfoot').at(0).findAll('.mock-router-link')
+    expect(footerLinks.length).toBe(1)
+    const toProp = JSON.parse(footerLinks.at(0).attributes('to'))
+    expect(toProp.query.db_id).toBeUndefined()
+    expect(toProp.query.fdr).toBe('0.5')
+  })
+
   it('it should render with no data warning when props empty', async () => {
     const wrapper = mount(testHarness, {
       global: {

--- a/metaspace/webapp/src/modules/Datasets/overview/AnnotationCountTable.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/AnnotationCountTable.tsx
@@ -133,34 +133,57 @@ export const AnnotationCountTable = defineComponent({
 
     const getSummaries = (param: any) => {
       const { columns, data } = param
+      const { header } = props
+      const maxFdr = Math.max(...header.map(Number)) / 100
+      const nonTargeted = data.filter((row: any) => !row?.isTargeted)
+      const hasTargeted = data.some((row: any) => row?.isTargeted)
+      // The per-FDR-level sums exclude targeted (no-FDR) databases, but a dataset-wide FDR filter
+      // would include their fdr=-1 annotations, and the annotation browser only filters by a single
+      // database. So an FDR-level summary link can only be made accurate when either:
+      //  - there are no targeted DBs (a dataset-wide FDR filter is exact), or
+      //  - there is exactly one non-targeted DB (scope the link to it).
+      // Otherwise (targeted DBs mixed with zero or several non-targeted DBs) no single link reproduces
+      // the displayed count, so the FDR-level cells are shown as plain text. Targeted annotations are
+      // represented only in the Total column (which links to "all databases at the highest FDR level").
+      const canLinkFdrSummary = !hasTargeted || nonTargeted.length === 1
+      const fdrSummaryDbId = hasTargeted && nonTargeted.length === 1 ? nonTargeted[0].id : undefined
       return columns.map((col: any, colIndex: number) => {
         if (colIndex === 0) {
           return props.sumRowLabel
         }
 
-        // Total column (last column) — sum the per-database totals.
+        // Total column (last column) — sum the per-database totals. This equals "all databases at
+        // the highest FDR level" (targeted annotations, fdr=-1, pass every threshold), so the
+        // linked annotation list matches the displayed number.
         if (col?.property === 'total') {
           const total = data.reduce((acc: number, row: any) => acc + (row?.total || 0), 0)
           return (
-            <RouterLink key={colIndex} from="dataset-overview" to={annotationsLink(props.id?.toString())}>
+            <RouterLink
+              key={colIndex}
+              from="dataset-overview"
+              to={annotationsLink(props.id?.toString(), undefined, maxFdr)}
+            >
               {total}
             </RouterLink>
           )
         }
 
         const currentFDR = props.header[colIndex - 1]
+        const sum = data.reduce((acc: number, row: any) => acc + (row[currentFDR] || 0), 0)
 
-        const reducer = (accumulator: number, currentValue: any) => {
-          return accumulator + (currentValue[currentFDR] || 0)
+        // No single annotation-browser link can reproduce this per-level sum (see above) — render
+        // plain text instead of a link that would open a mismatching count.
+        if (!canLinkFdrSummary) {
+          return <span>{sum}</span>
         }
 
         return (
           <RouterLink
             key={colIndex}
             from="dataset-overview"
-            to={annotationsLink(props.id?.toString(), undefined, parseInt(currentFDR, 10) / 100)}
+            to={annotationsLink(props.id?.toString(), fdrSummaryDbId, parseInt(currentFDR, 10) / 100)}
           >
-            {data.reduce(reducer, 0)}
+            {sum}
           </RouterLink>
         )
       })

--- a/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/AnnotationCountTable.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/AnnotationCountTable.spec.ts.snap
@@ -200,7 +200,7 @@ exports[`AnnotationCountTable > it should match snapshot 1`] = `
               </td>
               <td colspan=\\"1\\" rowspan=\\"1\\" class=\\"el-table__cell el-table_1_column_6 is-leaf\\">
                 <div class=\\"cell\\">
-                  <div class=\\"mock-router-link\\" to=\\"{&quot;name&quot;:&quot;dataset-annotations&quot;,&quot;params&quot;:{&quot;dataset_id&quot;:&quot;xxxx&quot;},&quot;state&quot;:{&quot;from&quot;:&quot;dataset-overview&quot;},&quot;query&quot;:{&quot;ds&quot;:&quot;xxxx&quot;}}\\" from=\\"dataset-overview\\">414</div>
+                  <div class=\\"mock-router-link\\" to=\\"{&quot;name&quot;:&quot;dataset-annotations&quot;,&quot;params&quot;:{&quot;dataset_id&quot;:&quot;xxxx&quot;},&quot;state&quot;:{&quot;from&quot;:&quot;dataset-overview&quot;},&quot;query&quot;:{&quot;ds&quot;:&quot;xxxx&quot;,&quot;fdr&quot;:&quot;0.5&quot;}}\\" from=\\"dataset-overview\\">414</div>
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
### Description

Fixed annotation count table links to datasets with multible no target and one target db