### PR TITLE
Fixed duplicated coord read bug

### DIFF
--- a/metaspace/engine/sm/engine/annotation/imzml_reader.py
+++ b/metaspace/engine/sm/engine/annotation/imzml_reader.py
@@ -61,8 +61,13 @@ class ImzMLReader:  # pylint: disable=too-many-instance-attributes
         # Positions are assigned in ascending pixel_index order to match the semantics of
         # mask.flatten()[sample_area_mask_flat] used elsewhere in the pipeline.
         # -1 for pixels that have no spectrum.
+        # NOTE: the masked-flat array is indexed by *unique pixel*, not by spectrum. Some exporters
+        # emit multiple spectra at the same coordinate, so n_spectra can exceed the number of
+        # unique pixels (sample_area_mask.sum()); those duplicates collapse onto one position here
+        # and are summed back together downstream (see formula_validator._coo_to_flat).
+        n_unique_pixels = np.count_nonzero(sample_area_mask)
         self.pixel_to_flat_idx = np.full(self.h * self.w, -1, dtype=np.intp)
-        self.pixel_to_flat_idx[sample_area_mask] = np.arange(self.n_spectra)
+        self.pixel_to_flat_idx[sample_area_mask] = np.arange(n_unique_pixels)
 
         # raw_coord_bounds is the RAW min/max coordinates, purely for diagnostics
         self.raw_coord_bounds = (

--- a/metaspace/engine/sm/engine/tests/annotation/test_imzml_reader.py
+++ b/metaspace/engine/sm/engine/tests/annotation/test_imzml_reader.py
@@ -69,6 +69,22 @@ def test_imzml_reader_tic_image_from_metadata():
     assert np.array_equal(imzml_reader.tic_image(), metadata_tic, equal_nan=True)
 
 
+def test_imzml_reader_duplicate_coordinates():
+    # Some exporters emit multiple spectra at the same (x, y) pixel. n_spectra is then larger
+    # than the number of unique pixels, which must not break pixel_to_flat_idx construction.
+    coordinates = [(1, 1, 1), (1, 1, 1), (2, 1, 1)]
+    spectra = [(np.arange(1, i + 2), np.full(i + 1, i + 1)) for i in range(len(coordinates))]
+    imzml_reader = make_imzml_reader_mock(coordinates=coordinates, spectra=spectra)
+
+    n_unique_pixels = int(np.count_nonzero(imzml_reader.mask))
+    assert n_unique_pixels == 2  # (1,1) and (2,1); the duplicate (1,1) collapses
+
+    # pixel_to_flat_idx indexes into the masked-flat array (size == unique pixels), with positions
+    # assigned in ascending pixel order. Valid (non -1) entries must be exactly 0..n_unique_pixels-1.
+    valid = imzml_reader.pixel_to_flat_idx[imzml_reader.pixel_to_flat_idx >= 0]
+    assert np.array_equal(np.sort(valid), np.arange(n_unique_pixels))
+
+
 def test_imzml_reader_lithops(executor):
     imzml_reader = make_lithops_imzml_reader(
         executor.storage, mz_precision='d', polarity='negative'


### PR DESCRIPTION
### Description 

PR #1744 added pixel_to_flat_idx[sample_area_mask] = np.arange(self.n_spectra) in ImzMLReader.__init__, which assumes one spectrum per pixel. On datasets where multiple spectra share a coordinate, n_spectra (total spectra) exceeds the number of unique pixels (mask.sum()), so the assignment raises ValueError: cannot assign N input values to the M output values where the mask is true — crashing annotation before image building.

Fix: Index pixel_to_flat_idx by unique-pixel count (np.count_nonzero(sample_area_mask)) instead of n_spectra, matching the masked-flat array size used downstream in formula_validator._coo_to_flat. This is a no-op for normal datasets (the two counts are equal) and for duplicate-coordinate datasets restores the pre-#1744 behavior, where np.add.at sums co-located spectra exactly as the old coo_matrix.toarray() path did.