### PR TITLE
Enable image segmentation

### DIFF
--- a/metaspace/postprocessing/image_segmentation/app.py
+++ b/metaspace/postprocessing/image_segmentation/app.py
@@ -147,15 +147,10 @@ def _run_and_callback(body):
         result = run_segmentation(
             dataset_id=dataset_id,
             algorithm=body.get('algorithm', 'pca_gmm'),
-            input_s3_key=body.get('input_s3_key'),
-            database_ids=body.get('database_ids'),
+            input_s3_key=body['input_s3_key'],
             parameters=body.get('parameters', {}),
             fdr=body.get('fdr', 0.1),
-            adducts=body.get('adducts'),
-            min_mz=body.get('min_mz'),
-            max_mz=body.get('max_mz'),
             use_tic=body.get('use_tic', True),
-            off_sample=body.get('off_sample'),  # None = no filter
             smoothing=body.get('smoothing', True),
             window_size=body.get('window_size', 3),
         )

--- a/metaspace/postprocessing/image_segmentation/image_segmentation/segm_pipeline.py
+++ b/metaspace/postprocessing/image_segmentation/image_segmentation/segm_pipeline.py
@@ -15,33 +15,20 @@ from image_segmentation.types import SegmentationResult
 logger = logging.getLogger(__name__)
 
 
-def run_segmentation(  # pylint: disable=too-many-arguments,too-many-locals
+def run_segmentation(
     dataset_id: str,
     algorithm: str,
-    database_ids: Optional[List[int]] = None,
+    input_s3_key: str,
     parameters: Optional[Dict] = None,
     fdr: float = 0.1,
-    adducts: Optional[List[str]] = None,
-    min_mz: Optional[float] = None,
-    max_mz: Optional[float] = None,
     ion_labels: Optional[List[str]] = None,
     use_tic: bool = True,
-    off_sample: Optional[bool] = False,
     smoothing: bool = True,
     window_size: int = 3,
-    input_s3_key: Optional[str] = None,
 ) -> SegmentationResult:
-    """Run the segmentation pipeline.
-
-    Loading priority:
-      1. input_s3_key provided  → load pre-built arrays from S3 (engine path, default)
-      2. databases provided      → fetch via the METASPACE Python client (fallback)
-    """
+    """Run the segmentation pipeline, loading input arrays from S3."""
     if parameters is None:
         parameters = {}
-
-    # Kept for API parity with the engine / future client loader path.
-    _ = (adducts, min_mz, max_mz, off_sample)
 
     pipeline_start_time = time.time()
     logger.info("[SEGMENTATION_PERF] Pipeline started for dataset %s", dataset_id)
@@ -52,42 +39,19 @@ def run_segmentation(  # pylint: disable=too-many-arguments,too-many-locals
         fdr,
     )
 
-    # 1. Load — prefer S3 pre-built input, fall back to Python client
+    # 1. Load
     load_start_time = time.time()
-    if input_s3_key is not None:
-        logger.info(
-            "Dataset %s: loading input from S3 key '%s'",
-            dataset_id,
-            input_s3_key,
-        )
-        (
-            intensity_matrix,
-            pixel_coordinates,
-            ion_labels,
-            image_shape,
-        ) = load_segmentation_input_from_s3(s3_key=input_s3_key)
-    else:
-        if not database_ids:
-            raise ValueError(
-                f"Dataset {dataset_id}: either 'input_s3_key' or 'database_ids' must be provided"
-            )
-        logger.info(
-            "Dataset %s: loading input via Python client (database_ids=%s)",
-            dataset_id,
-            database_ids,
-        )
-        # from image_segmentation.loader import load_segmentation_input
-        # intensity_matrix, pixel_coordinates, ion_labels, image_shape = load_segmentation_input(
-        #     dataset_id=dataset_id,
-        #     database_ids=database_ids,
-        #     fdr=fdr,
-        #     adducts=adducts,
-        #     min_mz=min_mz,
-        #     max_mz=max_mz,
-        #     ion_labels=ion_labels,
-        #     use_tic=use_tic,
-        #     off_sample=off_sample,
-        # )
+    logger.info(
+        "Dataset %s: loading input from S3 key '%s'",
+        dataset_id,
+        input_s3_key,
+    )
+    (
+        intensity_matrix,
+        pixel_coordinates,
+        ion_labels,
+        image_shape,
+    ) = load_segmentation_input_from_s3(s3_key=input_s3_key)
 
     load_time = time.time() - load_start_time
     logger.info(
@@ -166,64 +130,3 @@ def run_segmentation(  # pylint: disable=too-many-arguments,too-many-locals
     )
 
     return result
-
-
-# python 3.9+
-# def run_segmentation_from_anndata(
-#     adata,
-#     dataset_id: str,
-#     algorithm: str,
-#     parameters: Optional[Dict] = None,
-#     ion_labels: Optional[List[str]] = None,
-#     use_tic: bool = False,
-#     smoothing: bool = True,
-#     window_size: int = 3,
-# ) -> SegmentationResult:
-
-#     if parameters is None:
-#         parameters = {}
-
-#     logger.info(
-#         f"Dataset {dataset_id}: starting segmentation from AnnData "
-#         f"(algorithm={algorithm})"
-#     )
-
-#     # 1. Load from existing AnnData
-#     from image_segmentation.loader import anndata_to_segmentation_input
-#     intensity_matrix, pixel_coordinates, ion_labels, image_shape = anndata_to_segmentation_input(
-#         adata=adata,
-#         dataset_id=dataset_id,
-#         ion_labels=ion_labels,
-#     )
-
-#     # 2. Preprocess
-#     segmentation_input = preprocess(
-#         intensity_matrix=intensity_matrix,
-#         pixel_coordinates=pixel_coordinates,
-#         ion_labels=ion_labels,
-#         image_shape=image_shape,
-#         dataset_id=dataset_id,
-#         use_tic=use_tic,
-#     )
-
-#     # 3. Dispatch
-#     raw_output = dispatch(
-#         segmentation_input=segmentation_input,
-#         algorithm=algorithm,
-#         parameters=parameters,
-#     )
-
-#     # 4. Postprocess
-#     result = postprocess(
-#         raw_output=raw_output,
-#         segmentation_input=segmentation_input,
-#         smoothing=smoothing,
-#         window_size=window_size,
-#     )
-
-#     logger.info(
-#         f"Dataset {dataset_id}: segmentation complete "
-#         f"(n_segments={result.n_segments})"
-#     )
-
-#     return result

--- a/metaspace/webapp/src/lib/config.ts
+++ b/metaspace/webapp/src/lib/config.ts
@@ -86,7 +86,7 @@ const defaultConfig: ClientConfig = {
   features: {
     coloc: true,
     ignore_ibd_size: false,
-    segmentation: false,
+    segmentation: true,
     diff_analysis: false,
     enrichment: true,
     show_dataset_overview: true,

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.spec.ts
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.spec.ts
@@ -152,7 +152,7 @@ describe('DatasetActionsDropdown', () => {
     await flushPromises()
     await nextTick()
 
-    expect(wrapper.findAll('.mock-el-dropdown-item').length).toBe(8)
+    expect(wrapper.findAll('.mock-el-dropdown-item').length).toBe(9)
   })
 
   it('it show all options except reprocess if user is the ds owner, but not admin', async () => {
@@ -169,7 +169,7 @@ describe('DatasetActionsDropdown', () => {
     await flushPromises()
     await nextTick()
 
-    expect(wrapper.findAll('.mock-el-dropdown-item').length).toBe(7)
+    expect(wrapper.findAll('.mock-el-dropdown-item').length).toBe(8)
   })
 
   it('it show only canDownload option for normalUser', async () => {

--- a/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
+++ b/metaspace/webapp/src/modules/Datasets/overview/DatasetActionsDropdown.tsx
@@ -202,7 +202,7 @@ export const DatasetActionsDropdown = defineComponent({
             lockScroll: false,
             type: 'warning',
             confirmButtonText: 'Go to segmentation',
-            cancelButtonText: 'Change  parameters',
+            cancelButtonText: 'Change parameters',
           }
         )
           .then(() => {

--- a/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/DatasetActionsDropdown.spec.ts.snap
+++ b/metaspace/webapp/src/modules/Datasets/overview/__snapshots__/DatasetActionsDropdown.spec.ts.snap
@@ -23,7 +23,11 @@ exports[`DatasetActionsDropdown > it should match snapshot 1`] = `
         <div class=\\"el-badge sm-feature-badge\\">Imzml browser<sup class=\\"el-badge__content el-badge__content--danger is-fixed is-dot\\"></sup></div>
       </div>
     </div>
-    <!---->
+    <div class=\\"mock-el-dropdown-item\\" attrs=\\"[object Object]\\">
+      <div class=\\"relative actionBadge\\">
+        <div class=\\"el-badge sm-feature-badge\\">Image segmentation<sup class=\\"el-badge__content el-badge__content--danger is-fixed is-dot\\"></sup></div>
+      </div>
+    </div>
     <div class=\\"mock-el-dropdown-item\\" attrs=\\"[object Object]\\">Ontology enrichment</div>
     <div class=\\"mock-el-dropdown-item text-red-500\\" attrs=\\"[object Object]\\">Delete</div>
     <div class=\\"mock-el-dropdown-item text-red-500\\" attrs=\\"[object Object]\\">Reprocess data</div>

--- a/metaspace/webapp/src/modules/Datasets/segmentation/SegmentationDialog.tsx
+++ b/metaspace/webapp/src/modules/Datasets/segmentation/SegmentationDialog.tsx
@@ -13,6 +13,7 @@ import {
   ElInputNumber,
   ElTooltip,
   ElIcon,
+  ElNotification,
 } from '../../../lib/element-plus'
 import { ErrorLabelText } from '../../../components/Form'
 import { DefaultApolloClient } from '@vue/apollo-composable'
@@ -152,8 +153,7 @@ export const SegmentationDialog = defineComponent({
     }
 
     const validateThirdStep = () => {
-      // K is optional, but if provided, it must be between 2 and 10
-      if (state.numSegments !== null && (state.numSegments < 2 || state.numSegments > 50)) {
+      if (state.numSegments !== null && (state.numSegments < 2 || state.numSegments > 15)) {
         state.thirdStepError = true
         return false
       }
@@ -185,7 +185,7 @@ export const SegmentationDialog = defineComponent({
         })
         state.annotationCount = data.countAnnotations
 
-        if (state.annotationCount > 50) {
+        if (state.annotationCount >= 50) {
           setTimeout(
             () => {
               state.workflowStep = 2
@@ -236,12 +236,10 @@ export const SegmentationDialog = defineComponent({
         })
 
         emit('close')
-        // TODO: Add success notification
-        // ElNotification.success('Segmentation job started successfully')
+        ElNotification.success('Segmentation job queued — results will appear on the segmentation page once complete.')
       } catch (error) {
         console.error('Segmentation failed:', error)
-        // TODO: Add error notification
-        // ElNotification.error('Failed to start segmentation job')
+        ElNotification.error('Failed to start segmentation job. Please try again.')
       } finally {
         state.loading = false
       }
@@ -481,7 +479,7 @@ export const SegmentationDialog = defineComponent({
                   </div>
 
                   <ErrorLabelText class="mt-2" style={{ visibility: state.thirdStepError ? '' : 'hidden' }}>
-                    If specified, number of segments must be between 2 and 10.
+                    If specified, number of segments must be between 2 and 15.
                   </ErrorLabelText>
 
                   <div class="step-buttons">

--- a/metaspace/webapp/src/modules/Datasets/segmentation/SegmentationPage.tsx
+++ b/metaspace/webapp/src/modules/Datasets/segmentation/SegmentationPage.tsx
@@ -441,8 +441,8 @@ export default defineComponent({
               <div class="collapse-header !justify-start">
                 <span class="collapse-title">Segmentation diagnostics</span>
                 {renderHelpIcon(
-                  'How confidently each pixel was assigned to a cluster by the GMM model. The dashed line shows ' +
-                    'the median confidence threshold.'
+                  'How confidently each pixel was assigned to a cluster by the GMM model. The dashed line marks ' +
+                    'the most common confidence bin (peak).'
                 )}
               </div>
             ),


### PR DESCRIPTION
## Summary

Removes segmentation feature flag.
Streamlines the segmentation pipeline down to a
single, well-defined input path (pre-built arrays loaded from S3), tightens the
SegmentationDialog validation and adds user-facing job feedback.
Also includes a few minor UI text corrections.

## Changes

### Dialog validation & job feedback (`SegmentationDialog.tsx`)
- Lower the max number of segments from 50 to 15 (validation + helper text now
  consistent at "between 2 and 15").
- Replace the TODO comments with real `ElNotification` success/error toasts when
  a segmentation job is queued or fails.
- Change the annotation-count branch from `> 50` to `>= 50`.

### UI text corrections
- Fix double space in "Change  parameters" confirm button.
- Reword the GMM confidence tooltip on `SegmentationPage.tsx` to describe the
  dashed line as the most common confidence bin (peak).

### Test & tooling fixes
- Point `graphql/config/test.js` at docker service hostnames (`api`, `postgres`,
  `elasticsearch`, `rabbitmq`) and add `config.db.schema = 'sm'`.
- Update `DatasetActionsDropdown` dropdown-item counts (8→9, 7→8) and the
  snapshot to account for the newly visible segmentation action.
- Pin `packageManager` (yarn 1.22.22) in `graphql/package.json`.

## Notes for reviewers
- The pipeline now assumes the engine always provides `input_s3_key`; the
  client-loader fallback is gone, so any caller relying on `database_ids` will
  need updating.
