### PR TITLE
Parallelize m/z sorting of spectra in load_ds

### DIFF
--- a/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
@@ -13,6 +13,7 @@ from lithops.storage.utils import CloudObject
 from sm.engine.annotation.imzml_reader import LithopsImzMLReader
 from sm.engine.annotation_lithops.executor import Executor, MEM_LIMITS
 from sm.engine.annotation_lithops.io import CObj, load_cobj, save_cobj, multipart_upload_cobj
+from sm.engine.annotation_lithops.parallel_sort import sort_peaks
 from sm.engine.config import SMConfig
 from sm.engine.utils.perf_profile import SubtaskProfiler
 
@@ -44,7 +45,12 @@ def _load_spectra(storage, imzml_reader):
     return np.concatenate(mz_arrays), np.concatenate(int_arrays), sp_lens
 
 
-def _sort_spectra(imzml_reader, perf, mzs, ints, sp_lens):
+def _sort_spectra(imzml_reader, perf, mzs, ints, sp_lens, parallel: bool = True):
+    if parallel:
+        # Parallel sample sort - byte-for-byte identical output, but spread over all
+        # available cores instead of the single-threaded argsort below.
+        return sort_peaks(mzs, ints, sp_lens, imzml_reader.pixel_indexes, perf=perf)
+
     # Mergesort is used for 2 reasons:
     # * It's much faster than the default quicksort, because m/z data is already partially sorted
     #   and the underlying "Timsort" implementation is optimized for partially-sorted data.

--- a/metaspace/engine/sm/engine/annotation_lithops/parallel_sort.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/parallel_sort.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import Optional, Tuple
+
+import numpy as np
+
+from sm.engine.utils.perf_profile import Profiler
+
+logger = logging.getLogger('annotation-pipeline')
+
+TARGET_PARTITION_BYTES = 4 * 2 ** 20  # One partition's sort working set, kept L2/L3-resident
+MAX_PARTITIONS = 4096  # Python-level slicing work grows with n_blocks * n_parts
+SAMPLE_STRIDE = 1000  # Every SAMPLE_STRIDE'th peak is used to estimate the m/z distribution
+LAMBDA_MB_PER_VCPU = 1769  # AWS Lambda allocates 1 vCPU per 1769 MB of configured memory.
+
+
+def get_n_worker_threads() -> int:
+    """Number of vCPUs actually available to this process.
+
+    In AWS Lambda `os.cpu_count()` reports the host's core count rather than the share
+    allocated to the function, which scales with the configured memory instead.
+    """
+    lambda_mb = os.environ.get('AWS_LAMBDA_FUNCTION_MEMORY_SIZE')
+    if lambda_mb:
+        return max(1, round(int(lambda_mb) / LAMBDA_MB_PER_VCPU))
+    try:
+        return len(os.sched_getaffinity(0))  # type: ignore[attr-defined]
+    except AttributeError:  # non Linux
+        return os.cpu_count() or 1
+
+
+def _define_block_bounds(sp_lens: np.ndarray, n_blocks: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Split the spectra into n_blocks groups of roughly equal peak count.
+
+    Returns (spectrum bounds, peak bounds).
+    * Blocks always start and end on a spectrum boundary - not required for correctness,
+      but it keeps `np.repeat` in `sort_block` simple.
+    * Duplicate bounds (more blocks requested than spectra available, or runs of
+      zero-length spectra) are collapsed, so fewer blocks than requested may come back.
+    """
+    peak_offsets = np.insert(np.cumsum(sp_lens), 0, 0)
+    targets = np.linspace(0, peak_offsets[-1], n_blocks + 1)
+    sp_bounds = np.unique(np.searchsorted(peak_offsets, targets, side='left'))
+
+    # searchsorted finds the *first* offset equal to n_peaks, missing trailing zero-length spectra
+    sp_bounds[-1] = len(sp_lens)
+    return sp_bounds, peak_offsets[sp_bounds]
+
+
+def _choose_splitters(mzs: np.ndarray, n_parts: int) -> np.ndarray:
+    """
+    At most n_parts-1 m/z values that separate the partitions, as quantiles of a sample.
+    Duplicate quantiles are collapsed, so the caller must recompute n_parts from the result.
+    """
+    if n_parts <= 1:
+        return np.empty(0, dtype=mzs.dtype)
+    sample = np.sort(mzs[::SAMPLE_STRIDE])
+    idx = (np.arange(1, n_parts) * len(sample)) // n_parts
+
+    # Duplicates (one m/z value spanning >1/n_parts of the sample) would produce empty partitions.
+    return np.unique(sample[idx])
+
+
+def _calc_n_partitions(n_peaks: int, mz_itemsize: int, n_threads: int, target_bytes: int) -> int:
+    """
+    Number of partitions sized so one partition's sort stays within target_bytes, clamped
+    to [min(4*n_threads, MAX_PARTITIONS), MAX_PARTITIONS] and to one peak per partition.
+    """
+    # One sorted element costs its m/z value plus an int64 permutation entry.
+    sort_bytes = mz_itemsize + 8
+    n_parts = int(np.ceil(n_peaks * sort_bytes / target_bytes))
+    n_parts = int(np.clip(n_parts, min(4 * n_threads, MAX_PARTITIONS), MAX_PARTITIONS))
+    return min(n_parts, n_peaks)
+
+
+def _sort_blocks(
+    mzs: np.ndarray,
+    ints: np.ndarray,
+    pixel_indexes: np.ndarray,
+    sp_lens: np.ndarray,
+    sp_bounds: np.ndarray,
+    pk_bounds: np.ndarray,
+    splitters: np.ndarray,
+    n_threads: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Sort every block in place, in parallel, and locate the partition boundaries.
+
+    Returns (sp_idxs, cuts).
+    * `sp_idxs` is built here, alongside the in-place sort, and comes back block-sorted
+      like `mzs` and `ints`.
+    * cuts[i, j] = how many peaks of block i are below splitter j, shape (n_blocks, n_parts - 1).
+    * `side='left'` keeps equal m/z values on one side of every boundary, which
+      stability relies on.
+    """
+    n_blocks = len(sp_bounds) - 1
+    sp_idxs = np.empty(pk_bounds[-1], np.uint32)
+
+    def sort_block(i):
+        pk_start, pk_end = pk_bounds[i], pk_bounds[i + 1]
+        sp_start, sp_end = sp_bounds[i], sp_bounds[i + 1]
+        sp_idxs[pk_start:pk_end] = np.repeat(
+            pixel_indexes[sp_start:sp_end], sp_lens[sp_start:sp_end]
+        )
+
+        # kind='stable' picks Timsort, which besides stability is much faster than the
+        # default quicksort here: a block is many per-spectrum runs of ascending m/z.
+        perm = np.argsort(mzs[pk_start:pk_end], kind='stable')
+        mzs[pk_start:pk_end] = mzs[pk_start:pk_end][perm]
+        ints[pk_start:pk_end] = ints[pk_start:pk_end][perm]
+        sp_idxs[pk_start:pk_end] = sp_idxs[pk_start:pk_end][perm]
+        return np.searchsorted(mzs[pk_start:pk_end], splitters, side='left')
+
+    with ThreadPoolExecutor(n_threads) as pool:
+        block_cuts = list(pool.map(sort_block, range(n_blocks)))
+
+    return sp_idxs, np.stack(block_cuts)
+
+
+def _define_partition_layout(
+    cuts: np.ndarray, pk_bounds: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Global start/end of every (block, partition) piece, and where each partition lands.
+
+    Returns (piece_lo, piece_hi, offsets): piece_lo/piece_hi are the (n_blocks, n_parts)
+    bounds of each piece within the block-sorted arrays, offsets[p] is where partition p
+    starts in the output - so partition sizes are np.diff(offsets).
+    """
+    n_blocks = len(pk_bounds) - 1
+    piece_lo = np.column_stack([np.zeros(n_blocks, np.int64), cuts]) + pk_bounds[:-1, None]
+    piece_hi = np.column_stack([cuts, np.diff(pk_bounds)]) + pk_bounds[:-1, None]
+    sizes = (piece_hi - piece_lo).sum(axis=0)
+    offsets = np.insert(np.cumsum(sizes), 0, 0)
+
+    # Catches an inconsistent `side` between blocks, which would leave gaps or duplicates.
+    assert offsets[-1] == pk_bounds[-1], (offsets[-1], pk_bounds[-1])
+    return piece_lo, piece_hi, offsets
+
+
+def _gather_partitions(
+    mzs: np.ndarray,
+    ints: np.ndarray,
+    sp_idxs: np.ndarray,
+    piece_lo: np.ndarray,
+    piece_hi: np.ndarray,
+    offsets: np.ndarray,
+    n_threads: int,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Gather each partition from the block-sorted arrays, in parallel.
+
+    This is where stability is decided, for 2 reasons:
+    * Every block's piece of a partition is concatenated in block order - and therefore
+      in spectrum order - before sorting.
+    * The `kind='stable'` sort then preserves that order for equal m/z values.
+    """
+    n_peaks = len(mzs)
+    n_blocks = piece_lo.shape[0]
+    out_mz = np.empty(n_peaks, mzs.dtype)
+    out_int = np.empty(n_peaks, ints.dtype)
+    out_sp = np.empty(n_peaks, np.uint32)
+
+    def build_partition(part_i):
+        out_start, out_end = offsets[part_i], offsets[part_i + 1]
+        if out_start == out_end:
+            return
+
+        # Block order here is what makes the sort stable.
+        slices = [slice(piece_lo[i, part_i], piece_hi[i, part_i]) for i in range(n_blocks)]
+        mz_p = np.concatenate([mzs[x] for x in slices])
+        perm = np.argsort(mz_p, kind='stable')
+        out_mz[out_start:out_end] = mz_p[perm]
+        del mz_p
+        out_int[out_start:out_end] = np.concatenate([ints[x] for x in slices])[perm]
+        out_sp[out_start:out_end] = np.concatenate([sp_idxs[x] for x in slices])[perm]
+
+    with ThreadPoolExecutor(n_threads) as pool:
+        list(pool.map(build_partition, range(len(offsets) - 1)))
+
+    return out_mz, out_int, out_sp
+
+
+def sort_peaks(
+    mzs: np.ndarray,
+    ints: np.ndarray,
+    sp_lens: np.ndarray,
+    pixel_indexes: np.ndarray,
+    *,
+    perf: Profiler,
+    n_threads: Optional[int] = None,
+    n_blocks: Optional[int] = None,
+    target_partition_bytes: int = TARGET_PARTITION_BYTES,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Sort mzs/ints/sp_idxs by m/z in parallel, stably.
+
+    "Stably" is a hard requirement, not an optimization: equal m/z values must preserve
+    their ordering by spectrum index, because the order of pixels affects some metrics.
+
+    Both points below are about peak memory:
+    * `sp_idxs` is built here from `sp_lens` and `pixel_indexes` rather than being passed
+      in. An unsorted copy held by the caller couldn't be garbage-collected during the
+      sort, so it's kept in this compacted form until the last minute.
+    * `mzs` and `ints` are sorted in place blockwise, so the caller's copies are left
+      permuted. Use only the returned arrays afterwards.
+    """
+    n_peaks = len(mzs)
+    assert len(ints) == n_peaks, (len(ints), n_peaks)
+    if n_peaks == 0:
+        return mzs, ints, np.empty(0, np.uint32)
+
+    n_threads = n_threads or get_n_worker_threads()
+    n_blocks = n_blocks or max(1, min(4 * n_threads, len(sp_lens)))
+
+    n_parts = _calc_n_partitions(n_peaks, mzs.itemsize, n_threads, target_partition_bytes)
+    splitters = _choose_splitters(mzs, n_parts)
+    n_parts = len(splitters) + 1
+    perf.record_entry('sort_splitters')
+
+    sp_bounds, pk_bounds = _define_block_bounds(sp_lens, n_blocks)
+    n_blocks = len(sp_bounds) - 1
+    sp_idxs, cuts = _sort_blocks(
+        mzs, ints, pixel_indexes, sp_lens, sp_bounds, pk_bounds, splitters, n_threads
+    )
+
+    piece_lo, piece_hi, offsets = _define_partition_layout(cuts, pk_bounds)
+    sizes = np.diff(offsets)
+    logger.debug(
+        f'Sorting {n_peaks} peaks: {n_blocks} blocks, {n_parts} partitions, '
+        f'{n_threads} threads, largest partition {sizes.max()}'
+    )
+    perf.record_entry(
+        'sort_blocks',
+        n_blocks=n_blocks,
+        n_parts=n_parts,
+        n_threads=n_threads,
+        max_part=int(sizes.max()),
+        median_part=int(np.median(sizes)),
+    )
+
+    sorted_arrays = _gather_partitions(mzs, ints, sp_idxs, piece_lo, piece_hi, offsets, n_threads)
+    perf.record_entry('sort_partitions')
+    return sorted_arrays

--- a/metaspace/engine/sm/engine/tests/annotation_lithops/test_parallel_sort.py
+++ b/metaspace/engine/sm/engine/tests/annotation_lithops/test_parallel_sort.py
@@ -1,0 +1,223 @@
+from itertools import product
+
+import numpy as np
+import pytest
+
+from sm.engine.annotation_lithops.parallel_sort import get_n_worker_threads, sort_peaks
+from sm.engine.utils.perf_profile import SubtaskProfiler
+
+
+def make_peaks(rng, n_spectra, mz_dtype='d', peaks_lo=50, peaks_hi=400, mz_alphabet=None):
+    """Build (mzs, ints, sp_lens, pixel_indexes) shaped like a real imzML read.
+
+    Each spectrum is internally sorted and spectra are laid out back-to-back, which is
+    what `_load_spectra` produces. `mz_alphabet` restricts m/z to a small set of values
+    to force ties.
+    """
+    sp_lens = rng.integers(peaks_lo, peaks_hi + 1, n_spectra).astype(np.int64)
+    n_peaks = int(sp_lens.sum())
+
+    if mz_alphabet is None:
+        mzs = (rng.random(n_peaks) * 1000).astype(mz_dtype)
+    else:
+        mzs = rng.choice(mz_alphabet, n_peaks).astype(mz_dtype)
+
+    offsets = np.insert(np.cumsum(sp_lens), 0, 0)
+    for start, end in zip(offsets[:-1], offsets[1:]):
+        mzs[start:end] = np.sort(mzs[start:end])
+
+    ints = (rng.random(n_peaks) * 100).astype(np.float32)
+    # Shuffled so that a bug that reconstructs sp_idxs positionally would show up
+    pixel_indexes = rng.permutation(n_spectra).astype(np.int64)
+    return mzs, ints, sp_lens, pixel_indexes
+
+
+def reference_sort(mzs, ints, sp_lens, pixel_indexes):
+    """The current single-threaded implementation, as the definition of correctness."""
+    by_mz = np.argsort(mzs, kind='mergesort')
+    sp_idxs = np.repeat(pixel_indexes, sp_lens).astype(np.uint32)
+    return mzs[by_mz], ints[by_mz], sp_idxs[by_mz]
+
+
+def assert_matches_reference(peaks, **kwargs):
+    mzs, ints, sp_lens, pixel_indexes = peaks
+    exp_mz, exp_int, exp_sp = reference_sort(mzs.copy(), ints.copy(), sp_lens, pixel_indexes)
+    # sort_peaks sorts mzs/ints in place, so it must not see the reference's arrays
+    got_mz, got_int, got_sp = sort_peaks(
+        mzs.copy(), ints.copy(), sp_lens, pixel_indexes, perf=SubtaskProfiler(), **kwargs
+    )
+
+    assert np.array_equal(got_mz, exp_mz, equal_nan=True)
+    assert np.array_equal(got_int, exp_int)
+    assert np.array_equal(got_sp, exp_sp)
+    return got_mz, got_int, got_sp
+
+
+@pytest.mark.parametrize(
+    'mz_dtype, n_threads, n_blocks',
+    list(product(['f', 'd'], [1, 2, 8], [None, 1, 3, 64])),
+)
+def test_matches_reference(mz_dtype, n_threads, n_blocks):
+    rng = np.random.default_rng(42)
+    peaks = make_peaks(rng, 500, mz_dtype=mz_dtype)
+    assert_matches_reference(peaks, n_threads=n_threads, n_blocks=n_blocks)
+
+
+@pytest.mark.parametrize('target_partition_bytes', [1024, 4 * 2 ** 20, 2 ** 30])
+def test_partition_size_extremes(target_partition_bytes):
+    """Both ends of the partition-count estimate, as the clamps actually leave it.
+
+    Neither end reaches the count the parameter asks for. 1024 bytes works out to ~1000
+    partitions, but SAMPLE_STRIDE leaves only ~69 samples to cut on, so `_choose_splitters`
+    caps it at ~70. The two larger values both work out to a single partition and are
+    both lifted to 16 by the `4 * n_threads` floor - i.e. they are the same code path.
+    """
+    rng = np.random.default_rng(1)
+    peaks = make_peaks(rng, 300)
+    assert_matches_reference(peaks, n_threads=4, target_partition_bytes=target_partition_bytes)
+
+
+def test_stability_when_all_mz_equal():
+    """The one case that catches a lost `kind='stable'` or a shuffled block order.
+
+    With every m/z identical the sort has no ordering information to work with, so the
+    output must be exactly the input order - i.e. spectrum by spectrum.
+    """
+    n_spectra, sp_len = 40, 25
+    sp_lens = np.full(n_spectra, sp_len, np.int64)
+    pixel_indexes = np.random.default_rng(2).permutation(n_spectra).astype(np.int64)
+    mzs = np.full(n_spectra * sp_len, 123.456)
+    ints = np.arange(n_spectra * sp_len, dtype=np.float32)
+
+    _, got_int, got_sp = sort_peaks(
+        mzs.copy(), ints.copy(), sp_lens, pixel_indexes, perf=SubtaskProfiler()
+    )
+
+    assert np.array_equal(got_sp, np.repeat(pixel_indexes, sp_lens).astype(np.uint32))
+    assert np.array_equal(got_int, ints)  # untouched input order
+
+
+def test_ties_across_partition_boundaries():
+    """Heavy duplicates make splitters land on repeated values, where an inconsistent
+    `side` would drop or duplicate peaks."""
+    rng = np.random.default_rng(3)
+    peaks = make_peaks(rng, 400, mz_alphabet=np.arange(5.0))
+    got_mz, _, _ = assert_matches_reference(peaks, n_threads=8, target_partition_bytes=4096)
+
+    assert len(got_mz) == len(peaks[0])
+    assert np.all(np.diff(got_mz) >= 0)
+
+
+def test_nan_mz():
+    rng = np.random.default_rng(4)
+    mzs, ints, sp_lens, pixel_indexes = make_peaks(rng, 200)
+    mzs[rng.integers(0, len(mzs), len(mzs) // 50)] = np.nan
+    assert_matches_reference((mzs, ints, sp_lens, pixel_indexes), n_threads=4)
+
+
+def test_zero_length_spectra():
+    """Spectra can end up empty after zero-intensity peaks are filtered out."""
+    rng = np.random.default_rng(5)
+    mzs, ints, sp_lens, pixel_indexes = make_peaks(rng, 300)
+    sp_lens[rng.random(300) < 0.2] = 0
+    mzs, ints = mzs[: sp_lens.sum()], ints[: sp_lens.sum()]
+    assert_matches_reference((mzs, ints, sp_lens, pixel_indexes), n_threads=4)
+
+
+def test_fewer_spectra_than_blocks():
+    rng = np.random.default_rng(6)
+    peaks = make_peaks(rng, 3)
+    assert_matches_reference(peaks, n_threads=8, n_blocks=64)
+
+
+def test_single_spectrum():
+    rng = np.random.default_rng(7)
+    assert_matches_reference(make_peaks(rng, 1), n_threads=4)
+
+
+def test_single_peak():
+    peaks = (
+        np.array([1.0]),
+        np.array([2.0], np.float32),
+        np.array([1], np.int64),
+        np.array([7], np.int64),
+    )
+    assert_matches_reference(peaks)
+
+
+def test_empty():
+    mzs, ints, sp_lens, pixel_indexes = (
+        np.empty(0, 'd'),
+        np.empty(0, np.float32),
+        np.zeros(3, np.int64),
+        np.arange(3, dtype=np.int64),
+    )
+    got_mz, got_int, got_sp = sort_peaks(mzs, ints, sp_lens, pixel_indexes, perf=SubtaskProfiler())
+
+    assert len(got_mz) == len(got_int) == len(got_sp) == 0
+    assert got_sp.dtype == np.uint32
+
+
+@pytest.mark.parametrize('mz_dtype', ['f', 'd'])
+def test_output_dtypes(mz_dtype):
+    """validate_ds_segments asserts int is float32 and sp_i is uint32."""
+    rng = np.random.default_rng(8)
+    mzs, ints, sp_lens, pixel_indexes = make_peaks(rng, 50, mz_dtype=mz_dtype)
+    got_mz, got_int, got_sp = sort_peaks(mzs, ints, sp_lens, pixel_indexes, perf=SubtaskProfiler())
+
+    assert got_mz.dtype == np.dtype(mz_dtype)
+    assert got_int.dtype == np.float32
+    assert got_sp.dtype == np.uint32
+
+
+def test_spectra_longer_than_sample_stride():
+    """A spectrum length that is a multiple of SAMPLE_STRIDE is the aliasing shape:
+    a fixed stride hits the same offsets inside every spectrum."""
+    rng = np.random.default_rng(9)
+    peaks = make_peaks(rng, 60, peaks_lo=2000, peaks_hi=2000)
+    assert_matches_reference(peaks, n_threads=4)
+
+
+def test_perf_entries_recorded():
+    """`perf` is mandatory, so every run reports the same marks and the same extra data.
+
+    load_ds aggregates these across subtasks by name, so renaming or dropping one silently
+    puts a hole in the profile rather than failing anything.
+    """
+    rng = np.random.default_rng(10)
+    mzs, ints, sp_lens, pixel_indexes = make_peaks(rng, 100)
+    perf = SubtaskProfiler()
+
+    sort_peaks(mzs, ints, sp_lens, pixel_indexes, perf=perf, n_threads=4)
+
+    assert set(perf.entries) == {'sort_splitters', 'sort_blocks', 'sort_partitions'}
+    assert set(perf.extra_data) == {'n_blocks', 'n_parts', 'n_threads', 'max_part', 'median_part'}
+    assert perf.extra_data['n_threads'] == 4
+    assert perf.extra_data['max_part'] >= perf.extra_data['median_part']
+
+
+def test_perf_not_recorded_when_empty():
+    """The zero-peak early return happens before any mark. `make_report` fills the gap
+    with None, so an empty dataset thins the profile rather than breaking it."""
+    perf = SubtaskProfiler()
+
+    sort_peaks(
+        np.empty(0, 'd'),
+        np.empty(0, np.float32),
+        np.zeros(3, np.int64),
+        np.arange(3, dtype=np.int64),
+        perf=perf,
+    )
+
+    assert perf.entries == {}
+
+
+def test_get_n_worker_threads_uses_lambda_memory(monkeypatch):
+    monkeypatch.setenv('AWS_LAMBDA_FUNCTION_MEMORY_SIZE', '8192')
+    assert get_n_worker_threads() == 5  # 8192 / 1769
+
+    monkeypatch.setenv('AWS_LAMBDA_FUNCTION_MEMORY_SIZE', '1024')
+    assert get_n_worker_threads() == 1  # never below one thread
+
+    monkeypatch.delenv('AWS_LAMBDA_FUNCTION_MEMORY_SIZE')
+    assert get_n_worker_threads() >= 1


### PR DESCRIPTION
Sorting all peaks by m/z in _sort_spectra was a single-threaded np.argsort(kind='mergesort') over the full m/z array plus three fancy-index passes. On large datasets this is 30+% of the whole load_ds step while all other cores sit idle.

**Change**

New `parallel_sort.sort_peaks` is a [parallel sample sort](https://en.wikipedia.org/wiki/Samplesort) that produces byte-for-byte identical output to the old path:

1. Spectra are split into ~4×n_threads blocks of roughly equal peak count; each block is arg-sorted in place in parallel with kind='stable'.
2. Partition splitters are picked as quantiles of a 1/1000 strided sample of the m/z values; the partition count is chosen so one partition's sort working set is ~4 MB, i.e. cache-resident.
3. Each partition gathers its pieces from all blocks (in block order — this is what preserves stability) and is stable-sorted in parallel.

Stability is a hard requirement, not an optimization: equal m/z values must keep their spectrum order, because pixel order affects some metrics. The equivalence with the old mergesort path is covered by tests.

Implementation notes:

  - Peak memory stays flat (±1.5% in benchmarks): mzs/ints are sorted in place blockwise, and sp_idxs is materialized inside the sort from sp_lens + pixel_indexes instead of being passed in as a third full-size array held by the caller.
 - Thread count comes from sched_getaffinity, except on Lambda, where vCPUs are derived from AWS_LAMBDA_FUNCTION_MEMORY_SIZE (1 vCPU per 1769 MB).

**Benchmarks**

Isolated (this change only), medians over 5 runs; same 5 datasets as in the issue:
```
┌─────────┬───────┬────────────────────┬─────────────┬────────────┬─────────┬─────────────────┐
│ dataset │ peaks │ backend (threads)  │ sort before │ sort after │ speedup │ Δ load_ds total │
├─────────┼───────┼────────────────────┼─────────────┼────────────┼─────────┼─────────────────┤
│ 01      │ 4.7M  │ Lambda 2 GB (1)    │ 0.7 s       │ 0.7 s      │ ×0.9    │ — (noise)       │
├─────────┼───────┼────────────────────┼─────────────┼────────────┼─────────┼─────────────────┤
│ 02      │ 62M   │ Lambda 4 GB (2)    │ 12.5 s      │ 5.9 s      │ ×2.1    │ −13%            │
├─────────┼───────┼────────────────────┼─────────────┼────────────┼─────────┼─────────────────┤
│ 03      │ 163M  │ Lambda 8 GB (5)    │ 37.5 s      │ 6.1 s      │ ×6.1    │ −24%            │
├─────────┼───────┼────────────────────┼─────────────┼────────────┼─────────┼─────────────────┤
│ 04      │ 347M  │ EC2 r6a.xlarge (4) │ 53.1 s      │ 15.5 s     │ ×3.4    │ −20%            │
├─────────┼───────┼────────────────────┼─────────────┼────────────┼─────────┼─────────────────┤
│ 05      │ 623M  │ EC2 r6a.xlarge (4) │ 95.9 s      │ 28.6 s     │ ×3.3    │ −21%            │
└─────────┴───────┴────────────────────┴─────────────┴────────────┴─────────┴─────────────────┘
```

The ×6.1 speedup on 5 threads (and ×2.1 on 2) is superlinear: many small, cache-resident partition sorts replace one global argsort over a 1.3 GB array. On a 1-thread 2 GB Lambda there is no parallelism to use, so the sort time stays the same.

On EC2 the scaling is lower (×3.3–3.4 on 4 threads): r6a.xlarge has only 2 physical cores with SMT, so the 4 sorting threads share 2 real cores. It is worth trying r7a.xlarge: there SMT is disabled and every vCPU is a physical core, so the sort should scale close to ×4.