### PR TITLE
Speed up spectra reading in load_ds with bulk chunk decoding

### DIFF
--- a/metaspace/engine/sm/engine/annotation/imzml_reader.py
+++ b/metaspace/engine/sm/engine/annotation/imzml_reader.py
@@ -189,7 +189,11 @@ class LithopsImzMLReader(ImzMLReader):
         ):
             raise Exception('Incomplete .ibd file')
 
-    def iter_spectra(self, storage: Storage, sp_inds: Sequence[int]):
+    def _read_ranges(self, storage: Storage, sp_inds: Sequence[int]):
+        """Download the raw mz/intensity buffers for the given spectra.
+
+        Returns (mz_data, int_data) - one bytes object per spectrum each.
+        """
         # pylint: disable=import-outside-toplevel # avoid pulling Lithops into Spark pipeline
         from sm.engine.annotation_lithops.io import get_ranges_from_cobject
 
@@ -208,9 +212,10 @@ class LithopsImzMLReader(ImzMLReader):
         int_ranges = np.stack([int_starts, int_ends], axis=1)
         ranges_to_read = np.vstack([mz_ranges, int_ranges])
         data_ranges = get_ranges_from_cobject(storage, self._ibd_cobject, ranges_to_read)
-        mz_data = data_ranges[: len(sp_inds)]
-        int_data = data_ranges[len(sp_inds) :]
-        del data_ranges
+        return data_ranges[: len(sp_inds)], data_ranges[len(sp_inds) :]
+
+    def iter_spectra(self, storage: Storage, sp_inds: Sequence[int]):
+        mz_data, int_data = self._read_ranges(storage, sp_inds)
 
         for i, sp_idx in enumerate(sp_inds):
             # Copy the arrays, as np.frombuffer only makes a view over the existing buffer,
@@ -231,3 +236,71 @@ class LithopsImzMLReader(ImzMLReader):
                 sp_idx, mzs, ints = self._process_spectrum(sp_idx, mzs, ints)
 
             yield sp_idx, mzs, ints
+
+    def read_spectra_chunk(self, storage: Storage, sp_inds: Sequence[int], int_dtype=np.float32):
+        """Read a run of spectra and decode them in bulk into three flat arrays
+        (mzs, ints, sp_lens) - the same peaks iter_spectra yields, in sp_inds order.
+
+        Decoding spectra one at a time was the bottleneck of the read stage; bulk decode
+        removes that per-spectrum overhead and also lowers peak memory, as downloaded
+        buffers are freed as soon as they are consumed instead of piling up as
+        per-spectrum copies.
+        """
+        sp_inds = np.asarray(sp_inds)
+        mz_data, int_data = self._read_ranges(storage, sp_inds)
+        return self._decode_chunk(sp_inds, mz_data, int_data, int_dtype)
+
+    def _decode_chunk(self, sp_inds, mz_data, int_data, int_dtype):
+        # pylint: disable=too-many-locals
+        reader = self.imzml_reader
+        n_spectra = len(sp_inds)
+        mz_lens = np.asarray(reader.mzLengths)[sp_inds]
+        int_lens = np.asarray(reader.intensityLengths)[sp_inds]
+
+        # Data validation: vectorised equivalent of the per-spectrum _check_consistency
+        mz_bytes = np.fromiter(map(len, mz_data), np.int64, n_spectra)
+        int_bytes = np.fromiter(map(len, int_data), np.int64, n_spectra)
+        bad = mz_lens != int_lens
+        if bad.any():
+            raise IbdError(f"Spectrum {sp_inds[bad.argmax()]} mz and intensity counts don't match")
+        bad = (mz_bytes != mz_lens * np.dtype(reader.mzPrecision).itemsize) | (
+            int_bytes != int_lens * np.dtype(reader.intensityPrecision).itemsize
+        )
+        if bad.any():
+            raise IbdError(f'Incomplete .ibd file (spectrum {sp_inds[bad.argmax()]})')
+
+        ends = np.cumsum(mz_lens)
+        starts = ends - mz_lens
+        mzs = np.empty(int(mz_lens.sum()), reader.mzPrecision)
+        ints = np.empty(len(mzs), int_dtype)
+        for i in range(n_spectra):
+            # Slice assignment casts in C, so there are no per-spectrum .copy()/.astype()
+            # temporaries, and the buffers can be dropped as soon as they are consumed.
+            mzs[starts[i] : ends[i]] = np.frombuffer(mz_data[i], reader.mzPrecision)
+            ints[starts[i] : ends[i]] = np.frombuffer(int_data[i], reader.intensityPrecision)
+            mz_data[i] = None
+            int_data[i] = None
+
+        # Remove zero-intensity peaks, as some export processes generate them in large
+        # numbers, but they add no value at all.
+        keep = ints > 0
+        sp_lens = mz_lens.astype(np.int64, copy=False)
+        if not keep.all():
+            kept_counts = np.concatenate([[0], np.cumsum(keep)])
+            sp_lens = kept_counts[ends] - kept_counts[starts]
+            mzs = mzs[keep]
+            ints = ints[keep]
+
+        chunk_min_mz = chunk_max_mz = None
+        if len(mzs) and not self.is_mz_from_metadata:
+            chunk_min_mz, chunk_max_mz = mzs.min(), mzs.max()
+        with _process_spectrum_lock:
+            if not self.is_tic_from_metadata:
+                cum_ints = np.concatenate([[0.0], np.cumsum(ints, dtype=np.float64)])
+                sp_ends = np.cumsum(sp_lens)
+                self._sp_tic[sp_inds] = cum_ints[sp_ends] - cum_ints[sp_ends - sp_lens]
+            if chunk_min_mz is not None:
+                self.min_mz = min(self.min_mz, chunk_min_mz)
+                self.max_mz = max(self.max_mz, chunk_max_mz)
+
+        return mzs, ints, sp_lens

--- a/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, List, Tuple, Union, Any
 
@@ -19,29 +20,30 @@ from sm.engine.utils.perf_profile import SubtaskProfiler
 logger = logging.getLogger('annotation-pipeline')
 
 
+def _get_n_read_threads():
+    """Measured optimum: 8 S3 connections saturate EC2 download throughput, while Lambda is
+    network-capped and gains nothing past 4 (see bench_s3_download.py)."""
+    if os.environ.get('AWS_LAMBDA_FUNCTION_MEMORY_SIZE'):
+        return 4
+    return 8
+
+
 def _load_spectra(storage, imzml_reader):
-    # Pre-allocate lists of mz & int arrays
-    mz_arrays = [np.array([], dtype=imzml_reader.mz_precision)] * imzml_reader.n_spectra
-    int_arrays = [np.array([], dtype=np.float32)] * imzml_reader.n_spectra
-    sp_lens = np.empty(imzml_reader.n_spectra, np.int64)
-
-    def read_spectrum_chunk(start_end):
-        for sp_i, mzs, ints in imzml_reader.iter_spectra(storage, list(range(*start_end))):
-            mz_arrays[sp_i] = mzs
-            int_arrays[sp_i] = ints.astype(np.float32)
-            sp_lens[sp_i] = len(ints)
-
     # Break into approx. 100MB chunks to read in parallel
     n_peaks = np.sum(imzml_reader.imzml_reader.mzLengths)
-    n_chunks = min(int(np.ceil(n_peaks / (10 * 2 ** 20))), imzml_reader.n_spectra)
+    n_chunks = max(min(int(np.ceil(n_peaks / (10 * 2 ** 20))), imzml_reader.n_spectra), 1)
     chunk_bounds = np.linspace(0, imzml_reader.n_spectra, n_chunks + 1, dtype=np.int64)
-    spectrum_chunks = zip(chunk_bounds, chunk_bounds[1:])
+    spectrum_chunks = list(zip(chunk_bounds, chunk_bounds[1:]))
 
-    with ThreadPoolExecutor(4) as executor:
-        for _ in executor.map(read_spectrum_chunk, spectrum_chunks):
-            pass
+    def read_chunk(start_end):
+        return imzml_reader.read_spectra_chunk(storage, np.arange(*start_end))
 
-    return np.concatenate(mz_arrays), np.concatenate(int_arrays), sp_lens
+    with ThreadPoolExecutor(_get_n_read_threads()) as executor:
+        chunks = list(executor.map(read_chunk, spectrum_chunks))
+    mzs = np.concatenate([chunk_mzs for chunk_mzs, _, _ in chunks])
+    ints = np.concatenate([chunk_ints for _, chunk_ints, _ in chunks])
+    sp_lens = np.concatenate([chunk_lens for _, _, chunk_lens in chunks])
+    return mzs, ints, sp_lens
 
 
 def _sort_spectra(imzml_reader, perf, mzs, ints, sp_lens):


### PR DESCRIPTION
Before this change, `_load_spectra` processed spectra one by one via `iter_spectra`. For every spectrum it did:

  - two buffer copies out of np.frombuffer views, plus an .astype(np.float32) temporary;
  - TIC and min/max m/z updates under a lock;
  - an append to a Python list, so n_spectra small arrays had to be concatenated at the end.

On large EC2 datasets this per-spectrum overhead took most of the read stage time. The extra copies also raised peak memory.

**Change**

New `read_spectra_chunk` and `_decode_chunk` on LithopsImzMLReader, used by `_load_spectra` instead of the per-spectrum path:

  - A chunk's raw buffers are decoded directly into two preallocated flat arrays; slice assignment casts in C, so there are no per-spectrum .copy()/.astype() temporaries, and each downloaded buffer is dropped as soon as it's consumed instead of piling up.
  - The .ibd consistency checks, the zero-intensity peak filter, and per-spectrum TIC (one float64 cumsum per chunk) are vectorized; the lock is taken once per chunk instead of once per spectrum.
  - _load_spectra now concatenates per-chunk arrays (~100 MB each) instead of n_spectra per-spectrum arrays.
  - Read threads: 4 -> 8 on EC2; Lambda stays at 4, it's network-capped and gains nothing past that.
  - iter_spectra is left in place unchanged (the range-download part is factored out and shared).


**Benchmarks**

Isolated (this change only), medians; same 5 datasets as in the issue:
```
┌─────────┬───────┬────────────────┬─────────────┬────────────┬───────────┬─────────────┐
│ dataset │ peaks │    backend     │ read before │ read after │  Δ read   │ peak memory │
├─────────┼───────┼────────────────┼─────────────┼────────────┼───────────┼─────────────┤
│ 01      │ 4.7M  │ Lambda 2 GB    │ 1.2 s       │ 0.9 s      │ −25%      │ −1%         │
├─────────┼───────┼────────────────┼─────────────┼────────────┼───────────┼─────────────┤
│ 02      │ 62M   │ Lambda 4 GB    │ 8.6 s       │ 8.8 s      │ +2%       │ −14%        │
├─────────┼───────┼────────────────┼─────────────┼────────────┼───────────┼─────────────┤
│ 03      │ 163M  │ Lambda 8 GB    │ 25.8 s      │ 25.7 s     │ —         │ −12%        │
├─────────┼───────┼────────────────┼─────────────┼────────────┼───────────┼─────────────┤
│ 04      │ 347M  │ EC2 r6a.xlarge │ 54.1 s      │ 31.4 s     │ −42%      │ −18%        │
├─────────┼───────┼────────────────┼─────────────┼────────────┼───────────┼─────────────┤
│ 05      │ 623M  │ EC2 r6a.xlarge │ 88.5 s      │ 53.3 s     │ −40%      │ −21%        │
└─────────┴───────┴────────────────┴─────────────┴────────────┴───────────┴─────────────┘
```

On Lambda, the read stage was already limited by network bandwidth (~72–80 MB/s), so bulk decoding does not make it faster there. The benefit is lower memory use (−12…−14%). 

On EC2, both parts of the change work together (bulk decoding + 8 read threads), and the read stage becomes ~40% faster. The memory effect is the same for all dataset sizes: peak memory drops from ~4.05× to ~3.35× of the .ibd file size.