### PR TITLE
Speed up imzML browser file upload in load_ds

### DIFF
--- a/metaspace/engine/sm/engine/annotation_lithops/io.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/io.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import pickle
 from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import ExitStack
 from typing import TypeVar, Generic, List, Iterable, overload, Any, Tuple, Union
 
 import uuid
@@ -16,6 +17,7 @@ logger = logging.getLogger('annotation-pipeline')
 TItem = TypeVar('TItem')
 TArg = TypeVar('TArg')
 TRet = TypeVar('TRet')
+MAX_MULTIPART_THREADS = 4
 
 
 class CObj(Generic[TItem], CloudObject):
@@ -56,17 +58,28 @@ def deserialize(data):
 
 
 def multipart_upload_cobj(
-    storage: Storage, data: bytes, bucket: str = None, key: str = None, part_size_mb: int = 100
+    storage: Storage,
+    data: np.ndarray,
+    bucket: str = None,
+    key: str = None,
+    dtype=None,
+    part_size_mb: int = 32,
+    pool: ThreadPoolExecutor = None,
 ) -> Union[CObj, CloudObject]:
-    """
-    Upload large data to S3 using multipart upload.
+    """Upload data to S3 as a multipart upload, sending the parts in parallel.
 
     Args:
         storage: The Storage instance to use
-        data: The binary data to upload
+        data: The payload array. It is sliced and converted one part at a time, so its
+            bytes are never materialised in full. Wrap raw bytes in a zero-copy
+            np.frombuffer view to send them.
         bucket: The S3 bucket name (defaults to storage.bucket)
         key: The S3 key (path) to upload to
-        part_size_mb: Size of each part in MB (default 100MB)
+        dtype: dtype to convert each part to before sending.
+        part_size_mb: Size of each uploaded part. S3 requires >= 5 MB for every part but the
+            last, and allows at most 10 000 parts.
+        pool: Pool to send the parts through; private if not given. Share one pool across
+            objects to cap in-flight parts and memory; don't call from inside it (deadlock).
 
     Returns:
         A CloudObject or CObj pointing to the uploaded data
@@ -79,57 +92,50 @@ def multipart_upload_cobj(
         key = '/'.join(["lithops.jobs/tmp", name])
         logger.debug(f"No key provided, generated key following lithops pattern: {key}")
 
-    data_size = len(data)
     bucket = bucket or storage.bucket
-
-    # Get the underlying boto3 client
     s3_client = storage.get_client()
 
-    # Calculate part size in bytes
-    part_size = part_size_mb * 1024 * 1024
+    # Parts are sliced in elements, so that part_size_mb always refers to what actually
+    # goes over the wire after the dtype conversion.
+    itemsize = np.dtype(dtype or data.dtype).itemsize
+    part_len = max(1, int(part_size_mb * 2 ** 20) // itemsize)
+    parts_count = max(1, (len(data) + part_len - 1) // part_len)
 
-    # Log start of multipart upload
-    logger.info(f"Using multipart upload for large file: {key} ({data_size/(1024**3):.2f} GB)")
-    logger.info(f"Using multipart upload for large file bucket: {bucket}")
-    logger.info(f"Using multipart upload for large file s3_client: {s3_client}")
-
-    # Initialize multipart upload
+    logger.info(
+        f'Multipart upload of {key}: {len(data) * itemsize / 1024 ** 3:.2f} GB '
+        f'in {parts_count} parts'
+    )
     mpu = s3_client.create_multipart_upload(Bucket=bucket, Key=key)
     upload_id = mpu['UploadId']
 
-    # Calculate number of parts
-    parts_count = (data_size + part_size - 1) // part_size  # ceiling division
-    parts = []
+    def upload_part(part_i):
+        # Slicing and converting inside the worker keeps only `pool size` parts in memory
+        part = data[part_i * part_len : (part_i + 1) * part_len]
+        if dtype:
+            part = part.astype(dtype, copy=False)
+        body = part.tobytes()
+        response = s3_client.upload_part(
+            Bucket=bucket, Key=key, PartNumber=part_i + 1, UploadId=upload_id, Body=body
+        )
+        return {'PartNumber': part_i + 1, 'ETag': response['ETag']}
 
     try:
-        # Upload each part
-        for i in range(parts_count):
-            part_number = i + 1
-            start = i * part_size
-            end = min(start + part_size, data_size)
+        with ExitStack() as stack:
+            if pool is None:
+                pool = stack.enter_context(
+                    ThreadPoolExecutor(min(MAX_MULTIPART_THREADS, parts_count))
+                )
+            # S3 requires `Parts` sorted by PartNumber. `map` yields in submission
+            # order, so it already is; collect by completion and you must sort again.
+            parts = list(pool.map(upload_part, range(parts_count)))
 
-            logger.info(f"Uploading part {part_number}/{parts_count} for {key}")
-            response = s3_client.upload_part(
-                Bucket=bucket,
-                Key=key,
-                PartNumber=part_number,
-                UploadId=upload_id,
-                Body=data[start:end],
-            )
-
-            # Add part info to list
-            parts.append({'PartNumber': part_number, 'ETag': response['ETag']})
-
-        # Complete the multipart upload
         s3_client.complete_multipart_upload(
             Bucket=bucket, Key=key, UploadId=upload_id, MultipartUpload={'Parts': parts}
         )
 
-        # Return appropriate object type
         return CObj(storage.backend, bucket, key)
 
     except Exception as e:
-        # Abort multipart upload if something goes wrong
         logger.error(f"Error in multipart upload: {str(e)}")
         s3_client.abort_multipart_upload(Bucket=bucket, Key=key, UploadId=upload_id)
         raise
@@ -140,12 +146,12 @@ def save_cobj(storage: Storage, obj: TItem, bucket: str = None, key: str = None)
     data = serialize(obj)
     data_size = len(data)
 
-    # # # Use regular upload for files under 5GB
+    # Use regular upload for files under 5GB
     if data_size < 5 * 1024 ** 3:
         return storage.put_cloudobject(data, bucket, key)
 
-    # For files >= 5GB, use multipart upload
-    return multipart_upload_cobj(storage, data, bucket, key)
+    # For files >= 5GB, frombuffer is a zero-copy view, the parts are sliced and copied from it one at a time
+    return multipart_upload_cobj(storage, np.frombuffer(data, np.uint8), bucket, key)
 
 
 @overload

--- a/metaspace/engine/sm/engine/annotation_lithops/io.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/io.py
@@ -150,7 +150,8 @@ def save_cobj(storage: Storage, obj: TItem, bucket: str = None, key: str = None)
     if data_size < 5 * 1024 ** 3:
         return storage.put_cloudobject(data, bucket, key)
 
-    # For files >= 5GB, frombuffer is a zero-copy view, the parts are sliced and copied from it one at a time
+    # For files >= 5GB, frombuffer is a zero-copy view, the parts are sliced
+    # and copied from it one at a time
     return multipart_upload_cobj(storage, np.frombuffer(data, np.uint8), bucket, key)
 
 

--- a/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
@@ -20,6 +20,7 @@ logger = logging.getLogger('annotation-pipeline')
 
 
 BROWSER_ARRAY_FILES = ['mzs.npy', 'ints.npy', 'sp_idxs.npy']
+BROWSER_FILES = [*BROWSER_ARRAY_FILES, 'mz_index.npy', 'portable_spectrum_reader.pickle']
 BROWSER_UPLOAD_THREADS = 4
 MULTIPART_THRESHOLD_MB = 64
 BROWSER_BYTES_PER_PEAK = 4
@@ -121,8 +122,17 @@ def _upload_imzml_browser_files(
     imzml_reader: LithopsImzMLReader,
     browser_storage: Storage,
     uuid: str,
-) -> None:
-    """Save imzML browser files on the object storage"""
+) -> bool:
+    """Save imzML browser files on the object storage.
+
+    Returns True if the upload was skipped because a complete set was already there.
+    """
+    # The files are a pure function of the .ibd/.imzML behind this per-session uuid, so an
+    # existing set is never stale; S3 PUTs are atomic, so a partial upload fails this check.
+    existing = set(browser_storage.list_keys(browser_storage.bucket, f'{uuid}/'))
+    if all(f'{uuid}/{name}' in existing for name in BROWSER_FILES):
+        logger.info(f'imzML browser files for {uuid} already exist, skipping upload')
+        return True
 
     def upload_file(data: np.array, key: str, pool: ThreadPoolExecutor) -> CloudObject:
         if len(data) * BROWSER_BYTES_PER_PEAK < MULTIPART_THRESHOLD_MB * 2 ** 20:
@@ -145,6 +155,7 @@ def _upload_imzml_browser_files(
 
     key = f'{uuid}/portable_spectrum_reader.pickle'
     cobjs.append(save_cobj(browser_storage, imzml_reader.imzml_reader, key=key))
+    return False
 
 
 def _load_ds(
@@ -174,8 +185,8 @@ def _load_ds(
 
     logger.info('Uploading imzml browser files')
     browser_storage, uuid = _prepare_storage_imzml_browser_files(imzml_cobject, conf)
-    _upload_imzml_browser_files(mzs, ints, sp_idxs, imzml_reader, browser_storage, uuid)
-    perf.record_entry('uploaded imzml browser files')
+    skipped = _upload_imzml_browser_files(mzs, ints, sp_idxs, imzml_reader, browser_storage, uuid)
+    perf.record_entry('uploaded imzml browser files', skipped=skipped)
 
     logger.info('Uploading segments')
     ds_segms_cobjs, ds_segments_bounds, ds_segm_lens = _upload_segments(

--- a/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
+++ b/metaspace/engine/sm/engine/annotation_lithops/load_ds.py
@@ -19,6 +19,12 @@ from sm.engine.utils.perf_profile import SubtaskProfiler
 logger = logging.getLogger('annotation-pipeline')
 
 
+BROWSER_ARRAY_FILES = ['mzs.npy', 'ints.npy', 'sp_idxs.npy']
+BROWSER_UPLOAD_THREADS = 4
+MULTIPART_THRESHOLD_MB = 64
+BROWSER_BYTES_PER_PEAK = 4
+
+
 def _load_spectra(storage, imzml_reader):
     # Pre-allocate lists of mz & int arrays
     mz_arrays = [np.array([], dtype=imzml_reader.mz_precision)] * imzml_reader.n_spectra
@@ -118,29 +124,23 @@ def _upload_imzml_browser_files(
 ) -> None:
     """Save imzML browser files on the object storage"""
 
-    def upload_file(data: np.array, key: str) -> CloudObject:
-        bytes_data = data.astype('f').tobytes()
-        size_bytes = len(bytes_data)
+    def upload_file(data: np.array, key: str, pool: ThreadPoolExecutor) -> CloudObject:
+        if len(data) * BROWSER_BYTES_PER_PEAK < MULTIPART_THRESHOLD_MB * 2 ** 20:
+            return browser_storage.put_cloudobject(data.astype('f').tobytes(), key=key)
 
-        if size_bytes < 5 * 1024 ** 3:
-            return browser_storage.put_cloudobject(bytes_data, key=key)
-
-        return multipart_upload_cobj(browser_storage, bytes_data, key=key)
-
-    # Convert large precision types to float32 if needed
-    if mzs.itemsize > 4:
-        mzs = mzs.astype('f')
-    if ints.itemsize > 4:
-        ints = ints.astype('f')
+        return multipart_upload_cobj(browser_storage, data, key=key, dtype='f', pool=pool)
 
     # there was no point in saving `sp_idxs` like float, it was a mistake
     # due to the thousands of files stored on S3, we cannot now store this array as np.int32 now
-    keys = [f'{uuid}/{k}' for k in ['mzs.npy', 'ints.npy', 'sp_idxs.npy']]
-    with ThreadPoolExecutor(3) as executor:
-        cobjs = list(executor.map(upload_file, [mzs, ints, sp_idxs], keys))
+    keys = [f'{uuid}/{k}' for k in BROWSER_ARRAY_FILES]
+
+    # One shared pool, and the files go through it one at a time: three files each with
+    # their own pool would put 3x the parts in flight, well past the throughput optimum.
+    with ThreadPoolExecutor(BROWSER_UPLOAD_THREADS) as pool:
+        cobjs = [upload_file(*args, pool) for args in zip([mzs, ints, sp_idxs], keys)]
 
     chunk_records_number = 1024
-    mz_index = mzs[::chunk_records_number]
+    mz_index = mzs[::chunk_records_number].astype('f')
     cobjs.append(browser_storage.put_cloudobject(mz_index.tobytes(), key=f'{uuid}/mz_index.npy'))
 
     key = f'{uuid}/portable_spectrum_reader.pickle'

--- a/metaspace/engine/sm/engine/tests/annotation_lithops/test_load_ds.py
+++ b/metaspace/engine/sm/engine/tests/annotation_lithops/test_load_ds.py
@@ -1,0 +1,170 @@
+"""Unit tests for the imzML browser file upload in load_ds."""
+
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from sm.engine.annotation_lithops import load_ds
+from sm.engine.annotation_lithops.io import multipart_upload_cobj
+from sm.engine.annotation_lithops.load_ds import (
+    BROWSER_UPLOAD_THREADS,
+    _upload_imzml_browser_files,
+)
+
+
+UUID = 'the-uuid'
+
+
+def _args():
+    mzs = np.array([100.0, 200.0, 300.0], dtype='d')
+    ints = np.array([10.0, 20.0, 30.0], dtype='f')
+    sp_idxs = np.array([0, 1, 1], dtype=np.uint32)
+    imzml_reader = MagicMock()
+    return mzs, ints, sp_idxs, imzml_reader
+
+
+def _storage():
+    storage = MagicMock()
+    storage.bucket = 'browser-bucket'
+    return storage
+
+
+class FakeS3:
+    """Records what a multipart upload actually sent, and reassembles it by PartNumber.
+
+    Takes **kwargs because boto3's parameters are PascalCase and keyword-only.
+    """
+
+    def __init__(self):
+        self.started = []
+        self.parts = {}
+        self.completed = {}
+        self.aborted = []
+
+    def create_multipart_upload(self, **kwargs):
+        self.started.append(kwargs['Key'])
+        return {'UploadId': f'upload-{kwargs["Key"]}'}
+
+    def upload_part(self, **kwargs):
+        number, body = kwargs['PartNumber'], kwargs['Body']
+        assert isinstance(body, bytes), f'part {number} sent {type(body)}'
+        self.parts.setdefault(kwargs['Key'], {})[number] = body
+        return {'ETag': f'etag-{number}'}
+
+    def complete_multipart_upload(self, **kwargs):
+        numbers = [part['PartNumber'] for part in kwargs['MultipartUpload']['Parts']]
+        assert numbers == sorted(numbers), f'parts out of order: {numbers}'
+        self.completed[kwargs['Key']] = b''.join(self.parts[kwargs['Key']][n] for n in numbers)
+
+    def abort_multipart_upload(self, **kwargs):
+        self.aborted.append(kwargs['Key'])
+
+
+def _multipart_storage():
+    storage = MagicMock()
+    storage.bucket = 'bucket'
+    storage.backend = 'aws_s3'
+    storage.get_client.return_value = FakeS3()
+    return storage
+
+
+KB_MB = 1 / 1024
+
+
+def test_multipart_streams_an_array_without_a_full_copy():
+    """Every part is sliced and cast on its own - a full float32 copy never exists."""
+    storage = _multipart_storage()
+    mzs = np.linspace(100, 1000, 5000, dtype='d')
+
+    multipart_upload_cobj(storage, mzs, key='mzs.npy', dtype='f', part_size_mb=4 * KB_MB)
+
+    s3 = storage.get_client.return_value
+    assert len(s3.parts['mzs.npy']) > 1, 'payload was sent as a single part'
+    assert s3.completed['mzs.npy'] == mzs.astype('f').tobytes()
+
+
+def test_multipart_converts_sp_idxs_to_float32_per_part():
+    storage = _multipart_storage()
+    data = np.arange(5000, dtype=np.uint32)
+
+    multipart_upload_cobj(storage, data, key='sp.npy', dtype='f', part_size_mb=4 * KB_MB)
+
+    assert storage.get_client.return_value.completed['sp.npy'] == data.astype('f').tobytes()
+
+
+def test_multipart_uploads_a_bytes_view_unchanged():
+    """save_cobj feeds it serialized DataFrames as a zero-copy uint8 view of the bytes;
+    the reassembled object must stay byte-identical."""
+    storage = _multipart_storage()
+    payload = bytes(range(256)) * 400
+    data = np.frombuffer(payload, np.uint8)
+
+    multipart_upload_cobj(storage, data, key='blob', part_size_mb=16 * KB_MB)
+
+    s3 = storage.get_client.return_value
+    assert len(s3.parts['blob']) > 1
+    assert s3.completed['blob'] == payload
+
+
+def test_multipart_aborts_when_a_part_fails():
+    storage = _multipart_storage()
+    s3 = storage.get_client.return_value
+    s3.upload_part = MagicMock(side_effect=ValueError('boom'))
+
+    with pytest.raises(ValueError):
+        multipart_upload_cobj(storage, np.zeros(5000, 'd'), key='k', part_size_mb=4 * KB_MB)
+
+    assert s3.aborted == ['k'], 'a failed upload must not leave the MPU dangling'
+
+
+def test_browser_files_keep_their_old_bytes():
+    """Byte-for-byte identical to what the single-PUT path produced, which the imzML
+    browser reads back with ranged GETs at fixed float32 offsets."""
+    n_peaks = 3 * 1024
+    mzs = np.linspace(100, 1000, n_peaks, dtype='d')
+    ints = np.linspace(1, 9, n_peaks, dtype='f')
+    sp_idxs = np.arange(n_peaks, dtype=np.uint32)
+    storage = _storage()
+    s3 = FakeS3()
+    storage.get_client.return_value = s3
+
+    with patch.object(load_ds, 'MULTIPART_THRESHOLD_MB', 0), patch.object(load_ds, 'save_cobj'):
+        _upload_imzml_browser_files(mzs, ints, sp_idxs, MagicMock(), storage, UUID)
+
+    assert s3.completed[f'{UUID}/mzs.npy'] == mzs.astype('f').tobytes()
+    assert s3.completed[f'{UUID}/ints.npy'] == ints.astype('f').tobytes()
+    assert s3.completed[f'{UUID}/sp_idxs.npy'] == sp_idxs.astype('f').tobytes()
+    # mz_index stays a single PUT, and is built off the float64 source
+    (index_call,) = storage.put_cloudobject.call_args_list
+    assert index_call.kwargs['key'] == f'{UUID}/mz_index.npy'
+    assert index_call.args[0] == mzs.astype('f')[::1024].tobytes()
+
+
+def test_upload_concurrency_stays_at_the_measured_optimum():
+    """Pinned on purpose, so raising it means reading this first.
+
+    Aggregate S3 throughput peaks at 4 concurrent uploads - 294 MB/s on r6a.large,
+    351 on r6a.2xlarge - and falls off beyond it. 12 was shipped once and measured 39%
+    slower on this very block. Re-measure with bench_s3_upload.py before changing this.
+    """
+    assert BROWSER_UPLOAD_THREADS == 4
+
+
+def test_browser_files_share_a_single_pool(monkeypatch):
+    """Three files with a pool each would put 3x the parts in flight, past the optimum."""
+    pool_sizes = []
+    real_pool = ThreadPoolExecutor
+    monkeypatch.setattr(
+        load_ds,
+        'ThreadPoolExecutor',
+        lambda max_workers: pool_sizes.append(max_workers) or real_pool(max_workers),
+    )
+    storage = _storage()
+    storage.get_client.return_value = FakeS3()
+
+    with patch.object(load_ds, 'MULTIPART_THRESHOLD_MB', 0), patch.object(load_ds, 'save_cobj'):
+        _upload_imzml_browser_files(*_args(), storage, UUID)
+
+    assert pool_sizes == [BROWSER_UPLOAD_THREADS], f'expected one pool of {BROWSER_UPLOAD_THREADS}'

--- a/metaspace/engine/sm/engine/tests/annotation_lithops/test_load_ds.py
+++ b/metaspace/engine/sm/engine/tests/annotation_lithops/test_load_ds.py
@@ -9,6 +9,7 @@ import pytest
 from sm.engine.annotation_lithops import load_ds
 from sm.engine.annotation_lithops.io import multipart_upload_cobj
 from sm.engine.annotation_lithops.load_ds import (
+    BROWSER_FILES,
     BROWSER_UPLOAD_THREADS,
     _upload_imzml_browser_files,
 )
@@ -25,10 +26,76 @@ def _args():
     return mzs, ints, sp_idxs, imzml_reader
 
 
-def _storage():
+def _storage(keys):
     storage = MagicMock()
     storage.bucket = 'browser-bucket'
+    storage.list_keys.return_value = list(keys)
     return storage
+
+
+def _uploaded_keys(storage, save_cobj):
+    """Every key written by the block. The pickle goes through save_cobj, the rest direct."""
+    written = {call.kwargs['key'] for call in storage.put_cloudobject.call_args_list}
+    return written | {call.kwargs['key'] for call in save_cobj.call_args_list}
+
+
+def test_browser_files_matches_what_the_rest_api_expects():
+    """DatasetFiles.check_imzml_browser_files requires exactly these 5 keys per uuid.
+
+    Pinning the list also keeps it non-empty, which the skip check relies on: `all()` over
+    an empty iterable is True, so an emptied constant would silently skip every upload.
+    """
+    assert set(BROWSER_FILES) == {
+        'mzs.npy',
+        'ints.npy',
+        'sp_idxs.npy',
+        'mz_index.npy',
+        'portable_spectrum_reader.pickle',
+    }
+
+
+@patch('sm.engine.annotation_lithops.load_ds.save_cobj')
+def test_skips_upload_when_complete_set_already_exists(save_cobj):
+    storage = _storage(f'{UUID}/{name}' for name in BROWSER_FILES)
+
+    skipped = _upload_imzml_browser_files(*_args(), storage, UUID)
+
+    assert skipped is True
+    storage.list_keys.assert_called_once_with('browser-bucket', f'{UUID}/')
+    assert _uploaded_keys(storage, save_cobj) == set()
+
+
+@patch('sm.engine.annotation_lithops.load_ds.save_cobj')
+def test_uploads_every_file_when_bucket_is_empty(save_cobj):
+    storage = _storage([])
+
+    skipped = _upload_imzml_browser_files(*_args(), storage, UUID)
+
+    assert skipped is False
+    assert _uploaded_keys(storage, save_cobj) == {f'{UUID}/{name}' for name in BROWSER_FILES}
+
+
+@patch('sm.engine.annotation_lithops.load_ds.save_cobj')
+def test_uploads_when_the_set_is_incomplete(save_cobj):
+    """An interrupted run leaves some keys behind - they must not pass as a complete set."""
+    for missing in BROWSER_FILES:
+        save_cobj.reset_mock()
+        storage = _storage(f'{UUID}/{name}' for name in BROWSER_FILES if name != missing)
+
+        skipped = _upload_imzml_browser_files(*_args(), storage, UUID)
+
+        assert skipped is False, f'a set missing {missing} was treated as complete'
+        assert _uploaded_keys(storage, save_cobj) == {f'{UUID}/{name}' for name in BROWSER_FILES}
+
+
+@patch('sm.engine.annotation_lithops.load_ds.save_cobj')
+def test_ignores_keys_belonging_to_another_dataset(save_cobj):
+    storage = _storage(f'other-uuid/{name}' for name in BROWSER_FILES)
+
+    skipped = _upload_imzml_browser_files(*_args(), storage, UUID)
+
+    assert skipped is False
+    assert _uploaded_keys(storage, save_cobj) == {f'{UUID}/{name}' for name in BROWSER_FILES}
 
 
 class FakeS3:
@@ -126,13 +193,14 @@ def test_browser_files_keep_their_old_bytes():
     mzs = np.linspace(100, 1000, n_peaks, dtype='d')
     ints = np.linspace(1, 9, n_peaks, dtype='f')
     sp_idxs = np.arange(n_peaks, dtype=np.uint32)
-    storage = _storage()
+    storage = _storage([])
     s3 = FakeS3()
     storage.get_client.return_value = s3
 
     with patch.object(load_ds, 'MULTIPART_THRESHOLD_MB', 0), patch.object(load_ds, 'save_cobj'):
-        _upload_imzml_browser_files(mzs, ints, sp_idxs, MagicMock(), storage, UUID)
+        skipped = _upload_imzml_browser_files(mzs, ints, sp_idxs, MagicMock(), storage, UUID)
 
+    assert skipped is False
     assert s3.completed[f'{UUID}/mzs.npy'] == mzs.astype('f').tobytes()
     assert s3.completed[f'{UUID}/ints.npy'] == ints.astype('f').tobytes()
     assert s3.completed[f'{UUID}/sp_idxs.npy'] == sp_idxs.astype('f').tobytes()
@@ -161,7 +229,7 @@ def test_browser_files_share_a_single_pool(monkeypatch):
         'ThreadPoolExecutor',
         lambda max_workers: pool_sizes.append(max_workers) or real_pool(max_workers),
     )
-    storage = _storage()
+    storage = _storage([])
     storage.get_client.return_value = FakeS3()
 
     with patch.object(load_ds, 'MULTIPART_THRESHOLD_MB', 0), patch.object(load_ds, 'save_cobj'):


### PR DESCRIPTION
`_upload_imzml_browser_files` stores three peak-length arrays (mzs, ints, sp_idxs) on S3 for the imzML browser. The old path had three problems:

  - Extra memory. Each array was first converted to float32 and then to one big bytes object, so up to two full copies of the largest arrays existed at the same time.
  - Sequential upload. multipart_upload_cobj uploaded parts one by one, in a plain loop with 100 MB parts.
  - Repeated work. The files were uploaded again on every reprocessing of a dataset, although they depend only on the input .ibd/.imzML files.


**Change**

Two commits:

1. Parallel multipart upload without full copies.

  - multipart_upload_cobj now takes a numpy array. Each part is sliced, converted, and uploaded inside a worker thread, so memory holds only a few parts at a time instead of a full copy of the array. 
  - Parts are uploaded in parallel through a thread pool (4 threads); part size 100 -> 32 MB.
  - The three browser arrays share one pool, so the number of in-flight parts (and their memory) stays capped. Files under 64 MB go as a single PUT.

2. Skip the upload when the files already exist.

  - Before uploading, the code lists the keys under {uuid}/; if the complete set of 5 files is already there, the upload is skipped. This is safe: the files are a pure function of the input files behind that uuid, and S3 PUTs are atomic, so a partial old upload cannot pass the completeness check.
  - The perf record gets a skipped flag, so the case is visible in profiles.

The uploaded files stay byte-identical to the old code.


**Benchmarks**

Isolated (multipart change only), medians; same 5 datasets as in the issue:
```
┌─────────┬─────────────┬────────────────┬───────────────────────────────┬─────────────┐
│ dataset │ array sizes │    backend     │         browser stage         │ peak memory │
├─────────┼─────────────┼────────────────┼───────────────────────────────┼─────────────┤
│ 01      │ 3 × 19 MB   │ Lambda 2 GB    │ 0.7 → 1.0 s (see note)        │ −11%        │
├─────────┼─────────────┼────────────────┼───────────────────────────────┼─────────────┤
│ 02      │ 3 × 246 MB  │ Lambda 4 GB    │ 8.0 → 8.3 s (network-limited) │ ±0%         │
├─────────┼─────────────┼────────────────┼───────────────────────────────┼─────────────┤
│ 03      │ 3 × 651 MB  │ Lambda 8 GB    │ 25.5 → 24.0 s (−6%)           │ −18%        │
├─────────┼─────────────┼────────────────┼───────────────────────────────┼─────────────┤
│ 04      │ 3 × 1.4 GB  │ EC2 r6a.xlarge │ ~parity (VM noise)            │ −18%        │
├─────────┼─────────────┼────────────────┼───────────────────────────────┼─────────────┤
│ 05      │ 3 × 2.5 GB  │ EC2 r6a.xlarge │ ~parity (VM noise)            │ −17%        │
└─────────┴─────────────┴────────────────┴───────────────────────────────┴─────────────┘
```

Upload time stays about the same on the tested backends: Lambda is limited by its network bandwidth (~80–90 MB/s), and r6a.xlarge has only 2 physical cores, so the upload threads compete for CPU; a time win is expected on larger instances. The measured win of this part is memory: the full float32 + bytes copies are gone, peak memory drops 11–18%, and on the largest datasets the peak stage is no longer the browser upload.

The skip part removes the stage almost completely on reprocessing: 7.7 -> 0.18 s, 24.9 -> 0.15 s, 17.4 -> 0.17 s, 31.0 -> 0.19 s (−98…−99%).

Note on dataset 01: files under 64 MB now go as three sequential PUTs from the main thread instead of a 3-thread pool, which costs +0.3 s on the smallest dataset. If this ever matters, small PUTs can be sent through the same shared pool.                      